### PR TITLE
DCOS_OSS-1811 Fixes ELK example

### DIFF
--- a/pages/1.8/administration/logging/elk/index.md
+++ b/pages/1.8/administration/logging/elk/index.md
@@ -1,10 +1,15 @@
 ---
 layout: layout.pug
 navigationTitle:  Log Management with ELK
-excerpt:
 title: Log Management with ELK
 menuWeight: 1
+excerpt:
+
+enterprise: false
 ---
+
+<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
+
 
 You can pipe system and application logs from the nodes in a DC/OS cluster to an Elasticsearch server. This document describes how to send Filebeat output from each node to a centralized Elasticsearch instance. This document does not explain how to setup and configure an Elasticsearch server.
 
@@ -19,7 +24,7 @@ These instructions are based on CentOS 7 and might differ substantially from oth
 *   An existing Elasticsearch installation that can ingest data for indexing.
 *   All DC/OS nodes must be able to connect to your Elasticsearch server on the port used for communication between Elasticsearch and Filebeat (9200 by default).
 
-# <a name="all"></a>Step 1: All nodes
+# <a name="all"></a>Step 1: Install filebeat
 
 For all nodes in your DC/OS cluster:
 
@@ -40,7 +45,7 @@ For all nodes in your DC/OS cluster:
     ```bash
     sudo mv /etc/filebeat/filebeat.yml /etc/filebeat/filebeat.yml.BAK
     ```
-    
+
 1.  Populate a new `filebeat.yml` configuration file, including an additional input entry for the file `/var/log/dcos/dcos.log`. The additional log file will be used to capture the DC/OS logs in a later step. Remember to substitute the variables `$ELK_HOSTNAME` and `$ELK_PORT` below for the actual values of the host and port where your Elasticsearch is listening on.
 
     ```bash
@@ -56,13 +61,15 @@ For all nodes in your DC/OS cluster:
       hosts: ["$ELK_HOSTNAME:$ELK_PORT"]
     ```
 
-# <a name="master"></a>Step 2a: Master nodes
+**Important:** The agent node Filebeat configuration expects tasks to write logs to `stdout` and `stderr`. Some DC/OS services, including Cassandra and Kafka, do not write logs to `stdout` and `stderr`. If you want to log these services, you must customize your agent node Filebeat configuration.
 
-For each master node in your DC/OS cluster:
+# <a name="all-2"></a>Step 2: Setup service for parsing the journal
 
-1.  Create a script that parses the output of the DC/OS master `journalctl` logs and funnels them to `/var/log/dcos/dcos.log`.
+For all nodes in your DC/OS cluster:
 
-    **Tip:** This script can be used with DC/OS and DC/OS Enterprise. Log entries that do not apply are ignored.
+1.  Create a script `/etc/systemd/system/dcos-journalctl-filebeat.service` that parses the output of the DC/OS master `journalctl` logs and funnels them to `/var/log/dcos/dcos.log`.
+
+    **Tip:** This script can be used with DC/OS and Enterprise DC/OS. Log entries that do not apply are ignored.
 
     ```bash
     sudo tee /etc/systemd/system/dcos-journalctl-filebeat.service<<-EOF
@@ -70,116 +77,76 @@ For each master node in your DC/OS cluster:
     Description=DCOS journalctl parser to filebeat
     Wants=filebeat.service
     After=filebeat.service
-    
+
     [Service]
     Restart=always
     RestartSec=5
-    ExecStart=/bin/sh -c '/usr/bin/journalctl --no-tail -f \
-    -u dcos-3dt.service \
-    -u dcos-3dt.socket \
-    -u dcos-adminrouter-reload.service \
-    -u dcos-adminrouter-reload.timer \
-    -u dcos-adminrouter.service \
-    -u dcos-bouncer.service \
-    -u dcos-ca.service \
-    -u dcos-cfn-signal.service \
-    -u dcos-cosmos.service \
-    -u dcos-download.service \
-    -u dcos-epmd.service \
-    -u dcos-exhibitor.service \
-    -u dcos-gen-resolvconf.service \
-    -u dcos-gen-resolvconf.timer \
-    -u dcos-history.service \
-    -u dcos-link-env.service \
-    -u dcos-logrotate-master.timer \
-    -u dcos-marathon.service \
-    -u dcos-mesos-dns.service \
-    -u dcos-mesos-master.service \
-    -u dcos-metronome.service \
-    -u dcos-minuteman.service \
-    -u dcos-navstar.service \
-    -u dcos-networking_api.service \
-    -u dcos-secrets.service \
-    -u dcos-setup.service \
-    -u dcos-signal.service \
-    -u dcos-signal.timer \
-    -u dcos-spartan-watchdog.service \
-    -u dcos-spartan-watchdog.timer \
-    -u dcos-spartan.service \
-    -u dcos-vault.service \
-    -u dcos-logrotate-master.service \
-    > /var/log/dcos/dcos.log 2>&1'
-    ExecStartPre=/usr/bin/journalctl --vacuum-size=10M
-    
+    ExecStart=/bin/sh -c '/usr/bin/journalctl --since="5 minutes ago" --no-tail --follow --unit="dcos*.service" >> /var/log/dcos/dcos.log 2>&1'
+
     [Install]
     WantedBy=multi-user.target
     EOF
     ```
 
