### PR TITLE
configuration-parameters: add adminrouter_auth_check_enabled

### DIFF
--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -98,19 +98,8 @@ _This option was Added in DC/OS 1.10.6._
 
 Controls whether the Admin Router authorization cache is enabled.
 
-Most DC/OS authorizers (Mesos, Marathon, etc.) cache a user's permissions for 5 seconds after performing an authorization check for that user.
-This prevents users who issue bursts of requests from overloading the IAM.
-To date Admin Router did not implement caching of permissions.
-This meant that every request to certain endpoints through Admin Router triggered an authorization check to ensure that the user has sufficient permissions to do so.
-While this works well for typical human interaction with a DC/OS cluster we found that applications connecting to the cluster through Admin Router often issued many requests in the space of a fewf seconds.
-Such a high volume of requests, each leading to a separate authorization check, easily placed too much load on the IAM.
-With the IAM overloaded its performance would degrade and authorization checks throughout the cluster would begin to timeout.
-The solution was to give Admin Router a short-lived authorization cache similar to that implemented by Mesos and Marathon.
-As some users may rely on Admin Router not caching permissions we decided not to enable this feature by default until the next major DC/OS release, namely DC/OS 1.12.
-Users who can tolerate a 5 seconds delay from modifying a user's permissions to having them take effect through Admin Router are recommended to enable this feature.
-
 *   `adminrouter_auth_cache_enabled: false` (default) Every authorization check Admin Router performs will load the user's permissions from the IAM.
-*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check. This prevents users that issue bursts of requests from overloading the IAM.
+*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check.
 
 ### agent_list
 A YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.10/overview/concepts/#private-agent-node) host names.

--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -94,7 +94,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 ### adminrouter_auth_cache_enabled
 [/enterprise]
 
-_This option was Added in DC/OS 1.10.6._
+_This option was added in DC/OS 1.10.6._
 
 Controls whether the Admin Router authorization cache is enabled.
 

