### PR TITLE
[INFINITY-3273] Corrected slight error in HDFS client docs

### DIFF
--- a/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/quick-start/index.md
+++ b/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  List the contents.

--- a/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/quick-start/index.md
+++ b/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/quick-start/index.md
@@ -81,7 +81,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  List the contents.

--- a/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/quick-start/index.md
+++ b/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/quick-start/index.md
@@ -81,7 +81,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  List the contents.

--- a/pages/services/beta-hdfs/v1.3.2-2.6.0-cdh5.9.1-beta/quick-start/index.md
+++ b/pages/services/beta-hdfs/v1.3.2-2.6.0-cdh5.9.1-beta/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/beta-hdfs/v1.3.3-2.6.0-cdh5.11.0-beta/quick-start/index.md
+++ b/pages/services/beta-hdfs/v1.3.3-2.6.0-cdh5.11.0-beta/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/beta-hdfs/v2.0.0-2.6.0-cdh5.11.0/quick-start/index.md
+++ b/pages/services/beta-hdfs/v2.0.0-2.6.0-cdh5.11.0/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/hdfs/2.0.1-2.6.0-cdh5.11.0/quick-start/index.md
+++ b/pages/services/hdfs/2.0.1-2.6.0-cdh5.11.0/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/hdfs/2.0.2-2.6.0-cdh5.11.0/quick-start/index.md
+++ b/pages/services/hdfs/2.0.2-2.6.0-cdh5.11.0/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/hdfs/2.0.3-2.6.0-cdh5.11.0/quick-start/index.md
+++ b/pages/services/hdfs/2.0.3-2.6.0-cdh5.11.0/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/hdfs/2.0.4-2.6.0-cdh5.11.0/quick-start/index.md
+++ b/pages/services/hdfs/2.0.4-2.6.0-cdh5.11.0/quick-start/index.md
@@ -81,7 +81,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/hdfs/2.1.0-2.6.0-cdh5.11.0/quick-start/index.md
+++ b/pages/services/hdfs/2.1.0-2.6.0-cdh5.11.0/quick-start/index.md
@@ -84,7 +84,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `{{ model.serviceName }}` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  List the contents.

--- a/pages/services/hdfs/v1.3.0-2.6.0-cdh5.9.1/quick-start/index.md
+++ b/pages/services/hdfs/v1.3.0-2.6.0-cdh5.9.1/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    HDFS_SERVICE_NAME=<hdfs-name> chmod +x configure-hdfs.sh && ./configure-hdfs.sh
+    HDFS_SERVICE_NAME=<hdfs-name> chmod +x configure-hdfs.sh && /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.

--- a/pages/services/hdfs/v2.0.0-2.6.0-cdh5.11.0/quick-start/index.md
+++ b/pages/services/hdfs/v2.0.0-2.6.0-cdh5.11.0/quick-start/index.md
@@ -82,7 +82,7 @@ This tutorial will get you up and running in minutes with HDFS. You will install
     By default, the client is configured to be configured to connect to an HDFS service named `hdfs` and no further client configuration is required. If you want to configure with a different name, run this command with name (`<hdfs-name>`) specified:
 
     ```bash
-    $ HDFS_SERVICE_NAME=<hdfs-name> ./configure-hdfs.sh
+    $ HDFS_SERVICE_NAME=<hdfs-name> /configure-hdfs.sh
     ```
 
 1.  Navigate to the Hadoop installation directory and list the contents.


### PR DESCRIPTION
## Description
The quick start for the HDFS service have a small error in describing how to run the client. This fixes said error. The file being referenced lives at the root of the FS in the Docker image and not the working directory that's specified in the Dockerfile so when one enters the container, the `configure-hdfs.sh` file is referenced wrong by one level.

https://jira.mesosphere.com/browse/INFINITY-3273

## Urgency
- [ ] Blocker
- [ ] High
- [X] Medium