-# <a name="agent"></a>Step 2b: Agent nodes
+# <a name="all-3"></a>Step 3: Start and enable filebeat
 
-For each agent node in your DC/OS cluster:
-
-1.  Create a script that parses the output of the DC/OS agent `journalctl` logs and funnels them to `/var/log/dcos/dcos.log`.
-
-    **Tip:** This script can be used with DC/OS and DC/OS Enterprise. Log entries that do not apply are ignored.
-
-    ```bash
-    sudo tee /etc/systemd/system/dcos-journalctl-filebeat.service<<-EOF 
-    [Unit]
-    Description=DCOS journalctl parser to filebeat
-    Wants=filebeat.service
-    After=filebeat.service
-    
-    [Service]
-    Restart=always
-    RestartSec=5
-    ExecStart=/bin/sh -c '/usr/bin/journalctl --no-tail -f \
-    -u dcos-3dt.service \
-    -u dcos-logrotate-agent.timer \
-    -u dcos-3dt.socket \
-    -u dcos-mesos-slave.service \
-    -u dcos-adminrouter-agent.service \
-    -u dcos-minuteman.service \
-    -u dcos-adminrouter-reload.service \
-    -u dcos-navstar.service \
-    -u dcos-adminrouter-reload.timer \
-    -u dcos-rexray.service \
-    -u dcos-cfn-signal.service \
-    -u dcos-setup.service \
-    -u dcos-download.service \
-    -u dcos-signal.timer \
-    -u dcos-epmd.service \
-    -u dcos-spartan-watchdog.service \
-    -u dcos-gen-resolvconf.service \
-    -u dcos-spartan-watchdog.timer \
-    -u dcos-gen-resolvconf.timer \
-    -u dcos-spartan.service \
-    -u dcos-link-env.service \
-    -u dcos-vol-discovery-priv-agent.service \
-    -u dcos-logrotate-agent.service \
-    > /var/log/dcos/dcos.log 2>&1'
-    ExecStartPre=/usr/bin/journalctl --vacuum-size=10M
-    
-    [Install]
-    WantedBy=multi-user.target
-    EOF
-    ```
-
-# <a name="all-3"></a>Step 3: All nodes
-
-1.  For all nodes, start and enable the Filebeat log parsing services created above:
+1.  For all nodes, start and enable the filebeat log parsing services created above:
 
     ```bash
     sudo chmod 0755 /etc/systemd/system/dcos-journalctl-filebeat.service
     sudo systemctl daemon-reload
-    sudo systemctl enable dcos-journalctl-filebeat.service
     sudo systemctl start dcos-journalctl-filebeat.service
-    sudo systemctl enable filebeat
+    sudo systemctl enable dcos-journalctl-filebeat.service
     sudo systemctl start filebeat
+    sudo systemctl enable filebeat
     ```
 
