### PR TITLE
Speed up rendering, improve output while rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,9 +178,21 @@ CB.use(permalinks())
 CB.use(timer('CB: Permalinks'))
 
 // Layouts
-CB.use(layouts({
-  engine: 'pug'
-}))
+if(!process.env.RENDER_PATH_PATTERN) {
+  // Default: Render all pages.
+  CB.use(layouts({
+    engine: 'pug',
+    cache: true,
+  }))
+} else {
+  // Dev optimization: Only render within a specific path (much faster turnaround)
+  // For example, "services/beta-cassandra/latest/**"
+  CB.use(layouts({
+    engine: 'pug',
+    pattern: process.env.RENDER_PATH_PATTERN,
+    cache: true,
+  }))
+}
 CB.use(timer('CB: Layouts'))
 
 //
@@ -201,7 +213,7 @@ if(ALGOLIA_UPDATE == "true") {
     index: ALGOLIA_INDEX,
     clearIndex: (ALGOLIA_CLEAR_INDEX != undefined) ? (ALGOLIA_CLEAR_INDEX == "true") : true,
   }))
-  CB.use(timer('Algolia'));
+  CB.use(timer('CB: Algolia'));
 }
 
 // Enable watching
@@ -214,6 +226,7 @@ if(process.env.NODE_ENV === 'development') {
       },
     })
   )
+  CB.use(timer('CB: Watch'));
 }
 
 // WkhtmltopdfLinkResolver

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "node": "8.1.2"
   },
   "scripts": {
-    "dev": "NODE_ENV=development DEBUG=metalsmith-timer,metalsmith-revision,metalsmith-algolia node index.js",
-    "build": "NODE_ENV=production DEBUG=metalsmith-timer,metalsmith-algolia node index.js",
-    "build-pdf": "NODE_ENV=pdf DEBUG=metalsmith-timer node index.js",
+    "dev": "NODE_ENV=development DEBUG=metalsmith-timer,metalsmith-algolia,metalsmith-layouts node index.js",
+    "build": "NODE_ENV=production DEBUG=metalsmith-timer,metalsmith-algolia,metalsmith-layouts node index.js",
+    "build-pdf": "NODE_ENV=pdf DEBUG=metalsmith-timer,metalsmith-algolia,metalsmith-layouts node index.js",
     "webpack": "webpack --progress --colors",
     "eslint": "eslint js/**.js",
     "eslint-init": "eslint --init",


### PR DESCRIPTION
## Description

Rendering tweaks to speed up rendering:
- Improve rendering speed with `cache: true`: I found this sped up the rendering step from 5 minutes to 2 minutes on my (pretty beefy) laptop.
- Adds a developer option to specify a subset of pages to be rendered. Useful when making local edits and just want to verify those changes.
- Also adds some timer calls where they were previously missing.

Console output tweaks to display progress while rendering:
- Add `metalsmith-layouts`: As layouts are being rendered, print something to the console, rather than going totally silent for potentially several minutes
- Remove `metalsmith-revision`: Didn't find this output to be useful when rendering in dev mode.
- Also updates the `build-pdf` step to match the others.

## Urgency
- [ ] Blocker
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
