### PR TITLE
Change the issue settings for Feedback link to account for Jira changes

### DIFF
--- a/layouts/components/content-actions.pug
+++ b/layouts/components/content-actions.pug
@@ -13,7 +13,8 @@ if !rssPath
 - feedbackPath += '&summary=Feedback+for+' + title.replace(' ', '+')
 - feedbackPath += '&description=Source:%20' + url + '/' + path
 - feedbackPath += '&labels=documentation'
-- feedbackPath += '&components=documentation'
+- feedbackPath += '&components=19804'
+- feedbackPath += '&priority=3'
 
 div(class='actions')
   ul(class='actions__list')


### PR DESCRIPTION
## Description
When users click the Feedback button at the top of the docs pages, it automatically files a Jira ticket. This PR changes the project of that ticket to `DCOS_OSS` and the issue type to `Bug` in order to account for the new Jira landscape simplification. 
## Testing
Build this branch locally and then click on the Feedback button in your local build while signed into jira.mesosphere.com. A ticket creation dialog will open up with the appropriate fields populated. 
### Current Limitations
- [x] as of 4/24 the Components field is populated, but users still have to confirm the input by clicking enter while the field is selected in order for the Components filed to be set in the resulting issue. Checkbox to be ticked when this issue is fixed. 

## Urgency
- [x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
