### PR TITLE
Document CLI version requirements for DC/OS <=1.9

### DIFF
--- a/pages/1.10/cli/index.md
+++ b/pages/1.10/cli/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The DC/OS command line interface (DC/OS CLI) is a utility to manage cluster nodes, install and manage packages, inspect the cluster state, and manage services and tasks.
 
-DC/OS 1.10.0 requires DC/OS CLI 0.5.x.
+DC/OS 1.10 requires the DC/OS CLI 0.5.x.
 
 To list available commands, run `dcos` with no parameters:
 

--- a/pages/1.11/cli/index.md
+++ b/pages/1.11/cli/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The DC/OS command line interface (DC/OS CLI) utility allows you to manage cluster nodes, install and manage packages, inspect the cluster state, and manage services and tasks.
 
-DC/OS 1.11.0 requires DC/OS CLI 0.6.x.
+DC/OS 1.11 requires the DC/OS CLI 0.6.x.
 
 To list available commands, run `dcos` with no parameters:
 

--- a/pages/1.7/usage/cli/install/index.md
+++ b/pages/1.7/usage/cli/install/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
-**Important:** DC/OS 1.8 introduces binary CLIs for Linux, Windows, and Mac. The install script is replaced with a simple binary CLI. The 1.8 CLI is compatible with DC/OS 1.6.1 forward. For more information, see the [documentation](/1.7/usage/cli/install/).
+**Important:** DC/OS 1.8 introduces binary CLIs for Linux, Windows, and Mac. The install script is replaced with a simple binary CLI. The 1.8 CLI (version 0.4.x) is compatible with DC/OS 1.7, 1.8, and 1.9. For more information, see the [documentation](/1.7/usage/cli/install/).
 
 *   [Installing the DC/OS CLI on Unix, Linux, and macOS][1]
 *   [Installing the DC/OS CLI on Windows][2]

--- a/pages/1.8/usage/cli/index.md
+++ b/pages/1.8/usage/cli/index.md
@@ -15,6 +15,8 @@ You can use the DC/OS command-line interface (CLI) to manage your cluster nodes,
 
 You can quickly [install](/1.8/usage/cli/install) the CLI from the DC/OS web interface.
 
+DC/OS 1.8 requires the DC/OS CLI 0.4.x.
+
 To list available commands, either run `dcos` with no parameters or run `dcos help`:
 
 ```bash

--- a/pages/1.9/cli/index.md
+++ b/pages/1.9/cli/index.md
@@ -15,6 +15,8 @@ You can use the DC/OS command-line interface (CLI) to manage your cluster nodes,
 
 You can quickly [install](/1.9/cli/install) the CLI from the DC/OS web interface.
 
+DC/OS 1.9 requires the DC/OS CLI 0.4.x.
+
 To list available commands, either run `dcos` with no parameters or run `dcos help`:
 
 ```bash


### PR DESCRIPTION
The CLI versions requirements are:
- DC/OS <=1.9: CLI 0.4.x
- DC/OS 1.10: CLI 0.5.x
- DC/OS 1.11: CLI 0.6.x

## Description
https://jira.mesosphere.com/browse/DCOS-37542

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
