### PR TITLE
Add master_external_loadbalancer config param to the config reference.

### DIFF
--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -36,6 +36,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
+| [master_external_loadbalancer](#master-external-loadbalancer)         | The DNS name for the load balancer.         |
 | [mesos_container_log_sink](#mesos-container-log-sink)                 | The log manager for containers (tasks). |
 | [platform](#platform)                                                 | The infrastructure platform. |
 | [public_agent_list](#public-agent-list)                               | A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.10/overview/concepts/#public-agent-node) host names.  |
@@ -388,6 +389,9 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 
 *  `master_dns_bindall: 'true'` The master DNS port is open. This is the default value.
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
+
+### master_external_loadbalancer
+The DNS name for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.10/security/ent/tls-ssl/).
 
 
 ### mesos_container_log_sink

--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -36,7 +36,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
-| [master_external_loadbalancer](#master-external-loadbalancer)         | The DNS name for the load balancer.         |
+| [master_external_loadbalancer](#master-external-loadbalancer)         | The DNS name or IP address for the load balancer.         |
 | [mesos_container_log_sink](#mesos-container-log-sink)                 | The log manager for containers (tasks). |
 | [platform](#platform)                                                 | The infrastructure platform. |
 | [public_agent_list](#public-agent-list)                               | A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.10/overview/concepts/#public-agent-node) host names.  |
@@ -391,7 +391,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.10/security/ent/tls-ssl/).
+The DNS name or IP address for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.10/security/ent/tls-ssl/).
 
 
 ### mesos_container_log_sink

--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -391,8 +391,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.10/security/ent/tls-ssl/) of the host on which the load balancer is running.
-
+The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.10/security/ent/tls-ssl/) of the Admin Router on the master nodes.
 
 ### mesos_container_log_sink
 

--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -391,7 +391,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name or IP address for the load balancer. If specified, this name is included in [DC/OS certificates](/1.10/security/ent/tls-ssl/).
+The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.10/security/ent/tls-ssl/) of the host on which the load balancer is running.
 
 
 ### mesos_container_log_sink

--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -391,7 +391,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name or IP address for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.10/security/ent/tls-ssl/).
+The DNS name or IP address for the load balancer. If specified, this name is included in [DC/OS certificates](/1.10/security/ent/tls-ssl/).
 
 
 ### mesos_container_log_sink

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -441,7 +441,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name or IP address for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.11/security/ent/tls-ssl/).
+The DNS name or IP address for the load balancer. If specified, this name is included in [DC/OS certificates](/1.11/security/ent/tls-ssl/).
 
 ### mesos_container_log_sink
 

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -441,7 +441,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name or IP address for the load balancer. If specified, this name is included in [DC/OS certificates](/1.11/security/ent/tls-ssl/).
+The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.11/security/ent/tls-ssl/) of the host on which the load balancer is running.
 
 ### mesos_container_log_sink
 

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -441,7 +441,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.11/security/ent/tls-ssl/) of the host on which the load balancer is running.
+The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.11/security/ent/tls-ssl/) of the Admin Router on the master nodes.
 
 ### mesos_container_log_sink
 

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -36,6 +36,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
+| [master_external_loadbalancer](#master-external-loadbalancer)         | The DNS name for the load balancer.        |
 | [mesos_container_log_sink](#mesos-container-log-sink)                 | The log manager for containers (tasks). |
 | [platform](#platform)                                                 | The infrastructure platform. |
 | [public_agent_list](#public-agent-list)                               | A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.11/overview/concepts/#public-agent-node) host names.  |
@@ -438,6 +439,9 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 
 *  `master_dns_bindall: 'true'` The master DNS port is open. This is the default value.
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
+
+### master_external_loadbalancer
+The DNS name for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.11/security/ent/tls-ssl/).
 
 ### mesos_container_log_sink
 

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -36,7 +36,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
-| [master_external_loadbalancer](#master-external-loadbalancer)         | The DNS name for the load balancer.        |
+| [master_external_loadbalancer](#master-external-loadbalancer)         | The DNS name or IP address for the load balancer.        |
 | [mesos_container_log_sink](#mesos-container-log-sink)                 | The log manager for containers (tasks). |
 | [platform](#platform)                                                 | The infrastructure platform. |
 | [public_agent_list](#public-agent-list)                               | A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.11/overview/concepts/#public-agent-node) host names.  |
@@ -441,7 +441,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 *  `master_dns_bindall: 'false'` The master DNS port is closed.
 
 ### master_external_loadbalancer
-The DNS name for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.11/security/ent/tls-ssl/).
+The DNS name or IP address for the load balancer.  If specified, this name is included in [DC/OS certificates](/1.11/security/ent/tls-ssl/).
 
 ### mesos_container_log_sink
 


### PR DESCRIPTION
## Description
This PR adds the configuration parameter `master_external_loadbalancer` to the configuration reference sections for DC/OS EE 1.10 and 1.11.
https://jira.mesosphere.com/browse/COPS-2114

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ x] High
- [ ] Medium
