### PR TITLE
Removed `dcos storage` from the 1.11 enterprise CLI link.

### DIFF
--- a/pages/1.11/cli/enterprise-cli/index.md
+++ b/pages/1.11/cli/enterprise-cli/index.md
@@ -12,7 +12,6 @@ The DC/OS Enterprise CLI provides commands for DC/OS Enterprise features:
 - [`dcos backup`](/1.11/cli/command-reference/dcos-backup)
 - [`dcos license`](/1.11/cli/command-reference/dcos-license)
 - [`dcos security`](/1.11/cli/command-reference/dcos-security)
-- [`dcos storage`](/1.11/cli/command-reference/dcos-storage)
 
 # <a name="ent-cli-install"></a>Installing the DC/OS Enterprise CLI
 


### PR DESCRIPTION
We decided to install storage service as a package, rather than a DC/OS
component. As a result, this link does not apply anymore.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
