### PR TITLE
update enterprise flag to true

### DIFF
--- a/pages/services/edge-lb/1.0.0/index.md
+++ b/pages/services/edge-lb/1.0.0/index.md
@@ -5,7 +5,7 @@ title: Edge-LB 1.0.0
 menuWeight: 0
 excerpt:
 
-enterprise: false
+enterprise: true
 ---
 
 Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides both North-South (external to internal) load balancing, while the [Minuteman component](/1.10/overview/architecture/components/#minuteman) provides East-West (internal to internal) load balancing.


### PR DESCRIPTION
Just double checked with Yriex that Edge-LB is enterprise only. Not sure if any other updates need to be made in other parts of the docs.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
