### PR TITLE
1.11.1 release notes: add manually curated items, consolidate

### DIFF
--- a/pages/1.11/release-notes/1.11.1/index.md
+++ b/pages/1.11/release-notes/1.11.1/index.md
@@ -14,9 +14,9 @@ These are the release notes for DC/OS 1.11.1.
 
 # <a name="known-issue"></a>Known Issue in DC/OS 1.11.1
 
-- DCOS-22128 - When using pods with volumes, if a container in the pod is not configured to mount the volume, the cluster cannot access any service via the UI. As a workaround, when using pods with volumes, use the CLI instead. 
+- DCOS-22128 - When using pods with volumes, if a container in the pod is not configured to mount the volume, the cluster cannot access any service via the UI. As a workaround, when using pods with volumes, use the CLI instead.
 
-# <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.1 
+# <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.1
 
 - CORE-1447 - Fixed a bug in which, under certain conditions, mesos would never refresh its token.
 - DCOS-21305 - Introduced 'minimal DC/OS version' when installing universe packages (e.g., cannot install a package which requires DC/OS 1.11 on DC/OS 1.10).
@@ -24,8 +24,10 @@ These are the release notes for DC/OS 1.11.1.
 - DCOS-21266 - DC/OS UI: Fixed file navigation when browsing task sandbox.
 - DCOS-21128 - DC/OS UI: Fixed a scenario in which the services tab crashed after uninstalling a service.
 - DCOS-19648 - Added a placement constraint validator to the service creation view.
-- DCOS-21683 - Fixed a rare IAM database deadlock as of which the cluster installation might fail.
 - DCOS-21359 - Prevented an uninstalled service to break the UI when the "remove" modal was open.
+- DCOS-21374 - Cosmos: Fixed a crash upon uninstalling Marathon apps that don't define env.
+- DCOS-21451 - Fixed a bug where the Admin Router would not pick up Mesos leader changes (leading to unexpected 404 HTTP responses when using the service endpoint).
+- DCOS-21486 - Networking: Enhanced compatibility with Kubernetes.
 - DCOS_OSS-2292 - Fixed a situation where dcos task --follow task might crash.
 - DCOS_OSS-2247 - Fixed bug in dcos-checks to treat command timeout as a failed check.
 - DCOS_OSS-2210 - Fixed an edge case as of which the history service would crash-loop.
