### PR TITLE
kubernetes: fix tls image broken by dodgy import of latest docs

### DIFF
--- a/pages/services/kubernetes/1.0.1-1.9.4/advanced-install/index.md
+++ b/pages/services/kubernetes/1.0.1-1.9.4/advanced-install/index.md
@@ -150,7 +150,7 @@ only this version provides the mechanisms needed for PKI:
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
 implement TLS on Open DC/OS? The answer comes in the form of the diagram below:
 
-![alt text](/services/kubernetes/1.0.1-1.9.3/img/tls.png "TLS design")
+![alt text](/services/kubernetes/1.0.1-1.9.4/img/tls.png "TLS design")
 
 ### Leveraging Enterprise DC/OS PKI
 


### PR DESCRIPTION
Fixes https://jira.mesosphere.com/browse/DCOS-21664

- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).