### PR TITLE
Add Limits page to DC/OS Spark 2.3.0-2.2.1-2 docs

### DIFF
--- a/pages/services/spark/2.3.0-2.2.1-2/limitations/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/limitations/index.md
@@ -22,7 +22,7 @@ featureMaturity:
     dependency management.
 
 *   With Spark SSL/TLS enabled, if you specify environment-based secrets with
-    `spark.mesos.[driver|executor].secret.envkeys, the keystore and truststore secrets will also show up as
+    `spark.mesos.[driver|executor].secret.envkeys`, the keystore and truststore secrets will also show up as
     environment-based secrets, due to the way secrets are implemented. You can ignore these extra environment variables.
 
 *   Anyone who has access to the Spark (Dispatcher) service instance has access to all secrets available to it. Do not
@@ -31,7 +31,7 @@ featureMaturity:
 
 *   When using Kerberos and HDFS, the Spark Driver generates delegation tokens and distributes them to it's Executors
     via RPC.  Authentication of the Executors with the Driver is done with a [shared
-    secret][https://spark.apache.org/docs/latest/security.html#spark-security]. Without authentication, it is possible
+    secret](https://spark.apache.org/docs/latest/security.html#spark-security). Without authentication, it is possible
     for executor containers to register with the Driver and retrieve the delegation tokens. To secure delegation token
     distribution, use the `--executor-auth-secret` option. 
 

--- a/pages/services/spark/2.3.0-2.2.1-2/limits/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/limits/index.md
@@ -14,15 +14,16 @@ featureMaturity:
 Mesosphere has scale-tested Spark on DC/OS by running a CPU-bound Monte Carlo application on the following hardware:
 
 ## Cluster characteristics
-- 1024 cores total
-- 16 m4.16xlarge EC2 instances
+- 2560 cores total
+- 40 m4.16xlarge EC2 instances
  
 ### Single executor per node:
-- 16 executors
+- 40 executors
 - Each executor: 64 cores, 2GB memory 
 - CPU utilization was > 90%, with majority of time spent in task computation
 
 ### Multiple executors per node: 
+On a smaller, 1024-core, 16 node (m4.16xlarge) cluster, the following variations were tested:
 
  | Executors | Time to Launch all Executors | Executors per Node |
  | --------- | ---------------------------  | -----------------  |
@@ -30,4 +31,4 @@ Mesosphere has scale-tested Spark on DC/OS by running a CPU-bound Monte Carlo ap
  | 400       | 17 s.                        | 64                 |
  | 820       | 28 s.                        | 64                 |
 
-In all variations, the application completed successfully. 
+In all tests, the application completed successfully. 

--- a/pages/services/spark/2.3.0-2.2.1-2/limits/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/limits/index.md
@@ -1,0 +1,33 @@
+---
+layout: layout.pug
+navigationTitle: 
+excerpt:
+title: Limits
+menuWeight: 0
+featureMaturity:
+
+---
+
+<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+
+# DC/OS Spark Limits
+Mesosphere has scale-tested Spark on DC/OS by running a CPU-bound Monte Carlo application on the following hardware:
+
+## Cluster characteristics
+- 1024 cores total
+- 16 m4.16xlarge EC2 instances
+ 
+### Single executor per node:
+- 16 executors
+- Each executor: 64 cores, 2GB memory 
+- CPU utilization was > 90%, with majority of time spent in task computation
+
+### Multiple executors per node: 
+
+ | Executors | Time to Launch all Executors | Executors per Node |
+ | --------- | ---------------------------  | -----------------  |
+ | 82        | 7 s.                         | 16                 |
+ | 400       | 17 s.                        | 64                 |
+ | 820       | 28 s.                        | 64                 |
+
+In all variations, the application completed successfully. 


### PR DESCRIPTION
## Description
Addresses: [SPARK-691](https://jira.mesosphere.com/browse/SPARK-691)
This PR updates DC/OS Spark docs to report how much scale-testing we've done.

DC/OS Spark has been run on a 2.5K core cluster. 
The plan was to test on 10K cores but that was cost prohibitive.

## Urgency
- [x] Medium