### PR TITLE
Fix some CLI versions

### DIFF
--- a/pages/1.10/cli/index.md
+++ b/pages/1.10/cli/index.md
@@ -54,14 +54,14 @@ dcos --version
 <a name="configuration-files"></a>
 # DC/OS CLI versions and configuration files
 
-DC/OS CLI 0.4.x and 0.5.x use a different structure for the location of configuration files. 
+DC/OS CLI 0.4.x and 0.5.x use a different structure for the location of configuration files.
 
 DC/OS CLI 0.4.x has a single configuration file, which by default is stored in `~/.dcos/dcos.toml`. In DC/OS CLI 0.4.x you can optionally change the location of the configuration file using the [`DCOS_CONFIG`](#dcos-config) environment variable.
 
 DC/OS CLI 0.5.x has a configuration file for each connected cluster, which by default are stored in `~/.dcos/clusters/<cluster_id>/dcos.toml`. In DC/OS CLI 0.5.x you can optionally change the base portion (`~/.dcos`) of the configuration directory using the [`DCOS_DIR`](#dcos-dir) environment variable.
 
 **Note:**
-- Updating to the DC/OS CLI 0.5.x and running any CLI command triggers conversion from the old to the new configuration structure. 
+- Updating to the DC/OS CLI 0.5.x and running any CLI command triggers conversion from the old to the new configuration structure.
 - After you call `dcos cluster setup`, (or after conversion has occurred), if you attempt to update the cluster configuration using a `dcos config set` command, the command prints a warning message saying the command is deprecated and cluster configuration state may now be corrupted.
 
 # Environment variables

--- a/pages/1.10/cli/index.md
+++ b/pages/1.10/cli/index.md
@@ -69,7 +69,7 @@ DC/OS CLI 0.5.x has a configuration file for each connected cluster, which by de
 The DC/OS CLI supports the following environment variables, which can be set dynamically.
 
 <a name="dcos-cluster"></a>
-#### `DCOS_CLUSTER` (DC/OS CLI O.5.x and higher only)
+#### `DCOS_CLUSTER` (DC/OS CLI 0.5.x and higher only)
 
 The [attached](/1.10/cli/command-reference/dcos-cluster/dcos-cluster-attach/) cluster. To set the attached cluster, set the variable with the command:
 
@@ -78,7 +78,7 @@ export DCOS_CLUSTER=<cluster_name>
 ```
 
 <a name="dcos-config"></a>
-#### `DCOS_CONFIG` (DC/OS CLI O.4.x only)
+#### `DCOS_CONFIG` (DC/OS CLI 0.4.x only)
 
 The path to a DC/OS configuration file. If you put the DC/OS configuration file in `/home/jdoe/config/dcos.toml`, set the variable with the command:
 
@@ -93,7 +93,7 @@ If you have the `DCOS_CONFIG` environment variable configured:
 
 
 <a name="dcos-dir"></a>
-#### `DCOS_DIR` (DC/OS CLI O.5.x and higher only)
+#### `DCOS_DIR` (DC/OS CLI 0.5.x and higher only)
 
 The path to a DC/OS configuration directory. If you want the DC/OS configuration directory to be `/home/jdoe/config`, set the variable with the command:
 

--- a/pages/1.11/cli/index.md
+++ b/pages/1.11/cli/index.md
@@ -69,7 +69,7 @@ DC/OS CLI 0.5.x has a configuration file for each connected cluster, which by de
 The DC/OS CLI supports the following environment variables, which can be set dynamically.
 
 <a name="dcos-cluster"></a>
-#### `DCOS_CLUSTER` (DC/OS CLI O.5.x and higher only)
+#### `DCOS_CLUSTER` (DC/OS CLI 0.5.x and higher only)
 
 The [attached](/1.10/cli/command-reference/dcos-cluster/dcos-cluster-attach/) cluster. To set the attached cluster, set the variable with the command:
 
@@ -78,7 +78,7 @@ export DCOS_CLUSTER=<cluster_name>
 ```
 
 <a name="dcos-config"></a>
-#### `DCOS_CONFIG` (DC/OS CLI O.4.x only)
+#### `DCOS_CONFIG` (DC/OS CLI 0.4.x only)
 
 The path to a DC/OS configuration file. If you put the DC/OS configuration file in `/home/jdoe/config/dcos.toml`, set the variable with the command:
 
@@ -93,7 +93,7 @@ If you have the `DCOS_CONFIG` environment variable configured:
 
 
 <a name="dcos-dir"></a>
-#### `DCOS_DIR` (DC/OS CLI O.5.x and higher only)
+#### `DCOS_DIR` (DC/OS CLI 0.5.x and higher only)
 
 The path to a DC/OS configuration directory. If you want the DC/OS configuration directory to be `/home/jdoe/config`, set the variable with the command:
 

--- a/pages/1.11/cli/index.md
+++ b/pages/1.11/cli/index.md
@@ -54,14 +54,14 @@ dcos --version
 <a name="configuration-files"></a>
 # DC/OS CLI versions and configuration files
 
-DC/OS CLI 0.4.x and 0.5.x use a different structure for the location of configuration files. 
+DC/OS CLI 0.4.x and 0.5.x use a different structure for the location of configuration files.
 
 DC/OS CLI 0.4.x has a single configuration file, which by default is stored in `~/.dcos/dcos.toml`. In DC/OS CLI 0.4.x you can optionally change the location of the configuration file using the [`DCOS_CONFIG`](#dcos-config) environment variable.
 
 DC/OS CLI 0.5.x has a configuration file for each connected cluster, which by default are stored in `~/.dcos/clusters/<cluster_id>/dcos.toml`. In DC/OS CLI 0.5.x you can optionally change the base portion (`~/.dcos`) of the configuration directory using the [`DCOS_DIR`](#dcos-cdir) environment variable.
 
 **Note:**
-- Updating to the DC/OS CLI 0.5.x and running any CLI command triggers conversion from the old to the new configuration structure. 
+- Updating to the DC/OS CLI 0.5.x and running any CLI command triggers conversion from the old to the new configuration structure.
 - After you call `dcos cluster setup`, (or after conversion has occurred), if you attempt to update the cluster configuration using a `dcos config set` command, the command prints a warning message saying the command is deprecated and cluster configuration state may now be corrupted.
 
 # Environment variables


### PR DESCRIPTION
Some CLI versions are spelled with O instead if 0.