-[2]: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html
-[3]: ../filter-elk/
-[5]: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
-[8]: https://www.elastic.co/guide/en/logstash/current/index.html
+
+# <a name="all"></a>Step 3: ELK Node Notes
+
+The ELK stack will receive, store, search and display information about the logs parsed by the Filebeat instances configured above for all nodes in the cluster.
+
+**Important:** This document describes how to directly stream from Filebeat into ElasticSearch. Logstash is not used in this architecture. If you're interested in filtering, parsing and grok'ing the logs with an intermediate Logstash stage, please check the Logstash [documentation][8].
+
+You must modify the default parameter values to prepare ElasticSearch to receive information. For example, edit the ElasticSearch configuration file (typically `/etc/elasticsearch/elasticsearch.yml`):
+
+```bash
+network.host = [IP address from the interface in your ElasticSearch node connecting to the Filebeat instances]
+```
+
+Other parameters in the file are beyond the scope of this document. For details, please check the ElasticSearch [documentation][5].
+
+
+# <a name="all-4"></a>Step 4: Configure Log Rotation
+
+You should configure logrotate on all of your nodes to prevent the file /var/log/dcos/dcos.log growing without limit and filling up your disk.
+Your logrotate config should contain 'copytruncate' because otherwise the 'journalctl' pipe remains open and pointing to the same file even after it's been rotated.
+Note: With using 'copytruncate' there is a very small time slice between copying the file and truncating it, so some logging data might be lost - you should balance pros and cons between filling up the disk and losing some lines of logs.
+
+For example your logrotate configuration should look like this:
+
+```
+/var/log/dcos/dcos.log {    
+  size 100M
+  copytruncate
+  rotate 5
+  compress
+  compresscmd /bin/xz
+}
+```
+
+### Known Issue
+
+The agent node Filebeat configuration expects tasks to write logs to `stdout` and `stderr`. Some DC/OS services, including Cassandra and Kafka, do not write logs to `stdout` and `stderr`. If you want to log these services, you must customize your agent node Filebeat configuration.
+
+# What's Next
+
+For details on how to filter your logs with ELK, see [Filtering DC/OS logs with ELK][3].
+
+ [2]: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html
+ [3]: ../filter-elk/
+ [4]: https://www.elastic.co/guide/en/elastic-stack/current/index.html
+ [5]: https://www.elastic.co/guide/en/elasticsearch/reference/5.0/index.html
+ [6]: https://www.elastic.co/guide/en/kibana/current/install.html
+ [7]: https://www.elastic.co/guide/en/logstash/current/installing-logstash.html
+ [8]: https://www.elastic.co/guide/en/logstash/current/index.html

--- a/pages/1.9/monitoring/logging/aggregating/elk/index.md
+++ b/pages/1.9/monitoring/logging/aggregating/elk/index.md
@@ -1,10 +1,15 @@
 ---
 layout: layout.pug
 navigationTitle:  Log Management with ELK
-excerpt:
 title: Log Management with ELK
 menuWeight: 1
+excerpt:
+
+enterprise: false
 ---
+
+<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
+
 
 You can pipe system and application logs from the nodes in a DC/OS cluster to an Elasticsearch server. This document describes how to send Filebeat output from each node to a centralized Elasticsearch instance. This document does not explain how to setup and configure an Elasticsearch server.
 
@@ -19,7 +24,7 @@ These instructions are based on CentOS 7 and might differ substantially from oth
 *   An existing Elasticsearch installation that can ingest data for indexing.
 *   All DC/OS nodes must be able to connect to your Elasticsearch server on the port used for communication between Elasticsearch and Filebeat (9200 by default).
 
-# <a name="all"></a>Step 1: All nodes
+# <a name="all"></a>Step 1: Install filebeat
 
 For all nodes in your DC/OS cluster:
 
@@ -40,7 +45,7 @@ For all nodes in your DC/OS cluster:
     ```bash
     sudo mv /etc/filebeat/filebeat.yml /etc/filebeat/filebeat.yml.BAK
     ```
-    
+
 1.  Populate a new `filebeat.yml` configuration file, including an additional input entry for the file `/var/log/dcos/dcos.log`. The additional log file will be used to capture the DC/OS logs in a later step. Remember to substitute the variables `$ELK_HOSTNAME` and `$ELK_PORT` below for the actual values of the host and port where your Elasticsearch is listening on.
 
     ```bash
@@ -56,13 +61,15 @@ For all nodes in your DC/OS cluster:
       hosts: ["$ELK_HOSTNAME:$ELK_PORT"]
     ```
 
-# <a name="master"></a>Step 2a: Master nodes
+**Important:** The agent node Filebeat configuration expects tasks to write logs to `stdout` and `stderr`. Some DC/OS services, including Cassandra and Kafka, do not write logs to `stdout` and `stderr`. If you want to log these services, you must customize your agent node Filebeat configuration.
 
-For each master node in your DC/OS cluster:
+# <a name="all-2"></a>Step 2: Setup service for parsing the journal
 
