### PR TITLE
docker-ce-17.05.0.ce is not present in repo

### DIFF
--- a/pages/1.10/installing/oss/custom/system-requirements/install-docker-centos/index.md
+++ b/pages/1.10/installing/oss/custom/system-requirements/install-docker-centos/index.md
@@ -93,7 +93,7 @@ The following instructions demonstrate how to use Docker with OverlayFS on CentO
 1.  Install the Docker engine, daemon, and service.
 
     ```bash
-    sudo yum install docker-ce-17.05.0.ce
+    sudo yum install docker-engine-1.13.1 docker-engine-selinux-1.13.1
     sudo systemctl start docker
     sudo systemctl enable docker
     ```


### PR DESCRIPTION
Docker 17.05 is an unsupported edge version not present on the repo, so the documentation provides blocking, wrong information.

Rolled back to 1.13.1 as widely supported by all CentOS versions: https://docs.mesosphere.com/version-policy/#dcos-platform-version-compatibility-matrix

## Description
<!-- Link to JIRA issue -->

## Urgency
- [x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
