### PR TITLE
Fixes to storage CLI reference

### DIFF
--- a/pages/services/beta-storage/0.1.0-beta/cli-references/dcos-storage-profile/index.md
+++ b/pages/services/beta-storage/0.1.0-beta/cli-references/dcos-storage-profile/index.md
@@ -184,14 +184,14 @@ $ dcos storage profile list --json
 {
     "profiles": [
         {
-            "name": "logs",
-            "description": "spun down drives for log archives",
+            "name": "fast",
+            "description": "fast storage",
             "spec": {
                 "provider-selector": {
                     "plugin": "lvm",
                     "matches": {
                         "labels": {
-                            "rotational": "true"
+                            "rotational": "false"
                         }
                     }
                 },
@@ -204,14 +204,14 @@ $ dcos storage profile list --json
             }
         },
         {
-            "name": "fast",
-            "description": "fast storage",
+            "name": "logs",
+            "description": "spun down drives for log archives",
             "spec": {
                 "provider-selector": {
                     "plugin": "lvm",
                     "matches": {
                         "labels": {
-                            "rotational": "false"
+                            "rotational": "true"
                         }
                     }
                 },

--- a/pages/services/beta-storage/0.1.0-beta/cli-references/dcos-storage-volume/index.md
+++ b/pages/services/beta-storage/0.1.0-beta/cli-references/dcos-storage-volume/index.md
@@ -33,7 +33,7 @@ For example, if you have a profile called `fast`, which is configured to represe
 ## Usage
 
 ```bash
-$ dcos storage volume create [<name> <size> <profile>] [flags]
+$ dcos storage volume create <name> <size> <profile> [flags]
 ```
 
 ## Flags


### PR DESCRIPTION
## Description
This PR updates the storage CLI reference in response to the work done in https://jira.mesosphere.com/browse/DSS_EE-114.

It removes 'optional' markers around the `volume create` parameters. It also fixes the order in `profile list`. 

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