--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -72,6 +72,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 
 | Parameter                          | Description                                                                                                                                                |
 |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [adminrouter_auth_cache_enabled](#adminrouter-auth-cache-enabled-enterprise)    | [enterprise type="inline" size="small" /] Controls whether the Admin Router authorization cache is enabled. |
 | [auth_cookie_secure_flag](#auth-cookie-secure-flag-enterprise)    | [enterprise type="inline" size="small" /] Indicates whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. |
 | [bouncer_expiration_auth_token_days](#bouncer-expiration-auth-token-days-enterprise) | [enterprise type="inline" size="small" /] Sets the auth token time-to-live (TTL) for Identity and Access Management. |
 | [customer_key](#customer-key-enterprise)                       | [enterprise type="inline" size="small" /] (Required) The DC/OS Enterprise customer key. |
@@ -88,6 +89,28 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 | [zk_super_credentials](#zk-superuser)            | [enterprise type="inline" size="small" /] The ZooKeeper superuser credentials.  |
 | [zk_master_credentials](#zk-master)          | [enterprise type="inline" size="small" /] The ZooKeeper master credentials.  |
 | [zk_agent_credentials](#zk-agent)           | [enterprise type="inline" size="small" /] The ZooKeeper agent credentials.  |
+
+[enterprise]
+### adminrouter_auth_cache_enabled
+[/enterprise]
+
+_This option was Added in DC/OS 1.10.6._
+
+Controls whether the Admin Router authorization cache is enabled.
+
+Most DC/OS authorizers (Mesos, Marathon, etc.) cache a user's permissions for 5 seconds after performing an authorization check for that user.
+This prevents users who issue bursts of requests from overloading the IAM.
+To date Admin Router did not implement caching of permissions.
+This meant that every request to certain endpoints through Admin Router triggered an authorization check to ensure that the user has sufficient permissions to do so.
+While this works well for typical human interaction with a DC/OS cluster we found that applications connecting to the cluster through Admin Router often issued many requests in the space of a fewf seconds.
+Such a high volume of requests, each leading to a separate authorization check, easily placed too much load on the IAM.
+With the IAM overloaded its performance would degrade and authorization checks throughout the cluster would begin to timeout.
+The solution was to give Admin Router a short-lived authorization cache similar to that implemented by Mesos and Marathon.
+As some users may rely on Admin Router not caching permissions we decided not to enable this feature by default until the next major DC/OS release, namely DC/OS 1.12.
+Users who can tolerate a 5 seconds delay from modifying a user's permissions to having them take effect through Admin Router are recommended to enable this feature.
+
+*   `adminrouter_auth_cache_enabled: false` (default) Every authorization check Admin Router performs will load the user's permissions from the IAM.
+*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check. This prevents users that issue bursts of requests from overloading the IAM.
 
 ### agent_list
 A YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.10/overview/concepts/#private-agent-node) host names.
@@ -405,7 +428,7 @@ The default is `logrotate`. Due to performance issues, `journald` is not recomme
 
 ### mesos_dns_set_truncate_bit
 
-Indicates whether Mesos-DNS sets the truncate bit if the response is too large to fit in a single packet.  
+Indicates whether Mesos-DNS sets the truncate bit if the response is too large to fit in a single packet.
 
 *  `mesos_dns_set_truncate_bit: 'true'`  Mesos-DNS sets the truncate bit if the response is too large to fit in a single packet and is truncated. This is the default behavior and is in compliance with RFC7766.
 *  `mesos_dns_set_truncate_bit: 'false'`  Mesos-DNS does not set the truncate bit if the response is too large to fit in a single packet. If you know your applications crash when resolving truncated DNS responses over TCP, or for performance reasons you want to avoid receiving the complete set of DNS records in response to your DNS requests, you should set this option to `false` and note that the DNS responses you receive from Mesos-DNS may be missing entries that were silently discarded. This means that truncated DNS responses will appear complete even though they aren't and therefore won't trigger a retry over TCP. This behavior does not conform to RFC7766.
@@ -445,8 +468,8 @@ A YAML nested list (`-`) of DNS resolvers for your DC/OS cluster nodes. You can 
 The <a href="https://rexray.readthedocs.io/en/v0.9.0/user-guide/config/" target="_blank">REX-Ray</a> configuration for enabling external persistent volumes in Marathon. REX-Ray is a storage orchestration engine. The following is an example configuration.
 
     rexray_config:
-        rexray: 
-          loglevel: info 
+        rexray:
+          loglevel: info
           service: ebs
         libstorage:
           integration:
@@ -530,7 +553,7 @@ For more information, see the [examples](/1.10/installing/ent/custom/configurati
 ### zk_super_credentials
 [/enterprise]
 
-On DC/OS `strict` and `permissive` mode clusters the information stored in ZooKeeper is protected using access control lists (ACLs) so that a malicious user cannot connect to the ZooKeeper Quorum and directly modify service metadata. ACLs specify sets of resource IDs (RIDs) and actions that are associated with those IDs. ZooKeeper supports pluggable authentication schemes and has a few built in schemes: `world`, `auth`, `digest`, `host`, and `ip`. 
+On DC/OS `strict` and `permissive` mode clusters the information stored in ZooKeeper is protected using access control lists (ACLs) so that a malicious user cannot connect to the ZooKeeper Quorum and directly modify service metadata. ACLs specify sets of resource IDs (RIDs) and actions that are associated with those IDs. ZooKeeper supports pluggable authentication schemes and has a few built in schemes: `world`, `auth`, `digest`, `host`, and `ip`.
 
 DC/OS ZooKeeper credentials `zk_super_credentials`, `zk_master_credentials`, and `zk_agent_credentials` use `digest` authentication, which requires a `<uid>:<password>` string which is then used as an ID while checking if a client can access a particular resource.
 

--- a/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.10/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -99,7 +99,7 @@ _This option was added in DC/OS 1.10.6._
 Controls whether the Admin Router authorization cache is enabled.
 
 *   `adminrouter_auth_cache_enabled: false` (default) Every authorization check Admin Router performs will load the user's permissions from the IAM.
-*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check.
+*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5 seconds after performing an authorization check.
 
 ### agent_list
 A YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.10/overview/concepts/#private-agent-node) host names.

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -107,7 +107,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 ### adminrouter_auth_cache_enabled
 [/enterprise]
 
-_This option was Added in DC/OS 1.11.1._
+_This option was added in DC/OS 1.11.1._
 
 Controls whether the Admin Router authorization cache is enabled.
 

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -111,19 +111,8 @@ _This option was Added in DC/OS 1.11.1._
 
 Controls whether the Admin Router authorization cache is enabled.
 
-Most DC/OS authorizers (Mesos, Marathon, etc.) cache a user's permissions for 5 seconds after performing an authorization check for that user.
-This prevents users who issue bursts of requests from overloading the IAM.
-To date Admin Router did not implement caching of permissions.
-This meant that every request to certain endpoints through Admin Router triggered an authorization check to ensure that the user has sufficient permissions to do so.
-While this works well for typical human interaction with a DC/OS cluster we found that applications connecting to the cluster through Admin Router often issued many requests in the space of a fewf seconds.
-Such a high volume of requests, each leading to a separate authorization check, easily placed too much load on the IAM.
-With the IAM overloaded its performance would degrade and authorization checks throughout the cluster would begin to timeout.
-The solution was to give Admin Router a short-lived authorization cache similar to that implemented by Mesos and Marathon.
-As some users may rely on Admin Router not caching permissions we decided not to enable this feature by default until the next major DC/OS release, namely DC/OS 1.12.
-Users who can tolerate a 5 seconds delay from modifying a user's permissions to having them take effect through Admin Router are recommended to enable this feature.
-
 *   `adminrouter_auth_cache_enabled: false` (default) Every authorization check Admin Router performs will load the user's permissions from the IAM.
-*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check. This prevents users that issue bursts of requests from overloading the IAM.
+*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check.
 
 ### adminrouter_tls_1_0_enabled
 

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -55,11 +55,11 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 | [mesos_dns_set_truncate_bit](#mesos-dns-set-truncate-bit)   |  Indicates whether to set the truncate bit if the response is too large to fit in a single packet. |
 | [resolvers](#resolvers)                               | A YAML nested list (`-`) of DNS resolvers for your DC/OS cluster nodes.|
 | [use_proxy](#use-proxy)                               | Indicates whether to enable the DC/OS proxy. |
-|[enable_ipv6](#enable-ipv6)                            | A boolean that indicates if IPv6 networking support is available in DC/OS. Default value is `true`. | 
+|[enable_ipv6](#enable-ipv6)                            | A boolean that indicates if IPv6 networking support is available in DC/OS. Default value is `true`. |
 | [dcos_l4lb_enable_ipv6](#dcos-l4lb-enable-ipv6)        | A boolean that indicates if layer 4 load-balancing is available for IPv6 networks. This takes affect only if `enable_ipv6` is set to `true`. Default value is `false`.|
-|[dcos_ucr_default_bridge_subnet](#dcos-ucr-default-bridge-subnet) |IPv4 subnet allocated to the `mesos-bridge` CNI network for UCR bridge-mode networking. | 
+|[dcos_ucr_default_bridge_subnet](#dcos-ucr-default-bridge-subnet) |IPv4 subnet allocated to the `mesos-bridge` CNI network for UCR bridge-mode networking. |
 
-# Storage 
+# Storage
 
 | Parameter                    | Description                                                                                                                                                       |
 |------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -81,6 +81,7 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 
 | Parameter                          | Description                                                                                                                                                |
 |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [adminrouter_auth_cache_enabled](#adminrouter-auth-cache-enabled-enterprise)    | [enterprise type="inline" size="small" /] Controls whether the Admin Router authorization cache is enabled. |
 | [adminrouter_tls_1_0_enabled](#adminrouter-tls-1-0-enabled)    | Indicates whether to enable TLSv1 support in Admin Router. |
 | [adminrouter_tls_1_1_enabled](#adminrouter-tls-1-1-enabled)    | Indicates whether to enable TLSv1.1 support in Admin Router. |
 | [adminrouter_tls_1_2_enabled](#adminrouter-tls-1-2-enabled)    | Indicates whether to enable TLSv1.2 support in Admin Router. |
@@ -101,6 +102,28 @@ This topic provides configuration parameters available for [DC/OS Enterprise](ht
 | [zk_super_credentials](#zk-superuser)            | [enterprise type="inline" size="small" /] The ZooKeeper superuser credentials.  |
 | [zk_master_credentials](#zk-master)          | [enterprise type="inline" size="small" /] The ZooKeeper master credentials.  |
 | [zk_agent_credentials](#zk-agent)           | [enterprise type="inline" size="small" /] The ZooKeeper agent credentials.  |
+
+[enterprise]
+### adminrouter_auth_cache_enabled
+[/enterprise]
+
+_This option was Added in DC/OS 1.11.1._
+
+Controls whether the Admin Router authorization cache is enabled.
+
+Most DC/OS authorizers (Mesos, Marathon, etc.) cache a user's permissions for 5 seconds after performing an authorization check for that user.
+This prevents users who issue bursts of requests from overloading the IAM.
+To date Admin Router did not implement caching of permissions.
+This meant that every request to certain endpoints through Admin Router triggered an authorization check to ensure that the user has sufficient permissions to do so.
+While this works well for typical human interaction with a DC/OS cluster we found that applications connecting to the cluster through Admin Router often issued many requests in the space of a fewf seconds.
+Such a high volume of requests, each leading to a separate authorization check, easily placed too much load on the IAM.
+With the IAM overloaded its performance would degrade and authorization checks throughout the cluster would begin to timeout.
+The solution was to give Admin Router a short-lived authorization cache similar to that implemented by Mesos and Marathon.
+As some users may rely on Admin Router not caching permissions we decided not to enable this feature by default until the next major DC/OS release, namely DC/OS 1.12.
+Users who can tolerate a 5 seconds delay from modifying a user's permissions to having them take effect through Admin Router are recommended to enable this feature.
+
+*   `adminrouter_auth_cache_enabled: false` (default) Every authorization check Admin Router performs will load the user's permissions from the IAM.
+*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check. This prevents users that issue bursts of requests from overloading the IAM.
 
 ### adminrouter_tls_1_0_enabled
 
@@ -455,7 +478,7 @@ The default is `logrotate`. Due to performance issues, `journald` is not recomme
 
 ### mesos_dns_set_truncate_bit
 
-Indicates whether Mesos-DNS sets the truncate bit if the response is too large to fit in a single packet.  
+Indicates whether Mesos-DNS sets the truncate bit if the response is too large to fit in a single packet.
 
 *  `mesos_dns_set_truncate_bit: 'true'`  Mesos-DNS sets the truncate bit if the response is too large to fit in a single packet and is truncated. This is the default behavior and is in compliance with RFC7766.
 *  `mesos_dns_set_truncate_bit: 'false'`  Mesos-DNS does not set the truncate bit if the response is too large to fit in a single packet. If you know your applications crash when resolving truncated DNS responses over TCP, or for performance reasons you want to avoid receiving the complete set of DNS records in response to your DNS requests, you should set this option to `false` and note that the DNS responses you receive from Mesos-DNS may be missing entries that were silently discarded. This means that truncated DNS responses will appear complete even though they aren't and therefore won't trigger a retry over TCP. This behavior does not conform to RFC7766.
@@ -585,7 +608,7 @@ Currently IPv6 networks are supported only for Docker containers. Setting this f
 * Layer-4 load-balancing will be available for IPv6 Docker containers if [dcos_l4lb_enable_ipv6](#dcos-l4lb-enable-ipv6) is set to `true`.
 
 ### dcos_l4lb_enable_ipv6
-Indicates whether layer-4 load-balancing is available for IPv6 containers. 
+Indicates whether layer-4 load-balancing is available for IPv6 containers.
 *  `dcos_l4lb_enable_ipv6: 'false'` Disables [layer-4 load balancing](/1.11/networking/load-balancing-vips) for IPv6 containers. This is the default value.
 *  `dcos_l4lb_enable_ipv6: 'true'` Enables layer-4 load balancing for IPv6 containers. `NOTE: Layer-4 load balancing for IPv6 containers should be turned on with caution.`[DCOS_OSS-2010](https://jira.mesosphere.com/browse/DCOS_OSS-2010)
 
@@ -600,7 +623,7 @@ The only constraint in selecting an IPv4 subnet for `dcos_ucr_default_bridge_sub
 ### feature_dcos_storage_enabled
 [/enterprise]
 
-Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins. 
+Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
 * `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
 * `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/services/beta-storage)
 

--- a/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
+++ b/pages/1.11/installing/ent/custom/configuration/configuration-parameters/index.md
@@ -112,7 +112,7 @@ _This option was added in DC/OS 1.11.1._
 Controls whether the Admin Router authorization cache is enabled.
 
 *   `adminrouter_auth_cache_enabled: false` (default) Every authorization check Admin Router performs will load the user's permissions from the IAM.
-*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5s after performing an authorization check.
+*   `adminrouter_auth_cache_enabled: true` Admin Router will cache the user's permissions for 5 seconds after performing an authorization check.
 
 ### adminrouter_tls_1_0_enabled
 


### PR DESCRIPTION
## Description
This PR adds documentation for a new `adminrouter_auth_cache_enabled` parameter added in https://github.com/mesosphere/dcos-enterprise/pull/2496 (1.10) and https://github.com/mesosphere/dcos-enterprise/pull/2318 (1.11).

The diff includes a some trailing whitespace removal.

This should go live when 1.10.6 and 1.11.1 are released.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