-1.  Create a script that parses the output of the DC/OS master `journalctl` logs and funnels them to `/var/log/dcos/dcos.log`.
+For all nodes in your DC/OS cluster:
 
-    **Tip:** This script can be used with DC/OS and DC/OS Enterprise. Log entries that do not apply are ignored.
+1.  Create a script `/etc/systemd/system/dcos-journalctl-filebeat.service` that parses the output of the DC/OS master `journalctl` logs and funnels them to `/var/log/dcos/dcos.log`.
+
+    **Tip:** This script can be used with DC/OS and Enterprise DC/OS. Log entries that do not apply are ignored.
 
     ```bash
     sudo tee /etc/systemd/system/dcos-journalctl-filebeat.service<<-EOF
@@ -70,116 +77,76 @@ For each master node in your DC/OS cluster:
     Description=DCOS journalctl parser to filebeat
     Wants=filebeat.service
     After=filebeat.service
-    
+
     [Service]
     Restart=always
     RestartSec=5
-    ExecStart=/bin/sh -c '/usr/bin/journalctl --no-tail -f \
-    -u dcos-3dt.service \
-    -u dcos-3dt.socket \
-    -u dcos-adminrouter-reload.service \
-    -u dcos-adminrouter-reload.timer \
-    -u dcos-adminrouter.service \
-    -u dcos-bouncer.service \
-    -u dcos-ca.service \
-    -u dcos-cfn-signal.service \
-    -u dcos-cosmos.service \
-    -u dcos-download.service \
-    -u dcos-epmd.service \
-    -u dcos-exhibitor.service \
-    -u dcos-gen-resolvconf.service \
-    -u dcos-gen-resolvconf.timer \
-    -u dcos-history.service \
-    -u dcos-link-env.service \
-    -u dcos-logrotate-master.timer \
-    -u dcos-marathon.service \
-    -u dcos-mesos-dns.service \
-    -u dcos-mesos-master.service \
-    -u dcos-metronome.service \
-    -u dcos-minuteman.service \
-    -u dcos-navstar.service \
-    -u dcos-networking_api.service \
-    -u dcos-secrets.service \
-    -u dcos-setup.service \
-    -u dcos-signal.service \
-    -u dcos-signal.timer \
-    -u dcos-spartan-watchdog.service \
-    -u dcos-spartan-watchdog.timer \
-    -u dcos-spartan.service \
-    -u dcos-vault.service \
-    -u dcos-logrotate-master.service \
-    > /var/log/dcos/dcos.log 2>&1'
-    ExecStartPre=/usr/bin/journalctl --vacuum-size=10M
-    
+    ExecStart=/bin/sh -c '/usr/bin/journalctl --since="5 minutes ago" --no-tail --follow --unit="dcos*.service" >> /var/log/dcos/dcos.log 2>&1'
+
     [Install]
     WantedBy=multi-user.target
     EOF
     ```
 
-# <a name="agent"></a>Step 2b: Agent nodes
+# <a name="all-3"></a>Step 3: Start and enable filebeat
 
