### PR TITLE
COPS-2982 Removing mention of dcos-config.yaml from 1.10 and 1.10

### DIFF
--- a/pages/1.10/monitoring/debugging/slow-docker/index.md
+++ b/pages/1.10/monitoring/debugging/slow-docker/index.md
@@ -37,7 +37,9 @@ You will need to change the configurations for your DC/OS installation (if you a
 
 ### Reinstallation method
 
-1. In your [dcos-config.yaml](https://raw.githubusercontent.com/dcos/dcos/master/gen/dcos-config.yaml) set `MESOS_CGROUPS_ENABLE_CFS=false`.
+1. If the file `/var/lib/dcos/mesos-slave-common` does not exist, create it.
+
+1. Edit `/var/lib/dcos/mesos-slave-common` to add `MESOS_CGROUPS_ENABLE_CFS=false`. 
 
 1. [Reinstall](/1.10/installing/oss/) DC/OS.
 

--- a/pages/1.11/monitoring/debugging/slow-docker/index.md
+++ b/pages/1.11/monitoring/debugging/slow-docker/index.md
@@ -37,7 +37,9 @@ You will need to change the configurations for your DC/OS installation (if you a
 
 ### Reinstallation method
 
-1. In your [dcos-config.yaml](https://raw.githubusercontent.com/dcos/dcos/master/gen/dcos-config.yaml) set `MESOS_CGROUPS_ENABLE_CFS=false`.
+1. If the file `/var/lib/dcos/mesos-slave-common` does not exist, create it.
+
+1. Edit `/var/lib/dcos/mesos-slave-common` to add `MESOS_CGROUPS_ENABLE_CFS=false`. 
 
 1. [Reinstall](/1.11/installing/oss/) DC/OS.
 


### PR DESCRIPTION
## Description
COPS-2982 https://jira.mesosphere.com/browse/COPS-2982
## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
