### PR TITLE
added backslash to beginning of redirect paths.

### DIFF
--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -14,8 +14,8 @@
 /services/edge-lb/architecture/ /services/edge-lb/1.0.0/;
 /1.11/networking/edge-lb/quickstart/ /services/edge-lb/1.0.0/;
 ~^/1.11/networking/marathon-lb/(.*)$ /services/marathon-lb/$1;
-/1.11/monitoring/logging/logging-api/logging-v1/ 1.11/monitoring/logging/logging-api/;
-/1.11/monitoring/logging/logging-api/logging-v2/ 1.11/monitoring/logging/logging-api/;
+/1.11/monitoring/logging/logging-api/logging-v1/ /1.11/monitoring/logging/logging-api/;
+/1.11/monitoring/logging/logging-api/logging-v2/ /1.11/monitoring/logging/logging-api/;
 /1.11/release-notes/version-policy/ /version-policy/;
 /1.10/administration/access-node/(.*)$ /1.10/administering-clusters/$1;
 /1.10/administration/access-node/tunnel/ /1.10/developing-services/tunnel/;


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
