### PR TITLE
Add vagrant user to be able to ssh

### DIFF
--- a/pages/1.10/tutorials/dcos-101/redis-package/index.md
+++ b/pages/1.10/tutorials/dcos-101/redis-package/index.md
@@ -46,6 +46,7 @@ By the end of this session you will have installed your first service - [Redis](
         ```
     
       * Because Redis is running in a Docker container, you can list all Docker containers using `docker ps` and get the ContainerID of the container running the redis service.
+      * If you are running the Vagrant version of DC/OS, then add `--user vagrant`
       * Start a bash session in the running container, substituting CONTAINER_ID with the ContainerID you got from the previous command: 
       
         ```bash


### PR DESCRIPTION
If using the Vagrant DC/OS distribution, one has to add `--user vagrant` in order to be able to ssh into nodes.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
