### PR TITLE
Used beta-storage consistently in the doc

### DIFF
--- a/pages/services/beta-storage/0.1.0-beta/cli-references/dcos-storage-volume/index.md
+++ b/pages/services/beta-storage/0.1.0-beta/cli-references/dcos-storage-volume/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: CLI References
-title: CLI References
+navigationTitle: dcos storage volume
+title: dcos storage volume
 menuWeight: 40
 excerpt:
 ---

--- a/pages/services/beta-storage/0.1.0-beta/install/index.md
+++ b/pages/services/beta-storage/0.1.0-beta/install/index.md
@@ -82,7 +82,7 @@ EOF
 :; dcos package repo add storage-artifacts-<SHA> http://storage-artifacts<SHA>.marathon.l4lb.thisdcos.directory:10000/repo.json --index=0
 
 4. Install the package
-:; dcos package install storage --package-version=<VERSION>
+:; dcos package install beta-storage --package-version=<VERSION>
 ```
 
 Follow the instructions and push the newly built docker image to a docker registry accessible in the cluster.
@@ -141,7 +141,7 @@ When the above step is successful, install the DSS package by using the below co
 This command will install the DC/OS storage sub-command.
 
 ```bash
-$ dcos package install storage --package-version=<VERSION>
+$ dcos package install beta-storage --package-version=<VERSION>
 ```
 
 # Verify that the DSS is running

--- a/pages/services/beta-storage/0.1.0-beta/uninstall/index.md
+++ b/pages/services/beta-storage/0.1.0-beta/uninstall/index.md
@@ -11,7 +11,7 @@ excerpt:
 You can simply uninstall the DSS using the following command:
 
 ```bash
-$ dcos package uninstall storage
+$ dcos package uninstall beta-storage
 ```
 
 # Uninstall the local universe


### PR DESCRIPTION
## Description

Given that storage service is still beta, use beta-storage for the package name.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