-For each agent node in your DC/OS cluster:
-
-1.  Create a script that parses the output of the DC/OS agent `journalctl` logs and funnels them to `/var/log/dcos/dcos.log`.
-
-    **Tip:** This script can be used with DC/OS and DC/OS Enterprise. Log entries that do not apply are ignored.
-
-    ```bash
-    sudo tee /etc/systemd/system/dcos-journalctl-filebeat.service<<-EOF 
-    [Unit]
-    Description=DCOS journalctl parser to filebeat
-    Wants=filebeat.service
-    After=filebeat.service
-    
-    [Service]
-    Restart=always
-    RestartSec=5
-    ExecStart=/bin/sh -c '/usr/bin/journalctl --no-tail -f \
-    -u dcos-3dt.service \
-    -u dcos-logrotate-agent.timer \
-    -u dcos-3dt.socket \
-    -u dcos-mesos-slave.service \
-    -u dcos-adminrouter-agent.service \
-    -u dcos-minuteman.service \
-    -u dcos-adminrouter-reload.service \
-    -u dcos-navstar.service \
-    -u dcos-adminrouter-reload.timer \
-    -u dcos-rexray.service \
-    -u dcos-cfn-signal.service \
-    -u dcos-setup.service \
-    -u dcos-download.service \
-    -u dcos-signal.timer \
-    -u dcos-epmd.service \
-    -u dcos-spartan-watchdog.service \
-    -u dcos-gen-resolvconf.service \
-    -u dcos-spartan-watchdog.timer \
-    -u dcos-gen-resolvconf.timer \
-    -u dcos-spartan.service \
-    -u dcos-link-env.service \
-    -u dcos-vol-discovery-priv-agent.service \
-    -u dcos-logrotate-agent.service \
-    > /var/log/dcos/dcos.log 2>&1'
-    ExecStartPre=/usr/bin/journalctl --vacuum-size=10M
-    
-    [Install]
-    WantedBy=multi-user.target
-    EOF
-    ```
-
-# <a name="all-3"></a>Step 3: All nodes
-
-1.  For all nodes, start and enable the Filebeat log parsing services created above:
+1.  For all nodes, start and enable the filebeat log parsing services created above:
 
     ```bash
     sudo chmod 0755 /etc/systemd/system/dcos-journalctl-filebeat.service
     sudo systemctl daemon-reload
-    sudo systemctl enable dcos-journalctl-filebeat.service
     sudo systemctl start dcos-journalctl-filebeat.service
-    sudo systemctl enable filebeat
+    sudo systemctl enable dcos-journalctl-filebeat.service
     sudo systemctl start filebeat
+    sudo systemctl enable filebeat
     ```
 
-[2]: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html
-[3]: ../filter-elk/
-[5]: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
-[8]: https://www.elastic.co/guide/en/logstash/current/index.html
+
+# <a name="all"></a>Step 3: ELK Node Notes
+
+The ELK stack will receive, store, search and display information about the logs parsed by the Filebeat instances configured above for all nodes in the cluster.
+
+**Important:** This document describes how to directly stream from Filebeat into ElasticSearch. Logstash is not used in this architecture. If you're interested in filtering, parsing and grok'ing the logs with an intermediate Logstash stage, please check the Logstash [documentation][8].
+
+You must modify the default parameter values to prepare ElasticSearch to receive information. For example, edit the ElasticSearch configuration file (typically `/etc/elasticsearch/elasticsearch.yml`):
+
+```bash
+network.host = [IP address from the interface in your ElasticSearch node connecting to the Filebeat instances]
+```
+
+Other parameters in the file are beyond the scope of this document. For details, please check the ElasticSearch [documentation][5].
+
+
+# <a name="all-4"></a>Step 4: Configure Log Rotation
+
+You should configure logrotate on all of your nodes to prevent the file /var/log/dcos/dcos.log growing without limit and filling up your disk.
+Your logrotate config should contain 'copytruncate' because otherwise the 'journalctl' pipe remains open and pointing to the same file even after it's been rotated.
+Note: With using 'copytruncate' there is a very small time slice between copying the file and truncating it, so some logging data might be lost - you should balance pros and cons between filling up the disk and losing some lines of logs.
+
+For example your logrotate configuration should look like this:
+
+```
+/var/log/dcos/dcos.log {    
+  size 100M
+  copytruncate
+  rotate 5
+  compress
+  compresscmd /bin/xz
+}
+```
+
+### Known Issue
+
+The agent node Filebeat configuration expects tasks to write logs to `stdout` and `stderr`. Some DC/OS services, including Cassandra and Kafka, do not write logs to `stdout` and `stderr`. If you want to log these services, you must customize your agent node Filebeat configuration.
+
+# What's Next
+
+For details on how to filter your logs with ELK, see [Filtering DC/OS logs with ELK][3].
+
+ [2]: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html
+ [3]: ../filter-elk/
+ [4]: https://www.elastic.co/guide/en/elastic-stack/current/index.html
+ [5]: https://www.elastic.co/guide/en/elasticsearch/reference/5.0/index.html
+ [6]: https://www.elastic.co/guide/en/kibana/current/install.html
+ [7]: https://www.elastic.co/guide/en/logstash/current/installing-logstash.html
+ [8]: https://www.elastic.co/guide/en/logstash/current/index.html


### PR DESCRIPTION
- change to append instead of create in systemd file / add logrotate
- Remove the journalctl --vacuum-size=10M since this complicates debugging and RCAs
- Added Example config for logrotate
- Stream-lined the filebeat-journald service

## Description
https://jira.mesosphere.com/browse/DCOS_OSS-1811

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
