### PR TITLE
Added a new entry for DCOS-19586 in 1.11.1 RN

### DIFF
--- a/pages/1.11/release-notes/1.11.1/index.md
+++ b/pages/1.11/release-notes/1.11.1/index.md
@@ -31,6 +31,7 @@ These are the release notes for DC/OS 1.11.1.
 - DCOS-21359 - Prevented an uninstalled service to break the UI when the "remove" modal was open.
 - DCOS_OSS-1878 - Prevented dcos-checks from ignoring the value of  --detect-ip flag when looking for the location of IP detect script.
 - DCOS_OSS-2162 - Modified mesos modules to accept ZK configuration stored in files.
+- DCOS-19586 - Updated volume table and volume detail for pods.
 
 # <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.1 
 - DCOS_OSS-2130 - Support for CoreOS 1632.2.1.


### PR DESCRIPTION
## Description
 DCOS-19586 is a last minute bug reported by Philipp Hinrichsen on 4/19/2018.
## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
