### PR TITLE
docs(kubernetes): placement constraints not supported

### DIFF
--- a/pages/services/kubernetes/1.0.0-1.9.3/limitations/index.md
+++ b/pages/services/kubernetes/1.0.0-1.9.3/limitations/index.md
@@ -11,7 +11,8 @@ excerpt:
 
 Currently, the DC/OS Kubernetes package has the following limitations:
 
-* Strict-mode DC/OS is not supported.
+* Strict-mode DC/OS is not yet supported.
+* Placement constraints are not yet supported.
 * There can only be **one** Kubernetes cluster per DC/OS cluster.
 * There can only be **one** Kubernetes worker node per DC/OS agent.
 * DC/OS and Mesos tasks can only reach Kubernetes Service(s) if `kube-proxy` is running on the same DC/OS agent where the request originates from.


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->
Adding to limitations based on field feedback.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
