### PR TITLE
Removed references to out-of-date tool.

### DIFF
--- a/pages/1.11/monitoring/debugging/stuck-deployment/index.md
+++ b/pages/1.11/monitoring/debugging/stuck-deployment/index.md
@@ -47,4 +47,4 @@ There are several reasons why your service or pod may fail to deploy. Some possi
   ```
 
 - Your application or application group definition is otherwise badly configured.
-  The DC/OS web interface performs some validation of Marathon application and pod definitions. You can also use the [marathon-validate](https://github.com/dcos-labs/marathon-validate) script to validate your app or group definition locally, before you deploy it to DC/OS.
+  The DC/OS web interface performs some validation of Marathon application and pod definitions.


### PR DESCRIPTION
We are trying to update the tool for supporting the new marathon raml api definitions, but currently it is outdated.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
