### PR TITLE
Fixed dead URL

### DIFF
--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -122,7 +122,7 @@
 /1.10/installing/custom/ /1.10/installing/oss/custom/;
 /1.10/installing/custom/configuration/configuration-parameters/ /1.10/installing/ent/custom/configuration/configuration-parameters/;
 /1.10/installing/custom/configuration-parameters/ /1.10/installing/oss/custom/configuration/configuration-parameters/;
-/1.10/installing/local/ /1.10/installing/oss/local/;
+/1.10/installing/local/ /1.10/installing/ent/local/;
 /1.10/monitoring/debugging/cli-debugging/task-exec/ /1.10/monitoring/debugging/task-exec/;
 /1.10/networking/mesos-dns/http-interface/ /1.10/networking/mesos-dns/mesos-dns-api/;
 ~^/1.10/networking/edge-lb/(.*)$ /services/edge-lb/$1;

--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -466,6 +466,7 @@
 /1.9/developing-services/service-requirements-spec/ https://github.com/mesosphere/universe/blob/version-3.x/tutorial/GetStarted.md;
 /1.9/development/ /1.9/developing-services/;
 /1.9/installing/custom/configuration-parameters/ /1.9/installing/custom/configuration/configuration-parameters/;
+/1.9/installing/local/ /1.9/installing/ent/local/;
 /1.9/monitoring/debugging/cli-debugging/task-exec/ /1.9/monitoring/debugging/task-exec/;
 /1.9/networking/mesos-dns/http-interface/ /1.9/networking/mesos-dns/mesos-dns-api/;
 /1.9/overview/components/ /1.9/overview/architecture/components/;


### PR DESCRIPTION
Customer facing issue. 
Redirected  /1.9/installing/local/ to point to /1.9/installing/ent/local/;

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
