### PR TITLE
Removing link to install_prereqs.sh script for CentOS 7.

### DIFF
--- a/pages/1.10/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.10/installing/oss/custom/system-requirements/index.md
@@ -95,7 +95,7 @@ High speed internet access is recommended for DC/OS installation. A minimum 10 M
 
 # Software Prerequisites
 
-**Tip:** Refer to [this shell script](https://raw.githubusercontent.com/dcos/dcos/1.10/cloud_images/centos7/install_prereqs.sh) for an example of how to install the software requirements for DC/OS masters and agents on a CentOS 7 host.
+**Tip:** Refer to this shell script for an example of how to install the software requirements for DC/OS masters and agents on a CentOS 7 host.
 
 ## All Nodes
 


### PR DESCRIPTION
In response to the comments on this JIRA: https://jira.mesosphere.com/browse/DOCS-2454, the link to the install_prereqs.sh script has been removed. The new CentOS script that is linked in the JIRA needs to be tested before adding to the docs.