### PR TITLE
fixed minor typo in DigitalOcean install docs

### DIFF
--- a/pages/1.11/installing/oss/cloud/digitalocean/index.md
+++ b/pages/1.11/installing/oss/cloud/digitalocean/index.md
@@ -97,7 +97,7 @@ The included Terraform templates are configured to run Mesosphere DC/OS on Digit
 
     - key_file_path - The path to your ssh private key created in step 4 - defaults to ./do-key
 
-5.  Also from that same directory, run `terraform init` anf then `terraform apply` which will deploy the servers into your project at DigitalOcean, and run the DC/OS installation routine. When it completes, you will see output similar to the following, but with the IP addresses assigned to your servers:
+5.  Also from that same directory, run `terraform init` and then `terraform apply` which will deploy the servers into your project at DigitalOcean, and run the DC/OS installation routine. When it completes, you will see output similar to the following, but with the IP addresses assigned to your servers:
 
     ![terraform apply output](/1.11/img/digitalocean_terraform_output.png)
 


### PR DESCRIPTION
## Description
fixed minor typo (`anf` to `and`) in digitalocean install docs

## Urgency
- [x] Low

## Requirements
really?