### PR TITLE
Specifies which information is no longer in the diagnostic bundles.

### DIFF
--- a/pages/1.10/release-notes/1.10.4/index.md
+++ b/pages/1.10/release-notes/1.10.4/index.md
@@ -15,7 +15,7 @@ These are the release notes for DC/OS 1.10.4.
 - CORE-1375 - Docker executor does not hang due to lost messages.
 - DOCS-2169	- Updated [ports list](https://docs.mesosphere.com/1.10/installing/ent/ports/) for DC/OS. [enterprise type="inline" size="small"/]
 - DCOS-18777 - DC/OS CA certificate bundle now gets propagated to public slaves.
-- DCOS-19327 - Diagnostics bundles no longer contain sensitive cluster configuration values.
+- DCOS-19327 - Diagnostics bundles no longer contain sensitive cluster configuration values related to Cloudformation templates.
 - DCOS-19399 - Marathon now supports upgrading to JDK 1.8.0_152.
 - DCOS_OSS-1828	- Prometheus plugin now authenticates on master nodes.
 - DCOS_OSS-1898	- DC/OS CLI can now retrieve metrics for Dockerized tasks.


### PR DESCRIPTION
The initial description claimed that the bundles didn't contain
sensitive configuration values. However, from [DCOS-19073](https://jira.mesosphere.com/browse/DCOS-19073) we can
conclude that passwords from ZooKeeper can still leak in the
diagnostic bundles.

## Description
[DCOS-19073](https://jira.mesosphere.com/browse/DCOS-19073): ZK credentials for Mesos master show up in diagnostics bundles

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
