### PR TITLE
Removed INFINITY-3331 in 1.11.1 RN

### DIFF
--- a/pages/1.11/release-notes/1.11.1/index.md
+++ b/pages/1.11/release-notes/1.11.1/index.md
@@ -14,7 +14,6 @@ These are the release notes for DC/OS 1.11.1.
 
 # <a name="issues-fixed"></a>Improvements and Issues Fixed in DC/OS 1.11.1 
 
-- INFINITY-3331 - Fixed cleaning up other framework's volumes.
 - DCOS_OSS-2292 - Fixed a situation where dcos task --follow task might crash.
 - DCOS_OSS-2247 - Fixed bug in dcos-checks to treat command timeout as a failed check.
 - DCOS_OSS-2210 - Fixed an edge case as of which the history service would crash-loop.


### PR DESCRIPTION
## Description
Based on feedback from Jan Philip, I've removed INFINITY-3331 in 1.11.1 RN.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
