### PR TITLE
[INFINITY-3026] Add limitations for toggling TLS on HDFS 

### DIFF
--- a/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/limitations/index.md
+++ b/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/limitations/index.md
@@ -42,3 +42,7 @@ Each service task has some number of environment variables, which are used to co
 ### Toggling Kerberos
 
 Kerberos authentication cannot be toggled (enabled / disabled). In order to enable or disable Kerberos, the service must be uninstalled and reinstalled with the desired configuration.
+
+### Toggling Transport Encryption
+
+Transport Encryption (TLS) cannot toggled (enabled / disabled). In order to enable or disable TLS, the service must be uninstalled and reinstalled with the desired configuration.

--- a/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/limitations/index.md
+++ b/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/limitations/index.md
@@ -45,3 +45,7 @@ DC/OS Zones allow the service to implement rack-awareness. When the service is d
 ### Toggling Kerberos
 
 Kerberos authentication cannot be toggled (enabled / disabled). In order to enable or disable Kerberos, the service must be uninstalled and reinstalled with the desired configuration.
+
+### Toggling Transport Encryption
+
+Transport Encryption (TLS) cannot toggled (enabled / disabled). In order to enable or disable TLS, the service must be uninstalled and reinstalled with the desired configuration.

--- a/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/limitations/index.md
+++ b/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/limitations/index.md
@@ -45,3 +45,7 @@ DC/OS Zones allow the service to implement rack-awareness. When the service is d
 ### Toggling Kerberos
 
 Kerberos authentication cannot be toggled (enabled / disabled). In order to enable or disable Kerberos, the service must be uninstalled and reinstalled with the desired configuration.
+
+### Toggling Transport Encryption
+
+Transport Encryption (TLS) cannot toggled (enabled / disabled). In order to enable or disable TLS, the service must be uninstalled and reinstalled with the desired configuration.

--- a/pages/services/hdfs/2.1.0-2.6.0-cdh5.11.0/limitations/index.md
+++ b/pages/services/hdfs/2.1.0-2.6.0-cdh5.11.0/limitations/index.md
@@ -23,4 +23,6 @@ DC/OS Zones allow the service to implement rack-awareness. When the service is d
 
 Kerberos authentication cannot be toggled (enabled / disabled). In order to enable or disable Kerberos, the service must be uninstalled and reinstalled with the desired configuration.
 
-<!-- TBD? ### Transport Encryption -->
+### Toggling Transport Encryption
+
+Transport Encryption (TLS) cannot toggled (enabled / disabled). In order to enable or disable TLS, the service must be uninstalled and reinstalled with the desired configuration.


### PR DESCRIPTION
## Description

This is a follow-up of #769 where the TLS limitations are also added.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
