### PR TITLE
Adding Spark-2.2.1-2.2.0-2-beta docs.

### DIFF
--- a/pages/services/spark/2.1.0-2.2.0-1/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Spark 2.1.0-2.2.0-1
 title: Spark 2.1.0-2.2.0-1
-menuWeight: 20
+menuWeight: 40
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/spark/2.1.0-2.2.1-1/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Spark 2.1.0-2.2.1-1
 title: Spark 2.1.0-2.2.1-1
-menuWeight: 10
+menuWeight: 30
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/custom-docker/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/custom-docker/index.md
@@ -1,0 +1,34 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Custom Docker Images
+menuWeight: 95
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+**Note:** Customizing the Spark image Mesosphere provides is supported. However, customizations have the potential to adversely affect the integration between Spark and DC/OS. In situations where Mesosphere support suspects a customization may be adversely impacting Spark with DC/OS, Mesosphere support may request that the customer reproduce the issue with an unmodified
+Spark image.
+
+You can customize the Docker image in which Spark runs by extending the standard Spark Docker image. In this way, you can install your own libraries, such as a custom Python library.
+
+1. In your Dockerfile, extend from the standard Spark image and add your customizations:
+
+    ```
+    FROM mesosphere/spark:1.0.4-2.0.1
+    RUN apt-get install -y python-pip
+    RUN pip install requests
+    ```
+
+1. Then, build an image from your Dockerfile.
+
+        docker build -t username/image:tag .
+        docker push username/image:tag
+
+1. Reference your custom Docker image with the `--docker-image` option when running a Spark job.
+
+        dcos spark run --docker-image=myusername/myimage:v1 --submit-args="http://external.website/mysparkapp.py 30"

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/fault-tolerance/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/fault-tolerance/index.md
@@ -1,0 +1,135 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Fault Tolerance
+menuWeight: 100
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+Failures such as host, network, JVM, or application failures can affect the behavior of three types of Spark components:
+
+- DC/OS Apache Spark Service
+- Batch Jobs
+- Streaming Jobs
+
+# DC/OS Apache Spark Service
+
+The DC/OS Apache Spark service runs in Marathon and includes the Mesos Cluster Dispatcher and the Spark History Server.  The Dispatcher manages jobs you submit via `dcos spark run`.  Job data is persisted to Zookeeper. The Spark History Server reads event logs from HDFS. If the service dies, Marathon will restart it, and it will reload data from these highly available stores.
+
+# Batch Jobs
+
+Batch jobs are resilient to executor failures, but not driver failures.  The Dispatcher will restart a driver if you submit with `--supervise`.
+
+## Driver
+
+When the driver fails, executors are terminated, and the entire Spark application fails.  If you submitted your job with `--supervise`, then the Dispatcher will restart the job.
+
+## Executors
+
+Batch jobs are resilient to executor failure.  Upon failure, cached data, shuffle files, and partially computed RDDs are lost.  However, Spark RDDs are fault-tolerant, and Spark will start a new executor to recompute this data from the original data source, caches, or shuffle files.  There is a performance cost as data is recomputed, but an executor failure will not cause a job to fail.
+
+# Streaming Jobs
+
+Whereas batch jobs run once and can usually be restarted upon failure, streaming jobs often need to run constantly.  The application must survive driver failures, often with no data loss.
+
+In summary, to experience no data loss, you must run with the WAL enabled.  The one exception is that, if you're consuming from Kafka, you can use the Direct Kafka API.
+
+For exactly once processing semantics, you must use the Direct Kafka API.  All other receivers provide at least once semantics.
+
+## Failures
+
+There are two types of failures:
+
+- Driver
+- Executor
+
+## Job Features
+
+There are a few variables that affect the reliability of your job:
+
+- [WAL][1]
+- [Receiver reliability][2]
+- [Storage level][3]
+
+## Reliability Features
+
+The two reliability features of a job are data loss and processing semantics.  Data loss occurs when the source sends data, but the job fails to process it.  Processing semantics describe how many times a received message is processed by the job.  It can be either "at least once" or "exactly once"
+
+### Data loss
+
+A Spark Job loses data when delivered data does not get processed. The following is a list of configurations with increasing data preservation guarantees:
+
+- Unreliable receivers
+
+Unreliable receivers do not ack data they receive from the source. This means that buffered data in the receiver will be lost upon executor failure.
+
+executor failure => **data loss** driver failure => **data loss**
+
+- Reliable receivers, unreplicated storage level
+
+This is an unusual configuration.  By default, Spark Streaming receivers run with a replicated storage level.  But if you happen reduce the storage level to be unreplicated, data stored on the receiver but not yet processed will not survive executor failure.
+
+  executor failure => **data loss**  
+  driver failure => **data loss**
+
+- Reliable receivers, replicated storage level
+
+This is the default configuration.  Data stored in the receiver is replicated, and can thus survive a single executor failure.  Driver failures, however, result in all executors failing, and therefore result in data loss.
+
+  (single) executor failure => **no data loss**  
+  driver failure => **data loss**
+
+- Reliable receivers, WAL
+
+With a WAL enabled, data stored in the receiver is written to a highly available store such as S3 or HDFS.  This means that an app can recover from even a driver failure.
+
+  executor failure => **no data loss**  
+  driver failure => **no data loss**
+
+- Direct Kafka Consumer, no checkpointing
+
+Since Spark 1.3, The Spark+Kafka integration has supported an experimental Direct Consumer, which doesn't use traditional receivers.  With the direct approach, RDDs read directly from kafka, rather than buffering data in receivers.
+
+However, without checkpointing, driver restarts mean that the driver will start reading from the latest Kafka offset, rather than where the previous driver left off.
+
+  executor failure => **no data loss**  
+  driver failure => **data loss**
+
+- Direct Kafka Consumer, checkpointing
+
+With checkpointing enabled, Kafka offsets are stored in a reliable store such as HDFS or S3.  This means that an application can restart exactly where it left off.
+
+  executor failure => **no data loss**  
+  driver failure => **no data loss**
+
+### Processing semantics
+
+Processing semantics apply to how many times received messages get processed.  With Spark Streaming, this can be either "at least once" or "exactly once".
+
+The semantics below describe apply to Spark's receipt of the data.  To provide an end-to-end exactly-once guarantee, you must additionally verify that your output operation provides exactly-once guarantees. More info [here][4].
+
+- Receivers
+
+  **at least once**
+
+Every Spark Streaming consumer, with the exception of the Direct Kafka Consumer described below, uses receivers.  Receivers buffer blocks of data in memory, then write them according to the storage level of the job.  After writing out the data, it will send an ack to the source so the source knows not to resend.  However, if this ack fails, or the node fails between writing out the data and sending the ack, then an inconsistency arises.  Spark believes that the data has been received, but the source does not.  This results in the source resending the data, and it being processed twice.
+
+- Direct Kafka Consumer
+
+  **exactly once**
+
+The Direct Kafka Consumer avoids the problem described above by reading directly from Kafka, and storing the offsets itself in the checkpoint directory.
+
+  More information [here][5].
+
+
+[1]: https://spark.apache.org/docs/1.6.0/streaming-programming-guide.html#requirements
+[2]: https://spark.apache.org/docs/1.6.0/streaming-programming-guide.html#with-receiver-based-sources
+[3]: http://spark.apache.org/docs/latest/programming-guide.html#which-storage-level-to-choose
+[4]: http://spark.apache.org/docs/latest/streaming-programming-guide.html#semantics-of-output-operations
+[5]: https://databricks.com/blog/2015/03/30/improvements-to-kafka-integration-of-spark-streaming.html

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/hdfs/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/hdfs/index.md
@@ -1,0 +1,60 @@
+---
+layout: layout.pug
+excerpt:
+title: Integration with HDFS
+navigationTitle: HDFS
+menuWeight: 20
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+# HDFS
+
+If you plan to read and write from HDFS using Spark, there are two Hadoop configuration files that should be included on Spark's classpath: `hdfs-site.xml`, which provides default behaviors for the HDFS client. `core-site.xml`, which sets the default filesystem name. You can specify the location of these files at install time or for each job.
+
+## Spark Installation
+Within the Spark service configuration, set `hdfs.config-url` to be a URL that serves your `hdfs-site.xml` and `core-site.xml`, use this example where `http://mydomain.com/hdfs-config/hdfs-site.xml` and `http://mydomain.com/hdfs-config/core-site.xml` are valid URLs:
+
+```json
+{
+  "hdfs": {
+    "config-url": "http://mydomain.com/hdfs-config"
+  }
+}
+```
+This can also be done through the UI. If you are using the default installation of HDFS from Mesosphere this is probably `http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints`.
+
+## Adding HDFS configuration files per-job
+To add the configuration files manually for a job, use `--conf spark.mesos.uris=<location_of_hdfs-site.xml>,<location_of_core-site.xml>`. This will download the files to the sandbox of the Driver Spark application, and DC/OS Spark will automatically load these files into the correct location. **Note** It is important these files are called `hdfs-site.xml` and `core-site.xml`.
+
+### Spark Checkpointing
+
+In order to use spark with checkpointing make sure you follow the instructions [here](https://spark.apache.org/docs/latest/streaming-programming-guide.html#checkpointing) and use an hdfs directory as the checkpointing directory. For example:
+```
+val checkpointDirectory = "hdfs://hdfs/checkpoint"
+val ssc = ...
+ssc.checkpoint(checkpointDirectory)
+```
+That hdfs directory will be automatically created on hdfs and spark streaming app will work from checkpointed data even in the presence of application restarts/failures.
+
+# S3
+You can read/write files to S3 using environment-based secrets to pass your AWS credentials. Your credentials must first be uploaded to the DC/OS secret store:
+
+```
+dcos security secrets create <secret_path_for_key_id> -v <AWS_ACCESS_KEY_ID>
+dcos security secrets create <secret_path_for_secret_key> -v <AWS_SECRET_ACCESS_KEY> 
+```
+Then your Spark jobs can get these credentials directly:
+
+```
+dcos spark run --submit-args="\
+...
+--conf spark.mesos.containerizer=mesos  # required for secrets
+--conf spark.mesos.driver.secret.names=<secret_path_for_key_id>,<secret_path_for_secret_key>
+--conf spark.mesos.driver.secret.envkeys=AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
+...
+```
+
+[8]: http://spark.apache.org/docs/latest/configuration.html#inheriting-hadoop-cluster-configuration
+[9]: /services/spark/2.1.0-2.2.0-1/limitations/

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/history-server/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/history-server/index.md
@@ -1,0 +1,60 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: History Server
+menuWeight: 30
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+DC/OS Apache Spark includes The [Spark History Server][3]. Because the history server requires HDFS, you must explicitly enable it.
+
+1.  Install HDFS:
+
+        dcos package install hdfs
+
+    **Note:** HDFS requires 5 private nodes.
+
+1.  Create a history HDFS directory (default is `/history`). [SSH into your cluster][10] and run:
+
+        docker run -it mesosphere/hdfs-client:1.0.0-2.6.0 bash
+        ./bin/hdfs dfs -mkdir /history
+
+1. Create `spark-history-options.json`:
+
+        {
+          "service": {
+            "hdfs-config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+          }
+        }
+
+1. Install The Spark History Server:
+
+        dcos package install spark-history --options=spark-history-options.json
+
+1. Create `spark-dispatcher-options.json`;
+
+        {
+          "service": {
+            "spark-history-server-url": "http://<dcos_url>/service/spark-history"
+          },
+          "hdfs": {
+            "config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+          }
+        }
+
+1.  Install the Spark dispatcher:
+
+        dcos package install spark --options=spark-dispatcher-options.json
+
+1.  Run jobs with the event log enabled:
+
+        dcos spark run --submit-args="--conf spark.eventLog.enabled=true --conf spark.eventLog.dir=hdfs://hdfs/history ... --class MySampleClass  http://external.website/mysparkapp.jar"
+
+1.  Visit your job in the dispatcher at `http://<dcos_url>/service/spark/`. It will include a link to the history server entry for that job.
+
+ [3]: http://spark.apache.org/docs/latest/monitoring.html#viewing-after-the-fact
+ [10]: https://dcos.io/docs/1.9/administering-clusters/sshcluster/

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/index.md
@@ -1,14 +1,14 @@
 ---
 layout: layout.pug
-navigationTitle: 
-title: Spark 2.2.0-2.2.0-2-beta
-menuWeight: 20
+navigationTitle: Spark 2.2.1-2.2.0-2-beta
+title: Spark 2.2.1-2.2.0-2-beta
+menuWeight: 10
 excerpt:
 featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
 
 Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
@@ -54,8 +54,8 @@ DC/OS Apache Spark includes:
  [1]: http://spark.apache.org/documentation.html
  [2]: http://spark.apache.org/docs/latest/running-on-mesos.html#cluster-mode
  [3]: http://spark.apache.org/docs/latest/monitoring.html#viewing-after-the-fact
- [4]: /service-docs/hdfs/
- [5]: /service-docs/kafka/
+ [4]: /services/hdfs/
+ [5]: /services/kafka/
  [6]: https://zeppelin.incubator.apache.org/
  [17]: https://github.com/mesosphere/spark
  [18]: https://github.com/mesosphere/spark-build

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/install/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/install/index.md
@@ -1,0 +1,322 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Install and Customize
+menuWeight: 0
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+Spark is available in the Universe and can be installed by using either the GUI or the DC/OS CLI.
+
+**Prerequisites:**
+
+- [DC/OS and DC/OS CLI installed](/1.10/installing/oss/).
+- Depending on your [security mode](/1.10/security/ent/#security-modes), Spark requires
+  service authentication for access to DC/OS. For more information:  
+
+  | Security mode | Service Account       |
+  |---------------|-----------------------|
+  | Disabled      | Not available         |
+  | Permissive    | Optional              |
+  | Strict        | **Required**          |
+
+
+# Default Installation
+To install the DC/OS Apache Spark service, run the following command on the DC/OS CLI. This installs the Spark DC/OS
+service, Spark CLI, dispatcher, and, optionally, the history server. See [Custom Installation][7] to install the history
+server.
+
+```bash
+dcos package install spark
+```
+
+Go to the **Services** > **Deployments** tab of the DC/OS GUI to monitor the deployment. When it has finished deploying
+, visit Spark at `http://<dcos-url>/service/spark/`.
+
+You can also [install Spark via the DC/OS GUI](/1.9/usage/webinterface/#universe).
+
+
+## Spark CLI
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need
+the Spark CLI. 
+
+**Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS
+CLI.
+
+```bash
+dcos package install spark --cli
+```
+
+<a name="custom"></a>
+
+# Custom Installation
+
+You can customize the default configuration properties by creating a JSON options file and passing it to `dcos package
+install --options`. For example, to install the history server, create a file called `options.json`:
+
+```json
+{
+  "history-server": {
+    "enabled": true
+  }
+}
+```
+
+Install Spark with the  configuration specified in the `options.json` file:
+
+```bash
+dcos package install --options=options.json spark
+```
+
+**Tip:** Run this command to see all configuration options:
+
+```bash
+dcos package describe spark --config
+```
+
+## Customize Spark Distribution
+
+DC/OS Apache Spark does not support arbitrary Spark distributions, but Mesosphere does provide multiple pre-built
+distributions, primarily used to select Hadoop versions.  
+
+To use one of these distributions, select your Spark distribution from
+[here](https://github.com/mesosphere/spark-build/blob/master/docs/spark-versions.md), then select the corresponding
+Docker image from [here](https://hub.docker.com/r/mesosphere/spark/tags/), then use those values to set the following
+configuration variables:
+
+```json
+{
+  "service": {
+    "docker-image": "<docker-image>"
+  }
+}
+```
+
+# Minimal Installation
+
+For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
+
+1. Install DC/OS Vagrant:
+
+	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+
+1. Install Spark:
+
+   ```bash
+   dcos package install spark
+   ```
+
+1. Run a simple Job:
+
+   ```bash
+   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   ```
+
+**Note**: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache
+Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install
+DC/OS HDFS, and you thus won't be able to enable the history server.
+
+Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
+
+# Multiple Installations
+
+Installing multiple instances of the DC/OS Apache Spark package provides basic multi-team support. Each dispatcher
+displays only the jobs submitted to it by a given team, and each team can be assigned different resources.
+
+To install multiple instances of the DC/OS Apache Spark package, set each `service.name` to a unique name (e.g.:
+`spark-dev`) in your JSON configuration file during installation. For example, create a JSON options file name
+`multiple.json`:
+
+```json
+{
+  "service": {
+    "name": "spark-dev"
+  }
+}
+```
+
+Install Spark with the options file specified:
+
+```bash
+dcos package install --options=multiple.json spark
+```
+
+To specify which instance of Spark to use add `--name=<service_name>` to your CLI, for example
+
+```bash
+$ dcos spark --name=spark-dev run ...
+```
+
+# Installation for Strict mode (setting service authentication)
+
+If your cluster is setup for [strict](/1.10/security/ent/#strict) security then you will need
+to follow these steps to install and run Spark.
+
+## Service Accounts and Secrets
+
+1.  Install the `dcos-enterprise-cli` to get CLI security commands (if you haven't already):
+
+    ```bash
+    $ dcos package install dcos-enterprise-cli
+    ```
+
+1.  Create a key pair, a 2048-bit RSA public-private key pair is created using the Enterprise DC/OS CLI. Create a
+    public-private key pair and save each value into a separate file within the current directory.
+
+    ```bash
+    $ dcos security org service-accounts keypair <your-private-key>.pem <your-public-key>.pem
+    ```
+
+    For example:
+
+    ```bash
+    dcos security org service-accounts keypair private-key.pem public-key.pem
+    ```
+
+1.  Create a new service account, `service-account-id` (e.g. `spark-principal`) containing the public key,
+    `your-public-key.pem`.
+
+    ```bash
+    $ dcos security org service-accounts create -p <your-public-key>.pem -d "Spark service account" <service-account>
+    ```
+
+    For example: 
+
+    ```bash
+    dcos security org service-accounts create -p public-key.pem -d "Spark service account" spark-principal
+    
+    ```
+
+    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here. 
+
+    **Note** You can verify your new service account using the following command.
+
+    ```bash
+    $ dcos security org service-accounts show <service-account>
+    ```
+
+1.  Create a secret (e.g. `spark/<secret-name>`) with your service account, `service-account`, and private key
+    specified, `your-private-key.pem`.
+
+    ```bash
+    # permissive mode
+    $ dcos security secrets create-sa-secret <your-private-key>.pem <service-account> spark/<secret-name>
+    # strict mode
+    $ dcos security secrets create-sa-secret --strict <private-key>.pem <service-account> spark/<secret-name>
+    ```
+
+    For example, on a strict-mode DC/OS cluster:
+
+    ```bash
+    dcos security secrets create-sa-secret --strict private-key.pem spark-principal spark/spark-secret
+    ```
+
+    **Note* You can verify the secrets were created with:
+
+    ```bash
+    $ dcos security secrets list /
+    ```
+
+## Assigning permissions
+Permissions must be created so that the Spark service will be able to start Spark jobs and so the jobs themselves can
+launch the executors that perform the work on their behalf. There are a few points to keep in mind depending on your
+cluster:
+
+*   RHEL/CentOS users cannot currently run Spark in strict mode as user `nobody`, but must run as user `root`. This is
+    due to how accounts are mapped to UIDs. CoreOS users are unaffected, and can run as user `nobody`. We designate the
+    user as `spark-user` below.
+
+*   Spark runs by default under the Mesos default role, which is represented by the `*` symbol. You can deploy multiple
+    instances of Spark without modifying this default. If you want to override the default Spark role, you must modify
+    these code samples accordingly. We use `spark-service-role` to designate the role used below.
+
+Permissions can also be assigned through the UI. 
+
+1.  Run the following to create the required permissions for Spark:
+    ```bash
+    $ dcos security org users grant <service-account> dcos:mesos:master:task:user:<user> create --description "Allows the Linux user to execute tasks"
+    $ dcos security org users grant <service-account> dcos:mesos:master:framework:role:<spark-service-role> create --description "Allows a framework to register with the Mesos master using the Mesos default role"
+    $ dcos security org users grant <service-account> dcos:mesos:master:task:app_id:/<service_name> create --description "Allows reading of the task state"
+    ```
+    
+    Note that above the `dcos:mesos:master:task:app_id:/<service_name>` will likely be `dcos:mesos:master:task:app_id:/spark`
+
+    For example, continuing from above:
+    
+    ```bash
+    dcos security org users grant spark-principal dcos:mesos:master:task:user:root create --description "Allows the Linux user to execute tasks"
+    dcos security org users grant spark-principal dcos:mesos:master:framework:role:* create --description "Allows a framework to register with the Mesos master using the Mesos default role"
+    dcos security org users grant spark-principal dcos:mesos:master:task:app_id:/spark create --description "Allows reading of the task state"
+    
+    ```
+
+    Note that here we're using the service account `spark-principal` and the user `root`.
+
+1.  If you are running the Spark service as `root` (as we are in this example) you will need to add an additional
+    permission for Marathon:
+
+    ```bash
+    dcos security org users grant dcos_marathon dcos:mesos:master:task:user:root create --description "Allow Marathon to launch containers as root"
+    ```
+
+## Install Spark with necessary configuration 
+
+1.  Make a configuration file with the following before installing Spark, these settings can also be set through the UI:
+    ```json
+    $ cat spark-strict-options.json 
+    {
+    "service": {
+            "service_account": "<service-account-id>",
+            "user": "<user>",
+            "service_account_secret": "spark/<secret_name>"
+            }
+    }
+    ```
+
+    A minimal example would be: 
+
+    ```json
+    { 
+    "service": {
+            "service_account": "spark-principal",
+            "user": "root",
+            "service_account_secret": "spark/spark-secret"
+            }
+    }
+    ```
+
+    Then install:
+
+    ```bash
+    $ dcos package install spark --options=spark-strict-options.json
+    ```
+
+
+## Add necessary configuration to your Spark jobs when submitting them
+
+*   To run a job on a strict mode cluster, you must add the `principal` to the command line. For example:
+    ```bash
+    $ dcos spark run --verbose --submit-args=" \
+    --conf spark.mesos.principal=<service-account> \
+    --conf spark.mesos.containerizer=mesos \
+    --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
+    ```
+
+If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable: 
+
+    ```bash
+    $ dcos spark run --verbose --submit-args="\
+    --conf spark.mesos.principal=<service-account> \
+    --conf spark.mesos.driverEnv.SPARK_USER=nobody \
+    --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
+    ```
+
+
+
+ [7]: #custom
+ [16]: https://github.com/mesosphere/dcos-vagrant

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/job-scheduling/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/job-scheduling/index.md
@@ -1,0 +1,304 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Job Scheduling
+menuWeight: 110
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+This document is a simple overview of material described in greater detail in the Apache Spark documentation [here][1]
+and [here][2].
+
+# Modes
+
+Spark on Mesos supports two modes of operation: coarse-grained mode and fine-grained mode. Coarse-grained mode
+provides lower latency, whereas fine-grained mode provides higher utilization. More info [here][2].
+
+# Coarse-grained mode
+
+"Coarse-grained" mode is so-called because each Spark **executor** is represented by a single Mesos task. As a result,
+executors have a constant size throughout their lifetime.
+
+*   **Executor memory**: `spark.executor.memory`
+*   **Executor CPUs**: `spark.executor.cores`, or all the cores in the offer.
+*   **Number of Executors**: `spark.cores.max` / `spark.executor.cores`. Executors are brought up until
+    `spark.cores.max` is reached. Executors survive for duration of the job.
+*   **Executors per agent**: Multiple
+
+Notes:
+
+*   We highly recommend you set `spark.cores.max`. If you do not, your Spark job may consume all available resources in
+    your cluster, resulting in unhappy peers.
+
+# Quota for Drivers and Executors
+
+Setting [Mesos Quota](http://mesos.apache.org/documentation/latest/quota/) for the Drivers prevents the Dispatcher from
+greedily consuming too many resources and assists queueing behavior. To control the concurrent number of Drivers the
+Spark service will run concurrently, we **strongly** recommend setting Quota for the Drivers. The Quota will both
+guarantee that the Spark Dispatcher has resources available to launch Drivers _and limit_ the total impact on the
+cluster due to Drivers.  Optionally, set Quota for the Drivers to consume, this ensures that Drivers will not be starved
+of resources by other frameworks as well as make sure they do not consume too much of the cluster (see coarse-grained
+mode above).
+
+## Setting Quota for the Drivers
+
+Quota for the Drivers allows the operator of the cluster to ensure that only a given number of Drivers are concurrently
+running. As additional Drivers are submitted, they will be enqueued by the Spark Dispatcher. Below are the recommended
+steps for setting Quota for the Drivers:
+
+1.  Set the Quota conservatively, keeping in mind that it will effect the number of jobs that can run concurrently.
+1.  Decide how much of your cluster's resources to allocate to running Drivers. These resources will only be used for
+    the Spark Drivers, meaning that here we can decide roughly how many concurrent jobs we’d like to have running at a
+    time. As additional jobs are submitted, they will be enqueued and run with first-in-first-out semantics.
+1.  For the most predictable behavior, enforce uniform driver resource requirements and a particular Quota size for the
+    Dispatcher.  If each driver consumes 1.0 cpu and it is desirable to run up to 5 Spark jobs concurrently, Quota with
+    5 cpus should be created.
+        
+ssh to the Mesos master and set the Quota for a role (`dispatcher` in this example):
+
+```bash
+$ cat dispatcher-quota.json
+{
+ "role": "dispatcher",
+ "guarantee": [
+   {
+     "name": "cpus",
+     "type": "SCALAR",
+     "scalar": { "value": 5.0 }
+   },
+   {
+     "name": "mem",
+     "type": "SCALAR",
+     "scalar": { "value": 5120.0 }
+   }
+ ]
+}
+$ curl -d @dispatcher-quota.json -X POST http://<master>:5050/quota
+```
+
+Then install the Spark service with the following options (at a minimum):
+
+```bash
+$ cat options.json
+{
+    "service": {
+        "role": "dispatcher"
+    }
+}
+$ dcos package install spark --options=options.json
+```
+
+## Setting Quota for the Executors
+        
+It is recommended to allocate Quota for Spark job executors.  Allocating Quota for the Spark executors provides:
+1.  A guarantee that Spark jobs will receive the requested amount of resources.
+1.  Additional assurance that even misconfigured (e.g. greedy Driver with unset `spark.cores.max`) Spark jobs do not consume
+    too many resources impacting other tenants on the cluster.
+
+The drawback to allocating Quota to the Executors is that Quota resources cannot be used by other frameworks in the
+cluster.
+
+Quota can be allocated for Spark executors in the same way it was allocated for Spark dispatchers.  If we assume we want
+to be able to run 100 executors concurrently each with 1.0 cpu and 4096 MB of memory we should do the following:
+
+```bash
+$ cat executor-quota.json
+{
+  "role": "executor",
+  "guarantee": [
+    {
+      "name": "cpus",
+      "type": "SCALAR",
+      "scalar": { "value": 100.0 }
+    },
+    {
+      "name": "mem",
+      "type": "SCALAR",
+      "scalar": { "value": 409600.0 }
+    }
+  ]
+}
+$ curl -d @executor-quota.json -X POST http://<master>:5050/quota
+
+```
+
+When Spark jobs are submitted they must indicate the role for which the Quota has been set in order to consume resources
+from this quota, for example:
+
+```bash
+$ dcos spark run --verbose --name=spark --submit-args="\
+--driver-cores=1 \
+--driver-memory=1024M \
+--conf spark.cores.max=8 \
+--conf spark.mesos.role=executor \
+--class org.apache.spark.examples.SparkPi \
+http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 3000"
+
+```
+
+**Special consideration for streaming and long-running Spark jobs**: to prevent a single long-running or streaming Spark
+job from consuming the entire Quota the max CPUs for that Spark job should be set to roughly one “job’s worth” of the
+Quota’s resources. This ensures that the Spark job will get sufficient resources to make progress, setting the max CPUs
+ensures it will not starve other Spark jobs of resources as well as predictable offer suppression semantics.
+
+## Permissions when using Quota with Strict mode 
+
+Strict mode clusters (see [security modes](/1.10/security/ent/#security-modes)) require extra
+permissions to be set in order to use Quota. Follow the instructions in
+[installing](https://github.com/mesosphere/spark-build/blob/master/docs/install.md) and add the additional permissions
+for the roles you intend to use, detailed below. Following the example above they would be set as follows:
+
+1.    First set Quota for the Dispatcher's role (`dispatcher`)
+
+    ```bash
+    $ cat dispatcher-quota.json
+    {
+     "role": "dispatcher",
+     "guarantee": [
+       {
+         "name": "cpus",
+         "type": "SCALAR",
+         "scalar": { "value": 5.0 }
+       },
+       {
+         "name": "mem",
+         "type": "SCALAR",
+         "scalar": { "value": 5120.0 }
+       }
+     ]
+    }
+    ```
+
+    Then set the Quota *from your local machine*, this assumes you've downloaded the CA certificate,`dcos-ca.crt` to
+    your local machine via the `https://<dcos_url>/ca/dcos-ca.crt` endpoint:
+    
+    ```bash
+    curl -X POST --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/mesos/quota -d @dispatcher-quota.json -H 'Content-Type: application/json'
+    ```
+
+1.    Optionally set Quota for the executors also, this is the same as above:
+
+    ```bash
+    $ cat executor-quota.json
+    {
+      "role": "executor",
+      "guarantee": [
+        {
+          "name": "cpus",
+          "type": "SCALAR",
+          "scalar": { "value": 100.0 }
+        },
+        {
+          "name": "mem",
+          "type": "SCALAR",
+          "scalar": { "value": 409600.0 }
+        }
+      ]
+    }
+    ```
+
+    Then set the Quota from your local machine, again assuming you have `dcos-ca.crt` locally:
+
+    ```bash
+    curl -X POST --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/mesos/quota -d @executor-quota.json -H 'Content-Type: application/json'
+    ```
+
+1.    Install Spark with these minimal configurations:
+
+    ```bash
+    { 
+        "service": {
+                "service_account": "spark-principal",
+                "role": "dispatcher",
+                "user": "root",
+                "service_account_secret": "spark/spark-secret"
+        }
+    }
+    ```
+
+1.    Now you're ready to run a Spark job using the principal you set and the roles:
+
+    ```bash
+    dcos spark run --verbose --submit-args=" \
+    --conf spark.mesos.principal=spark-principal \
+    --conf spark.mesos.role=executor \
+    --conf spark.mesos.containerizer=mesos \
+    --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
+    ```
+
+# Setting `spark.cores.max`
+
+To improve Spark job execution reliability, set the maximum number of cores consumed by any given job.  This avoids
+any particular Spark job consuming too many resources in a cluster.  It is highly recommended that each Spark job be
+submitted with a limitation on the maximum number of cores (cpus) it can consume. This is especially important for
+long-running and streaming Spark jobs. 
+
+```bash
+$ dcos spark run --verbose --name=spark --submit-args="\
+--driver-cores=1 \
+--driver-memory=1024M \
+--conf spark.cores.max=8 \ #<< Very important!
+--class org.apache.spark.examples.SparkPi \
+http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 3000"
+```
+
+When running multiple concurrent Spark jobs, consider setting spark.cores.max between
+`<total_executor_quota>/<max_concurrent_jobs>` and `<total_executor_quota>`, depending on your workload characteristics
+and goals.
+
+# Fine-grained mode
+
+**Note** Fine-grained mode has been deprecated and does not have all of the features of coarse-grained mode.
+
+In "fine-grained" mode, each Spark **task** is represented by a single Mesos task. When a Spark task finishes, the
+resources represented by its Mesos task are relinquished. Fine-grained mode enables finer-grained resource allocation at
+the cost of task startup latency.
+
+*   **Executor memory**: `spark.executor.memory`
+*   **Executor CPUs**: Increases and decreases as tasks start and terminate.
+*   **Number of Executors**: Increases and decreases as tasks start and terminate.
+*   **Executors per agent**: At most 1
+
+# Properties
+
+The following is a description of the most common Spark on Mesos scheduling properties. For a full list, see the [Spark
+configuration page][1] and the [Spark on Mesos configuration page][2].
+
+<table class="table">
+<tr>
+<th>property</th>
+<th>default</th>
+<th>description</th>
+</tr>
+	
+<tr>
+<td>spark.mesos.coarse</td>
+<td>true</td>
+<td>Described above.</td>
+</tr>
+
+<tr>
+<td>spark.executor.memory</td>
+<td>1g</td>
+<td>Executor memory allocation.</td>
+</tr>
+
+<tr>
+<td>spark.executor.cores</td>
+<td>All available cores in the offer</td>
+<td>Coarse-grained mode only. DC/OS Apache Spark >= 1.6.1. Executor CPU allocation.</td>
+</tr>
+
+<tr>
+<td>spark.cores.max</td>
+<td>unlimited</td>
+<td>Maximum total number of cores to allocate.</td>
+</tr>
+</table>
+ [1]: http://spark.apache.org/docs/latest/configuration.html
+ [2]: http://spark.apache.org/docs/latest/running-on-mesos.html

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/limitations/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/limitations/index.md
@@ -1,0 +1,41 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Limitations
+menuWeight: 135
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+*   Mesosphere does not provide support for Spark app development, such as writing a Python app to process data from
+    Kafka or writing Scala code to process data from HDFS.
+
+*   Spark jobs run in Docker containers. The first time you run a Spark job on a node, it might take longer than you
+    expect because of the `docker pull`.
+
+*   DC/OS Apache Spark only supports running the Spark shell from within a DC/OS cluster. See the Spark Shell section
+    for more information. For interactive analytics, we recommend Zeppelin, which supports visualizations and dynamic
+    dependency management.
+
+*   With Spark SSL/TLS enabled, if you specify environment-based secrets with
+    `spark.mesos.[driver|executor].secret.envkeys, the keystore and truststore secrets will also show up as
+    environment-based secrets, due to the way secrets are implemented. You can ignore these extra environment variables.
+    
+*   When using Kerberos and HDFS, the Spark Driver generates delegation tokens and distributes them to it's Executors
+    via RPC.  Authentication of the Executors with the Driver is done with a [shared
+    secret][https://spark.apache.org/docs/latest/security.html#spark-security]. Without authentication, it is possible
+    for executor containers to register with the Driver and retrieve the delegation tokens. To secure delegation token
+    distribution, use the `--executor-auth-secret` option. 
+
+*   Spark runs all of its components in Docker containers. Since the Docker image contains a full Linux userspace with
+    its own `/etc/users` file, it is possible for the user `nobody` to have a different UID inside the
+    container than on the host system. Although user `nobody` has UID 65534 by convention on many systems, this is not
+    always the case. As Mesos does not perform UID mapping between Linux user namespaces, specifying a service user of
+    `nobody` in this case will cause access failures when the container user attempts to open or execute a filesystem
+    resource owned by a user with a different UID, preventing the service from launching. If the hosts in your cluster
+    have a UID for `nobody` other than 65534, you will need to maintain the default use (`root`) to run DC/OS Spark
+    successfully.

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/quickstart/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/quickstart/index.md
@@ -1,0 +1,161 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Spark Quickstart
+menuWeight: 10
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+This tutorial will get you up and running in minutes with Spark. You will install the DC/OS Apache Spark service.
+
+**Prerequisites:**
+
+-  [DC/OS and DC/OS CLI installed](/1.9/installing/) with a minimum of three agent nodes with eight GB of memory and ten GB of disk available on each agent.
+-  Depending on your [security mode](/1.9/overview/security/security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
+
+   | Security mode | Service Account |
+   |---------------|-----------------------|
+   | Disabled      | Not available   |
+   | Permissive    | Optional   |
+   | Strict        | Required |
+
+
+1.  Install the Spark package. This may take a few minutes. This installs the Spark DC/OS service, Spark CLI, dispatcher, and, optionally, the history server. See [Custom Installation](/services/spark/v1.0.9-2.1.0-1/install/#custom) to install the history server.
+
+    ```bash
+    dcos package install spark
+    ```
+    
+    Your output should resemble:
+    
+    ```bash
+    Installing Marathon app for package [spark] version [1.1.0-2.1.1]
+    Installing CLI subcommand for package [spark] version [1.1.0-2.1.1]
+    New command available: dcos spark
+    DC/OS Spark is being installed!
+    
+    	Documentation: /services/spark/
+    	Issues: https://docs.mesosphere.com/support/
+    ```
+   
+    **Tips:** 
+    
+    -  You can view the status of your Spark installation from the DC/OS GUI **Services** tab.
+       
+       ![Verify spark installation](/img/spark-gui-install.png)
+       
+    -  Type `dcos spark` to view the Spark CLI options.
+    -  You can install the Spark CLI with this command:
+     
+       ```bash
+       dcos package install spark --cli
+       ```
+
+1.  Run the sample SparkPi jar for DC/OS. This runs a Spark job which calculates the value of Pi. You can view the example source [here](https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar). 
+
+    1.  Run this command: 
+
+        ```bash
+        dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
+        ```
+        
+        Your output should resemble:
+        
+        ```bash
+        2017/08/24 15:42:07 Using docker image mesosphere/spark:2.0.0-2.2.0-1-hadoop-2.6 for drivers
+        2017/08/24 15:42:07 Pulling image mesosphere/spark:2.0.0-2.2.0-1-hadoop-2.6 for executors, by default. To bypass set spark.mesos.executor.docker.forcePullImage=false
+        2017/08/24 15:42:07 Setting DCOS_SPACE to /spark
+        Run job succeeded. Submission id: driver-20170824224209-0001
+        ```
+        
+    1.  View the standard output from your job:
+    
+        ```bash
+        dcos spark log driver-20170824224209-0001
+        ```
+        
+        Your output should resemble:
+        
+        ```bash
+        Pi is roughly 3.141853333333333
+        ```
+
+1.  Run a Python SparkPi jar. This runs a Python Spark job which calculates the value of Pi. You can view the example source [here](https://downloads.mesosphere.com/spark/examples/pi.py). 
+
+    1.  Run this command:
+    
+        ```bash
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/pi.py 30"
+        ``` 
+        
+        Your output should resemble:
+        
+        ```bash
+        2017/08/24 15:44:20 Parsing application as Python job
+        2017/08/24 15:44:23 Using docker image mesosphere/spark:2.0.0-2.2.0-1-hadoop-2.6 for drivers
+        2017/08/24 15:44:23 Pulling image mesosphere/spark:2.0.0-2.2.0-1-hadoop-2.6 for executors, by default. To bypass set spark.mesos.executor.docker.forcePullImage=false
+        2017/08/24 15:44:23 Setting DCOS_SPACE to /spark
+        Run job succeeded. Submission id: driver-20170824224423-0002
+        ```
+        
+    1.  View the standard output from your job:
+    
+        ```bash
+        dcos task log --completed driver-20170616213917-0002
+        ```
+        
+        Your output should resemble:
+        
+        ```bash
+        Pi is roughly 3.142715
+        ```
+
+1.  Run an R job. You can view the example source [here](https://downloads.mesosphere.com/spark/examples/dataframe.R). 
+
+    1.  Run this command:
+    
+        ```bash
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/dataframe.R"
+        ```
+        
+        Your output should resemble:
+        
+        ```bash
+        2017/08/24 15:45:21 Parsing application as R job
+        2017/08/24 15:45:23 Using docker image mesosphere/spark:2.0.0-2.2.0-1-hadoop-2.6 for drivers
+        2017/08/24 15:45:23 Pulling image mesosphere/spark:2.0.0-2.2.0-1-hadoop-2.6 for executors, by default. To bypass set spark.mesos.executor.docker.forcePullImage=false
+        2017/08/24 15:45:23 Setting DCOS_SPACE to /spark
+        Run job succeeded. Submission id: driver-20170824224524-0003
+        ```
+        
+    1.  View the standard output from your job:
+    
+        ```bash
+        dcos spark log --lines_count=10 driver-20170824224524-0003
+        ```
+        
+        Your output should resemble:
+        
+        ```bash
+        In Filter(nzchar, unlist(strsplit(input, ",|\\s"))) :
+          bytecode version mismatch; using eval
+        root
+         |-- name: string (nullable = true)
+         |-- age: double (nullable = true)
+        root
+         |-- age: long (nullable = true)
+         |-- name: string (nullable = true)
+            name
+        1 Justin        
+        ```
+
+## Next Steps
+
+- To view the status of your job, run the `dcos spark webui` command and then visit the Spark cluster dispatcher UI at `http://<dcos-url>/service/spark/` .
+- To view the logs, the Mesos UI at `http://<your-master-ip>/mesos`.
+- To view details about your Spark job, run the `dcos task log --completed <submissionId>` command.

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/release-notes/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/release-notes/index.md
@@ -1,0 +1,113 @@
+---
+layout: layout.pug
+navigationTitle: 
+title: Release Notes
+menuWeight: 140
+excerpt:
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+## Version 2.1.0-2.2.0-1
+
+### Improvements
+- Changed image to run as user `nobody` instead of `root` by default. (https://github.com/mesosphere/spark-build/pull/189)
+
+### Bug fixes
+- Configuration to allow custom Dispatcher docker image. (https://github.com/mesosphere/spark-build/pull/179)
+- CLI breaks with multiple spaces in submit args. (https://github.com/mesosphere/spark-build/pull/193)
+
+### Documentation
+- Updated HDFS endpoint in hdfs doc page.
+- Added checkpointing instructions. (https://github.com/mesosphere/spark-build/pull/181)
+- Updated custom docker image support policy. (https://github.com/mesosphere/spark-build/pull/200)
+
+## Version 2.2.0-2.2.0-2-beta
+
+### Improvements
+* Added secrets support in Driver. (SPARK-22131)
+* Added Kerberos ticket renewal. (SPARK-21842)
+* Added Mesos sandbox URI to Dispatcher UI. (SPARK-13041)
+* Updated JRE version to 8u152 JCE.
+* Added support for Driver<->Executor TLS with file-based secrets.
+* Added support for Driver<->Executor SASL (RPC endpoint authentication and encryption), via file-based secrets.
+* Added CLI command to generate a random secret.
+* Enabled native BLAS for MLLib.
+* Added configuration to deploy Dispatcher on UCR (default is Docker).
+
+### Bug fixes
+* First delegation token renewal time is not 75% of renewal time. (SPARK-22583)
+* Fixed `supervise` mode with checkpointing. (SPARK-22145)
+* Added support for older `SPARK_MESOS_KRB5_CONF_BASE64` environment variable.
+
+### Tests
+* Added integration test that reads / writes to a Kerberized HDFS.
+* Added integration test that reads / writes to a Kerberized Kafka.
+* Added integration test of checkpointing and supervise.
+
+### Documentation
+* Updated naming of DC/OS.
+* Updated docs links in package post-install notes.
+* Updated Kerberos docs. 
+* Documented running Spark Streaming jobs with Kerberized Kafka.
+* Documented `nobody` limitation on certain OSes.
+
+
+## Version 2.1.0-2.2.0-1
+
+### Improvements
+- Changed image to run as user `nobody` instead of `root` by default. (https://github.com/mesosphere/spark-build/pull/189)
+
+### Bug fixes
+- Configuration to allow custom Dispatcher docker image. (https://github.com/mesosphere/spark-build/pull/179)
+- CLI breaks with multiple spaces in submit args. (https://github.com/mesosphere/spark-build/pull/193)
+
+### Documentation
+- Updated HDFS endpoint in hdfs doc page.
+- Added checkpointing instructions. (https://github.com/mesosphere/spark-build/pull/181)
+- Updated custom docker image support policy. (https://github.com/mesosphere/spark-build/pull/200)
+
+## Version 2.0.1-2.2.0-1
+
+### Improvements
+- Exposed isR and isPython spark run args
+
+### Bug fixes
+- Allowed for application args to have arguments without equals sign
+- Fixed docs link in Universe package description
+
+## Version 2.0.0-2.2.0-1
+
+### Improvements
+- Kerberos support changed to use common code from `spark-core` instead of custom implementation.
+- Added file and environment-based secret support.
+- Kerberos key tab/TGT login from the DC/OS Spark CLI in cluster mode (uses file-based secrets).
+- Added CNI network label support.
+- CLI doesn't require spark-submit to be present on client machine.
+
+### Bug fixes
+- Drivers are successfully re-launched when `--supervise` flag is set.
+- CLI works on 1.9 and 1.10 DC/OS clusters.
+
+### Breaking changes
+- Setting `spark.app_id` has been removed (e.g. `dcos config set spark.app_id <dispatcher_app_id>`). To submit jobs with a given
+dispatcher use `dcos spark --name <dispatcher_app_id>`.
+- `principal` is now `service_account` and `secret` is now `service_account_secret`.
+
+## Version 1.1.1-2.2.0
+
+### Improvements
+* Upgrade to Spark 2.2.0
+* Spark driver now supports configurable failover_timeout. The default value is 0 when the configuration is not set.
+[SPARK-21456](https://issues.apache.org/jira/browse/SPARK-21456). 
+
+### Breaking change
+
+*  Spark CLI no longer supports -Dspark args.
+
+## Version 1.0.9-2.1.0-1 
+
+- The history server has been removed from the "spark" package, and put into a dedicated "spark-history" package.

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/run-job/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/run-job/index.md
@@ -1,0 +1,176 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Run a Spark Job
+menuWeight: 80
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+1.  Before submitting your job, upload the artifact (e.g., jar file)
+    to a location visible to the cluster (e.g., HTTP, S3, or HDFS). [Learn more][13].
+
+1.  Run the job.
+    Include all configuration flags before the jar url and the args for your spark job after the jar url. Generally following the template `dcos spark run --submit-args="<flags> URL [args]` where `<flags>` can be things like `--conf spark.cores.max=16` and `--class my.aprk.App`, `URL` is the location of the application, and `[args]` are any arguments for the application.
+        
+        dcos spark run --submit-args=--class MySampleClass http://external.website/mysparkapp.jar"
+
+        dcos spark run --submit-args="--py-files mydependency.py http://external.website/mysparkapp.py"
+
+        dcos spark run --submit-args="http://external.website/mysparkapp.R"
+
+	If your job runs successfully, you will get a message with the job’s submission ID:
+
+        Run job succeeded. Submission id: driver-20160126183319-0001
+
+1.  View the Spark scheduler progress by navigating to the Spark dispatcher at `http://<dcos-url>/service/spark/`.
+
+1.  View the job's logs through the Mesos UI at `http://<dcos-url>/mesos/`. Or `dcos task log --follow <submission_id>`
+
+# Setting Spark properties
+
+Spark job settings are controlled by configuring [Spark properties][14].
+
+## Submission
+
+All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in Spark Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by Spark can be passed through the command-line with within the `--submit-args` string. 
+
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+
+## Setting automatic configuration defaults
+
+To set Spark properties with a configuration file, create a
+`spark-defaults.conf` file and set the environment variable
+`SPARK_CONF_DIR` to the containing directory. [Learn more][15].
+
+## Using a properties file
+
+To reuse spark properties without cluttering the command line the CLI supports passing a path to a local file containing Spark properties. Such a file is whitespace separated properties and values, for example
+```text
+spark.mesos.containerizer   mesos
+spark.executors.cores       4
+spark.eventLog.enabled      true
+spark.eventLog.dir          hdfs:///history
+```
+will set the containerizer to `mesos`, the executor cores to `4` and enable the history server. This file is parsed locally so it will not be available to your driver applications. 
+
+
+## Secrets
+Enterprise DC/OS provides a secrets store to enable access to sensitive data such as database passwords, private keys, and API tokens. DC/OS manages secure transportation of secret data, access control and authorization, and secure storage of secret content. The content of a secret is copied and made available within the pod.  A secret can be exposed to drivers as a file and/or as an environment variable. Secrets in Spark are specified with the following configuration properties:
+#### File-based secret
+```bash
+dcos spark run --submit-args="\
+...
+--conf spark.mesos.driver.secret.name=/mysecret \
+--conf spark.mesos.driver.secret.filename=asecret \
+...
+```
+#### Environment-based secret
+```bash
+dcos spark run --submit-args="\
+...
+--conf spark.mesos.driver.secret.name=/mysecret \
+--conf spark.mesos.driver.secret.envkey=SECRETKEY \
+...
+```
+Multiple secrets can be injected by using a comma-separated list:
+```bash
+dcos spark run --submit-args="\
+...
+--conf spark.mesos.driver.secret.name=/user,/password \
+--conf spark.mesos.driver.secret.filename=secretuser,seretpassword \
+--conf spark.mesos.driver.secret.envkey=USER,PASSWORD \
+...
+```
+
+**Note:** Secrets are available only in Enterprise DC/OS 1.9 onwards. [Learn more about the secrets store](/1.9/security/secrets/).
+
+### Authorization for Secrets
+
+The path of a secret defines which service IDs can have access to it. You can think of secret paths as namespaces. _Only_ services that are under the same namespace can read the content of the secret.
+
+
+| Secret                               | Service ID                          | Can service access secret? |
+|--------------------------------------|-------------------------------------|----------------------------|
+| `secret-svc/Secret_Path1`            | `/user`                             | No                         |
+| `secret-svc/Secret_Path1`            | `/user/dev1`                        | No                         |
+| `secret-svc/Secret_Path1`            | `/secret-svc`                       | Yes                        |
+| `secret-svc/Secret_Path1`            | `/secret-svc/dev1`                  | Yes                        |
+| `secret-svc/Secret_Path1`            | `/secret-svc/instance2/dev2`        | Yes                        |
+| `secret-svc/Secret_Path1`            | `/secret-svc/a/b/c/dev3`            | Yes                        |
+| `secret-svc/instance1/Secret_Path2`  | `/secret-svc/dev1`                  | No                         |
+| `secret-svc/instance1/Secret_Path2`  | `/secret-svc/instance2/dev3`        | No                         |
+| `secret-svc/instance1/Secret_Path2`  | `/secret-svc/instance1`             | Yes                        |
+| `secret-svc/instance1/Secret_Path2`  | `/secret-svc/instance1/dev3`        | Yes                        |
+| `secret-svc/instance1/Secret_Path2`  | `/secret-svc/instance1/someDir/dev3`| Yes                        |
+
+
+
+**Note:** Absolute paths (paths with a leading slash) to secrets are not supported. The file path for a secret must be relative to the sandbox.
+
+### Binary Secrets
+
+When you need to store binary files into DC/OS secrets store, for example a Kerberos keytab file, your file needs to be base64-encoded as specified in RFC 4648. 
+
+You can use standard `base64` command line utility. Take a look at the following example that is using BSD `base64` command.
+``` 
+$  base64 -i krb5.keytab -o kerb5.keytab.base64-encoded 
+```
+
+`base64` command line utility in Linux inserts line-feeds in the encoded data by default. Disable line-wrapping via  `-w 0` argument.  Here is a sample base64 command in Linux.
+``` 
+$  base64 -w 0 -i krb5.keytab > kerb5.keytab.base64-encoded 
+```
+
+Give the secret basename prefixed with `__dcos_base64__`. For example, `some/path/__dcos_base64__mysecret` and `__dcos_base64__mysecret` will be base64-decoded automatically.
+
+``` 
+$  dcos security secrets  create -f kerb5.keytab.base64-encoded  some/path/__dcos_base64__mysecret
+```
+When you reference the `__dcos_base64__mysecret` secret in your service, the content of the secret will be first base64-decoded, and then copied and made available to your Spark application. Refer to a binary secret only as a file such that it will be automatically decoded and made available as a temporary in-memory file mounted within your container (file-based secrets). 
+
+# DC/OS Overlay Network
+
+To submit a Spark job inside the [DC/OS Overlay Network][16]:
+
+    dcos spark run --submit-args="--conf spark.mesos.containerizer=mesos --conf spark.mesos.network.name=dcos --class MySampleClass http://external.website/mysparkapp.jar"
+
+Note that DC/OS Overlay support requires the [UCR][17], rather than
+the default Docker Containerizer, so you must set `--conf spark.mesos.containerizer=mesos`.
+
+# Driver Failover Timeout
+
+The `--conf spark.mesos.driver.failoverTimeout` option specifies the amount of time 
+(in seconds) that the master will wait for the driver to reconnect, after being 
+temporarily disconnected, before it tears down the driver framework by killing 
+all its executors. The default value is zero, meaning no timeout: if the 
+driver disconnects, the master immediately tears down the framework.
+
+To submit a job with a nonzero failover timeout:
+
+    dcos spark run --submit-args="--conf spark.mesos.driver.failoverTimeout=60 --class MySampleClass http://external.website/mysparkapp.jar"
+
+**Note:** If you kill a job before it finishes, the framework will persist 
+as an `inactive` framework in Mesos for a period equal to the failover timeout. 
+You can manually tear down the framework before that period is over by hitting
+the [Mesos teardown endpoint][18].
+
+# Versioning
+
+The DC/OS Apache Spark Docker image contains OpenJDK 8 and Python 2.7.6.
+
+DC/OS Apache Spark distributions 1.X are compiled with Scala 2.10.  DC/OS Apache Spark distributions 2.X are compiled with Scala 2.11.  Scala is not binary compatible across minor verions, so your Spark job must be compiled with the same Scala version as your version of DC/OS Apache Spark.
+
+The default DC/OS Apache Spark distribution is compiled against Hadoop 2.6 libraries.  However, you may choose a different version by following the instructions in the "Customize Spark Distribution" section of the Installation page.
+
+
+[13]: http://spark.apache.org/docs/latest/submitting-applications.html
+[14]: http://spark.apache.org/docs/latest/configuration.html#spark-properties
+[15]: http://spark.apache.org/docs/latest/configuration.html#overriding-configuration-directory
+[16]: https://dcos.io/docs/overview/design/overlay/
+[17]: https://dcos.io/docs/1.9/deploying-services/containerizers/ucr/
+[18]: http://mesos.apache.org/documentation/latest/endpoints/master/teardown/
+[19]: /services/spark/v2.2.0-2.2.0-1/hdfs/

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/runtime-config-change/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/runtime-config-change/index.md
@@ -1,0 +1,25 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Runtime Configuration Change
+menuWeight: 70
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+You can customize DC/OS Apache Spark in-place when it is up and running.
+
+1.  Go to the DC/OS GUI.
+
+1.  Click the **Services** tab, then the name of the Spark
+framework to be updated.
+
+1.  Within the Spark instance details view, click the menu in the upper right, then choose **Edit**.
+
+1.  In the dialog that appears, click the **Environment** tab and update any field(s) to their desired value(s).
+
+1.  Click **REVIEW & RUN** to apply any changes and cleanly reload Spark.

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/security/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/security/index.md
@@ -1,0 +1,164 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Security
+menuWeight: 40
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+This topic describes how to configure DC/OS service accounts for Spark.
+
+When running in [DC/OS strict security mode](/1.9/security/), both the dispatcher and jobs
+must authenticate to Mesos using a [DC/OS Service Account](/1.9/security/service-auth/).
+
+Follow these instructions to [authenticate in strict mode](/services/spark/spark-auth/).
+
+# Using Mesos Secrets
+
+DC/OS Enterprise allows users to add privileged information in the form of a file to the DC/OS secret store. These files
+can be referenced in Spark jobs and used for authentication and authorization with various external services (e.g.
+HDFS). For example, we use this functionality to pass the Kerberos Keytab. Details about how to use Secrets can be found
+at [official documentation](/latest/security/ent/secrets/). Once the secret has been added,
+you can pass them to Spark with the `spark.mesos.<task-name>.secret.names` and
+`spark.mesos.<task-name>.secret.<filenames|envkeys>` confguration parameters where `<task-name>` is either `driver` or
+`executor`. Specifying `filenames` or `envkeys` will materialize the secret as either a file-based secret or an
+environment variable. These configuration parameters take comma-separated lists that are "zipped" together to make the
+final secret file or environment variable. We recommend using file-based secrets whenever possible as they are more
+secure than environment variables.
+ 
+For example to use a secret named `my-secret-file` as a file in the driver _and_ the executors add these configuration 
+parameters:
+```
+--conf spark.mesos.driver.secret.names=my-secret-file
+--conf spark.mesos.driver.secret.filenames=target-secret-file
+--conf spark.mesos.executor.secret.names=my-secret-file
+--conf spark.mesos.executor.secret.filenames=target-secret-file
+```
+this will put the contents of the secret `my-secret-file` in a secure RAM-FS mounted secret file named
+`target-secret-file` in the driver and executors sandboxes. If you want to use a secret as an environment variable (e.g.
+AWS credentials) you change the configurations to be the following: 
+```
+--conf spark.mesos.driver.secret.names=/my-aws-secret,/my-aws-key
+--conf spark.mesos.driver.secret.envkeys=AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID
+```
+This assumes that your secret access key is stored in a secret named `my-aws-secret` and your secret key in
+`my-aws-key`.
+
+### Limitations
+When using a combination of environment and file-based secrets there needs to be an equal number of sinks and secret
+sources (i.e. files and environment variables). For example
+```
+--conf spark.mesos.driver.secret.names=/my-secret-file,/my-secret-envvar
+--conf spark.mesos.driver.secret.filenames=target-secret-file,placeholder-file
+--conf spark.mesos.driver.secret.envkeys=PLACEHOLDER,SECRET_ENVVAR
+```
+will place the content of `my-secret-file` into the `PLACEHOLDER` environment variable and the `target-secret-file` file
+as well as the content of `my-secret-envvar` into the `SECRET_ENVVAR` and `placeholder-file`. In the case of binary
+secrets (tagged with `__dcos_base64__`, for example) the environment variable will still be empty because environment
+variables cannot be assigned to binary values.
+
+# Spark SSL
+
+SSL support in DC/OS Apache Spark encrypts the following channels:
+
+*   From the [DC/OS admin router][11] to the dispatcher.
+*   Files served from the drivers to their executors.
+
+To enable SSL, a Java keystore (and, optionally, truststore) must be provided, along with their passwords. The first
+three settings below are **required** during job submission. If using a truststore, the last two are also **required**:
+
+| Variable                         | Description                                     |
+|----------------------------------|-------------------------------------------------|
+| `--keystore-secret-path`         | Path to keystore in secret store                |
+| `--keystore-password`            | The password used to access the keystore        |
+| `--private-key-password`         | The password for the private key                |
+| `--truststore-secret-path`       | Path to truststore in secret store              |
+| `--truststore-password`          | The password used to access the truststore      |
+
+
+In addition, there are a number of Spark configuration variables relevant to SSL setup.  These configuration settings
+are **optional**:
+
+| Variable                         | Description           | Default Value |
+|----------------------------------|-----------------------|---------------|
+| `spark.ssl.enabledAlgorithms`    | Allowed cyphers       | JVM defaults  |
+| `spark.ssl.protocol`             | Protocol              | TLS           |
+
+
+The keystore and truststore are created using the [Java keytool][12]. The keystore must contain one private key and its
+signed public key. The truststore is optional and might contain a self-signed root-ca certificate that is explicitly
+trusted by Java.
+
+Both stores must be base64 encoded without newlines, for example:
+
+```bash
+cat keystore | base64 -w 0 > keystore.base64
+cat keystore.base64
+/u3+7QAAAAIAAAACAAAAAgA...
+```
+
+**Note:** The base64 string of the keystore will probably be much longer than the snippet above, spanning 50 lines or
+so.
+
+Add the stores to your secrets in the DC/OS secret store. For example, if your base64-encoded keystores and truststores
+are server.jks.base64 and trust.jks.base64, respectively, then use the following commands to add them to the secret
+store: 
+
+```bash
+dcos security secrets create /__dcos_base64__keystore --value-file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --value-file trust.jks.base64
+```
+
+You must add the following configurations to your `dcos spark run ` command.
+The ones in parentheses are optional:
+
+```bash
+
+dcos spark run --verbose --submit-args="\
+--keystore-secret-path=<path/to/keystore, e.g. __dcos_base64__keystore> \
+--keystore-password=<password to keystore> \
+--private-key-password=<password to private key in keystore> \
+(—-truststore-secret-path=<path/to/truststore, e.g. __dcos_base64__truststore> \)
+(--truststore-password=<password to truststore> \)
+(—-conf spark.ssl.enabledAlgorithms=<cipher, e.g., TLS_RSA_WITH_AES_128_CBC_SHA256> \)
+--class <Spark Main class> <Spark Application JAR> [application args]"
+```
+
+**Note:** If you have specified a space for your secrets other than the default value, `/spark`, then you must set
+`spark.mesos.task.labels=DCOS_SPACE:<dcos_space>` in the command above in order to access the secrets.  See the [Secrets
+Documentation about spaces][13] for more details about spaces.
+
+**Note:** If you specify environment-based secrets with `spark.mesos.[driver|executor].secret.envkeys`, the keystore and
+truststore secrets will also show up as environment-based secrets, due to the way secrets are implemented. You can
+ignore these extra environment variables.
+
+# Spark SASL (Executor authentication and BlockTransferService encryption)
+Spark uses Simple Authentication Security Layer (SASL) to authenticate Executors with the Driver and for encrypting
+messages sent between components. This functionality relies on a shared secret between all components you expect to
+communicate with each other. A secret can be generated with the DC/OS Spark CLI 
+```bash
+dcos spark secret <secret_path>
+# for example
+dcos spark secret /sparkAuthSecret
+```
+This will generate a random secret and upload it to the DC/OS secrets store [14] at the designated path. To use this
+secret for RPC authentication add the following configutations to your CLI command:
+```bash
+dcos spark run --submit-args="\
+...
+--executor-auth-secret=/sparkAuthSecret
+...
+"
+
+```
+
+
+
+ [11]: /1.9/overview/architecture/components/
+ [12]: http://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html
+ [13]: /1.10/security/#spaces
+ [14]: /latest/security/secrets/

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/spark-shell/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/spark-shell/index.md
@@ -1,0 +1,54 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Interactive Spark Shell
+menuWeight: 90
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+# Interactive Spark Shell
+
+You can run Spark commands interactively in the Spark shell. The Spark shell is available in Scala, Python, and R.
+
+1. [Launch a long-running interactive bash session using `dcos task exec`](https://dcos.io/docs/1.9/monitoring/debugging/cli-debugging/task-exec/#launch-a-long-running-interactive-bash-session).
+
+1. From your interactive bash session, pull and run a Spark Docker image.
+
+        docker pull mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6
+
+        docker run -it --net=host mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6 /bin/bash
+
+1. Run the Scala Spark shell from within the Docker image.
+
+        ./bin/spark-shell --master mesos://<internal-leader-ip>:5050 --conf spark.mesos.executor.docker.image=mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6 --conf spark.mesos.executor.home=/opt/spark/dist
+
+    Or, run the Python Spark shell.
+
+        ./bin/pyspark --master mesos://<internal-leader-ip>:5050 --conf spark.mesos.executor.docker.image=mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6 --conf spark.mesos.executor.home=/opt/spark/dist
+
+    Or, run the R Spark shell.
+
+        ./bin/sparkR --master mesos://<internal-leader-ip>:5050 --conf spark.mesos.executor.docker.image=mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6 --conf spark.mesos.executor.home=/opt/spark/dist
+
+    **Hint:** Find your internal leader IP by going to `<dcos-url>/mesos`. The internal leader IP is listed in the upper left hand corner.
+
+1. Run Spark commands interactively.
+
+    In the Scala shell:
+
+        val textFile = sc.textFile("/opt/spark/dist/README.md")
+        textFile.count()
+
+    In the Python shell:
+
+        textFile = sc.textFile("/opt/spark/dist/README.md")
+        textFile.count()
+
+    In the R shell:
+
+        df <- as.DataFrame(faithful)
+        head(df)

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/troubleshooting/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/troubleshooting/index.md
@@ -1,0 +1,73 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Troubleshooting
+menuWeight: 125
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+# Dispatcher
+
+*   The Mesos cluster dispatcher is responsible for queuing, tracking, and supervising drivers. Potential problems may
+    arise if the dispatcher does not receive the resources offers you expect from Mesos, or if driver submission is
+    failing. To debug this class of issue, visit the Mesos UI at `http://<dcos-url>/mesos/` and navigate to the sandbox
+    for the dispatcher.
+
+*   Spark has an internal mechanism for detecting the IP of the host. We use this method by default, but sometimes it
+    fails, returning errors like these:
+
+    ```
+    ERROR SparkUncaughtExceptionHandler: Uncaught exception in thread Thread[main,5,main]
+        java.net.UnknownHostException: ip-172-31-4-148: ip-172-31-4-148: Name or service not known
+            at java.net.InetAddress.getLocalHost(InetAddress.java:1505)
+            at org.apache.spark.util.Utils$.findLocalInetAddress(Utils.scala:891)
+            at org.apache.spark.util.Utils$.org$apache$spark$util$Utils$$localIpAddress$lzycompute(Utils.scala:884)
+            at org.apache.spark.util.Utils$.org$apache$spark$util$Utils$$localIpAddress(Utils.scala:884)
+            at org.apache.spark.util.Utils$$anonfun$localHostName$1.apply(Utils.scala:941)
+            at org.apache.spark.util.Utils$$anonfun$localHostName$1.apply(Utils.scala:941)
+            at scala.Option.getOrElse(Option.scala:121)
+            at org.apache.spark.util.Utils$.localHostName(Utils.scala:941)
+            at org.apache.spark.deploy.mesos.MesosClusterDispatcherArguments.<init>(MesosClusterDispatcherArguments.scala:27)
+            at org.apache.spark.deploy.mesos.MesosClusterDispatcher$.main(MesosClusterDispatcher.scala:103)
+            at org.apache.spark.deploy.mesos.MesosClusterDispatcher.main(MesosClusterDispatcher.scala)
+        Caused by: java.net.UnknownHostException: ip-172-31-4-148: Name or service not known
+            at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
+            at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:928)
+            at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1323)
+            at java.net.InetAddress.getLocalHost(InetAddress.java:1500)
+            ... 10 more
+    18/01/25 17:42:57 INFO ShutdownHookManager: Shutdown hook called
+    ```
+
+    In this case, enable the `service.use_bootstrap_for_IP_detect` option in the Dispatcher config, either via the UI,
+    editing the task or set to `true` in the options.json, and restart the service.  This will cause the DC/OS-specific
+    `bootstrap` utility to detect the IP, which may allow the initialization of the Spark service to complete. 
+
+# Jobs
+
+*   DC/OS Apache Spark jobs are submitted through the dispatcher, which displays Spark properties and job state. Start
+    here to verify that the job is configured as you expect.
+
+*   The dispatcher further provides a link to the job's entry in the history server, which displays the Spark Job UI.
+    This UI shows the for the job. Go here to debug issues with scheduling and performance.
+
+*   Jobs themselves log output to their sandbox, which you can access through the Mesos UI. The Spark logs will be sent
+    to `stderr`, while any output you write in your job will be sent to `stdout`.
+
+*   To disable using the Mesosphere `bootstrap` utility for host IP detection in jobs add
+    `spark.mesos.driverEnv.SKIP_BOOTSTRAP_IP_DETECT=true` to your job configuration.
+
+# CLI
+
+The Spark CLI is integrated with the dispatcher so that they always use the same version of Spark, and so that certain
+defaults are honored. To debug issues with their communication, run your jobs with the `--verbose` flag.
+
+# HDFS Kerberos
+
+To debug authentication in a Spark job, enable Java security debug output:
+
+    dcos spark run --submit-args="--conf sun.security.krb5.debug=true..."

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/uninstall/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/uninstall/index.md
@@ -1,0 +1,20 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Uninstall
+menuWeight: 60
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+    dcos package uninstall --app-id=<app-id> spark
+
+The Spark dispatcher persists state in ZooKeeper, so to fully
+uninstall the Spark DC/OS package, you must go to
+`http://<dcos-url>/exhibitor`, click on `Explorer`, and delete the
+znode corresponding to your instance of Spark. By default this is
+`spark_mesos_Dispatcher`.

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/upgrade/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/upgrade/index.md
@@ -1,0 +1,21 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Upgrade
+menuWeight: 50
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+1.  Go to the **Universe** > **Installed** page of the DC/OS GUI. Hover over your Spark Service to see the **Uninstall** button, then select it. Alternatively, enter the following from the DC/OS CLI:
+
+        dcos package uninstall spark
+
+1.  Verify that you no longer see your Spark service on the **Services** page.
+1.  Reinstall Spark.
+
+        dcos package install spark

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/usage-examples/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/usage-examples/index.md
@@ -1,0 +1,63 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Usage Example 
+menuWeight: 10
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+1.  Perform a default installation by following the instructions in the Install and Customize section of this topic.
+
+1.  Run a Spark job:
+
+        dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
+
+1.  Run a Python Spark job:
+
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/pi.py 30"
+
+1.  Run an R Spark job:
+
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/dataframe.R"
+
+1.  View your job:
+
+Visit the Spark cluster dispatcher at `http://<dcos-url>/service/spark/` to view the status of your job. Also visit the Mesos UI at `http://<dcos-url>/mesos/` to see job logs.
+
+## Advanced
+
+*   Run an Spark Streaming job with Kafka: Examples of Spark Streaming applications that connect to a secure Kafka cluster can be found at [spark-build][https://github.com/mesosphere/spark-build/blob/beta-2.1.1-2.2.0-2/tests/jobs/scala/src/main/scala/KafkaJobs.scala]. As mentioned in the [kerberos][/services/spark/2.1.0-2.2.0-2/kerberos/] section, Spark requires a JAAS file, the `krb5.conf`, and the keytab. An example of the JAAS file is: 
+        
+        KafkaClient {
+            com.sun.security.auth.module.Krb5LoginModule required
+            useKeyTab=true
+            storeKey=true
+            keyTab="/mnt/mesos/sandbox/kafka-client.keytab"
+            useTicketCache=false
+            serviceName="kafka"
+            principal="client@LOCAL";
+        };
+    
+    The corresponding `dcos spark` command would be: 
+
+        dcos spark run --submit-args="\
+        --conf spark.mesos.containerizer=mesos \  # required for secrets
+        --conf spark.mesos.uris=<URI_of_jaas.conf> \
+        --conf spark.mesos.driver.secret.names=__dcos_base64___keytab \  # __dcos_base64__ prefix required for decoding base64 encoded binary secrets
+        --conf spark.mesos.driver.secret.filenames=kafka-client.keytab \
+        --conf spark.mesos.executor.secret.names=__dcos_base64___keytab \
+        --conf spark.mesos.executor.secret.filenames=kafka-client.keytab \
+        --conf spark.mesos.task.labels=DCOS_SPACE:/spark \ 
+        --conf spark.scheduler.minRegisteredResourcesRatio=1.0 \
+        --conf spark.executorEnv.KRB5_CONFIG_BASE64=W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKCltyZWFsbXNdCiAgTE9DQUwgPSB7CiAgICBrZGMgPSBrZGMubWFyYXRob24uYXV0b2lwLmRjb3MudGhpc2Rjb3MuZGlyZWN0b3J5OjI1MDAKICB9Cg== \
+        --conf spark.mesos.driverEnv.KRB5_CONFIG_BASE64=W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKCltyZWFsbXNdCiAgTE9DQUwgPSB7CiAgICBrZGMgPSBrZGMubWFyYXRob24uYXV0b2lwLmRjb3MudGhpc2Rjb3MuZGlyZWN0b3J5OjI1MDAKICB9Cg== \
+        --class MyAppClass <URL_of_jar> [application args]"
+
+
+
+*Note* There are additional walkthroughs available in the `docs/walkthroughs/` directory of Mesosphere's `spark-build` [repo](https://github.com/mesosphere/spark-build/docs/walkthroughs/)

--- a/pages/services/spark/2.2.1-2.2.0-2-beta/version-policy/index.md
+++ b/pages/services/spark/2.2.1-2.2.0-2-beta/version-policy/index.md
@@ -1,0 +1,14 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Version Policy
+menuWeight: 130
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+
+We have selected the latest version of the [Apache Spark](http://spark.apache.org) stable release train for new releases. We support HDFS version 2.6 by default and version 2.7.

--- a/pages/services/spark/v1.0.9-2.1.0-1/index.md
+++ b/pages/services/spark/v1.0.9-2.1.0-1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Spark 1.0.9-2.1.0-1
 title: Spark 1.0.9-2.1.0-1
-menuWeight: 70
+menuWeight: 90
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/spark/v1.1.0-2.1.1/index.md
+++ b/pages/services/spark/v1.1.0-2.1.1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Spark 1.1.0-2.1.1
 title: Spark 1.1.0-2.1.1
-menuWeight: 60
+menuWeight: 80
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/spark/v1.1.1-2.2.0/index.md
+++ b/pages/services/spark/v1.1.1-2.2.0/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Spark 1.1.1-2.2.0
 title: Spark 1.1.1-2.2.0
-menuWeight: 50
+menuWeight: 70
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/spark/v2.0.0-2.2.0-1/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Spark 2.0.0-2.2.0-1
 title: Spark 2.0.0-2.2.0-1
-menuWeight: 40
+menuWeight: 60
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/spark/v2.0.1-2.2.0-1/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Spark 2.0.1-2.2.0-1
 title: Spark 2.0.1-2.2.0-1
-menuWeight: 30
+menuWeight: 50
 excerpt:
 featureMaturity:
 enterprise: false


### PR DESCRIPTION
## Description
Spark-2.2.1-2.2.0-2-beta documentation.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
