### PR TITLE
Fixed Splunk regex syntax

### DIFF
--- a/pages/1.10/monitoring/logging/aggregating/filter-splunk/index.md
+++ b/pages/1.10/monitoring/logging/aggregating/filter-splunk/index.md
@@ -44,7 +44,7 @@ The `agent`, `framework`, `executor`, and `run` fields should now be available t
 1.  Add the following entry to `props.conf` (see the [Splunk documentation][4] for details):
 
     [source::/var/lib/mesos/slave/...]
-    EXTRACT = /var/lib/mesos/slave/slaves/(?<agent>[^/]+)/frameworks/(?<framework>[^/]+)/executors/(?<executor>[^/]+)/runs/(?<run>[^/]+)/.* in source
+    EXTRACT =  /var/lib/mesos/slave/slaves/(?<mesos_agent>(([^/]+)))/frameworks/(?<mesos_framework>(([^/]+)))/executors/(?<mesos_executor>(([^/]+)))/runs/(?<mesos_run>(([^/]+)))' in source
 
 2.  Run the following search in the Splunk Web UI to ensure the changes take effect:
 

--- a/pages/1.9/monitoring/logging/aggregating/filter-splunk/index.md
+++ b/pages/1.9/monitoring/logging/aggregating/filter-splunk/index.md
@@ -28,7 +28,7 @@ You can configure Splunk either by using the Splunk [Web UI][2] or by editing th
     *   Type: `Inline`
     *   Extraction/Transform:
 
-        /var/lib/mesos/slave/slaves/(?<agent>[^/]+)/frameworks/(?<framework>[^/]+)/executors/(?<executor>[^/]+)/runs/(?<run>[^/]+)/.* in source
+         /var/lib/mesos/slave/slaves/(?<mesos_agent>(([^/]+)))/frameworks/(?<mesos_framework>(([^/]+)))/executors/(?<mesos_executor>(([^/]+)))/runs/(?<mesos_run>(([^/]+)))' in source
 
 3.  Click **Save**.
 


### PR DESCRIPTION
Just a fixe of Splunk Regex syntax to create fields and add title in the fields as describe the page.