### PR TITLE
Fix section formatting in HDFS documentation

### DIFF
--- a/pages/services/hdfs/hdfs-auth/index.md
+++ b/pages/services/hdfs/hdfs-auth/index.md
@@ -114,7 +114,6 @@ Use the following curl commands to rapidly provision the HDFS service account wi
     -H 'Content-Type: application/json'
     ```
 
-
     ## Strict
     Run these commands with your service account name (`<service-account-id>`) specified.
 


### PR DESCRIPTION
## Description

https://jira.mesosphere.com/browse/DOCS-2380

The "Development" documentation does not have content which shows me how to build the documentation. However, the problem, which has a screenshot on the JIRA issue, also shows up in Atom, GitHub's text editor, when using Markdown preview.

In Atom, this is the rendering before this change:

<img width="724" alt="bad formatting - atom" src="https://user-images.githubusercontent.com/797801/34606509-9b5ab5da-f207-11e7-9ba5-197e583d612d.png">

And after:

<img width="694" alt="good formatting - atom" src="https://user-images.githubusercontent.com/797801/34606515-9f746468-f207-11e7-93a2-7d2cb5908403.png">

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).

  
  