### PR TITLE
Improve security docs [1.10,1.11]

### DIFF
--- a/pages/1.10/security/ent/perms-reference/index.md
+++ b/pages/1.10/security/ent/perms-reference/index.md
@@ -33,6 +33,12 @@ By convention, `full` indicates that the permission supports all other action id
 
 ## <a name="admin-router"></a>Admin Router Permissions
 
+In each of these cases the principal is the client performing the HTTP
+request. The principal is authenticated using the DC/OS Authentication Token it
+presents in the `Authorization` HTTP header. Once the principal has been
+authenticated Admin Router checks that it has been assigned the necessary
+permission to enact the action (eg., `full`) on the resource (eg., `dcos:adminrouter:acs`).
+
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
 | `dcos:adminrouter:acs`<br>Controls access to the security and access management features.                                                                                                                                                                                         | x    |   |   |   |   |
@@ -55,17 +61,36 @@ By convention, `full` indicates that the permission supports all other action id
 
 ## <a name="mesos"></a>Mesos Permissions
 
+It is important to note that the principal issuing the command to Mesos is the
+one that must be authorized to do so. This is not always the DC/OS user that is
+logged into the UI or CLI. For example, when a DC/OS user uses the CLI or UI to
+launch a Marathon application the Marathon framework performs its own
+authorization of that user before deciding to create the application. Once
+Marathon has determined that the DC/OS user is permitted to create the
+application, Marathon uses its own DC/OS service account user called
+`dcos_marathon` to instruct Mesos to launch the actual Mesos tasks. At that
+point, Mesos will check that the `dcos_marathon` service account (and not the
+end user) is authorized to perform a `create` action on the
+`dcos:mesos:master:task:app_id` resource.
+
+Permission string sections for `<role-name>`s in square brackets are optional.
+These sections allow the permission scope to be narrowed.
+When no role name is specified, the permissions apply to all [Mesos roles](/1.10/overview/concepts/#mesos-role).
+For example, the permission string `dcos:mesos:agent:framework:role` controls view access to DC/OS services registered with any [Mesos role](/1.10/overview/concepts/#mesos-role), whereas the permission string `dcos:mesos:agent:framework:role:slave_public` controls view access to DC/OS services registered with the role `slave_public`.
+
+Applications launched with Root Marathon cannot receive offers with resources reserved for a role which is not `slave_public` or `*`.
+
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
 | `dcos:mesos:agent:container:app_id[:<service-or-job-group>]`<br> Controls access to the [debugging](/1.10/monitoring/debugging/debug-perms/) features for a specific service or job.                                                                                               |      |   |   | x |   |
-| `dcos:mesos:agent:container:role[:<role-name>]`<br>Controls access to the [debugging](/1.10/monitoring/debugging/debug-perms/) features for a specific role.                                                                                                                       |      |   |   | x |   |
+| `dcos:mesos:agent:container:role[:<role-name>]`<br>Controls access to the [debugging](/1.10/monitoring/debugging/debug-perms/) features for the given [Mesos role](/1.10/overview/concepts/#mesos-role).                                                                                                                       |      |   |   | x |   |
 | `dcos:mesos:agent:endpoint:path[:<endpoint>]`<br> Controls access to unprotected [Mesos endpoints](https://mesos.apache.org/documentation/latest/authorization/).                                                                                                                         |      |   | x |   |   |
 | `dcos:mesos:agent:executor:app_id[:<service-or-job-group>]`<br> Controls view access to service and job [executor information](https://mesos.apache.org/documentation/latest/app-framework-development-guide/).                                                                           |      |   | x |   |   |
 | `dcos:mesos:agent:flags`<br> Controls view access to [agent flag](https://mesos.apache.org/documentation/latest/slave/flags/) configurations.                                                                                                                                              |      |   | x |   |   |
-| `dcos:mesos:agent:framework:role[:<role-name>]`<br> Controls view access to DC/OS services registered with a particular role.                                                                                                                                                     |      |   | x |   |   |
+| `dcos:mesos:agent:framework:role[:<role-name>]`<br> Controls view access to DC/OS services registered with the given [Mesos role](/1.10/overview/concepts/#mesos-role).                                                                                                                                                     |      |   | x |   |   |
 | `dcos:mesos:agent:log`<br>Controls access to the [agent logs](/1.10/monitoring/logging/).                                                                                                                                                                                          |      |   | x |   |   |
 | `dcos:mesos:agent:nested_container_session:app_id[:<service-or-job-group>]`<br> Controls access, by service or job group, to launching a container within a container of a service or job while [debugging](/1.10/monitoring/debugging/).                                          |      | x |   |   |   |
-| `dcos:mesos:agent:nested_container_session:role[:<role-name>]`<br> Controls access, by role, to launching a container within a container of a service or job while [debugging](/1.10/monitoring/debugging/).                                                                       |      | x |   |   |   |
+| `dcos:mesos:agent:nested_container_session:role[:<role-name>]`<br> Controls access, by [Mesos role](/1.10/overview/concepts/#mesos-role), to launching a container within a container of a service or job while [debugging](/1.10/monitoring/debugging/).                                                                       |      | x |   |   |   |
 | `dcos:mesos:agent:nested_container_session:user[:<linux-user-name>]`<br> Controls access, by Linux user, to launching a container within a container of a service or job while [debugging](/1.10/monitoring/debugging/). The users of both nested containers must be the same.     |      | x |   |   |   |
 | `dcos:mesos:agent:sandbox:app_id[:<service-or-job-group>]`<br> Controls access to the Mesos sandbox.                                                                                                                                                                              |      |   | x |   |   |
 | `dcos:mesos:agent:task:app_id[:<service-or-job-group>]`<br> Controls access to task information.                                                                                                                                                                                  |      |   | x |   |   |
@@ -73,18 +98,25 @@ By convention, `full` indicates that the permission supports all other action id
 | `dcos:mesos:master:executor:app_id[:<service-or-job-group>]`<br> Controls access to [executor](https://mesos.apache.org/documentation/latest/app-framework-development-guide/) service and job groups.                                                                                    |      |   | x |   |   |
 | `dcos:mesos:master:flags`<br> Controls view access to [master flag](https://mesos.apache.org/documentation/latest/endpoints/master/flags/) configurations.                                                                                                                        |      |   | x |   |   |
 | `dcos:mesos:master:framework:principal[:<service-account-id>]`<br> Controls access, by service account ID, to the Mesos [tear down](https://mesos.apache.org/documentation/latest/endpoints/master/teardown/) endpoint, which allows you to uninstall a DC/OS service.            |      |   |   |   | x |
-| `dcos:mesos:master:framework:role[:<role-name>]` <br> Controls access, by role, to register as a framework with [Mesos](https://mesos.apache.org/documentation/latest/roles/).                                                                                                    |      | x | x |   |   |
+| `dcos:mesos:master:framework:role[:<role-name>]` <br> Controls access, by [Mesos role](/1.10/overview/concepts/#mesos-role), to register as a framework with [Mesos](https://mesos.apache.org/documentation/latest/roles/).                                                                                                    |      | x | x |   |   |
 | `dcos:mesos:master:log`<br> Controls access to the Mesos [master logs](/1.10/monitoring/logging/).                                                                                                                                                                                 |      |   | x |   |   |
-| `dcos:mesos:master:quota:role[:<role-name>]` <br> Controls access, by role, to the [resource quota](https://mesos.apache.org/documentation/latest/quota/).                                                                                                                         |      |   | x | x |   |
+| `dcos:mesos:master:quota:role[:<role-name>]` <br> Controls access, by [Mesos role](/1.10/overview/concepts/#mesos-role), to the [resource quota](https://mesos.apache.org/documentation/latest/quota/).                                                                                                                         |      |   | x | x |   |
 | `dcos:mesos:master:reservation:principal[:<service-account-id>]`<br> Controls access, by user or service account, to unreserve [resources](https://mesos.apache.org/documentation/latest/reservation/).                                                                           |      |   |   |   | x |
-| `dcos:mesos:master:reservation:role[:<role-name>]`<br> Controls access, by role, to reserve [resources](https://mesos.apache.org/documentation/latest/reservation/).                                                                                                              |      | x |   |   |   |
+| `dcos:mesos:master:reservation:role[:<role-name>]`<br> Controls access, by [Mesos role](/1.10/overview/concepts/#mesos-role), to reserve [resources](https://mesos.apache.org/documentation/latest/reservation/).                                                                                                              |      | x |   |   |   |
 | `dcos:mesos:master:task:app_id[:<service-or-job-group>]`<br> Controls access to run tasks.                                                                                                                                                                                        |      | x |   |   |   |
 | `dcos:mesos:master:task:user[:<linux-user-name>]`<br> Controls access to run tasks as a specific Linux user.                                                                                                                                                                      |      | x |   |   |   |
 | `dcos:mesos:master:volume:principal[:<service-account-id>]`<br> Controls access to destroy a volume.                                                                                                                                                                              |      |   |   |   | x |
-| `dcos:mesos:master:volume:role[:<role-name>]`<br> Controls access to create a volume for the given Mesos role.                                                                                                                                                                    |      | x |   |   |   |
-| `dcos:mesos:master:weight:role[:<role-name>]`<br> Control access to the [weight](https://mesos.apache.org/documentation/latest/weights/) for a given Mesos role.                                                                                                                  |      |   | x | x |   |
+| `dcos:mesos:master:volume:role[:<role-name>]`<br> Controls access to create a volume for the given [Mesos role](/1.10/overview/concepts/#mesos-role).                                                                                                                                                                    |      | x |   |   |   |
+| `dcos:mesos:master:weight:role[:<role-name>]`<br> Control access to the [weight](https://mesos.apache.org/documentation/latest/weights/) for the given [Mesos roles](/1.10/overview/concepts/#mesos-role).                                                                                                                  |      |   | x | x |   |
 
 ## <a name="marathon-metronome"></a>Marathon and Metronome Permissions
+
+In each of these cases the principal is the client performing the HTTP request
+to the Marathon or Metronome API. The principal is authenticated using the
+DC/OS Authentication Token it presents in the `Authorization` HTTP header. Once
+the principal has been authenticated Marathon or Metronome checks that the
+principal has been assigned permission to perform the action (eg., `read`) on
+the resource (eg., dcos:service:marathon:marathon:admin:config).
 
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
@@ -97,12 +129,23 @@ By convention, `full` indicates that the permission supports all other action id
 
 ## <a name="secrets"></a>Secret Store Permissions
 
+These permissions control access to the [Secrets API](/1.10/security/ent/secrets/secrets-api/). A Mesos framework must have
+permission granted to its DC/OS service account in order to read or otherwise
+operate on a given secret. If you are looking for information on how to launch
+Marathon applications using secrets see [Configuring services and pods to use secrets](/1.10/security/ent/secrets/use-secrets/) instead.
+
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
 | `dcos:secrets:default:[<path-name>/]<secret-name>`<br> Controls access to individual [secrets](/1.10/security/ent/secrets/).                                                                                                                                                           | x    | x | x | x | x |
 | `dcos:secrets:list:default:/[<path>]`<br> Controls view access to the names of [secrets](/1.10/security/ent/secrets/).                                                                                                                                                                 |      |   | x |   |   |
 
 ## <a name="superuser"></a>Superuser Permissions
+
+Windows has the `Administrator` user and Linux has the `root` user. Similarly,
+DC/OS as the concept of the `superuser`. A user with permission to perform the
+`full` action on the `dcos:superuser` resource has complete, unrestricted
+access to any operation throughout DC/OS. This is extremely powerful and this
+permission should be granted sparingly.
 
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|

--- a/pages/1.10/security/ent/users-groups/config-linux-user/index.md
+++ b/pages/1.10/security/ent/users-groups/config-linux-user/index.md
@@ -23,7 +23,9 @@ The procedure for overriding the default Linux user varies by the type of servic
 
 # <a name="universe"></a>Overriding the default Linux user of a Universe service
 
-Many Universe services ignore overrides of their user accounts except in `strict` mode. We provide detailed steps for overriding the default Linux user for services that support this in [Service Accounts](/1.10/security/ent/service-auth/). Refer to the section that pertains to the service of interest for step-by-step instructions. The procedures also include how to configure the service to use encryption and service accounts.  
+Many Universe services ignore overrides of their user accounts except in `strict` mode. We provide detailed steps for overriding the default Linux user for services that support this in [Service Accounts](/1.10/security/ent/service-auth/). Refer to the section that pertains to the service of interest for step-by-step instructions. The procedures also include how to configure the service to use encryption and service accounts.
+
+Remember to grant permission to perform the `create` action on the `dcos:mesos:master:task:user[:<linux-user-name>]` resource to the service account user that the universe service is launched with. See [Mesos Permissions](https://docs.mesosphere.com/1.10/security/ent/perms-reference/#mesos-permissions) for more information.
 
 
 # <a name="marathon-app-def"></a>Overriding the default Linux user via Marathon app definition
@@ -35,8 +37,9 @@ The following procedure will walk you through a quick tutorial to demonstrate ho
 - The Linux user account already exists on the agent.
 - You have installed and are logged into the [DC/OS CLI](/1.10/cli/).
 - If your [security mode](/1.10/security/ent/#security-modes) is `permissive` or `strict`, you must follow the steps in [Downloading the Root Cert](/1.10/security/ent/tls-ssl/get-cert/) before issuing the curl commands in this section. If your [security mode](/1.10/security/ent/#security-modes) is `disabled`, you must delete `--cacert dcos-ca.crt` from the commands before issuing them.
+- You have granted permission to perform the `create` action on the `dcos:mesos:master:task:user:<linux-user-name>` resource to the `dcos_marathon` DC/OS service account user.
 
-Once you have met these prerequisites, complete the following steps to override the default Linux user. 
+Once you have met these prerequisites, complete the following steps to override the default Linux user.
 
 1. Create a Marathon app definition and save it with an informative name such as `myservice.json`. The following service will write the name of the user it's running under to the logs, create a new file, and fetch the Mesosphere logo from dcos.io.
 
@@ -77,7 +80,7 @@ curl -X POST --cacert dcos-ca.crt $(dcos config show core.dcos_url)/service/mara
 
 # <a name="metronome-job-def"></a>Overriding the default Linux user via Metronome job definition
 
-Metronome job definitions provide a `"user"` key which you can use to override the default Linux user. 
+Metronome job definitions provide a `"user"` key which you can use to override the default Linux user.
 
 **Tip:** Refer to the [Jobs documentation](/1.10/deploying-jobs/quickstart/) for more information about creating and deploying jobs.
 
@@ -86,14 +89,15 @@ The following procedure will walk you through a quick tutorial to demonstrate ho
 - The Linux user account already exists on the agent.
 - You have installed and are logged into the [DC/OS CLI](/1.10/cli/).
 - If your [security mode](/1.10/security/ent/#security-modes) is `permissive` or `strict`, you must follow the steps in [Downloading the Root Cert](/1.10/security/ent/tls-ssl/get-cert/) before issuing the curl commands in this section. If your [security mode](/1.10/security/ent/#security-modes) is `disabled`, you must delete `--cacert dcos-ca.crt` from the commands before issuing them.
+- You have granted permission to perform the `create` action on the `dcos:mesos:master:task:user:<linux-user-name>` resource to the `dcos_metronome` DC/OS service account user.
 
-Once you have met these prerequisites, complete the following steps to override the default Linux user. 
+Once you have met these prerequisites, complete the following steps to override the default Linux user.
 
 
 1. Create a Metronome job definition and save it with an informative name such as `myjob.json`.
 
   ```json
-{ 
+{
   "id": "test-user-override",
   "run": {
     "artifacts": [

--- a/pages/1.11/security/ent/perms-reference/index.md
+++ b/pages/1.11/security/ent/perms-reference/index.md
@@ -34,6 +34,12 @@ By convention, `full` indicates that the permission supports all other action id
 
 ## <a name="admin-router"></a>Admin Router Permissions
 
+In each of these cases the principal is the client performing the HTTP
+request. The principal is authenticated using the DC/OS Authentication Token it
+presents in the `Authorization` HTTP header. Once the principal has been
+authenticated Admin Router checks that it has been assigned the necessary
+permission to enact the action (eg., `full`) on the resource (eg., `dcos:adminrouter:acs`).
+
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
 | `dcos:adminrouter:acs`<br>Controls access to the security and access management features.                                                                                                                                                                                         | x    |   |   |   |   |
@@ -56,6 +62,18 @@ By convention, `full` indicates that the permission supports all other action id
 | `dcos:adminrouter:service:metronome`<br>  Controls access to [DC/OS Jobs (Metronome)](/1.11/deploying-jobs/).                                                                                                                                                                      | x    |   |   |   |   |
 
 ## <a name="mesos"></a>Mesos Permissions
+
+It is important to note that the principal issuing the command to Mesos is the
+one that must be authorized to do so. This is not always the DC/OS user that is
+logged into the UI or CLI. For example, when a DC/OS user uses the CLI or UI to
+launch a Marathon application the Marathon framework performs its own
+authorization of that user before deciding to create the application. Once
+Marathon has determined that the DC/OS user is permitted to create the
+application, Marathon uses its own DC/OS service account user called
+`dcos_marathon` to instruct Mesos to launch the actual Mesos tasks. At that
+point, Mesos will check that the `dcos_marathon` service account (and not the
+end user) is authorized to perform a `create` action on the
+`dcos:mesos:master:task:app_id` resource.
 
 Permission string sections for `<role-name>`s in square brackets are optional.
 These sections allow the permission scope to be narrowed.
@@ -95,6 +113,13 @@ Applications launched with Root Marathon cannot receive offers with resources re
 
 ## <a name="marathon-metronome"></a>Marathon and Metronome Permissions
 
+In each of these cases the principal is the client performing the HTTP request
+to the Marathon or Metronome API. The principal is authenticated using the
+DC/OS Authentication Token it presents in the `Authorization` HTTP header. Once
+the principal has been authenticated Marathon or Metronome checks that the
+principal has been assigned permission to perform the action (eg., `read`) on
+the resource (eg., dcos:service:marathon:marathon:admin:config).
+
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
 | `dcos:service:marathon:marathon:admin:config`<br>  Controls access to the [GET /v2/info Marathon endpoint](/1.11/deploying-services/marathon-api/#/info).                                                                                                                         |      |   | x |   |   |
@@ -106,12 +131,19 @@ Applications launched with Root Marathon cannot receive offers with resources re
 
 ## <a name="secrets"></a>Secret Store Permissions
 
+These permissions control access to the [Secrets API](/1.11/security/ent/secrets/secrets-api/). A Mesos framework must have
+permission granted to its DC/OS service account in order to read or otherwise
+operate on a given secret. If you are looking for information on how to launch
+Marathon applications using secrets see [Configuring services and pods to use secrets](/1.11/security/ent/secrets/use-secrets/) instead.
+
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
 | `dcos:secrets:default:[<path-name>/]<secret-name>`<br> Controls access to individual [secrets](/1.11/security/secrets/).                                                                                                                                                           | x    | x | x | x | x |
 | `dcos:secrets:list:default:/[<path>]`<br> Controls view access to the names of [secrets](/1.11/security/secrets/).                                                                                                                                                                 |      |   | x |   |   |
 
 ## <a name="cluster-linker"></a> Cluster Linker Permissions
+
+In each of these cases the principal is the DC/OS user logged into the CLI or UI.
 
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|
@@ -120,6 +152,12 @@ Applications launched with Root Marathon cannot receive offers with resources re
 
 
 ## <a name="superuser"></a>Superuser Permissions
+
+Windows has the `Administrator` user and Linux has the `root` user. Similarly,
+DC/OS as the concept of the `superuser`. A user with permission to perform the
+`full` action on the `dcos:superuser` resource has complete, unrestricted
+access to any operation throughout DC/OS. This is extremely powerful and this
+permission should be granted sparingly.
 
 |                                                                                                                                 Permission string                                                                                                                                 | full | C | R | U | D |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---|---|---|---|

--- a/pages/1.11/security/ent/users-groups/config-linux-user/index.md
+++ b/pages/1.11/security/ent/users-groups/config-linux-user/index.md
@@ -23,8 +23,9 @@ The procedure for overriding the default Linux user varies by the type of servic
 
 # <a name="universe"></a>Overriding the default Linux user of a Universe service
 
-Many Universe services ignore overrides of their user accounts except in `strict` mode. We provide detailed steps for overriding the default Linux user for services that support this in [Service Accounts](/1.11/security/ent/service-auth/). Refer to the section that pertains to the service of interest for step-by-step instructions. The procedures also include how to configure the service to use encryption and service accounts.  
+Many Universe services ignore overrides of their user accounts except in `strict` mode. We provide detailed steps for overriding the default Linux user for services that support this in [Service Accounts](/1.11/security/ent/service-auth/). Refer to the section that pertains to the service of interest for step-by-step instructions. The procedures also include how to configure the service to use encryption and service accounts.
 
+Remember to grant permission to perform the `create` action on the `dcos:mesos:master:task:user[:<linux-user-name>]` resource to the service account user that the universe service is launched with. See [Mesos Permissions](https://docs.mesosphere.com/1.11/security/ent/perms-reference/#mesos-permissions) for more information.
 
 # <a name="marathon-app-def"></a>Overriding the default Linux user via Marathon app definition
 
@@ -35,8 +36,9 @@ The following procedure will walk you through a quick tutorial to demonstrate ho
 - The Linux user account already exists on the agent.
 - You have installed and are logged into the [DC/OS CLI](/1.11/cli/).
 - If your [security mode](/1.11/security/ent/#security-modes) is `permissive` or `strict`, you must follow the steps in [Downloading the Root Cert](/1.11/security/ent/tls-ssl/get-cert/) before issuing the curl commands in this section. If your [security mode](/1.11/security/ent/#security-modes) is `disabled`, you must delete `--cacert dcos-ca.crt` from the commands before issuing them.
+- You have granted permission to perform the `create` action on the `dcos:mesos:master:task:user:<linux-user-name>` resource to the `dcos_marathon` DC/OS service account user.
 
-Once you have met these prerequisites, complete the following steps to override the default Linux user. 
+Once you have met these prerequisites, complete the following steps to override the default Linux user.
 
 1. Create a Marathon app definition and save it with an informative name such as `myservice.json`. The following service will write the name of the user it's running under to the logs, create a new file, and fetch the Mesosphere logo from dcos.io.
 
@@ -77,7 +79,7 @@ curl -X POST --cacert dcos-ca.crt $(dcos config show core.dcos_url)/service/mara
 
 # <a name="metronome-job-def"></a>Overriding the default Linux user via Metronome job definition
 
-Metronome job definitions provide a `"user"` key which you can use to override the default Linux user. 
+Metronome job definitions provide a `"user"` key which you can use to override the default Linux user.
 
 **Tip:** Refer to the [Jobs documentation](/1.11/deploying-jobs/quickstart/) for more information about creating and deploying jobs.
 
@@ -86,14 +88,15 @@ The following procedure will walk you through a quick tutorial to demonstrate ho
 - The Linux user account already exists on the agent.
 - You have installed and are logged into the [DC/OS CLI](/1.11/cli/).
 - If your [security mode](/1.11/security/ent/#security-modes) is `permissive` or `strict`, you must follow the steps in [Downloading the Root Cert](/1.11/security/ent/tls-ssl/get-cert/) before issuing the curl commands in this section. If your [security mode](/1.11/security/ent/#security-modes) is `disabled`, you must delete `--cacert dcos-ca.crt` from the commands before issuing them.
+- You have granted permission to perform the `create` action on the `dcos:mesos:master:task:user:<linux-user-name>` resource to the `dcos_metronome` DC/OS service account user.
 
-Once you have met these prerequisites, complete the following steps to override the default Linux user. 
+Once you have met these prerequisites, complete the following steps to override the default Linux user.
 
 
 1. Create a Metronome job definition and save it with an informative name such as `myjob.json`.
 
   ```json
-{ 
+{
   "id": "test-user-override",
   "run": {
     "artifacts": [


### PR DESCRIPTION
## Description
This PR adds some help text to the Permissions Reference pages. It also mentions that a necessary permission must be granted when configuring tasks to run as a custom linux user.

If anyone feels it necessary to modify the 1.8 or 1.9 pages I'm happy to do so, too.

https://jira.mesosphere.com/projects/DCOS/issues/DCOS-18669

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
