### PR TITLE
Update docs on EE DC/OS 1.11 installation with a custom CA certificate

### DIFF
--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -76,9 +76,9 @@ This topic provides all available configuration parameters. Except where explici
 | [auth_cookie_secure_flag](#auth-cookie-secure-flag-enterprise)    | [enterprise type="inline" size="small" /] Indicates whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. |
 | [bouncer_expiration_auth_token_days](#bouncer-expiration-auth-token-days-enterprise) | [enterprise type="inline" size="small" /] Sets the auth token time-to-live (TTL) for Identity and Access Management. |
 | [customer_key](#customer-key-enterprise)                       | [enterprise type="inline" size="small" /] (Required) The DC/OS Enterprise customer key. |
-| [ca_certificate_path](#ca-certificate-path-enterprise)                   | [enterprise type="inline" size="small" /] Path to a file in the OpenSSL PEM format containing a single X.509 CA certificate. Can be a root (self-issued) certificate or an intermediate (cross-certificate) certificate. |
-| [ca_certificate_key_path](#ca-certificate-key-path-enterprise)           | [enterprise type="inline" size="small" /] Path to a file in the PKCS#8 PEM format containing the private key corresponding to the CA certificate in `ca_certificate_path`. Required if `ca_certificate_path` is specified. |
-| [ca_certificate_chain_path](#ca-certificate-chain-enterprise)       | [enterprise type="inline" size="small" /] Path to a file in the OpenSSL PEM format containing the complete CA certification chain required for end-entity certificate verification. Must be left undefined if `ca_certificate_path` is a root CA certificate. Required if `ca_certificate_path` is specified and the specified certificate is an intermediate CA certificate. |
+| ca_certificate_path                   | [enterprise type="inline" size="small" /] Use this to set up a custom CA certificate. See [this page](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) for a detailed configuration parameter reference. |
+| ca_certificate_key_path           | [enterprise type="inline" size="small" /] Use this to set up a custom CA certificate. See [this page](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) for a detailed configuration parameter reference. |
+| ca_certificate_chain_path       | [enterprise type="inline" size="small" /] Use this to set up a custom CA certificate. See [this page](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) for a detailed configuration parameter reference. |
 | [oauth_enabled](#oauth-enabled-dc-os-only-)                                | (DC/OS Only) Indicates whether to enable authentication for your cluster.  |
 | [security](#security-enterprise)                               | [enterprise type="inline" size="small" /] The security mode: disabled, permissive, or strict.  |
 | [ssh_key_path](#ssh-key-path)                            | The path to the installer uses to log into the target nodes. |
@@ -121,40 +121,6 @@ bouncer_expiration_auth_token_days: '0.5'
 ```
 
 For more information, see the [security documentation](/1.11/security/ent/).
-
-[enterprise]
-### ca_certificate_path
-[/enterprise]
-
-Path to a file within the `genconf` directory containing a single X.509 CA certificate in the OpenSSL PEM format. For example: `genconf/CA_cert`.
-
-Can be a _root CA certificate_ ("self-signed") or an _intermediate CA certificate_ ("cross-certificate") signed by some other certificate authority.
-
-If provided, this is the custom CA certificate. It is used as the signing CA certificate, i.e., the DC/OS CA will use this certificate for signing end-entity certificates (the subject of this certificate will be the issuer for certificates signed by the DC/OS CA).
-
-If not provided, the DC/OS cluster generates a unique root CA certificate during the initial bootstrap phase and uses that as the signing CA certificate.
-
-The public key associated with the custom CA certificate must be of type RSA.
-
-[enterprise]
-### ca_certificate_key_path
-[/enterprise]
-
-Path to a file within the `genconf` directory containing the private key corresponding to the custom CA certificate, encoded in the OpenSSL (PKCS#8) PEM format. For example: `genconf/CA_cert.key`.
-
-**Note:** this is highly sensitive data. The configuration processor accesses this file only for configuration validation purposes, and does not copy the data. After successful configuration validation this file needs to be placed out-of-band into the file system of all DC/OS master nodes to the path `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` before most DC/OS systemd units can start up. The file must be readable by the root user, and should have have 0600 permissions set.
-
-Required if `ca_certificate_path` is specified.
-
-[enterprise]
-### ca_certificate_chain_path
-[/enterprise]
-
-Path to a file within the `genconf` directory containing the complete CA certification chain required for end-entity certificate verification, in the OpenSSL PEM format. For example: `genconf/CA_cert_chain.pem`.
-
-Must be left undefined if `ca_certificate_path` points to a _root CA certificate_.
-
-Required if `ca_certificate_path` is specified and if the custom CA certificate is an _intermediate CA certificate_. This needs to contain all CA certificates comprising the complete sequence starting precisely with the CA certificate that was used to sign the custom CA certificate and ending with a root CA certificate (where issuer and subject are equivalent), yielding a gapless certification path. The order is significant and the list must contain at least one certificate.
 
 ### cluster_docker_credentials
 The dictionary of Docker credentials to pass.

--- a/pages/1.11/installing/oss/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/oss/custom/configuration/configuration-parameters/index.md
@@ -78,9 +78,9 @@ This topic provides all available configuration parameters. Except where explici
 | [auth_cookie_secure_flag](#auth-cookie-secure-flag-enterprise)    | ([enterprise type="inline" size="small" /]) Indicates whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. |
 | [bouncer_expiration_auth_token_days](#bouncer-expiration-auth-token-days-enterprise) | ([enterprise type="inline" size="small" /]) Sets the auth token time-to-live (TTL) for Identity and Access Management. |
 | [customer_key](#customer-key-enterprise)                       | ([enterprise type="inline" size="small" /]) (Required) The DC/OS Enterprise customer key. |
-| [ca_certificate_path](#ca-certificate-path-enterprise)                   | ([enterprise type="inline" size="small" /]) Path to a file in the OpenSSL PEM format containing a single X.509 CA certificate. Can be a root (self-issued) certificate or an intermediate (cross-certificate) certificate. |
-| [ca_certificate_key_path](#ca-certificate-key-path-enterprise)           | ([enterprise type="inline" size="small" /]) Path to a file in the PKCS#8 PEM format containing the private key corresponding to the CA certificate in `ca_certificate_path`. Required if `ca_certificate_path` is specified. |
-| [ca_certificate_chain_path](#ca-certificate-chain-path-enterprise)       | ([enterprise type="inline" size="small" /]) Path to a file in the OpenSSL PEM format containing the complete CA certification chain required for end-entity certificate verification. Must be left undefined if `ca_certificate_path` is a root CA certificate. Required if `ca_certificate_path` is specified and the specified certificate is an intermediate CA certificate. |
+| ca_certificate_path                    | ([enterprise type="inline" size="small" /]) Use this to set up a custom CA certificate. See [this page](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) for a detailed configuration parameter reference. |
+| ca_certificate_key_path           | ([enterprise type="inline" size="small" /]) Use this to set up a custom CA certificate. See [this page](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) for a detailed configuration parameter reference. |
+| ca_certificate_chain_path       | ([enterprise type="inline" size="small" /]) Use this to set up a custom CA certificate. See [this page](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) for a detailed configuration parameter reference. |
 | [oauth_enabled](#oauth-enabled-open-source)                                | [oss type="inline" size="small" /] Indicates whether to enable authentication for your cluster.  |
 | [security](#security-enterprise)                               | ([enterprise type="inline" size="small" /]) The security mode: disabled, permissive, or strict.  |
 | [ssh_key_path](#ssh-key-path)                            | The path to the installer uses to log into the target nodes. |
@@ -123,42 +123,6 @@ bouncer_expiration_auth_token_days: '0.5'
 ```
 
 For more information, see the [security documentation](/1.11/security/).
-
-[enterprise]
-### ca_certificate_path
-[/enterprise]
-
-Path to a file within the `genconf` directory containing a single X.509 CA certificate in the OpenSSL PEM format. For example: `genconf/CA_cert`.
-
-Can be a _root CA certificate_ ("self-signed") or an _intermediate CA certificate_ ("cross-certificate") signed by some other certificate authority. 
-
-If provided, this is the custom CA certificate. It is used as the signing CA certificate, i.e., the DC/OS CA will use this certificate for signing end-entity certificates (the subject of this certificate will be the issuer for certificates signed by the DC/OS CA). 
-
-If not provided, the DC/OS cluster generates a unique root CA certificate during the initial bootstrap phase and uses that as the signing CA certificate. 
-
-The public key associated with the custom CA certificate must be of type RSA.
-
-[enterprise]
-### ca_certificate_key_path
-[/enterprise]
-
-Path to a file within the `genconf` directory containing the private key corresponding to the custom CA certificate, encoded in the OpenSSL (PKCS#8) PEM format. For example: `genconf/CA_cert.key`.
-
-**Note:** this is highly sensitive data. The configuration processor accesses this file only for configuration validation purposes, and does not copy the data. After successful configuration validation this file needs to be placed out-of-band into the file system of all DC/OS master nodes to the path `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` before most DC/OS systemd units can start up. The file must be readable by the root user, and should have have 0600 permissions set.
-
-Required if `ca_certificate_path` is specified.
-
-[enterprise]
-### ca_certificate_chain_path
-[/enterprise]
-
-Path to a file within the `genconf` directory containing the complete CA certification chain required for end-entity certificate verification, in the OpenSSL PEM format. For example: `genconf/CA_cert_chain.pem`.
-
-Must be left undefined if `ca_certificate_path` points to a _root CA certificate_.
-
-Required if `ca_certificate_path` is specified and if the custom CA certificate is an _intermediate CA certificate_. This needs to contain all CA certificates comprising the complete sequence starting precisely with the CA certificate that was used to sign the custom CA certificate and ending with a root CA certificate (where issuer and subject are equivalent), yielding a gapless certification path. The order is significant and the list must contain at least one certificate.
-
-
 
 ### cluster_docker_credentials
 The dictionary of Docker credentials to pass.

--- a/pages/1.11/security/ent/tls-ssl/ca-custom/index.md
+++ b/pages/1.11/security/ent/tls-ssl/ca-custom/index.md
@@ -8,7 +8,8 @@ excerpt:
 enterprise: true
 ---
 
-Each DC/OS cluster has its own DC/OS certificate authority (CA). By default, that CA uses an automatically generated globally unique root CA certificate for signing other certificates. In lieu of using the auto-generated root CA certificate, you can configure DC/OS Enterprise to use a custom CA certificate, which can be a root CA certificate or an intermediate CA certificate.
+# Motivation
+Each DC/OS Enterprise cluster has its own DC/OS certificate authority (CA). By default, that CA uses a globally unique root CA certificate generated during the installation of DC/OS. That root CA certificate is used for signing certificates for the components of DC/OS, such as Admin Router. In lieu of using the auto-generated root CA certificate, you can configure DC/OS Enterprise to use a custom CA certificate, which is *either* a root CA certificate *or* an intermediate CA certificate. (see examples [below](#example-use-cases))
 
 The benefits of using a custom CA certificate for your DC/OS Enterprise cluster include:
 
@@ -16,18 +17,301 @@ The benefits of using a custom CA certificate for your DC/OS Enterprise cluster 
 - Controlling security properties of the key pair (such as type and strength) used for signing DC/OS component certificates.
 - Ensuring that all DC/OS components (including Admin Router) present browser-trusted certificates.
 
-Custom CA certificate support is enabled by three install time [configuration parameters](/1.11/installing/ent/custom/configuration/configuration-parameters/#ca-certificate-path-enterprise):
+# The structure of this document page
+To facilitate the reading of this page we start out by providing a glossary for general definition of terms, followed by an in-depth configuration parameter reference. An installation walkthrough is provided in section [Installing DC/OS Enterprise with a custom CA certificate](#installing-dcos-enterprise-with-a-custom-ca-certificate). Section [Example use cases](#example-use-cases) then provides example file contents for the custom CA certificate configuration files for three popular use cases.
 
-- `ca_certificate_path`
-- `ca_certificate_key_path`
-- `ca_certificate_chain_path`
+# What is supported and what is not
+- Only custom CA certificates that have an associated RSA-type key pair are supported. Other types of certificates, such as those using ECC-type key pair, are currently not supported. Support for ECC-type key pairs will be added in the future.
+- Custom CA certificates are only supported for a fresh installation of DC/OS Enterprise 1.10 or higher. Older versions of DC/OS are not supported, and it is not possible to add a custom CA certificate during an upgrade.
 
-**Note:** 
+# Glossary of the terms used in this documentation
+- **Custom CA certificate:** Your custom CA certificate in the PEM format, which will be used to issue certificates for DC/OS components such as Admin Router. The custom CA certificate is either an intermediate CA certificate (issued by another CA) or a root CA certificate (self-signed by the custom CA).
 
-- Only custom CA certificates that have an associated RSA-type key pair are supported.
-- You can use a custom CA certificate only with a new 1.10 install.
+- **Private key associated with the custom CA certificate:** The private key in the PKCS#8 format associated with the custom CA certificate.
 
-# Procedure
+- **Certificate chain associated with the custom CA certificate:** The complete CA certification chain required for end-entity certificate verification. It must include the certificates of all parent CAs of the intermediate custom CA up to and including the root CA certificate. If the custom CA certificate is a root CA certificate, the chain must be empty.
 
-1. Using a [custom setup file and the CLI or advanced installer](/1.11/installing), provide the paths to the custom CA certificate, corresponding private key, and optionally corresponding intermediate CA certificates and/or a root CA certificate as part of the chain. All files must be placed in `genconf` directory in the home directory of your bootstrap node. The installer verifies the data.
-1. Before installing DC/OS to all nodes, place the private key file corresponding to the custom CA certificate specified in `ca_certificate_key_path` securely on all master nodes in `/var/lib/dcos/pki/tls/CA/private/custom_ca.key`. The file must be readable by the root user and have 0600 permissions set.
+- **Installation directory:** The directory on the bootstrap node where the DC/OS installer resides. It is denoted with `$DCOS_INSTALL_DIR` in this document.
+
+- **Configuration:** The set of the configuration parameters that governs the specific aspects of the installation procedure. The configuration is stored in the DC/OS configuration file.
+
+- **DC/OS configuration file:** The file which contains the DC/OS configuration parameters. The DC/OS configuration file is normally called `config.yaml` and must be present in the `$DCOS_INSTALL_DIR/genconf/` directory on the bootstrap node during the installation. It is used by the DC/OS installer.
+
+
+# Requirements
+
+In order to install DC/OS Enterprise with a custom CA certificate you will need:
+
+- to use the [advanced DC/OS installation method](/1.11/installing/ent/custom/advanced/). Other installation methods are not supported.
+- A file containing the custom CA certificate.
+- A file containing the private key associated with the custom CA certificate.
+- If the CA is **not** a self-signed root CA, a file containing the certificate chain associated with the custom CA certificate. 
+
+## Manually placing the custom CA certificate, the associated private key and the certificate chain onto the bootstrap node
+The custom CA certificate, the associated private key and the certificate chain files must be put in the `$DCOS_INSTALL_DIR/genconf/` directory on the bootstrap node:
+
+```bash
+cd $DCOS_INSTALL_DIR
+ls genconf/
+```
+```bash 
+dcos-ca-certificate.crt
+dcos-ca-certificate-key.key
+dcos-ca-certificate-chain.crt
+```
+
+## Manually placing the private key associated with the custom CA certificate onto the master nodes
+
+For security reasons, the installer will not copy the private key from the bootstrap node to the master nodes. 
+The private key associated with the custom CA certificate must be distributed manually to every DC/OS master node **before starting the installation**. 
+
+The filesystem path for the private key file must be `/var/lib/dcos/pki/tls/CA/private/custom_ca.key`. 
+The directory `/var/lib/dcos/pki/tls/CA/private/` can be created manually with the following  command before putting the file `custom_ca.key` in the directory on every DC/OS master node:
+
+```bash
+ mkdir -p /var/lib/dcos/pki/tls/CA/private
+```
+
+Furthermore, the file containing the private key `custom_ca.key` corresponding to the custom CA certificate must be owned by the root Unix user and have 0600 permissions set.
+
+If you copy the private key file over the network onto the master nodes, the network channel must be adequately protected.
+An example of copying the CA private key is given below. The commands are executed on the bootstrap node. The `W.X.Y.Z` below indicates the IP address of a master node:
+
+```bash
+cd $DCOS_INSTALL_DIR/genconf
+scp dcos-ca-certificate-key.key centos@W.X.Y.Z:/var/lib/dcos/pki/tls/CA/private/custom_ca.key
+```
+
+## Specifying the locations of the custom CA certificate, the associated private key and the certificate chain files in the DC/OS configuration file
+
+The filesystem paths to the custom CA certificate, associated private key and certificate chain files in the `$DCOS_INSTALL_DIR/genconf/` directory on the bootstrap node must be specified in the DC/OS configuration file using, respectively, the `ca_certificate_path`, `ca_certificate_key_path` and  `ca_certificate_chain_path` parameters.
+The paths must be relative to `$DCOS_INSTALL_DIR`.
+
+The [Example use cases](#example-use-cases) section below shows how to set these configuration parameters.
+
+# Configuration parameter reference
+## ca\_certificate\_path
+Path (relative to the `$DCOS_INSTALL_DIR`) to a file containing a single X.509 CA certificate in the OpenSSL PEM format. For example: `genconf/dcos-ca-certificate.crt`. It is either a *root CA certificate* (“self-signed”) or an *intermediate CA certificate* (“cross-certificate”) signed by some other certificate authority.
+
+If provided, this is the custom CA certificate. It is used as the signing CA certificate, i.e., the DC/OS CA will use this certificate for signing end-entity certificates (the subject of this certificate will be the issuer for certificates signed by the DC/OS CA). If not provided, the DC/OS cluster generates a unique root CA certificate during the initial bootstrap phase and uses that as the signing CA certificate.
+
+The public key associated with the custom CA certificate must be of type RSA.
+
+## ca\_certificate\_key\_path
+Path (relative to the `$DCOS_INSTALL_DIR`) to a file containing the private key corresponding to the custom CA certificate, encoded in the OpenSSL (PKCS#8) PEM format. For example: `genconf/CA_cert.key`.
+
+**Note**: this is highly sensitive data. The configuration processor accesses this file only for configuration validation purposes, and does not copy the data. After successful configuration validation this file needs to be placed out-of-band into the file system of all DC/OS master nodes to the path `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` before most DC/OS systemd units start up. The file must be readable by the root user, and should have have 0600 permissions set.
+
+Required if `ca_certificate_path` is specified.
+
+## ca\_certificate\_chain\_path
+Path (relative to the `$DCOS_INSTALL_DIR`) to a file containing the complete CA certification chain required for end-entity certificate verification, in the OpenSSL PEM format. For example: `genconf/CA_cert_chain.pem`.
+
+The parameter must be left undefined if `ca_certificate_path` points to a root CA certificate.
+Required if `ca_certificate_path` is specified and if the custom CA certificate is an *intermediate CA certificate*. 
+
+For an intermediate CA, this needs to point to a file containing all CA certificates comprising the complete sequence starting precisely with the CA certificate that was used to sign the custom CA certificate and ending with a root CA certificate (where issuer and subject are equivalent), yielding a gapless certification path. The order is significant and the list must contain at least one certificate.
+
+
+# Installing DC/OS Enterprise with a custom CA certificate
+## Starting point
+Based on the requirements described above, this is the starting point for the installation:
+
+- The installation of DC/OS Enterprise via the Advanced Installer has been prepared according to the corresponding [documentation](/1.11/installing/ent/custom/advanced/). (up to the section **Install DC/OS** of that documentation)
+
+- On the bootstrap node, the files carrying custom CA certificate, the associated private key and, optionally, the CA certificate chain have been placed into the `$DCOS_INSTALL_DIR/genconf/` directory. (see the [section](#manually-placing-the-custom-ca-certificate-the-associated-private-key-and-the-certificate-chain-onto-the-bootstrap-node) above for more detailed description)
+
+- The private key associated with the custom CA certificate has been securely placed on all DC/OS master nodes (refer to [this section](#manually-placing-the-private-key-associated-with-the-custom-ca-certificate-onto-the-master-nodes) for more details). Example (command issued on one of the DC/OS master nodes):
+
+```bash
+stat /var/lib/dcos/pki/tls/CA/private/custom_ca.key
+```
+```bash
+File: ‘/var/lib/dcos/pki/tls/CA/private/custom_ca.key’
+Size: 9             Blocks: 8          IO Block: 4096   regular file
+Device: ca01h/51713d    Inode: 100671105   Links: 1
+Access: (0600/-rw-------)  Uid: (    0/    root)   Gid: (    0/    root)
+Context: unconfined_u:object_r:var_lib_t:s0
+Access: 2017-12-27 12:35:58.643278377 +0000
+Modify: 2017-12-27 12:35:58.643278377 +0000
+Change: 2017-12-27 12:36:13.019162417 +0000
+Birth: -
+```
+
+- The configuration parameters `ca_certificate_path`, `ca_certificate_key_path` and `ca_certificate_chain_path` are specified in the DC/OS configuration file `$DCOS_INSTALL_DIR/genconf/config.yaml` and point to the relevant locations in the file system. Example (commands issued on the bootstrap node):
+
+```bash
+cd $DCOS_INSTALL_DIR
+cat genconf/config.yaml
+```
+```bash
+[...]
+ca_certificate_path: genconf/dcos-ca-certificate.crt
+ca_certificate_key_path: genconf/dcos-ca-certificate-key.key
+ca_certificate_chain_path: genconf/dcos-ca-certificate-chain.crt
+[...]
+```
+Note that `ca_certificate_chain_path` must not be present when setting up DC/OS Enterprise with a root certificate as the custom CA certificate.
+
+## Installation
+Proceed with the installation as described in the [documentation of the Advanced Installer](/1.11/installing/ent/custom/advanced/#install-dcos).
+Note that the current working directory when executing `dcos_generate_config.ee.sh` must be the `$DCOS_INSTALL_DIR` directory.
+
+## Verify installation
+One method of verifying that the DC/OS Enterprise cluster was installed properly with the custom CA certificate is to initiate a TLS connection to Admin Router which, after installation, will present a certificate signed by the custom CA. 
+
+In order to do that you first need to obtain the DC/OS CA bundle of the deployed cluster. [This page](/1.11/security/ent/tls-ssl/get-cert/) shows how you can do that.
+
+Provided you have obtained the DC/OS CA bundle and stored it in a file named `dcos-ca.crt`, issue the following command in the directory containing the `dcos-ca.crt` file in order to check that Admin Router on a master node uses a certificate signed by the custom CA:
+
+```bash
+openssl s_client -verify_ip <private_ip_master_node_X> -CAfile dcos-ca.crt -connect <public_ip_master_node_X>:443 | grep -e "s:" -e "i:" -e "return code:"
+```
+
+The output should look similar to the following:
+
+```bash
+depth=3 DC = io, DC = integration-test, C = DE, ST = Utopia, O = DC/OS, OU = Programmer Unit, CN = Integration Test Root CA
+verify return:1
+depth=2 DC = io, DC = integration-test, C = DE, ST = Utopia, O = DC/OS, OU = Programmer Unit, CN = Integration Test Intermediate CA 01
+verify return:1
+depth=1 DC = io, DC = integration-test, C = DE, ST = Utopia, O = DC/OS, OU = Programmer Unit, CN = Integration Test Intermediate CA 02
+verify return:1
+depth=0 C = US, ST = CA, L = San Francisco, O = "Mesosphere, Inc.", CN = AdminRouter on 172.31.12.45
+verify return:1
+ 0 s:/C=US/ST=CA/L=San Francisco/O=Mesosphere, Inc./CN=AdminRouter on 172.31.12.45
+   i:/DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 02
+ 1 s:/DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 02
+   i:/DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 01
+ 2 s:/DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 01
+   i:/DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+    Verify return code: 0 (ok)
+```
+
+# Example use cases
+This section describes how the three configuration parameters `ca_certificate_path`, `ca_certificate_key_path` and `ca_certificate_chain_path` must be specified in the `$DCOS_INSTALL_DIR/genconf/config.yaml` DC/OS configuration file for the most common use cases of a custom CA certificate hierarchy.
+
+## Use case 1: The custom CA certificate is a root CA certificate
+In this case the custom CA certificate is a (self-signed) root CA certificate. The CA does not have a “parent” CA, hence the CA certificate chain is empty.
+
+The following files are present:
+
+- on the bootstrap node:
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate.crt` file containing the custom CA certificate
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate-key.key` file containing the private key associated with the custom CA certificate
+
+- on the master nodes:
+    - `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` file containing the private key associated with the custom CA certificate.
+
+Here is an example of the `issuer` and `subject` fields of a custom root CA certificate:
+
+```bash
+cd $DCOS_INSTALL_DIR
+openssl x509 -in genconf/dcos-ca-certificate.crt -issuer -subject -noout
+```
+```bash
+issuer= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+subject= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+```
+
+Since the custom CA certificate is a root CA certificate and the corresponding CA certificate chain is empty, we must omit the `ca_certificate_chain_path` parameter in the DC/OS configuration file. The configuration parameters must be specified as follows in the `$DCOS_INSTALL_DIR/genconf/config.yaml` file on the bootstrap node:
+
+```bash
+ca_certificate_path: genconf/dcos-ca-certificate.crt
+ca_certificate_key_path: genconf/dcos-ca-certificate-key.key
+```
+
+## Use case 2: The custom CA certificate is an intermediate CA certificate, directly issued by a root CA
+
+In this case the custom CA certificate is an intermediate one, issued directly by a root CA. The CA certificate chain consists of just that root CA certificate.
+
+The following files are present:
+
+- on the bootstrap node:
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate.crt` file containing the custom CA certificate in PEM format
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate-key.key` file containing the private key associated with the custom CA certificate in the PKCS#8 format
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate-chain.crt` file containing the certificate chain in PEM format
+
+- on the master nodes
+    - `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` file containing the private key associated with the custom CA certificate in the PKCS#8 format.
+
+Here is an example of an appropriate intermediate custom CA certificate: 
+
+```bash
+cd $DCOS_INSTALL_DIR
+openssl x509 -in genconf/dcos-ca-certificate.crt -issuer -subject -noout
+```
+```bash
+issuer= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+subject= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 01
+```
+ 
+Here is an example of a corresponding CA certificate chain:  
+
+```bash 
+cd $DCOS_INSTALL_DIR
+cat genconf/dcos-ca-certificate-chain.crt | awk -v cmd="openssl x509 -issuer -subject -noout && echo" '/-----BEGIN/ { c = $0; next } c { c = c "\n" $0 } /-----END/ { print c|cmd; close(cmd); c = 0 }'
+```
+```bash
+issuer= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+subject= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+```
+
+The configuration parameters must be specified similar to the following in the `$DCOS_INSTALL_DIR/genconf/config.yaml` DC/OS configuration file on the bootstrap node:
+
+```bash
+ca_certificate_path: genconf/dcos-ca-certificate.crt
+ca_certificate_key_path: genconf/dcos-ca-certificate-key.key
+ca_certificate_chain_path: genconf/dcos-ca-certificate-chain.crt
+```
+
+## Use case 3: The custom CA certificate is an intermediate CA certificate issued by another intermediate CA
+
+In this case the custom CA certificate is an intermediate one, issued directly by another intermediate CA that, in turn, has its certificate issued by a root CA. 
+
+The CA certificate chain is comprised of the **1)** CA certificate of the issuing intermediate CA and **2)** the root CA, in the given order.
+
+The following files are present:
+
+- on the bootstrap node:
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate.crt` file containing the custom CA certificate in PEM format
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate-key.key` file containing the private key associated with the custom CA certificate in the PKCS#8 format
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-certificate-chain.crt` file containing the certificate chain in PEM format
+
+- on the master nodes
+    - `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` file containing the private key associated with the custom CA certificate in the PKCS#8 format.
+ 
+Here is an example of an appropriate custom intermediate CA certificate: 
+
+```bash
+cd $DCOS_INSTALL_DIR
+openssl x509 -in genconf/dcos-ca-certificate.crt -issuer -subject -noout
+```
+```bash
+issuer= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 01
+subject= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 02
+```
+
+Here is an example of a corresponding CA certificate chain: 
+
+```bash
+cd $DCOS_INSTALL_DIR
+cat genconf/dcos-ca-certificate-chain.crt | awk -v cmd="openssl x509 -issuer -subject -noout && echo" '/-----BEGIN/ { c = $0; next } c { c = c "\n" $0 } /-----END/ { print c|cmd; close(cmd); c = 0 }'
+```
+```bash
+issuer= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+subject= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Intermediate CA 01
+
+issuer= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+subject= /DC=io/DC=integration-test/C=DE/ST=Utopia/O=DC/OS/OU=Programmer Unit/CN=Integration Test Root CA
+
+
+```
+
+The configuration parameters must be specified as follows in the `$DCOS_INSTALL_DIR/genconf/config.yaml` DC/OS configuration file on the bootstrap node:
+
+```bash
+ca_certificate_path: genconf/dcos-ca-certificate.crt
+ca_certificate_key_path: genconf/dcos-ca-certificate-key.key
+ca_certificate_chain_path: genconf/dcos-ca-certificate-chain.crt
+```


### PR DESCRIPTION
## Description
This PR updates the documentation on EE DC/OS v1.11 installation with a custom CA certificate. The update is similar to the earlier PR (https://github.com/mesosphere/dcos-docs-site/pull/385) on EE DC/OS v1.10 documentation.

https://jira.mesosphere.com/browse/DCOS-19638

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ X] High
- [ ] Medium
