### PR TITLE
pages/1.11/security: distinguish between EE and OSS security subsections

### DIFF
--- a/pages/1.11/security/ent/index.md
+++ b/pages/1.11/security/ent/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.pug
+navigationTitle: DC/OS Enterprise Security
 title: DC/OS Enterprise Security
 menuWeight: 80
 excerpt:

--- a/pages/1.11/security/ent/index.md
+++ b/pages/1.11/security/ent/index.md
@@ -1,7 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle:  Security
-title: Security
+title: DC/OS Enterprise Security
 menuWeight: 80
 excerpt:
 


### PR DESCRIPTION
## Description
This PR aligns the Security subsections' titles in `/pages/1.11` to that of `/pages/1.10`.

https://jira.mesosphere.com/browse/DCOS-20752

## Urgency
- [ ] Blocker
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
