### PR TITLE
Remove dcos-adminrouter-reload.service/timer refs

### DIFF
--- a/pages/1.10/monitoring/logging/quickstart/index.md
+++ b/pages/1.10/monitoring/logging/quickstart/index.md
@@ -139,8 +139,6 @@ You can view logs from tasks or the host subsystem with the `dcos node log` comm
         
         ```bash
         dcos-diagnostics.service
-        dcos-adminrouter-reload.service
-        dcos-adminrouter-reload.timer
         dcos-adminrouter.service
         dcos-cosmos.service
         dcos-epmd.service
@@ -162,8 +160,6 @@ You can view logs from tasks or the host subsystem with the `dcos node log` comm
        ```bash
        dcos-diagnostics.service
        dcos-diagnostics.socket
-       dcos-adminrouter-agent-reload.service
-       dcos-adminrouter-agent-reload.timer
        dcos-adminrouter-agent.service
        dcos-docker-gc.service
        dcos-docker-gc.timer


### PR DESCRIPTION
Since the dcos-adminrouter-reload.service and dcos-adminrouter-reload.timer do not exist anymore in DC/OS 1.10, they should not be displayed.

## Description
https://jira.mesosphere.com/browse/COPS-2187

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