@@ -33,19 +35,34 @@ These are the release notes for DC/OS 1.11.1.
 - DCOS_OSS-1759 - Cosmos: Updated package-manager.yaml to fix the schema error in package management API.
 - DCOS_OSS-2229 - Bumped dcos-net. Performance improvements and bug fixes in [lashup](https://github.com/dcos/lashup).
 - DCOS_OSS-1878 - Prevented dcos-checks from ignoring the value of  --detect-ip flag when looking for the location of IP detect script.
-- DCOS_OSS-2162 - Modified mesos modules to accept ZK configuration stored in files.
+- DCOS_OSS-2132 - DC/OS log: consolidated handling of journald log file rotation.
+- DCOS_OSS-2028 - Improved error reporting when sanity checks fail after an upgrade.
 - INFINITY-3358 - DC/OS UI: Implemented a region picker for region awareness.
-
-# <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.1 
-
-- DCOS-21938 - Bumped Mesos SHA to the latest 1.5.x version.[changelog](https://github.com/apache/mesos/blob/b0a33cb782db57d054f68335c8126ecae078b238/CHANGELOG).
-- DCOS-21703 - Added integration tests for DC/OS Enterprise Exhibitor checks.
+- MARATHON-8090 - Consolidated Marathon's configuration for GPU resources.
+- DCOS-21683 - Fixed a rare IAM database deadlock as of which the cluster installation might fail. [enterprise type="inline" size="small" /]
+- DCOS-21596 - DC/OS IAM: Fixed a bug as of which a local user would be added to a group during LDAP group import. [enterprise type="inline" size="small" /]
+- DCOS-20081 - DC/OS IAM: Consolidated LDAP group import by making the search/bind check case-insensitive. [enterprise type="inline" size="small" /]
+- DCOS-20999 - DC/OS IAM: Fixed a database crash when the disk fills up. [enterprise type="inline" size="small" /]
+- DSS_EE-161 - DC/OS Storage: Fixed a bug where the LVM plugin fails on CoreOS. [enterprise type="inline" size="small" /]
+- DCOS-21507 - DC/OS UI: Improved support for the DC/OS Storage Service. [enterprise type="inline" size="small" /]
+- COPS-2952 - Networking: Fixed a bug as of which the telemetry API did not emit metrics. [enterprise type="inline" size="small" /]
+- CORE-1447, CORE-1448, CORE-1449 - Consolidated Mesos' authentication token refresh logic. [enterprise type="inline" size="small" /]
 - DCOS-21000 - Fixed Marathon's authorization logic to support the 'full' action. [enterprise type="inline" size="small" /]
-- DCOS-19073 - Stores ZK configuration in files thus preventing their contents to appear in logs.
-- DC/OS 1.11.1 is based on Mesos 1.5.x version. View the [Mesos changelog](https://github.com/apache/mesos/blob/1.5.x/CHANGELOG).
-- DC/OS 1.11.1 is integrated with the latest 1.6.352 release of Marathon. For more information about Marathon 1.6, consult the [Marathon changelog](https://github.com/mesosphere/marathon/blob/master/changelog.md).
-- DC/OS 1.11.1 is integrated with Metronome 1.4.1 version. 
-- DCOS_OSS-2130 - Support for CoreOS 1632.2.1.
+
+# <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.1
+
+- Updated to [Mesos 1.5.1-dev](https://github.com/mesosphere/mesos/blob/b2eeb11ede805a7830cd6fb796d0b21a647aba04/CHANGELOG).
+- Updated to [Marathon 1.5.5](https://github.com/mesosphere/marathon/releases).
+- Updated to [Metronome 0.4.1](https://github.com/dcos/metronome/releases/tag/v0.4.1).
+- DCOS_OSS-2130 - Added support for CoreOS 1632.2.1.
+- DCOS-21545 - Moved Prometheus producer to port 61091.
+- DCOS-16431 - Introduced a new DC/OS configuration variable `adminrouter_auth_cache_enabled` for controlling Admin Router's permission cache. [enterprise type="inline" size="small" /]
+
+# <a name="notable-changes"></a>Security updates in DC/OS 1.11.1
+
+- DCOS_OSS-2162 - Mesos does not expose ZooKeeper credentials anymore via its state JSON document.
+- DCOS-21557 - Updated cURL to version 7.59.
+- DCOS_OSS-1903 - Updated OpenSSL to version 1.0.2n.
 
 
 # About DC/OS 1.11
@@ -105,5 +122,4 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 - DCOS-9751	- Marathon fails to authenticate with Mesos master during disabled -> permissive upgrade.
 - DCOS-18368 - The GUI installer has been retired in 1.11 and will no longer continue to function. It will be decommissioned in 1.12. For details of alternative installation methods, [view the documentation](https://docs.mesosphere.com/1.11/installing).
 - DCOS-19047 - `dcos-secrets` service is unavailable during upgrade from 1.10.x to 1.11. [enterprise type="inline" size="small" /]
-- DCOS_OSS-2132	- `dcos-log` does not handle the journald files rotation properly.
 - INFINITY-3116	- Deleting failed mnist Tensorflow package never completes.


### PR DESCRIPTION
## Description

I went through the commits of the dcos/dcos and mesosphere/dcos-enterprise repositories to manually curate a list of user-facing changes between our 1.11.0 and 1.11.1 releases. The primary outcome are these two changelog PRs:
https://github.com/dcos/dcos/pull/2365
https://github.com/mesosphere/dcos-enterprise/pull/2628

The secondary outcome is this PR here for updating our public release notes with critical entries (that we should not have missed in the first place). This PR also corrects one or more mistakes (wrong Metronome release was mentioned, ..), introduces missing `enterprise` tags, and introduces some minor improvements.

I believe that this PR is a good indication for how many valuable release note items we miss by purely relying on JIRA as a reference.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
