### PR TITLE
Added Container Image GC user doc to Containerizer section.

### DIFF
--- a/pages/1.11/deploying-services/containerizers/index.md
+++ b/pages/1.11/deploying-services/containerizers/index.md
@@ -39,7 +39,7 @@ The tables below enumerate the features available with each of the supported con
 | --------------------------------------- | ----------- | --------- | -------- |
 | **Command**                             | Yes         | Yes       |          |
 | **Container Images**                    | Yes         | Yes       |          |
-| **Image Garbage Collection**           | Yes         | Yes       |          |
+| **Image Garbage Collection**            | Yes         | Yes       |          |
 | **Pods**                                | Yes         | No        |          |
 | **GPUs**                                | Yes         | No        |          |
 | **URIs**                                | Yes         | Yes       |          |

--- a/pages/1.11/deploying-services/containerizers/index.md
+++ b/pages/1.11/deploying-services/containerizers/index.md
@@ -22,6 +22,7 @@ The Universal Container Runtime (UCR) has the following advantages:
 * Is more stable and allows deployment at scale.
 * Offers features not available in the Docker Engine, such as GPU and CNI support.
 * Allows you to take advantage of continuing innovation within both the Mesos and DC/OS, including features such as IP per container, strict container isolation, and more. Refer to the [features matrix](#container-runtime-features) for details.
+* Supports container image garbage collection automatically or manually.
 
 In summary, using the UCR instead of the Docker Engine:
 

--- a/pages/1.11/deploying-services/containerizers/index.md
+++ b/pages/1.11/deploying-services/containerizers/index.md
@@ -80,7 +80,7 @@ The tables below enumerate the features available with each of the supported con
 | **Bridge Networking**                   | Yes         | Yes       |           |
 | **CNI**                                 | Yes         | N/A       |           |
 | **CNM**                                 | N/A         | Yes       | Docker 1.11+ |
-| **L4lB**                                | Yes         | Yes       | Requires defined service endpoints. TCP health checks do not work with L4LB. |
+| **L4LB**                                | Yes         | Yes       | Requires defined service endpoints. TCP health checks do not work with L4LB. |
 
 ## Private Registry
 

--- a/pages/1.11/deploying-services/containerizers/ucr/index.md
+++ b/pages/1.11/deploying-services/containerizers/ucr/index.md
@@ -81,5 +81,21 @@ The [Universal Container Runtime (UCR)](http://mesos.apache.org/documentation/la
 
 **Important:** If you leave the `args` field empty, the default entry point will be the launch command for the container. If your container does not have a default entry point, you must specify a command in the `args` field. If you do not, your service will fail to deploy.
 
+# Container Image Garbage Collection
+
+For a long running cluster, container images may occupy disk spaces on the agent machines. To improve the operator's experience with UCR, container image GC is introduced, starting from Mesos 1.5.0 (please read [the Mesos docs](http://mesos.apache.org/documentation/latest/container-image/#garbage-collect-unused-container-images) for more details). The image GC is automatic by default in DC/OS while it can be triggered by the operator manually.
+
+## [Automatic Image GC](http://mesos.apache.org/documentation/latest/container-image/#automatic-image-gc-through-agent-flag)
+
+Container Image Auto GC is enabled by default, configured by an image GC config file. This config file can be updated via `MESOS_IMAGE_GC_CONFIG` environment variable at `/opt/mesosphere/etc/mesos-slave-common`. The default config file locates at `/opt/mesosphere/etc/mesos-slave-image-gc-config.json`, and the followings are the parameters of the config file:
+
+- `image_disk_headroom`: The image disk headroom used to calculate the threshold of container image store size. Image garbage collection will be triggered automatically if the image disk usage reaches that threshold. Please note that the headroom value has to be between 0.0 and 1.0. (defaults to be 0.1, which represents 90% disk usage as the threshold)
+- `image_disk_watch_interval`: The periodic time interval to check the image store disk usage. Please note that the unit of this time interval is 'nanosecond'. (defaults to be 300000000000, which represents the disk check every 5 minutes)
+- `excluded_images`: The excluded image list that should not be garbage collected. (defaults to be an empty list)
+
+## [Manual Image GC](http://mesos.apache.org/documentation/latest/container-image/#manual-image-gc-through-http-api)
+
+Comtainer Image Manual GC can be triggered via the HTTP Operator API. Please see `PRUNE_IMAGES` section in the [v1 Operator API doc](http://mesos.apache.org/documentation/latest/operator-http-api/#prune_images) for more details.
+
 # Further Reading
 - [View the Mesos docs for the UCR](http://mesos.apache.org/documentation/latest/container-image/).

--- a/pages/1.11/deploying-services/containerizers/ucr/index.md
+++ b/pages/1.11/deploying-services/containerizers/ucr/index.md
@@ -10,7 +10,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
-The [Universal Container Runtime (UCR)](http://mesos.apache.org/documentation/latest/container-image) launches Mesos containers from binary executables and extends the Mesos container runtime to support provisioning [Docker](https://docker.com/) images. The UCR has many [advantages](/1.11/deploying-services/containerizers/) over the Docker Engine for running Docker images.  Use the Docker Engine only if you need specific [features](/1.11/deploying-services/containerizers/#container-runtime-features) of the Docker package.
+The [Universal Container Runtime (UCR)](http://mesos.apache.org/documentation/latest/container-image) launches Mesos containers from binary executables and extends the Mesos container runtime to support provisioning [Docker](https://docker.com/) images. The UCR has many [advantages](/1.11/deploying-services/containerizers/) over the Docker Engine for running Docker images. Use the Docker Engine only if you need specific [features](/1.11/deploying-services/containerizers/#container-runtime-features) of the Docker package.
 
 # Provision a container with the UCR from the DC/OS web interface
 
@@ -80,9 +80,6 @@ The [Universal Container Runtime (UCR)](http://mesos.apache.org/documentation/la
 ```
 
 **Important:** If you leave the `args` field empty, the default entry point will be the launch command for the container. If your container does not have a default entry point, you must specify a command in the `args` field. If you do not, your service will fail to deploy.
-
-# Limitations
-- The UCR does not support the following: runtime privileges, Docker options, private registries with container authentication.
 
 # Further Reading
 - [View the Mesos docs for the UCR](http://mesos.apache.org/documentation/latest/container-image/).


### PR DESCRIPTION
## Description
[DOCS-2241](https://jira.mesosphere.com/browse/DOCS-2241) - Document UCR container image garbage collection for DC/OS and other parity improvements.

## Urgency
- [x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
