### PR TITLE
nav: fallback to sort by nagivationTitle (or else title) for items w/ equivalent menuWeight

### DIFF
--- a/plugins/metalsmith-hierarchy.js
+++ b/plugins/metalsmith-hierarchy.js
@@ -64,7 +64,18 @@ function walk(opts, file, files, array, children, level) {
   }
   // Sort
   children.sort((a, b) => {
-    return (a.menuWeight > b.menuWeight) ? 1 : (a.menuWeight < b.menuWeight) ? -1 : 0;
+    let x = (a.menuWeight > b.menuWeight) ? 1 : (a.menuWeight < b.menuWeight) ? -1 : 0;
+    if(x == 0 && a.navigationTitle && b.navigationTitle) {
+      let x1 = a.navigationTitle.toUpperCase();
+      let x2 = b.navigationTitle.toUpperCase();
+      x = (x1 > x2 ) ? 1 : (x1 < x2) ? -1 : 0;
+    }
+    if(x == 0 && a.title && b.title) {
+      let x1 = a.title.toUpperCase();
+      let x2 = b.title.toUpperCase();
+      x = (x1 > x2 ) ? 1 : (x1 < x2) ? -1 : 0;
+    }
+    return x;
   });
   return children;
 }

--- a/plugins/metalsmith-hierarchy.js
+++ b/plugins/metalsmith-hierarchy.js
@@ -66,13 +66,13 @@ function walk(opts, file, files, array, children, level) {
   children.sort((a, b) => {
     let x = (a.menuWeight > b.menuWeight) ? 1 : (a.menuWeight < b.menuWeight) ? -1 : 0;
     if(x == 0 && a.navigationTitle && b.navigationTitle) {
-      let x1 = a.navigationTitle.toUpperCase();
-      let x2 = b.navigationTitle.toUpperCase();
+      let x1 = a.navigationTitle.toString().toUpperCase();
+      let x2 = b.navigationTitle.toString().toUpperCase();
       x = (x1 > x2 ) ? 1 : (x1 < x2) ? -1 : 0;
     }
     if(x == 0 && a.title && b.title) {
-      let x1 = a.title.toUpperCase();
-      let x2 = b.title.toUpperCase();
+      let x1 = a.title.toString().toUpperCase();
+      let x2 = b.title.toString().toUpperCase();
       x = (x1 > x2 ) ? 1 : (x1 < x2) ? -1 : 0;
     }
     return x;


### PR DESCRIPTION
## Description
`menuWeight` is used to sort navigation items. If two `menuWeight` entries are the same for siblings then the order of navigation items is not guaranteed to be stable. This PR falls back to sorting on `navigationTitle` or else `title` in such cases.

<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
