### PR TITLE
Changed ordering of Kubernetes docs on services landing page.

### DIFF
--- a/pages/services/kubernetes/index.md
+++ b/pages/services/kubernetes/index.md
@@ -2,11 +2,10 @@
 layout: layout.pug
 navigationTitle:  Kubernetes
 title: Kubernetes
-menuWeight: 170
+menuWeight: 75
 excerpt:
 featureMaturity:
 enterprise: false
 ---
 
 Welcome to the documentation for Kubernetes. Choose a version to get started!
-


### PR DESCRIPTION
## Description
Change ordering of Kubernetes docs to be alphabetical. 

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
