### PR TITLE
[Spark docs] Updated Spark docs for release of spark-history 2.1.0-2.2.0-1

### DIFF
--- a/pages/services/spark/2.1.0-2.2.0-1/history-server/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/history-server/index.md
@@ -27,7 +27,9 @@ DC/OS Apache Spark includes The [Spark History Server][3]. Because the history s
 1. Create `spark-history-options.json`:
 
         {
-          "hdfs-config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+          "service": {
+            "hdfs-config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+          }
         }
 
 1. Install The Spark History Server:

--- a/pages/services/spark/2.1.0-2.2.0-1/release-notes/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/release-notes/index.md
@@ -11,11 +11,11 @@ enterprise: false
 ## Spark-History 2.1.0-2.2.0-1
 
 ### Improvements
-- Upgraded docker image to 2.1.0-2.2.0-1-hadoop-2.6.
+- Upgraded Docker image to 2.1.0-2.2.0-1-hadoop-2.6.
 - Wrapped the config properties in a "service" object. (See "Breaking Changes")
 
 ### Bug Fixes
-- Fixed field names in marathon.json. Installing from the DC/OS UI now works.
+- Fixed field names in `marathon.json`. Installing from the DC/OS UI now works.
 
 ### Breaking Changes
 - The configuration properties have been wrapped in a new "service" object.

--- a/pages/services/spark/2.1.0-2.2.0-1/release-notes/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/release-notes/index.md
@@ -8,6 +8,20 @@ featureMaturity:
 enterprise: false
 ---
 
+## Spark-History 2.1.0-2.2.0-1
+
+### Improvements
+- Upgraded docker image to 2.1.0-2.2.0-1-hadoop-2.6.
+- Wrapped the config properties in a "service" object. (See "Breaking Changes")
+
+### Bug Fixes
+- Fixed field names in marathon.json. Installing from the DC/OS UI now works.
+
+### Breaking Changes
+- The configuration properties have been wrapped in a new "service" object.
+If installing from the CLI, please update your `options.json` file accordingly.
+See the Spark history server docs for an example.
+
 ## Version 2.1.0-2.2.0-1
 
 ### Improvements

--- a/pages/services/spark/2.1.0-2.2.1-1/release-notes/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/release-notes/index.md
@@ -16,6 +16,20 @@ featureMaturity:
 ### Improvements
 - Upgraded Spark to 2.2.1.
 
+## Spark-History 2.1.0-2.2.0-1
+
+### Improvements
+- Upgraded Docker image to 2.1.0-2.2.0-1-hadoop-2.6.
+- Wrapped the config properties in a "service" object. (See "Breaking Changes")
+
+### Bug Fixes
+- Fixed field names in `marathon.json`. Installing from the DC/OS UI now works.
+
+### Breaking Changes
+- The configuration properties have been wrapped in a new "service" object.
+If installing from the CLI, please update your `options.json` file accordingly.
+See the Spark history server docs for an example.
+
 ## Version 2.1.0-2.2.0-1
 
 ### Improvements


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/RELEASE-483
- Updated the release notes 
- Updated the history-server page within version 2.1.0-2.2.0-1 of Spark

## Urgency
- [ x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium
