### PR TITLE
[TF-57] Add initial documentation for beta-tensorflow

### DIFF
--- a/pages/services/beta-tensorflow/data.yml
+++ b/pages/services/beta-tensorflow/data.yml
@@ -1,0 +1,36 @@
+# Common values:
+
+packageName: beta-tensorflow
+serviceName: tensorflow
+techName: TensorFlow
+techShortName: TensorFlow
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: three
+  nodeDescription: with three brokers
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/kafka/kafka-auth/
+
+managing:
+  podType: kafka
+  taskType: broker
+
+supportedVersions:
+  techExampleVersion: 0.11.0.2
+  techLink: "[Apache Kafka](https://kafka.apache.org/downloads)"
+
+security:
+  plaintext: ", \"allow_plaintext\": <true|false default false>"
+
+kerberos:
+  spn: example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory
+  upn: example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+  principal: example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+
+# Values specific to Kafka's own docs content:
+
+kafka:
+  zookeeperPackageName: beta-kafka-zookeeper
+  zookeeperServiceName: kafka-zookeeper
+  zookeeperTechName: Apache Zookeeper

--- a/pages/services/beta-tensorflow/index.md
+++ b/pages/services/beta-tensorflow/index.md
@@ -1,0 +1,14 @@
+---
+layout: layout.pug
+navigationTitle:  Beta TensorFlow
+title: Beta TensorFlow
+menuWeight: 70
+excerpt:
+featureMaturity:
+enterprise: false
+model: /services/beta-tensorflow/data.yml
+---
+
+Welcome to the documentation for the DC/OS {{ model.techName }}.
+
+Choose a version at the left to get started!

--- a/pages/services/beta-tensorflow/latest/hdfs/index.md
+++ b/pages/services/beta-tensorflow/latest/hdfs/index.md
@@ -30,7 +30,7 @@ For example, if `http://mydomain.com/hdfs-config/hdfs-site.xml` and `http://mydo
 ```
 This can also be done through the UI.
 
-If you are using a DC/OS {{ hdfs_model.techName }} service with a service name of {{ hdfs_mode.serviceName }}, the endpoint to specify here would be {{ hdfs_mode.endpoint }}.
+If you are using a DC/OS {{ hdfs_model.techName }} service with a service name of {{ hdfs_model.serviceName }}, the endpoint to specify here would be {{ hdfs_model.endpoint }}.
 
 ## Accessing files
 

--- a/pages/services/beta-tensorflow/latest/hdfs/index.md
+++ b/pages/services/beta-tensorflow/latest/hdfs/index.md
@@ -1,0 +1,47 @@
+---
+layout: layout.pug
+excerpt:
+title: Integration with HDFS
+navigationTitle: HDFS
+model: /services/beta-tensorflow/data.yml
+hdfs_model: /services/hdfs/data.yml
+menuWeight: 20
+---
+
+# Connecting to HDFS
+
+## Configuring the connection
+
+If you plan to read and write from HDFS using {{ model.techName}}, there are two Hadoop configuration files that should be included on {{ model.techShortName }}'s classpath:
+* `hdfs-site.xml`, which defines default behaviors for the HDFS client
+* `core-site.xml`, which sets the default filesystem name.
+
+In order to get access to these file, set the `service.hdfs.config_uri` option in the {{ model.techShortName }} service configuration to be an URL that serves your `hdfs-site.xml` and `core-site.xml` files.
+
+For example, if `http://mydomain.com/hdfs-config/hdfs-site.xml` and `http://mydomain.com/hdfs-config/core-site.xml` are valid URLs, add the following options in addition to your own
+```json
+{
+  "service": {
+    "hdfs": {
+      "config_url": "http://mydomain.com/hdfs-config"
+    }
+  }
+}
+```
+This can also be done through the UI.
+
+If you are using a DC/OS {{ hdfs_model.techName }} service with a service name of {{ hdfs_mode.serviceName }}, the endpoint to specify here would be {{ hdfs_mode.endpoint }}.
+
+## Accessing files
+
+In order to access files on HDFS, the path of the file should be specified starting with `hdfs://default`. In the case of summaries or checkpoints, an HDFS path should be specified in the `service.shared_filesystem` configuration option which in turn is passed to the job `main` entrypoint as the `log_dir` parameter where it can be used with code such as the following:
+```python
+train_writer = tf.summary.FileWriter(os.path.join(log_dir, 'train'), tf.get_default_graph())
+```
+
+If the `service.shared_filesystem` setting was defined as `hdfs://default`, the resultant summary file will be created in the `/train` folder on HDFS.
+
+
+## Authorization
+
+If the HDFS being used by {{ model.techName }} supports or requires Kerberos, it is important to set up the relevant permissions on the HDFS folders so that the Kerberos principal used by {{ model.techName }} has the required access permissions.

--- a/pages/services/beta-tensorflow/latest/index.md
+++ b/pages/services/beta-tensorflow/latest/index.md
@@ -1,0 +1,18 @@
+---
+layout: layout.pug
+navigationTitle: TensorFlow latest
+excerpt:
+title: TensorFlow latest
+menuWeight: 10
+model: /services/beta-tensorflow/data.yml
+render: mustache
+---
+
+DC/OS {{ model.techName }} is an automated service that makes it easy to deploy and manage {{ model.techName }} on Mesosphere DC/OS, eliminating nearly all of the complexity traditionally associated with managing a distributed {{ model.techShortName } cluster.
+
+## Benefits
+
+# Related Services
+
+*   [DC/OS Spark](/services/spark/)
+*   [DC/OS HDFS](/services/hdfs/)

--- a/pages/services/beta-tensorflow/latest/install/index.md
+++ b/pages/services/beta-tensorflow/latest/install/index.md
@@ -1,0 +1,45 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Install and Customize
+menuWeight: 20
+model: /services/beta-tensorflow/data.yml
+render: mustache
+---
+
+#include /services/include/install1.tmpl
+
+## Running custom models
+
+The default {{ model.techName }} installation runs a simple example that is used as a sanity check. In order to use {{ model.techShortName }} to train a machine learning model, the model must be specified as custom installation options.
+
+<!-- TODO: Add mnist URL -->
+For example, consider an existing model archive at `https://uri.path.to.model/models.tar.gz` that contains a `models/mnist.py` file defining an [MNIST](https://TODO.ADD.URL) model. If we wanted to start a {{ model.techName }} service with the name `{{ model.serviceName }}-models-mnist`, using three GPU workers each with two GPUs and a single parameter server, create an `options.json` file with the following contents:
+```json
+{
+  "service": {
+    "name": "{{ model.serviceName }}-models-mnist",
+    "job_url":"https://uri.path.to.model/models.tar.gz",
+    "job_path": "models",
+    "job_name": "mnist",
+  },
+  "gpu_worker": {
+    "count": 3,
+    "gpus": 2
+  },
+  "parameter_server": {
+    "count": 1
+  }
+}
+```
+
+The service (starting the model training) can then be installed using the command:
+```bash
+$ dcos package install {{ model.packageName }} --options=options.json
+```
+
+<!-- TODO: Check the relative link -->
+For more information on how to define a DC/OS {{ model.techShortName }} model, see the [../model-definition] documentation. More options for configuring the {{ modlel.techName }} service are listed in the [../configuration] documentation.
+
+#include /services/include/install2.tmpl

--- a/pages/services/beta-tensorflow/latest/install/index.md
+++ b/pages/services/beta-tensorflow/latest/install/index.md
@@ -40,6 +40,6 @@ $ dcos package install {{ model.packageName }} --options=options.json
 ```
 
 <!-- TODO: Check the relative link -->
-For more information on how to define a DC/OS {{ model.techShortName }} model, see the [../model-definition] documentation. More options for configuring the {{ modlel.techName }} service are listed in the [../configuration] documentation.
+For more information on how to define a DC/OS {{ model.techShortName }} model, see the [../model-definition] documentation. More options for configuring the {{ model.techName }} service are listed in the [../configuration] documentation.
 
 #include /services/include/install2.tmpl

--- a/pages/services/beta-tensorflow/latest/kerberos/index.md
+++ b/pages/services/beta-tensorflow/latest/kerberos/index.md
@@ -1,0 +1,59 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Security
+menuWeight: 22
+model: /services/beta-tensorflow/data.yml
+render: mustache
+---
+
+<!-- TODO: Should this be HDFS-specific? Could we want to allow access to other services? -->
+# HDFS Kerberos
+
+<!-- TODO: Add valid link to Kerberized HDFS -->
+Kerberos is an authentication system to allow {{ model.techName}} to securely read data from and write data to a Kerberos-enabled HDFS cluster such as a correctly configured (DC/OS HDFS service)[link-to-hdfs-kerberos].
+
+### Installation with Kerberos
+
+#include /services/include/security-transport-encryption-clients.tmpl
+
+#### Create principals
+
+The DC/OS {{ model.techName }} service requires a client Kerberos principal in order to access a Kerberized HDFS installation. This usually has the form `primary@REALM`.
+
+
+<!-- TODO: These are specific to the service keytabs we should template/duplicate it for client keytabs -->
+#include /services/include/security-kerberos-ad.tmpl
+#include /services/include/security-service-keytab.tmpl
+
+#### Install the service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own:
+```json
+{
+    "service": {
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "kdc": {
+                    "hostname": "<kdc host>",
+                    "port": <kdc port>
+                },
+                "primary": "<client primary default tensorflow>",
+                "realm": "<realm>",
+                "keytab_secret": "<path to keytab secret>",
+                "debug": <true|false default false>
+            }
+        },
+        "hdfs": {
+            "config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+        }
+    }
+}
+```
+
+Note, this assumes that you are connecting to a Kerberized HDFS cluster with `core-site.xml` and `hdfs-site.xml` files available from `http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints` (as is the case for the DC/OS HDFS service).
+
+<!-- TODO: Add a link to the HDFS authz documentation. Specifically setting up auth_to_local mappings. -->
+In order for the {{ model.TechName }} service to have access to a specified HDFS folder, it may be required to adjust the authorization options for HDFS. See, for example, the [authorization documentation for DC/OS HDFS](hdfs-authorization-documenation).

--- a/pages/services/beta-tensorflow/latest/release-notes/index.md
+++ b/pages/services/beta-tensorflow/latest/release-notes/index.md
@@ -4,31 +4,30 @@ menu_order: 120
 enterprise: 'no'
 ---
 
-## Version 1.0.0-1.5.0-beta
-
-<!-- TODO: Add a general note here how this is a full beta release -->
+## Version 0.2.0-1.5.0-beta
 
 ### Breaking changes
 - Dropped support for DC/OS 1.9 and earlier
-- TF-15: The configuration of HDFS requires a URI where `core-site.xml` and `hfds-site.xml` can be fetched, and not the DC/OS HDFS service name
+- The configuration of HDFS requires a URI where `core-site.xml` and `hfds-site.xml` can be fetched, and not the DC/OS HDFS service name
 
 ### New Features
-- Added region awareness to the scheduler <!-- TODO: Check the wording of this -->
+- Added support for RHEL / Centos clusters running with a strict security mode
+- Added region awareness to the scheduler
 - Added support support for using `hdfs://default` as an HDFS path
 - Added support for Kerberized HDFS (requires `kinit` in the Docker image used)
 - Added support for Marathon-style placement constraints
 
 ### Improvements
-<!-- TODO: Is it "airgapped" or "air-gapped" -->
-- Added DC/OS TensorFlow Docker images to resource definition to allow for use in air-gapped clusters
-- Move JDK and Hadoop dependencies out of the Docker
-- Update JRE to 8u162
-- Update bundled Hadoop version to 2.7.5
-- Update default TensorFlow version to 1.5.0
-- Enable caching in the Mesos fetcher
+- Added DC/OS TensorFlow Docker images to resource definition to allow for use in airgapped clusters
+- Moved JDK and Hadoop dependencies out of the Docker
+- Updated JRE to 8u162
+- Updated bundled Hadoop version to 2.7.5
+- Updated default TensorFlow version to 1.5.0
+- Enabled caching in the Mesos fetcher
 
 ### Bug Fixes
-- Fix installation on strict mode clusters
+- Fixed installation on strict mode clusters
+- Switched to Mesos healtchecks to address an issue where uninstall may not complete
 
 ## Version 0.1.1-1.3.0-beta
 

--- a/pages/services/beta-tensorflow/latest/release-notes/index.md
+++ b/pages/services/beta-tensorflow/latest/release-notes/index.md
@@ -1,0 +1,44 @@
+---
+post_title: Release Notes
+menu_order: 120
+enterprise: 'no'
+---
+
+## Version 1.0.0-1.5.0-beta
+
+<!-- TODO: Add a general note here how this is a full beta release -->
+
+### Breaking changes
+- Dropped support for DC/OS 1.9 and earlier
+- TF-15: The configuration of HDFS requires a URI where `core-site.xml` and `hfds-site.xml` can be fetched, and not the DC/OS HDFS service name
+
+### New Features
+- Added region awareness to the scheduler <!-- TODO: Check the wording of this -->
+- Added support support for using `hdfs://default` as an HDFS path
+- Added support for Kerberized HDFS (requires `kinit` in the Docker image used)
+- Added support for Marathon-style placement constraints
+
+### Improvements
+<!-- TODO: Is it "airgapped" or "air-gapped" -->
+- Added DC/OS TensorFlow Docker images to resource definition to allow for use in air-gapped clusters
+- Move JDK and Hadoop dependencies out of the Docker
+- Update JRE to 8u162
+- Update bundled Hadoop version to 2.7.5
+- Update default TensorFlow version to 1.5.0
+- Enable caching in the Mesos fetcher
+
+### Bug Fixes
+- Fix installation on strict mode clusters
+
+## Version 0.1.1-1.3.0-beta
+
+### New Features
+- Added support for HDFS
+
+### Bug Fixes
+- Uninstall now handles failed tasks correctly
+- Fixed a bug where setting `use_tensorboard` enabled GCE instead of the TensorBoard task
+
+## Version 0.1.0-1.3.0-beta
+
+- Initial beta release based on [TensorFlow r1.3](https://www.tensorflow.org/versions/r1.3/)

--- a/pages/services/hdfs/data.yml
+++ b/pages/services/hdfs/data.yml
@@ -19,7 +19,7 @@ managing:
 
 supportedVersions:
   techExampleVersion: 2.9.0
-  techLink: "[HDFS](http://hadoop.apache.org/releases.html)"
+  techLink: "[HDFS](https://hadoop.apache.org/releases.html)"
 
 security:
   plaintext: ", \"allow_plaintext\": <true|false default false>"
@@ -28,3 +28,6 @@ kerberos:
   spn: example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory
   upn: example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
   principal: example/name-0-node.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+
+
+endpoints: https://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/TF-57

Still todo:
- [ ] Settle on a version (currently `1.0.0-1.5.0-beta`)
- [ ] Address some TODOs with regards to hyperlinks in the pages

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
