### PR TITLE
Updated storage service install doc about download site

### DIFF
--- a/pages/services/beta-storage/0.1.0-beta/install/index.md
+++ b/pages/services/beta-storage/0.1.0-beta/install/index.md
@@ -1,5 +1,4 @@
----
-layout: layout.pug
+--- layout: layout.pug
 navigationTitle:  Install
 title: Install
 menuWeight: 30
@@ -11,6 +10,11 @@ excerpt:
 - DC/OS Enterprise 1.11 or above.
 - Storage feature flag is turned ON (`feature_dcos_storage_enabled: true` in config.yaml).
 - [DC/OS CLI](/latest/cli/install/) is installed and has been logged in as a superuser.
+
+# Download the package tarball
+
+DC/OS Storage Service (DSS) is packaged as a tarball.
+The tarball can be downloaded from [Mesosphere support site](https://support.mesosphere.com/hc/en-us/articles/213198586).
 
 # Build the local universe and artifacts server
 


### PR DESCRIPTION
## Description

Mentioned that storage service package can be downloaded from the support site.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
