### PR TITLE
Update documentation regarding update of a user-created service.

### DIFF
--- a/pages/1.11/deploying-services/update-user-service/index.md
+++ b/pages/1.11/deploying-services/update-user-service/index.md
@@ -15,15 +15,15 @@ You can easily view and update the configuration of a deployed app by using the 
 
 **Note:** The process for updating packages from the [DC/OS Catalog](/1.11/gui/catalog/) is different. For more information, see the [documentation](/1.11/deploying-services/config-universe-service/).
 
-# Update an Environment Variable
+# Update all Environment Variables
 
-Use the `dcos marathon app update` command from the DC/OS CLI to update any aspect of your service's JSON service definition. For instance, follow the instructions below to update the environment variable (`env` field) of the service definition.
-
-A single element of the [`env` field][2] can be updated by specifying a JSON string in a command argument.
+Use the `dcos marathon app update` command from the DC/OS CLI to update any aspect of your service's JSON service definition. For instance, follow the instructions below to update the environment variable ([`env` field][1]) of the service definition.
 
 ```bash
 dcos marathon app update test-app env='{"APISERVER_PORT":"25502"}'
 ```
+
+This will replace the entire `env` field by the new value specified.
 
 Now, run the command below to see the result of your update:
 
@@ -31,9 +31,9 @@ Now, run the command below to see the result of your update:
 dcos marathon app show test-app | jq '.env'
 ```
 
-# Update all Environment Variables
+## Using a JSON File
 
-The entire [`env` field][1] can also be updated by specifying a JSON file in a command argument.
+The [`env` field][1] can also be updated by specifying a JSON file in a command argument.
 
 First, save the existing environment variables to a file:
 
@@ -66,4 +66,3 @@ dcos marathon app show test-app | jq '.env'
 ```
 
  [1]: /1.11/cli/
- [2]: https://mesosphere.github.io/marathon/docs/task-environment-vars.html


### PR DESCRIPTION
The DC/OS CLI marathon subcommand does not allow the update of only
one specific key in a JSON field. The documentation has been updated
to not documenting this unexisting feature and to correspond to what
we have in the CLI since the merge of the [DCOS CLI PR 1215](https://github.com/dcos/dcos-cli/pull/1215).

## Description
https://jira.mesosphere.com/browse/DCOS_OSS-2391

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
