### PR TITLE
Update networking ports documentation for 1.11

### DIFF
--- a/pages/1.11/installing/oss/ports/index.md
+++ b/pages/1.11/installing/oss/ports/index.md
@@ -19,22 +19,18 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 
 | Port | DC/OS Component | systemd Unit | Source | Destination |
 |---|---|---|---|---|
+| 53 | DC/OS Net | `dcos-net.service` | agent/master | agent/master |
 | 61003 | REX-Ray | `dcos-rexray.service` | agent/master (may change due to specific REX-Ray configuration)| agent/master (may change due to specific REX-Ray configuration) |
-| 61053 | Mesos DNS | `dcos-mesos-dns.service` | agent/master | master |
 | 61091 | dcos-metrics | `dcos-metrics-agent.service/dcos-metrics-master.service` | agent/master | agent/extra |
-| 61420 | Erlang Port Mapping Daemon (EPMD) | `dcos-epmd.service` | agent/master | agent/master |
-| 62053 | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
-| 62080 | Navstar | `dcos-navstar.service` | agent/master | agent/master |
-| 62501 | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
-| 62502 | Navstar | `dcos-navstar.service` | agent/master | agent/master |
+| 61420 | DC/OS Net | `dcos-net.service` | agent/master | agent/master |
+| 62080 | DC/OS Net | `dcos-net.service` | agent/master | agent/master |
+| 62501 | DC/OS Net | `dcos-net.service` | agent/master | agent/master |
 
 ### UDP
 
 | Port | DC/OS Component | systemd Unit | Source | Destination |
 |---|---|---|---|---|
-| 61053 | Mesos DNS | `dcos-mesos-dns.service`| agent/master | master |
-| 62053 | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
-| 64000 | Navstar | `dcos-navstar.service` | agent/master | agent/master |
+| 53 | DC/OS Net | `dcos-net.service` | agent/master | agent/master |
 
 **Note:** UDP port 123 is open for communication with NTP.
 
@@ -44,7 +40,6 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 
 | Port | DC/OS Component | systemd Unit | Source | Destination |
 |---|---|---|---|---|
-| 53    | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 1337  | DC/OS Secrets |  `dcos-secrets.service` [enterprise type="inline" size="small" /] | localhost| localhost(master) |
@@ -54,7 +49,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |
 | 8101  | DC/OS Identity and Access Manager | `dcos-bouncer.service` [enterprise type="inline" size="small" /] | localhost| localhost(master) |
-| 8123  | Mesos DNS | `dcos-mesos-dns.service` | agent/master | master |
+| 8123  | Mesos DNS | `dcos-mesos-dns.service` | localhost | localhost |
 | 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
 | 8200  | Vault | `dcos-vault.service` [enterprise type="inline" size="small" /] | localhost| localhost(master) |
 | 8443  | Marathon SSL | `dcos-marathon.service` | agent/master | master |
@@ -65,14 +60,15 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 15055 | DC/OS History | `dcos-history-service.service` | localhost| localhost(master) |
 | 15101 | Marathon libprocess | `dcos-marathon.service` | master | agent/master |
 | 15201 | DC/OS Jobs (Metronome) libprocess | `dcos-metronome.service`| master | agent/master |
-| 62500 | DC/OS Network Metrics | `dcos-networking_api.service` [enterprise type="inline" size="small" /] | master | master |
+| 61053 | Mesos DNS | `dcos-mesos-dns.service` | agent/master | master |
+| 61430 | DC/OS Net | `dcos-net.service` [enterprise type="inline" size="small" /] | agent/master | master |
 | Ephemeral | DC/OS Component Package Manager (Pkgpanda) | `dcos-pkgpanda-api.service` | None | None |
 
 ### UDP
 
 | Port | DC/OS Component | systemd Unit | Source | Destination |
 |---|---|---|---|---|
-| 53 | DNS Forwarder (Spartan) | `dcos-spartan.service` | agent/master | agent/master |
+| 61053 | Mesos DNS | `dcos-mesos-dns.service`| agent/master | master |
 
 ## Agent
 


### PR DESCRIPTION
## Description

https://jira.mesosphere.com/browse/COPS-2964
https://jira.mesosphere.com/browse/DCOS-21712
https://github.com/dcos/dcos/blob/1.11/docs/admin-ports.md

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).