### PR TITLE
Fix content so ordered list closes

### DIFF
--- a/pages/1.11/security/ent/gui-permissions/services-tab/index.md
+++ b/pages/1.11/security/ent/gui-permissions/services-tab/index.md
@@ -36,74 +36,74 @@ You can grant users access to the Services tab. By default, new users have no pe
 
 1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.11/security/ent/#security-modes) and click **ADD PERMISSIONS** and then **Close**.
 
-    ## Disabled
-    
-    ### Services tab 
-    
-    ```bash
-    dcos:adminrouter:service:marathon full
-    ```
-    
-    ### Services tasks
-    
-    ```bash
-    dcos:adminrouter:ops:mesos full
-    ```
-    
-    ### Task details and logs
-    
-    ```bash
-    dcos:adminrouter:ops:slave full
-    ```
-    
-    ## Permissive
-    
-    ### Services tab
-    
-    ```
-    dcos:adminrouter:service:marathon full
-    dcos:service:marathon:marathon:services:/ full
-    ```
-    
-    ### Services tasks
-    
-    ```
-    dcos:adminrouter:ops:mesos full
-    ```
-    
-    ### Task details and logs
-    
-    ```
-    dcos:adminrouter:ops:slave full
-    ```
+## Disabled
 
-    ## Strict
+### Services tab 
 
-    ### Services tab
-    
-    ```
-    dcos:adminrouter:service:marathon full
-    dcos:service:marathon:marathon:services:/ full
-    ```
-    
-    ### Services tasks
-    
-    ```
-    dcos:adminrouter:ops:mesos full
-    ```
-    
-    ### Task details and logs
-    
-    ```
-    dcos:adminrouter:ops:slave full
-    dcos:mesos:master:framework:role:slave_public read
-    dcos:mesos:master:executor:app_id read
-    dcos:mesos:master:task:app_id read
-    dcos:mesos:agent:framework:role:slave_public read
-    dcos:mesos:agent:executor:app_id read
-    dcos:mesos:agent:task:app_id read
-    dcos:mesos:agent:sandbox:app_id read
-    ```
+```bash
+dcos:adminrouter:service:marathon full
+```
+
+### Services tasks
+
+```bash
+dcos:adminrouter:ops:mesos full
+```
+
+### Task details and logs
+
+```bash
+dcos:adminrouter:ops:slave full
+```
+
+## Permissive
+
+### Services tab
+
+```
+dcos:adminrouter:service:marathon full
+dcos:service:marathon:marathon:services:/ full
+```
+
+### Services tasks
+
+```
+dcos:adminrouter:ops:mesos full
+```
+
+### Task details and logs
+
+```
+dcos:adminrouter:ops:slave full
+```
+
+## Strict
+
+### Services tab
+
+```
+dcos:adminrouter:service:marathon full
+dcos:service:marathon:marathon:services:/ full
+```
+
+### Services tasks
+
+```
+dcos:adminrouter:ops:mesos full
+```
+
+### Task details and logs
+
+```
+dcos:adminrouter:ops:slave full
+dcos:mesos:master:framework:role:slave_public read
+dcos:mesos:master:executor:app_id read
+dcos:mesos:master:task:app_id read
+dcos:mesos:agent:framework:role:slave_public read
+dcos:mesos:agent:executor:app_id read
+dcos:mesos:agent:task:app_id read
+dcos:mesos:agent:sandbox:app_id read
+```
 
 # <a name="services-access-via-api"></a>Granting Access by using the API
 


### PR DESCRIPTION
The indentation here is was causing the ordered list not to close after the `Copy and paste the permission...` list item, which means headings were displaying inline instead of one after another.

This should fix that.

Before
![image](https://user-images.githubusercontent.com/15963/37182445-30f3fc3c-22e6-11e8-9e4d-d1154f92bbec.png)

After
![image](https://user-images.githubusercontent.com/15963/37182512-7e08f716-22e6-11e8-8eaf-8f5269d16bee.png)

