### PR TITLE
1.11.2 Release Notes

### DIFF
--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -14,12 +14,12 @@ These are the release notes for DC/OS 1.11.2.
 
 DC/OS 1.11.2 includes the following:
 
-Apache Mesos 1.5.x [change log](https://github.com/mesosphere/mesos/blob/27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8/CHANGELOG).
-Marathon 1.6.392 [change log](https://github.com/mesosphere/marathon/releases).
-Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4.2).
+- Apache Mesos 1.5.x [change log](https://github.com/mesosphere/mesos/blob/27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8/CHANGELOG).
+- Marathon 1.6.392 [change log](https://github.com/mesosphere/marathon/releases).
+- Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4.2).
 
 
-# <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.2
+# Issues Fixed in DC/OS 1.11.2
 
 - DCOS-14199 - Fixed an issue that prevented DC/OS from recovering when available disk space was low.
 - DCOS-21596-  Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
@@ -31,11 +31,8 @@ Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4
 - DCOS_OSS-2378/SOAK-88 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
 
 
-# <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.2
+# Notable Changes in DC/OS 1.11.2
 
-- Updated to [Mesos 1.5.1](https://github.com/mesosphere/mesos/blob/b2eeb11ede805a7830cd6fb796d0b21a647aba04/CHANGELOG).
-- Updated to [Marathon 1.6.392](https://github.com/mesosphere/marathon/releases).
-- Updated to [Metronome 0.4.2](https://github.com/dcos/metronome/releases/tag/v0.4.2).
 - DCOS-16431 - Cached PQ endpoint for bouncer/adminrouter. [enterprise type="inline" size="small" /]
 - DCOS-22021 - Removed IAM database migration from Zookeeper to Cockroach. [enterprise type="inline" size="small" /]
 - DCOS-22041 - Removed policyquery cache race condition in Bouncer. [enterprise type="inline" size="small" /]
@@ -46,7 +43,7 @@ Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4
 - DCOS-29122 - Upgraded multi-region SDK package to Universe services.
 - DCOS-29634 - Implement region validation and config-sniffing in SDK.
 - DCOS_OSS-2377 - Agent operator API: Displayed resource provider resources in GET_RESOURCE_PROVIDER response.
-- DCOS_OSS-2688 - Supported secrets in Metronome.
+- DCOS_OSS-2688 - Supported secrets in Metronome. [enterprise type="inline" size="small" /]
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
@@ -56,6 +53,8 @@ Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4
 1. Previous 1.11 point releases are not supported for CoreOS 1688.5.3.
 
 2. Implemented region awareness support for SDK based services are implemented in this release.
+
+3. New Docker versions supported on RHEL 7.4 and CoreOS 1688.5.3. For details see [compatibility matrix](https://docs.mesosphere.com/version-policy/).
 
 
 # <a name="known-issue"></a>Known Issue in DC/OS 1.11.2
@@ -74,7 +73,7 @@ DC/OS 1.11 includes many new capabilities, with a focus on:
 
 Provide feedback on the new features and services at: [support.mesosphere.com](https://support.mesosphere.com).
 
-<a name="new-features"></a>
+
 ## New Features and Capabilities
 
 ### Platform
@@ -117,8 +116,4 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 - You can now select a DC/OS data service version from a dropdown menu in the DC/OS UI.
 - Improved scalability for all DC/OS data services.
 
-## <a name="known-issues"></a>Known Issues
-- DCOS-9751	- Marathon fails to authenticate with Mesos master during disabled -> permissive upgrade.
-- DCOS-18368 - The GUI installer has been retired in 1.11 and will no longer continue to function. It will be decommissioned in 1.12. For details of alternative installation methods, [view the documentation](https://docs.mesosphere.com/1.11/installing).
-- DCOS-19047 - `dcos-secrets` service is unavailable during upgrade from 1.10.x to 1.11. [enterprise type="inline" size="small" /]
-- INFINITY-3116	- Deleting failed mnist Tensorflow package never completes.
+

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -21,10 +21,15 @@ DC/OS 1.11.2 includes the following:
 
 # Issues Fixed in DC/OS 1.11.2
 
+- COPS-3195 - Mesos: Fixed an issue as of which the authentication token refresh would not be performed. [enterprise type="inline" size="small" /]
 - DCOS-14199 - Consolidated the Exhibitor bootstrapping shortcut by atomically reading and writing the ZooKeeper PID file.
 - DCOS-20514 - Added licensing information to the diagnostics bundle.
 - DCOS-21596 - Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
+- DCOS-21611 - The IP detect script and fault domain detect script may now be changed with a config upgrade. 
 - DCOS-22128 - Fixed an issue in the Service view of DC/OS UI, when cluster has pods with not every container mounting a volume [enterprise type="inline" size="small" /]
+- DCOS-22133 - DC/OS IAM: Fixed a rare case where the database bootstrap transaction would not insert some data. [enterprise type="inline" size="small" /]
+- DCOS_OSS-2317 - Consolidated pkgpanda's package download method.
+- DCOS_OSS-2335 - Increased the Mesos executor re-registration timeout to consolidate an agent failover scenario.
 - DCOS_OSS-2360 - DC/OS Metrics: metric names are sanitized for better compatibility with Prometheus.
 - DCOS_OSS-2378 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
 - DC/OS UI: Incorporated [multiple](https://github.com/dcos/dcos/pull/2799) fixes and improvements.
@@ -36,17 +41,17 @@ DC/OS 1.11.2 includes the following:
 - DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /] 
 - DCOS-29122 - Support for launching services in a remote region.
 - DCOS-29634 - Implement region validation and config-sniffing in SDK.
+- MARATHON-8090 - Reverted the Marathon configuration change for GPU resources which was introduced with the 1.11.1 release.
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
 
 
 **Note:** 
-1. Previous 1.11 point releases are not supported for CoreOS 1688.5.3.
 
-2. Implemented region awareness support for SDK based services are implemented in this release. [enterprise type="inline" size="small" /]
+1. Implemented region awareness support for SDK based services are implemented in this release. [enterprise type="inline" size="small" /]
 
-3. New Docker versions supported on RHEL 7.4 and CoreOS 1688.5.3. See [compatibility matrix](https://docs.mesosphere.com/version-policy/) for further information.
+2. New Docker versions supported on RHEL 7.4. See [compatibility matrix](https://docs.mesosphere.com/version-policy/) for further information.
 
 
 # About DC/OS 1.11

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -1,6 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle:  Release Notes for 1.11.2
+navigationTitle: Release Notes for 1.11.2
 title: Release Notes for 1.11.2
 menuWeight: 0
 excerpt: Release notes for DC/OS 1.11.2
@@ -14,10 +14,23 @@ These are the release notes for DC/OS 1.11.2.
 
 # <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.2
 
+- DCOS-14199 - Prevented DC/OS from recovering when disk space is full.
+- DCOS_OSS-2378/SOAK-88 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
+- SOAK-92 - 
+- DCOS-22128: Supported pods with volumes but no volume mounts.
+
+
 # <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.2
+
+- DCOS-21557/DCOS-22326/DCOS_OSS-2367 - Mitigated security risk in DC/OS by providing more secure default settings.
+- DCOS_OSS-2367 - Updated curl to version 7.59.
+- DCOS-22326 - Disabled the 3DES bulk encryption, algorithm and TLS 1.1 protocol by default for master Admin router's TLS.
+- QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
+- QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported. 
 
 # <a name="known-issue"></a>Known Issue in DC/OS 1.11.2
 
+- DCOS-20568 - Fixed dcos-diagnostics master service account permission issue.
 
 
 

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -39,22 +39,18 @@ DC/OS 1.11.2 includes the following:
 
 # Notable Changes in DC/OS 1.11.2
 
-- DCOS-21465 - Updated python3-saml for [CVE-2017-11427](https://www.kb.cert.org/vuls/id/475445). [enterprise type="inline" size="small" /] 
-- DCOS-21958 - Admin Router on the DC/OS master nodes now does not support TLS 1.1 and the 3DES bulk encryption algorithm anymore by default.
 - DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /] 
-- DCOS-29122 - Support for launching services in a remote region.
-- DCOS-29634 - Implement region validation and config-sniffing in SDK.
 - MARATHON-8090 - Reverted the Marathon configuration change for GPU resources which was introduced in 1.11.1 release.
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
 
+# Security Enhancements
 
-**Note:** 
+- DCOS-21465 - Updated python3-saml for [CVE-2017-11427](https://www.kb.cert.org/vuls/id/475445). [enterprise type="inline" size="small" /] 
+- DCOS-21958 - Admin Router on the DC/OS master nodes now does not support TLS 1.1 and the 3DES bulk encryption algorithm anymore by default.
 
-1. Implemented region awareness support for SDK based services are implemented in this release. [enterprise type="inline" size="small" /]
-
-2. New Docker versions supported on RHEL 7.4. See [compatibility matrix](https://docs.mesosphere.com/version-policy/) for further information.
+**Note:** New Docker versions supported on RHEL 7.4. See [compatibility matrix](https://docs.mesosphere.com/version-policy/) for further information.
 
 
 # About DC/OS 1.11

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -34,7 +34,7 @@ These are the release notes for DC/OS 1.11.2.
 - DCOS-29122 - Upgraded multi-region SDK package to Universe services.
 - DCOS-29168 - 
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
-- QUALITY-2007/QUALITY-2055 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
+- QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2060 - Certified DC/OS 1.11.2 with CoreOS 1688.5.3.
 **Note:** Previous 1.11 point releases are not supported for CoreOS 1688.5.3.

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -40,7 +40,7 @@ DC/OS 1.11.2 includes the following:
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
-- QUALITY-2060 - Certified DC/OS 1.11.2 with CoreOS 1688.5.3.
+
 
 **Note:** 
 1. Previous 1.11 point releases are not supported for CoreOS 1688.5.3.

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -23,25 +23,28 @@ DC/OS 1.11.2 includes the following:
 
 - COPS-3195 - Mesos: Fixed an issue as of which the authentication token refresh would not be performed. [enterprise type="inline" size="small" /]
 - DCOS-14199 - Consolidated the Exhibitor bootstrapping shortcut by atomically reading and writing the ZooKeeper PID file.
-- DCOS-20514 - Added licensing information to the diagnostics bundle.
+- DCOS-20514 - Added licensing information to the diagnostics bundle. [enterprise type="inline" size="small" /]
+- DCOS-20568 - Fixed diagnostics bundle creation bug as of insufficient service account permissions. [enterprise type="inline" size="small" /]
 - DCOS-21596 - Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
-- DCOS-21611 - The IP detect script and fault domain detect script may now be changed with a config upgrade. 
+- DCOS-21611 - The IP detect script and fault domain detect script can be changed with a config upgrade. 
 - DCOS-22128 - Fixed an issue in the Service view of DC/OS UI, when cluster has pods with not every container mounting a volume [enterprise type="inline" size="small" /]
+- DCOS-22041 - Admin Router: Fixed a race condition in the permission data cache. [enterprise type="inline" size="small" /]
 - DCOS-22133 - DC/OS IAM: Fixed a rare case where the database bootstrap transaction would not insert some data. [enterprise type="inline" size="small" /]
 - DCOS_OSS-2317 - Consolidated pkgpanda's package download method.
 - DCOS_OSS-2335 - Increased the Mesos executor re-registration timeout to consolidate an agent failover scenario.
 - DCOS_OSS-2360 - DC/OS Metrics: metric names are sanitized for better compatibility with Prometheus.
-- DCOS_OSS-2378 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
-- DC/OS UI: Incorporated [multiple](https://github.com/dcos/dcos/pull/2799) fixes and improvements.
+- DCOS_OSS-2378 - DC/OS Net: Improved stability of distribution protocol over TLS. 
+- DC/OS UI: Incorporated [multiple](https://github.com/dcos/dcos/pull/2799) fixes and improvements. 
 
 
 # Notable Changes in DC/OS 1.11.2
 
+- DCOS-21465 - Updated python3-saml for [CVE-2017-11427](https://www.kb.cert.org/vuls/id/475445). [enterprise type="inline" size="small" /] 
 - DCOS-21958 - Admin Router on the DC/OS master nodes now does not support TLS 1.1 and the 3DES bulk encryption algorithm anymore by default.
 - DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /] 
 - DCOS-29122 - Support for launching services in a remote region.
 - DCOS-29634 - Implement region validation and config-sniffing in SDK.
-- MARATHON-8090 - Reverted the Marathon configuration change for GPU resources which was introduced with the 1.11.1 release.
+- MARATHON-8090 - Reverted the Marathon configuration change for GPU resources which was introduced in 1.11.1 release.
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -15,7 +15,7 @@ These are the release notes for DC/OS 1.11.2.
 DC/OS 1.11.2 includes the following:
 
 - Apache Mesos 1.5.1-dev [change log](https://github.com/mesosphere/mesos/blob/27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8/CHANGELOG).
-- Marathon 1.6.392 [change log](https://github.com/mesosphere/marathon/releases).
+- Marathon 1.6.392 [change log](https://github.com/dcos/dcos/pull/2678).
 - Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4.2).
 
 

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -39,7 +39,6 @@ DC/OS 1.11.2 includes the following:
 
 # Notable Changes in DC/OS 1.11.2
 
-- DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /] 
 - MARATHON-8090 - Reverted the Marathon configuration change for GPU resources which was introduced in 1.11.1 release.
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
@@ -49,6 +48,7 @@ DC/OS 1.11.2 includes the following:
 
 - DCOS-21465 - Updated python3-saml for [CVE-2017-11427](https://www.kb.cert.org/vuls/id/475445). [enterprise type="inline" size="small" /] 
 - DCOS-21958 - Admin Router on the DC/OS master nodes now does not support TLS 1.1 and the 3DES bulk encryption algorithm anymore by default.
+- DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /] 
 
 **Note:** New Docker versions supported on RHEL 7.4. See [compatibility matrix](https://docs.mesosphere.com/version-policy/) for further information.
 

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -1,64 +1,24 @@
 ---
 layout: layout.pug
-navigationTitle:  Release Notes for 1.11.1
-title: Release Notes for 1.11.1
-menuWeight: 5
-excerpt: Release notes for DC/OS 1.11.1
+navigationTitle:  Release Notes for 1.11.2
+title: Release Notes for 1.11.2
+menuWeight: 0
+excerpt: Release notes for DC/OS 1.11.2
 ---
 
-These are the release notes for DC/OS 1.11.1.
+These are the release notes for DC/OS 1.11.2.
 
 [button color="purple" href="https://downloads.dcos.io/dcos/stable/1.11.1/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 
 [button color="light" href="https://support.mesosphere.com/hc/en-us/articles/213198586"]Download DC/OS Enterprise[/button]
 
-# <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.1
+# <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.2
 
-- COPS-2952 - Networking: Fixed a bug due to which the telemetry API did not emit metrics. [enterprise type="inline" size="small" /]
-- CORE-1447, CORE-1448, and CORE-1449 - Consolidated Mesos' authentication token refresh logic. [enterprise type="inline" size="small" /]
-- DCOS-19648 - Added a placement constraint validator to the service creation view.
-- DCOS-20081 - DC/OS IAM: Consolidated LDAP group import by making the search/bind check case-insensitive. [enterprise type="inline" size="small" /]
-- DCOS-20999 - DC/OS IAM: Fixed a database crash when the disk fills up. [enterprise type="inline" size="small" /]
-- DCOS-21000 - Fixed Marathon's authorization logic to support the 'full' action. [enterprise type="inline" size="small" /]
-- DCOS-21128 - DC/OS UI: Fixed a scenario in which the services tab crashed after uninstalling a service.
-- DCOS-21266 - DC/OS UI: Fixed file navigation when browsing task sandbox.
-- DCOS-21305 - Introduced 'minimal DC/OS version' when installing universe packages (e.g., cannot install a package which requires DC/OS 1.11 on DC/OS 1.10).
-- DCOS-21337 - DC/OS UI: Improved error handling when consuming the Mesos event streaming HTTP API.
-- DCOS-21359 - Prevented an uninstalled service to break the UI when the "remove" modal was open.
-- DCOS-21374 - Cosmos: Fixed a crash upon uninstalling Marathon apps that don't define env.
-- DCOS-21451 - Fixed a bug where the Admin Router would not pick up Mesos leader changes (leading to unexpected 404 HTTP responses when using the service endpoint).
-- DCOS-21486 - Networking: Enhanced compatibility with Kubernetes.
-- DCOS-21507 - DC/OS UI: Improved support for the DC/OS Storage Service. [enterprise type="inline" size="small" /]
-- DCOS-21557 - Updated cURL to version 7.59.
-- DCOS-21596 - DC/OS IAM: Fixed a bug due to which a local user would be added to a group during LDAP group import. [enterprise type="inline" size="small" /]
-- DCOS-21683 - Fixed a rare IAM database deadlock due to which the cluster installation might fail. [enterprise type="inline" size="small" /]
-- DCOS_OSS-1759 - Cosmos: Updated package-manager.yaml to fix the schema error in package management API.
-- DCOS_OSS-1878 - Prevented dcos-checks from ignoring the value of  --detect-ip flag when looking for the location of IP detect script.
-- DCOS_OSS-1903 - Updated OpenSSL to version 1.0.2n.
-- DCOS_OSS-2028 - Improved error reporting when sanity checks fail after an upgrade.
-- DCOS_OSS-2087 - Cosmos: Improved readability on user facing messages during service uninstallation.
-- DCOS_OSS-2132 - DC/OS log: consolidated handling of journald log file rotation.
-- DCOS_OSS-2162 - Mesos does not expose ZooKeeper credentials anymore via its state JSON document.
-- DCOS_OSS-2210 - Fixed an edge case due to which the history service would crash-loop.
-- DCOS_OSS-2229 - Bumped dcos-net. Performance improvements and bug fixes in [lashup](https://github.com/dcos/lashup).
-- DCOS_OSS-2247 - Fixed bug in dcos-checks to treat command timeout as a failed check.
-- DCOS_OSS-2292 - Fixed a situation where dcos task --follow task might crash.
-- DSS_EE-161 - DC/OS Storage: Fixed a bug where the LVM plugin fails on CoreOS. [enterprise type="inline" size="small" /]
-- INFINITY-3358 - DC/OS UI: Implemented a region picker for region awareness.
-- MARATHON-8090 - Consolidated Marathon's configuration for GPU resources.
+# <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.2
 
-# <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.1
+# <a name="known-issue"></a>Known Issue in DC/OS 1.11.2
 
-- Updated to [Mesos 1.5.1-dev](https://github.com/mesosphere/mesos/blob/b2eeb11ede805a7830cd6fb796d0b21a647aba04/CHANGELOG).
-- Updated to [Marathon 1.5.5](https://github.com/mesosphere/marathon/releases).
-- Updated to [Metronome 0.4.1](https://github.com/dcos/metronome/releases/tag/v0.4.1).
-- DCOS-16431 - Introduced a new DC/OS configuration variable `adminrouter_auth_cache_enabled` for controlling Admin Router's permission cache. [enterprise type="inline" size="small" /]
-- DCOS-21545 - Moved Prometheus producer to port 61091.
-- DCOS_OSS-2130 - Added support for CoreOS 1632.2.1.
 
-# <a name="known-issue"></a>Known Issue in DC/OS 1.11.1
-
-- DCOS-22128 - When using pods with volumes, if a container in the pod is not configured to mount the volume, the cluster cannot access any service via the UI. As a workaround, when using pods with volumes, use the CLI instead.
 
 
 # About DC/OS 1.11

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -8,25 +8,38 @@ excerpt: Release notes for DC/OS 1.11.2
 
 These are the release notes for DC/OS 1.11.2.
 
-[button color="purple" href="https://downloads.dcos.io/dcos/stable/1.11.1/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
+[button color="purple" href="https://downloads.dcos.io/dcos/stable/1.11.2/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 
 [button color="light" href="https://support.mesosphere.com/hc/en-us/articles/213198586"]Download DC/OS Enterprise[/button]
 
 # <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.2
 
-- DCOS-14199 - Prevented DC/OS from recovering when disk space is full.
+- DCOS-14199 - Fixed an issue that prevented DC/OS from recovering when available disk space was low.
+- DCOS-22128 - Supported pods with volumes but no volume mounts. [enterprise type="inline" size="small" /]
 - DCOS_OSS-2378/SOAK-88 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
 - SOAK-92 - 
-- DCOS-22128: Supported pods with volumes but no volume mounts.
+
 
 
 # <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.2
 
-- DCOS-21557/DCOS-22326/DCOS_OSS-2367 - Mitigated security risk in DC/OS by providing more secure default settings.
-- DCOS_OSS-2367 - Updated curl to version 7.59.
-- DCOS-22326 - Disabled the 3DES bulk encryption, algorithm and TLS 1.1 protocol by default for master Admin router's TLS.
+- DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router.
+- DCOS-21557/DCOS_OSS-2367 - Upgraded curl to version 7.59, which fixed several curl security vulnerabilities from previous version.
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported. 
+- DCOS-29080, DCOS-29122, DCOS-29168, DCOS-29188, DCOS-29216, DCOS-29265, DCOS-29282, DCOS-29299, DCOS-29384, DCOS-29455, DCOS-29520, DCOS-29532, DCOS-29544, DCOS-29567, DCOS-29601, DCOS-29616, DCOS-29634, and DCOS-29703 - Implemented remote region support for data engineering services.
+
+- DCOS-29216, DCOS-29384, DCOS-29384, DCOS-29455, DCOS-29520, DCOS-29532, DCOS-29567, DCOS-29080 - Implemented remote region support for data engineering services.
+- DCOS-29634 - Implement region validation and config-sniffing in SDK.
+- DCOS-29122 - Upgraded multi-region SDK package to Universe services.
+- DCOS-29168 - 
+- QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
+- QUALITY-2007/QUALITY-2055 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
+- QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
+- QUALITY-2060 - Certified DC/OS 1.11.2 with CoreOS 1688.5.3.
+**Note:** Previous 1.11 point releases are not supported for CoreOS 1688.5.3.
+
+**Note:** Implemented region awareness support for SDK based services.
 
 # <a name="known-issue"></a>Known Issue in DC/OS 1.11.2
 
@@ -59,22 +72,22 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 ### Networking
 - Edge-LB 1.0. [View the documentation](https://docs.mesosphere.com/services/edge-lb/1.0/) [enterprise type="inline" size="small" /]
 - IPv6 is now supported for Docker containers.
-- Performance improvements to the DC/OS network stack - All networking components (minuteman, navstar, spartan) are aggregated into a single systemd unit called `dcos-net`. Please read this [note](/1.11/networking/#a-note-on-software-re-architecture) to learn more about the re-factoring of the network stack.
+- Performance improvements to the DC/OS network stack - All networking components (minuteman, navstar, spartan) are aggregated into a single systemd unit called `dcos-net`.  Read this [note](/1.11/networking/#a-note-on-software-re-architecture) to learn more about the re-factoring of the network stack.
 - The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/#dns-forward-zones) to understand its usage.
 
 [enterprise]
 ### Security
 [/enterprise]
 - Secrets Management Service
-  - Binary Secret files are now supported
-  - Hierarchical access control is now supported.
+  - Binary Secret files are supported now.
+  - Hierarchical access control is supported now.
 
 ### Monitoring
 - The DC/OS metrics component now produces metrics in [Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/) format. [View the documentation](/1.11/metrics).
-- Unified logging API that provides simple access to container (task) as well as system component logs. [View the documentation](/1.11/monitoring/logging/logging-api/logging-v2/).
+- Unified logging API provides simple access to container (task) and system component logs. [View the documentation](/1.11/monitoring/logging/logging-api/logging-v2/).
 
 ### Storage
-- DC/OS Storage Service 0.1 (beta) - DSS users will be able to dynamically create volumes based upon profiles or policies to fine-tune their applications' storage requirements. This feature leverages the industry-standard Container Storage Interface (CSI) to streamline the development of storage features in DC/OS by Mesosphere and our community and partner ecosystems. [View the documentation](https://docs.mesosphere.com/services/beta-storage/0.1.0-beta/).[beta type="inline" size="small" /][enterprise type="inline" size="small" /]
+- DC/OS Storage Service 0.1 (beta) - DSS users will be able to dynamically create volumes based upon profiles or policies to fine-tune their applications storage requirements. This feature leverages the industry-standard Container Storage Interface (CSI) to streamline the development of storage features in DC/OS by Mesosphere and our community and partner ecosystems. [View the documentation](https://docs.mesosphere.com/services/beta-storage/0.1.0-beta/).[beta type="inline" size="small" /][enterprise type="inline" size="small" /]
 - Pods now support persistent volumes. [View the documentation](/1.11/deploying-services/pods).[beta type="inline" size="small" /]
 
 **Note:** Because these storage features are beta in 1.11, they must be explicitly enabled. Beta features are not recommended for production usage, but are a good indication of the direction the project is headed.

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -24,7 +24,7 @@ DC/OS 1.11.2 includes the following:
 - DCOS-14199 - Consolidated the Exhibitor bootstrapping shortcut by atomically reading and writing the ZooKeeper PID file.
 - DCOS-20514 - Added licensing information to the diagnostics bundle.
 - DCOS-21596 - Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
-- DCOS-22128 - Supported pods with volumes but no volume mounts. [enterprise type="inline" size="small" /]
+- DCOS-22128 - Fixed an issue in the Service view of DC/OS UI, when cluster has pods with not every container mounting a volume [enterprise type="inline" size="small" /]
 - DCOS_OSS-2360 - DC/OS Metrics: metric names are sanitized for better compatibility with Prometheus.
 - DCOS_OSS-2378 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
 - DC/OS UI: Incorporated [multiple](https://github.com/dcos/dcos/pull/2799) fixes and improvements.
@@ -36,7 +36,6 @@ DC/OS 1.11.2 includes the following:
 - DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /] 
 - DCOS-29122 - Support for launching services in a remote region.
 - DCOS-29634 - Implement region validation and config-sniffing in SDK.
-- DCOS_OSS-2377 - Agent operator API: Displayed resource provider resources in GET_RESOURCE_PROVIDER response.
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -14,35 +14,29 @@ These are the release notes for DC/OS 1.11.2.
 
 DC/OS 1.11.2 includes the following:
 
-- Apache Mesos 1.5.x [change log](https://github.com/mesosphere/mesos/blob/27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8/CHANGELOG).
+- Apache Mesos 1.5.1-dev [change log](https://github.com/mesosphere/mesos/blob/27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8/CHANGELOG).
 - Marathon 1.6.392 [change log](https://github.com/mesosphere/marathon/releases).
 - Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4.2).
 
 
 # Issues Fixed in DC/OS 1.11.2
 
-- DCOS-14199 - Fixed an issue that prevented DC/OS from recovering when available disk space was low.
-- DCOS-21596 -  Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
-- DCOS-22016 - Updated Prometheus documentation.
+- DCOS-14199 - Consolidated the Exhibitor bootstrapping shortcut by atomically reading and writing the ZooKeeper PID file.
+- DCOS-20514 - Added licensing information to the diagnostics bundle.
+- DCOS-21596 - Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
 - DCOS-22128 - Supported pods with volumes but no volume mounts. [enterprise type="inline" size="small" /]
-- DCOS-34465 - Updated documentation on using multiple methods to SSH to a master node. 
-- DCOS_OSS-2132 - Added a new journal reader function `Follow()` to track the `journald` files rotation.
-- DCOS_OSS-2360 - Ordered numeric characters for Metric names in dcos-metrics Prometheus endpoint.
+- DCOS_OSS-2360 - DC/OS Metrics: metric names are sanitized for better compatibility with Prometheus.
 - DCOS_OSS-2378 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
+- DC/OS UI: Incorporated [multiple](https://github.com/dcos/dcos/pull/2799) fixes and improvements.
 
 
 # Notable Changes in DC/OS 1.11.2
 
-- DCOS-22021 - Removed IAM database migration from Zookeeper to Cockroach. [enterprise type="inline" size="small" /]
-- DCOS-22041 - Removed policyquery cache race condition in Bouncer. [enterprise type="inline" size="small" /]
-- DCOS-22296 - Added the lvm2 command-line utilities (e.g. lvcreate, vgs, etc.) for csilvm CSI plugin. [enterprise type="inline" size="small" /]
-- DCOS-22308 - Bumped CockroachDB to v1.1.8. [enterprise type="inline" size="small" /]
-- DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /]
-- DCOS-22439 - Promoted metrics documentation to staging. 
-- DCOS-29122 - Upgraded multi-region SDK package to Universe services.
+- DCOS-21958 - Admin Router on the DC/OS master nodes now does not support TLS 1.1 and the 3DES bulk encryption algorithm anymore by default.
+- DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /] 
+- DCOS-29122 - Support for launching services in a remote region.
 - DCOS-29634 - Implement region validation and config-sniffing in SDK.
 - DCOS_OSS-2377 - Agent operator API: Displayed resource provider resources in GET_RESOURCE_PROVIDER response.
-- DCOS_OSS-2688 - Supported secrets in Metronome. [enterprise type="inline" size="small" /]
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
@@ -51,15 +45,9 @@ DC/OS 1.11.2 includes the following:
 **Note:** 
 1. Previous 1.11 point releases are not supported for CoreOS 1688.5.3.
 
-2. Implemented region awareness support for SDK based services are implemented in this release.
+2. Implemented region awareness support for SDK based services are implemented in this release. [enterprise type="inline" size="small" /]
 
 3. New Docker versions supported on RHEL 7.4 and CoreOS 1688.5.3. See [compatibility matrix](https://docs.mesosphere.com/version-policy/) for further information.
-
-
-# Known Issue in DC/OS 1.11.2
-
-- DCOS-20568 - Fixed dcos-diagnostics master service account permission issue.
-
 
 
 # About DC/OS 1.11

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -22,18 +22,17 @@ DC/OS 1.11.2 includes the following:
 # Issues Fixed in DC/OS 1.11.2
 
 - DCOS-14199 - Fixed an issue that prevented DC/OS from recovering when available disk space was low.
-- DCOS-21596-  Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
+- DCOS-21596 -  Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
 - DCOS-22016 - Updated Prometheus documentation.
 - DCOS-22128 - Supported pods with volumes but no volume mounts. [enterprise type="inline" size="small" /]
 - DCOS-34465 - Updated documentation on using multiple methods to SSH to a master node. 
 - DCOS_OSS-2132 - Added a new journal reader function `Follow()` to track the `journald` files rotation.
 - DCOS_OSS-2360 - Ordered numeric characters for Metric names in dcos-metrics Prometheus endpoint.
-- DCOS_OSS-2378/SOAK-88 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
+- DCOS_OSS-2378 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
 
 
 # Notable Changes in DC/OS 1.11.2
 
-- DCOS-16431 - Cached PQ endpoint for bouncer/adminrouter. [enterprise type="inline" size="small" /]
 - DCOS-22021 - Removed IAM database migration from Zookeeper to Cockroach. [enterprise type="inline" size="small" /]
 - DCOS-22041 - Removed policyquery cache race condition in Bouncer. [enterprise type="inline" size="small" /]
 - DCOS-22296 - Added the lvm2 command-line utilities (e.g. lvcreate, vgs, etc.) for csilvm CSI plugin. [enterprise type="inline" size="small" /]
@@ -54,10 +53,10 @@ DC/OS 1.11.2 includes the following:
 
 2. Implemented region awareness support for SDK based services are implemented in this release.
 
-3. New Docker versions supported on RHEL 7.4 and CoreOS 1688.5.3. For details see [compatibility matrix](https://docs.mesosphere.com/version-policy/).
+3. New Docker versions supported on RHEL 7.4 and CoreOS 1688.5.3. See [compatibility matrix](https://docs.mesosphere.com/version-policy/) for further information.
 
 
-# <a name="known-issue"></a>Known Issue in DC/OS 1.11.2
+# Known Issue in DC/OS 1.11.2
 
 - DCOS-20568 - Fixed dcos-diagnostics master service account permission issue.
 

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -12,34 +12,51 @@ These are the release notes for DC/OS 1.11.2.
 
 [button color="light" href="https://support.mesosphere.com/hc/en-us/articles/213198586"]Download DC/OS Enterprise[/button]
 
+DC/OS 1.11.2 includes the following:
+
+Apache Mesos 1.5.x [change log](https://github.com/mesosphere/mesos/blob/27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8/CHANGELOG).
+Marathon 1.6.392 [change log](https://github.com/mesosphere/marathon/releases).
+Metronome 0.4.2 [change log](https://github.com/dcos/metronome/releases/tag/v0.4.2).
+
+
 # <a name="issues-fixed"></a>Issues Fixed in DC/OS 1.11.2
 
 - DCOS-14199 - Fixed an issue that prevented DC/OS from recovering when available disk space was low.
+- DCOS-21596-  Added local user to LDAP group if local username matches LDAP username. [enterprise type="inline" size="small" /]
+- DCOS-22016 - Updated Prometheus documentation.
 - DCOS-22128 - Supported pods with volumes but no volume mounts. [enterprise type="inline" size="small" /]
+- DCOS-34465 - Updated documentation on using multiple methods to SSH to a master node. 
+- DCOS_OSS-2132 - Added a new journal reader function `Follow()` to track the `journald` files rotation.
+- DCOS_OSS-2360 - Ordered numeric characters for Metric names in dcos-metrics Prometheus endpoint.
 - DCOS_OSS-2378/SOAK-88 - DC/OS Net: Improved stability of distribution protocol over TLS. [enterprise type="inline" size="small" /]
-- SOAK-92 - 
-
 
 
 # <a name="notable-changes"></a>Notable Changes in DC/OS 1.11.2
 
-- DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router.
-- DCOS-21557/DCOS_OSS-2367 - Upgraded curl to version 7.59, which fixed several curl security vulnerabilities from previous version.
-- QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
-- QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported. 
-- DCOS-29080, DCOS-29122, DCOS-29168, DCOS-29188, DCOS-29216, DCOS-29265, DCOS-29282, DCOS-29299, DCOS-29384, DCOS-29455, DCOS-29520, DCOS-29532, DCOS-29544, DCOS-29567, DCOS-29601, DCOS-29616, DCOS-29634, and DCOS-29703 - Implemented remote region support for data engineering services.
-
-- DCOS-29216, DCOS-29384, DCOS-29384, DCOS-29455, DCOS-29520, DCOS-29532, DCOS-29567, DCOS-29080 - Implemented remote region support for data engineering services.
-- DCOS-29634 - Implement region validation and config-sniffing in SDK.
+- Updated to [Mesos 1.5.1](https://github.com/mesosphere/mesos/blob/b2eeb11ede805a7830cd6fb796d0b21a647aba04/CHANGELOG).
+- Updated to [Marathon 1.6.392](https://github.com/mesosphere/marathon/releases).
+- Updated to [Metronome 0.4.2](https://github.com/dcos/metronome/releases/tag/v0.4.2).
+- DCOS-16431 - Cached PQ endpoint for bouncer/adminrouter. [enterprise type="inline" size="small" /]
+- DCOS-22021 - Removed IAM database migration from Zookeeper to Cockroach. [enterprise type="inline" size="small" /]
+- DCOS-22041 - Removed policyquery cache race condition in Bouncer. [enterprise type="inline" size="small" /]
+- DCOS-22296 - Added the lvm2 command-line utilities (e.g. lvcreate, vgs, etc.) for csilvm CSI plugin. [enterprise type="inline" size="small" /]
+- DCOS-22308 - Bumped CockroachDB to v1.1.8. [enterprise type="inline" size="small" /]
+- DCOS-22326 - Disabled the insecure 3DES bulk encryption algorithm and TLS 1.1 protocol by default for Master Admin Router. [enterprise type="inline" size="small" /]
+- DCOS-22439 - Promoted metrics documentation to staging. 
 - DCOS-29122 - Upgraded multi-region SDK package to Universe services.
-- DCOS-29168 - 
+- DCOS-29634 - Implement region validation and config-sniffing in SDK.
+- DCOS_OSS-2377 - Agent operator API: Displayed resource provider resources in GET_RESOURCE_PROVIDER response.
+- DCOS_OSS-2688 - Supported secrets in Metronome.
 - QUALITY-2006 - RHEL 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2007 - RHEL 7.4 with Docker 17.12.1-ce is supported. 
 - QUALITY-2057 - CentOS 7.4 with Docker EE 17.06.2 is supported.
 - QUALITY-2060 - Certified DC/OS 1.11.2 with CoreOS 1688.5.3.
-**Note:** Previous 1.11 point releases are not supported for CoreOS 1688.5.3.
 
-**Note:** Implemented region awareness support for SDK based services.
+**Note:** 
+1. Previous 1.11 point releases are not supported for CoreOS 1688.5.3.
+
+2. Implemented region awareness support for SDK based services are implemented in this release.
+
 
 # <a name="known-issue"></a>Known Issue in DC/OS 1.11.2
 


### PR DESCRIPTION
NOTE:
The following commit message is incorrect and should be "Removed CoreOS 1688.5.3 since it is not supported for this release."
<img width="940" alt="screen shot 2018-05-17 at 10 41 34 am" src="https://user-images.githubusercontent.com/36425832/40194340-ece67ffa-59be-11e8-871d-e2003bcaeff8.png">
