### PR TITLE
Fix edge-lb service account permissions

### DIFF
--- a/pages/services/edge-lb/0.1.9/installing/index.md
+++ b/pages/services/edge-lb/0.1.9/installing/index.md
@@ -85,18 +85,13 @@ Use the following CLI commands to provision the Edge-LB service account with the
 
 All CLI commands can also be executed via the [IAM API](/1.10/security/iam-api/).
 
-1.  Grant the permissions and the allowed actions to the service account using the following commands. The commands below allow your Edge-LB service to manage DC/OS packages, Marathon tasks, and Edge-LB tasks.
+1.  Grant the permissions and the allowed actions to the service account using the following commands. The commands below allow your Edge-LB service to manage DC/OS packages, Marathon tasks, Edge-LB pools and tasks.
 
     ```bash
     dcos security org users grant edge-lb-principal dcos:adminrouter:package full --description "Allow access to manage DC/OS packages"
     dcos security org users grant edge-lb-principal dcos:adminrouter:service:marathon full --description "Allow access to manage marathon tasks"
     dcos security org users grant edge-lb-principal dcos:service:marathon:marathon:services:/dcos-edgelb full --description "Allow access to manage dcos-edgelb tasks"
-    ```
-
-2.  Grant permissions to update your specific pool (replace `<pool-name>` with the name of the pool your Edge-LB will be servicing.  Repeat for each pool.
-
-    ```bash
-    dcos security org users grant edge-lb-principal dcos:adminrouter:service:dcos-edgelb/pools/<pool-name> full --description "Allow access to update pool <pool-name>"
+    dcos security org users grant edge-lb-principal dcos:adminrouter:service:dcos-edgelb/pools full --description "Allow access to update pools"
     ```
 
 For more information about required permissions, please see the [Edge-LB Permissions](/service-docs/edge-lb/0.1.9/permissions)

--- a/pages/services/edge-lb/0.1.9/installing/index.md
+++ b/pages/services/edge-lb/0.1.9/installing/index.md
@@ -17,7 +17,7 @@ Configure a service account and install the Edge-LB package using the instructio
 - Access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
 
 **Limitations**
-- Currently, Edge-LB works only with DC/OS Enterprise in permissive [security mode](/1.10/security/#security-modes). It does not work with strict or disabled.
+- Currently, Edge-LB works only with DC/OS Enterprise in permissive [security mode](/latest/security/ent/#security-modes). It does not work with strict or disabled.
 
 # Add Edge-LB package repositories
 The Edge-LB package is composed of two components: the Edge-LB API server and the Edge-LB pools. You must install universe repos for the Edge-LB API server and the Edge-LB pool in order to install Edge-LB. The Edge-LB API server is a restful API that manages one or more Edge-LB pools. Each Edge-LB pool is a collection of load balancers. An Edge-LB pool can be used to launch one or more instances of a load balancer to create a single highly available load balancer. Currently the Edge-LB pool supports only HAProxy as a load balancer.
@@ -36,7 +36,7 @@ dcos package repo add --index=0 edgelb-pool-aws \
 # Create a service account
 The Edge-LB API server needs to be associated with a service account so that it can launch Edge-LB pools on public and private nodes, based on user requests.
 
-[Service accounts](1.11/security/ent/service-auth/) are used in conjunction with public-private key pairs, secrets, permissions, and authentication tokens to provide access for DC/OS services to DC/OS. Service accounts control the communications and DC/OS API actions that the services are permitted to make.
+[Service accounts](/latest/security/ent/service-auth/) are used in conjunction with public-private key pairs, secrets, permissions, and authentication tokens to provide access for DC/OS services to DC/OS. Service accounts control the communications and DC/OS API actions that the services are permitted to make.
 
 Follow the steps below to create a service account, a principal associated with the service account, assign permissions to this principle, and associate a secret store with this service account. The secret store is used by Edge-LB to retrieve and install TLS certificates on the Edge-LB pools in order to enable TLS for all HTTP traffic between client and service backends.
 
@@ -49,7 +49,7 @@ Create a public-private key pair and save each value into a separate file within
 dcos security org service-accounts keypair edge-lb-private-key.pem edge-lb-public-key.pem
 ```
 
-**Tip:** You can use the [DC/OS Secret Store](/1.10/security/secrets/) to secure the key pair.
+**Tip:** You can use the [DC/OS Secret Store](/latest/security/ent/secrets/) to secure the key pair.
 
 ## Create the principal
 From a terminal prompt, create a new service account (`edge-lb-principal`) containing the public key (`edge-lb-public-key.pem`).
@@ -83,7 +83,7 @@ dcos security secrets list /
 
 Use the following CLI commands to provision the Edge-LB service account with the required permissions.
 
-All CLI commands can also be executed via the [IAM API](/1.10/security/iam-api/).
+All CLI commands can also be executed via the [IAM API](/latest/security/ent/iam-api/).
 
 1.  Grant the permissions and the allowed actions to the service account using the following commands. The commands below allow your Edge-LB service to manage DC/OS packages, Marathon tasks, Edge-LB pools and tasks.
 

--- a/pages/services/edge-lb/0.1.9/permissions/index.md
+++ b/pages/services/edge-lb/0.1.9/permissions/index.md
@@ -28,7 +28,7 @@ In order to install Edge-LB, the user must have the following permissions:
 
 # Service Account Permissions
 
-In order for Edge-LB to operate, it must be configured to use a [service account](/services/edge-lb/1.0.0/installing/#create-a-service-account/) with the following permissions:
+In order for Edge-LB to operate, it must be configured to use a [service account](/services/edge-lb/0.1.9/installing/#create-a-service-account/) with the following permissions:
 
 - `dcos:adminrouter:package`
 - `dcos:adminrouter:service:marathon`

--- a/pages/services/edge-lb/0.1.9/permissions/index.md
+++ b/pages/services/edge-lb/0.1.9/permissions/index.md
@@ -28,15 +28,15 @@ In order to install Edge-LB, the user must have the following permissions:
 
 # Service Account Permissions
 
-In order for Edge-LB to operate, it must be configured to use a [service account](/services/edge-lb/0.1.9/installing/#create-a-service-account/) with the following permissions:
+In order for Edge-LB to operate, it must be configured to use a [service account](/services/edge-lb/1.0.0/installing/#create-a-service-account/) with the following permissions:
 
 - `dcos:adminrouter:package`
 - `dcos:adminrouter:service:marathon`
 - `dcos:service:marathon:marathon:services:/dcos-edgelb`
+- `dcos:adminrouter:service:dcos-edgelb/pools`
+- `dcos:service:marathon:marathon:services:/dcos-edgelb/pools`
 
 In addition, for each pool your Edge-LB configuration will be managing, add a permission like this:
-
-- `dcos:adminrouter:service:dcos-edgelb/pools/<poolname>`
 
 # Multitenant Usage Permissions
 
@@ -45,4 +45,5 @@ To grant limited permission to manage only a single Edge-LB pool, the user must 
 - `dcos:adminrouter:package`
 - `dcos:adminrouter:service:edgelb`
 - `dcos:adminrouter:service:marathon`
+- `dcos:adminrouter:service:dcos-edgelb/pools/<pool-name>`
 - `dcos:service:marathon:marathon:services:/dcos-edgelb/pools/<pool-name>`

--- a/pages/services/edge-lb/1.0.0/installing/index.md
+++ b/pages/services/edge-lb/1.0.0/installing/index.md
@@ -12,12 +12,12 @@ Configure a service account and install the Edge-LB package using the instructio
 
 **Prerequisites:**
 
-- [DC/OS CLI installed](/1.10/cli/install/) and be logged in as a superuser.
+- [DC/OS CLI installed](/latest/cli/install/) and be logged in as a superuser.
 - The [DC/OS Enterprise CLI installed](https://docs.mesosphere.com/1.10/cli/enterprise-cli/).
 - Access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
 
 **Limitations**
-- Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/1.10/security/#security-modes). It does not work with disabled mode.
+- Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/latest/security/ent/#security-modes). It does not work with disabled mode.
 
 # Add Edge-LB package repositories
 The Edge-LB package is composed of two components: the Edge-LB API server and the Edge-LB pools. You must install universe repos for the Edge-LB API server and the Edge-LB pool in order to install Edge-LB. The Edge-LB API server is a restful API that manages one or more Edge-LB pools. Each Edge-LB pool is a collection of load balancers. An Edge-LB pool can be used to launch one or more instances of a load balancer to create a single highly available load balancer. Currently the Edge-LB pool supports only HAProxy as a load balancer.
@@ -36,7 +36,7 @@ dcos package repo add --index=0 edgelb-pool-aws \
 # Create a service account
 The Edge-LB API server needs to be associated with a service account so that it can launch Edge-LB pools on public and private nodes, based on user requests.
 
-[Service accounts](1.11/security/ent/service-auth/) are used in conjunction with public-private key pairs, secrets, permissions, and authentication tokens to provide access for DC/OS services to DC/OS. Service accounts control the communications and DC/OS API actions that the services are permitted to make.
+[Service accounts](/latest/security/ent/service-auth/) are used in conjunction with public-private key pairs, secrets, permissions, and authentication tokens to provide access for DC/OS services to DC/OS. Service accounts control the communications and DC/OS API actions that the services are permitted to make.
 
 Follow the steps below to create a service account, a principal associated with the service account, assign permissions to this principle, and associate a secret store with this service account. The secret store is used by Edge-LB to retrieve and install TLS certificates on the Edge-LB pools in order to enable TLS for all HTTP traffic between client and service backends.
 
@@ -49,7 +49,7 @@ Create a public-private key pair and save each value into a separate file within
 dcos security org service-accounts keypair edge-lb-private-key.pem edge-lb-public-key.pem
 ```
 
-**Tip:** You can use the [DC/OS Secret Store](/1.10/security/secrets/) to secure the key pair.
+**Tip:** You can use the [DC/OS Secret Store](/latest/security/ent/secrets/) to secure the key pair.
 
 ## Create the principal
 From a terminal prompt, create a new service account (`edge-lb-principal`) containing the public key (`edge-lb-public-key.pem`).
@@ -83,7 +83,7 @@ dcos security secrets list /
 
 Use the following CLI commands to provision the Edge-LB service account with the required permissions.
 
-All CLI commands can also be executed via the [IAM API](/1.10/security/iam-api/).
+All CLI commands can also be executed via the [IAM API](/latest/security/ent/iam-api/).
 
 1.  Grant the permissions and the allowed actions to the service account using the following commands. The commands below allow your Edge-LB service to manage DC/OS packages, Marathon tasks, Edge-LB pools and tasks.
 

--- a/pages/services/edge-lb/1.0.0/installing/index.md
+++ b/pages/services/edge-lb/1.0.0/installing/index.md
@@ -85,18 +85,13 @@ Use the following CLI commands to provision the Edge-LB service account with the
 
 All CLI commands can also be executed via the [IAM API](/1.10/security/iam-api/).
 
-1.  Grant the permissions and the allowed actions to the service account using the following commands. The commands below allow your Edge-LB service to manage DC/OS packages, Marathon tasks, and Edge-LB tasks.
+1.  Grant the permissions and the allowed actions to the service account using the following commands. The commands below allow your Edge-LB service to manage DC/OS packages, Marathon tasks, Edge-LB pools and tasks.
 
     ```bash
     dcos security org users grant edge-lb-principal dcos:adminrouter:package full --description "Allow access to manage DC/OS packages"
     dcos security org users grant edge-lb-principal dcos:adminrouter:service:marathon full --description "Allow access to manage marathon tasks"
     dcos security org users grant edge-lb-principal dcos:service:marathon:marathon:services:/dcos-edgelb full --description "Allow access to manage dcos-edgelb tasks"
-    ```
-
-2.  Grant permissions to update your specific pool (replace `<pool-name>` with the name of the pool your Edge-LB will be servicing.  Repeat for each pool.
-
-    ```bash
-    dcos security org users grant edge-lb-principal dcos:adminrouter:service:dcos-edgelb/pools/<pool-name> full --description "Allow access to update pool <pool-name>"
+    dcos security org users grant edge-lb-principal dcos:adminrouter:service:dcos-edgelb/pools full --description "Allow access to update pools"
     ```
 
 For more information about required permissions, please see the [Edge-LB Permissions](/service-docs/edge-lb/1.0.0/permissions)

--- a/pages/services/edge-lb/1.0.0/permissions/index.md
+++ b/pages/services/edge-lb/1.0.0/permissions/index.md
@@ -33,10 +33,10 @@ In order for Edge-LB to operate, it must be configured to use a [service account
 - `dcos:adminrouter:package`
 - `dcos:adminrouter:service:marathon`
 - `dcos:service:marathon:marathon:services:/dcos-edgelb`
+- `dcos:adminrouter:service:dcos-edgelb/pools`
+- `dcos:service:marathon:marathon:services:/dcos-edgelb/pools`
 
 In addition, for each pool your Edge-LB configuration will be managing, add a permission like this:
-
-- `dcos:adminrouter:service:dcos-edgelb/pools/<poolname>`
 
 # Multitenant Usage Permissions
 
@@ -45,4 +45,5 @@ To grant limited permission to manage only a single Edge-LB pool, the user must 
 - `dcos:adminrouter:package`
 - `dcos:adminrouter:service:edgelb`
 - `dcos:adminrouter:service:marathon`
+- `dcos:adminrouter:service:dcos-edgelb/pools/<pool-name>`
 - `dcos:service:marathon:marathon:services:/dcos-edgelb/pools/<pool-name>`


### PR DESCRIPTION
Grant access to the service account for all pools - this has caused confusion for several customers.