### PR TITLE
Update prometheus port number across docs

### DIFF
--- a/pages/1.11/installing/ent/ports/index.md
+++ b/pages/1.11/installing/ent/ports/index.md
@@ -21,6 +21,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 |---|---|---|---|---|
 | 61003 | REX-Ray | `dcos-rexray.service` | agent/master (may change due to specific REX-Ray configuration)| agent/master (may change due to specific REX-Ray configuration) |
 | 61053 | Mesos DNS | `dcos-mesos-dns.service` | agent/master | master |
+| 61091 | dcos-metrics | `dcos-metrics-agent.service/dcos-metrics-master.service` | agent/master | agent/extra |
 | 61420 | Erlang Port Mapping Daemon (EPMD) | `dcos-epmd.service` | agent/master | agent/master |
 | 62053 | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
 | 62080 | Navstar | `dcos-navstar.service` | agent/master | agent/master |

--- a/pages/1.11/installing/oss/ports/index.md
+++ b/pages/1.11/installing/oss/ports/index.md
@@ -21,12 +21,12 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 |---|---|---|---|---|
 | 61003 | REX-Ray | `dcos-rexray.service` | agent/master (may change due to specific REX-Ray configuration)| agent/master (may change due to specific REX-Ray configuration) |
 | 61053 | Mesos DNS | `dcos-mesos-dns.service` | agent/master | master |
+| 61091 | dcos-metrics | `dcos-metrics-agent.service/dcos-metrics-master.service` | agent/master | agent/extra |
 | 61420 | Erlang Port Mapping Daemon (EPMD) | `dcos-epmd.service` | agent/master | agent/master |
 | 62053 | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
 | 62080 | Navstar | `dcos-navstar.service` | agent/master | agent/master |
 | 62501 | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
 | 62502 | Navstar | `dcos-navstar.service` | agent/master | agent/master |
-| 9273  | dcos-metrics | `dcos-metrics-agent.service/dcos-metrics-master.service` | agent/master | agent/extra |
 
 ### UDP
 

--- a/pages/1.11/metrics/index.md
+++ b/pages/1.11/metrics/index.md
@@ -22,7 +22,7 @@ DC/OS provides these types of metrics:
 
 The [Metrics API](/1.11/metrics/metrics-api/) exposes these areas.
 
-The DC/OS metrics component produces Prometheus metrics on port 9273, the same port as used as the default Prometheus port in Telegraf, obviating the need to run the Prometheus plugin supported for previous versions of DC/OS.
+The DC/OS metrics component produces Prometheus metrics on port 61091, obviating the need to run the Prometheus plugin supported for previous versions of DC/OS.
 
 All three metrics layers are aggregated by a collector which is shipped as part of the DC/OS distribution. This enables metrics to run on every host in the cluster. It is the main entry point to the metrics ecosystem, aggregating metrics sent to it by the Mesos Metrics module, or gathering host and container level metrics on the machine on which it runs. 
 


### PR DESCRIPTION
## Description
[DOCS-2472](https://jira.mesosphere.com/browse/DOCS-2472) - Update dcos-metrics port number

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
