### PR TITLE
Added Docker 1.13.x to the list of supported versions, with a caveat.

### DIFF
--- a/pages/1.10/installing/ent/custom/system-requirements/index.md
+++ b/pages/1.10/installing/ent/custom/system-requirements/index.md
@@ -99,12 +99,13 @@ High speed internet access is recommended for DC/OS installation. A minimum 10 M
 
 Docker must be installed on all bootstrap and cluster nodes. The supported versions of Docker are:
 
+- 1.13.x
 - 1.12.x
 - 1.11.x
 
 **Recommendations**
 
-- Docker 1.11.x - 1.12.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>.
+- Docker 1.11.x - 1.13.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>. Note that due to an <a href="https://github.com/moby/moby/issues/33820" target="_blank">open issue in the moby project</a>, some users may experience Docker containers stuck in an unresponsive state when using version 1.13.x.
 
 * Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 

--- a/pages/1.10/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.10/installing/oss/custom/system-requirements/index.md
@@ -105,12 +105,13 @@ High speed internet access is recommended for DC/OS installation. A minimum 10 M
 
 Docker must be installed on all bootstrap and cluster nodes. The supported versions of Docker are:
 
+- 1.13.x
 - 1.12.x
 - 1.11.x
 
 **Recommendations**
 
-* Docker 1.11.x - 1.12.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>.
+- Docker 1.11.x - 1.13.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>. Note that due to an <a href="https://github.com/moby/moby/issues/33820" target="_blank">open issue in the moby project</a>, some users may experience Docker containers stuck in an unresponsive state when using version 1.13.x.
 
 * Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 

--- a/pages/1.11/installing/ent/custom/system-requirements/index.md
+++ b/pages/1.11/installing/ent/custom/system-requirements/index.md
@@ -99,12 +99,13 @@ High speed internet access is recommended for DC/OS installation. A minimum 10 M
 
 Docker must be installed on all bootstrap and cluster nodes. The supported versions of Docker are:
 
+- 1.13.x
 - 1.12.x
 - 1.11.x
 
 **Recommendations**
 
-- Docker 1.11.x - 1.12.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>.
+- Docker 1.11.x - 1.13.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>. Note that due to an <a href="https://github.com/moby/moby/issues/33820" target="_blank">open issue in the moby project</a>, some users may experience Docker containers stuck in an unresponsive state when using version 1.13.x.
 
 * Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 

--- a/pages/1.11/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.11/installing/oss/custom/system-requirements/index.md
@@ -105,12 +105,13 @@ High speed internet access is recommended for DC/OS installation. A minimum 10 M
 
 Docker must be installed on all bootstrap and cluster nodes. The supported versions of Docker are:
 
+- 1.13.x
 - 1.12.x
 - 1.11.x
 
 **Recommendations**
 
-* Docker 1.11.x - 1.12.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>.
+- Docker 1.11.x - 1.13.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>. Note that due to an <a href="https://github.com/moby/moby/issues/33820" target="_blank">open issue in the moby project</a>, some users may experience Docker containers stuck in an unresponsive state when using version 1.13.x.
 
 * Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 

--- a/pages/1.9/installing/ent/custom/system-requirements/index.md
+++ b/pages/1.9/installing/ent/custom/system-requirements/index.md
@@ -104,12 +104,13 @@ High speed internet access is recommended for DC/OS installation. A minimum 10 M
 
 Docker must be installed on all bootstrap and cluster nodes. The supported versions of Docker are:
 
+- 1.13.x
 - 1.12.x
 - 1.11.x
 
 **Recommendations**
 
-- Docker 1.11.x - 1.12.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>.
+- Docker 1.11.x - 1.13.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>. Note that due to an <a href="https://github.com/moby/moby/issues/33820" target="_blank">open issue in the moby project</a>, some users may experience Docker containers stuck in an unresponsive state when using version 1.13.x.
 
 * Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 

--- a/pages/1.9/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.9/installing/oss/custom/system-requirements/index.md
@@ -103,12 +103,13 @@ High speed internet access is recommended for DC/OS installation. A minimum 10 M
 
 Docker must be installed on all bootstrap and cluster nodes. The supported versions of Docker are:
 
+- 1.13.x
 - 1.12.x
 - 1.11.x
 
 **Recommendations**
 
-- Docker 1.11.x - 1.12.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>.
+- Docker 1.11.x - 1.13.x is recommended <a href="https://github.com/docker/docker/issues/9718" target="_blank">for stability reasons</a>. Note that due to an <a href="https://github.com/moby/moby/issues/33820" target="_blank">open issue in the moby project</a>, some users may experience Docker containers stuck in an unresponsive state when using version 1.13.x.
 
 * Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-2166

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
