### PR TITLE
fix(Sidebar): use navigationTitle to render dropdown selection

### DIFF
--- a/layouts/partials/sidebar.pug
+++ b/layouts/partials/sidebar.pug
@@ -25,7 +25,7 @@ if paths[0] === 'services' && paths[1]
 if semver.test(paths[0])
   - dropdown = hierarchy.children.filter(item => semver.test(item.id))
   - items = hierarchy.findByPath('/' + paths[0])
-  - versionTitle = paths[0]
+  - versionTitle = (items.navigationTitle) ? null : paths[0]
 
 mixin renderSidebarHeader()
   - var showDropdown = true
@@ -41,8 +41,11 @@ mixin renderSidebarHeader()
                 a(href=val.path, class='sidebar__dropdown__link')!= val.navigationTitle || val.title
       div(class='sidebar__dropdown__toggle')
         p(class='sidebar__dropdown__text')
-          span(class='sidebar__dropdown__text__title')!= (service) ? service.title : 'Mesosphere DC/OS'
-          span(class='sidebar__dropdown__text__version')!= ' ' + versionTitle
+          if versionTitle
+            span(class='sidebar__dropdown__text__title')!= (service) ? service.title : 'Mesosphere DC/OS'
+            span(class='sidebar__dropdown__text__version')!= ' ' + versionTitle
+          else
+            span(class='sidebar__dropdown__text__title')!= items.navigationTitle
         if showDropdown
           i(class='sidebar__dropdown__icon', data-feather='chevron-down')
 


### PR DESCRIPTION
## Description
Use `navigationTitle` to render dropdown selection in sidebar for DCOS docs. This decouples versioning with label. Example below has navigationTitle = `Mesosphere DC/OS 1.10 (BETA)`. Note the addition of `(BETA)`

![](https://cl.ly/023C1r2I001c/Image%202018-01-19%20at%2011.48.13%20AM.png)

cc/ @ashenden @pavisandhu 

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
