### PR TITLE
Master

### DIFF
--- a/pages/1.10/administering-clusters/update-a-node/index.md
+++ b/pages/1.10/administering-clusters/update-a-node/index.md
@@ -48,6 +48,8 @@ You can define a maintenance schedule to evacuate your tasks prior to changing a
     
     For a more complex example, see the [maintain-agents.sh](https://github.com/vishnu2kmohan/dcos-toolbox/blob/master/mesos/maintain-agents.sh) script.
  
+1.  Invoke the `⁠⁠⁠⁠maintenance/schedule` endpoint with the maintenance schedule JSON definition as described above. For example, [here](https://github.com/vishnu2kmohan/dcos-toolbox/blob/master/mesos/get-maintenance-schedule.sh) is a script that calls `⁠⁠⁠⁠maintenance/schedule` using GET, but you'll need to POST the JSON to trigger the maintenance mode.
+ 
 1.  Invoke the `⁠⁠⁠⁠machine/down` endpoint with the machine JSON definition specified. For example, [here](https://github.com/vishnu2kmohan/dcos-toolbox/blob/master/mesos/down-agents.sh) is a script that calls `/machine/down/`. 
 
     **Important:** Invoking `machine/down` sends a `⁠⁠⁠⁠TASK_LOST`⁠⁠⁠⁠ message for any tasks that were running on the agent. Some DC/OS services, for example Marathon, will relocate tasks, but others will not, for example Kafka and Cassandra. For more information, see the DC/OS [service guides](/services/) and the Mesos maintenance primitives [documentation](https://mesos.apache.org/documentation/latest/maintenance/).

--- a/pages/1.9/administering-clusters/update-a-node/index.md
+++ b/pages/1.9/administering-clusters/update-a-node/index.md
@@ -47,6 +47,8 @@ You can define a maintenance schedule to evacuate your tasks prior to changing a
     ```
     
     For a more complex example, see the [maintain-agents.sh](https://github.com/vishnu2kmohan/dcos-toolbox/blob/master/mesos/maintain-agents.sh) script.
+    
+1.  Invoke the `⁠⁠⁠⁠maintenance/schedule` endpoint with the maintenance schedule JSON definition as described above. For example, [here](https://github.com/vishnu2kmohan/dcos-toolbox/blob/master/mesos/get-maintenance-schedule.sh) is a script that calls `⁠⁠⁠⁠maintenance/schedule` using GET, but you'll need to POST the JSON to trigger the maintenance mode.
  
 1.  Invoke the `⁠⁠⁠⁠machine/down` endpoint with the machine JSON definition specified. For example, [here](https://github.com/vishnu2kmohan/dcos-toolbox/blob/master/mesos/down-agents.sh) is a script that calls `/machine/down/`. 
 


### PR DESCRIPTION
add missing step for setting maintenance mode on machines. 
This step is mandatory before running `machine/down` on them.

## Description
docs left out a crucial step that must be performed before running `machine/down`. added clarification.

## Urgency
- [ ] Blocker
- [ ] High
- [X] Medium

## Requirements
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11)

## Affects
- 1.9
- 1.10
