### PR TITLE
DCOS-25876 Edits to GCE installation docs for 1.10

### DIFF
--- a/pages/1.10/installing/oss/cloud/gce/index.md
+++ b/pages/1.10/installing/oss/cloud/gce/index.md
@@ -1,26 +1,25 @@
 ---
 layout: layout.pug
-excerpt:
+excerpt: Running DC/OS on Google Compute Engine
 title: Running DC/OS on Google Compute Engine
 navigationTitle: GCE
 menuWeight: 3
 ---
-
-The recommended way for deploying a OSS DC/OS cluster on GCE is using [Terraform](#terraform).
-
-
 # Terraform
- **Disclaimer: Please note this is a [community driven project](https://github.com/dcos/terraform-dcos/tree/master/gcp) and not officially supported by Mesosphere directly.**
+
+The recommended way to deploy a OSS DC/OS cluster on GCE is by using [Terraform](#terraform).
+
+ **Disclaimer: Please note this is a [community driven project](https://github.com/dcos/terraform-dcos/tree/master/gcp) and not officially supported by Mesosphere.**
 
 ## Prerequisites
 - [Terraform 0.11.x](https://www.terraform.io/downloads.html)
-- GCP Cloud Credentials. _[configure via: `gcloud auth login`](https://cloud.google.com/sdk/downloads)_
+- Google Cloud Platform (GCP) Credentials _[configure via: `gcloud auth login`](https://cloud.google.com/sdk/downloads)_
 - SSH Keys
-- Existing Google Project. Soon automated with Terraform using project creation as documented [here.](https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform)
+- Existing Google Project. This is automated with Terraform using project creation as documented [here.](https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform)
 
-## Install Google SDK
-
-Run this command to authenticate to the Google Provider. This will bring down your keys locally on the machine for terraform to use.
+## Authenticate to Google
+<!-- This section does not look right. Combines two steps which may not be correct together.  -->
+Run this command to authenticate to the Google Cloud Platform. Your credentials will be downloaded locally for Terraform to use.
 
 ```bash
 $ gcloud auth login
@@ -28,8 +27,7 @@ $ gcloud auth application-default login
 ```
 
 ## Configure your GCP SSH Keys
-
-Set the private key that you will be using to your ssh-agent and set public key in terraform. This will allow you to log into to the cluster after DC/OS is deployed and also helps Terraform setup your cluster at deployment time.
+You must set the private key that you will be using with `ssh-agent` and `set public key` in Terraform. Setting a private key will allow you to log in to to the cluster after DC/OS is deployed. A private key also helps Terraform set up your cluster at deployment time.
 
 ```bash
 $ ssh-add ~/.ssh/your_private_key.pem
@@ -43,7 +41,7 @@ gcp_ssh_pub_key_file = "INSERT_PUBLIC_KEY_PATH_HERE"
 
 ## Configure a Pre-existing Google Project
 
-Currently terraform-dcos assumes a project already exist in GCP to start deploying your resources against. This repo soon will have support for terraform to create projects on behalf of the user via this [document](https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform). For the time being a user will have to create this project before time or leverage an existing project.
+Currently `terraform-dcos` assumes that a project already exists in GCP, for you to start deploying your resources against. This repo will soon have support for Terraform to create projects on behalf of the user via this [document](https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform). For the time being, you will have to create this project ahead of time, or else leverage an existing project.
 
 ```bash
 $ cat desired_cluster_profile.tfvars
@@ -55,8 +53,9 @@ gcp_project = "massive-bliss-781"
 
 ### Quick Start
 
-We've provided all the sensible defaults that you would want to play around with DC/OS. Just run this command to deploy a multi-master setup in the cloud. Three agents will be deployed for you. Two private agents, one public agent.
+We have provided all the typical defaults that you would want available to play around with DC/OS. Run the following commands to deploy a multi-master setup in the cloud.
 
+- Three agents will be deployed for you: two private agents and one public agent.
 - There is no git clone of this repo required. Terraform does this for you under the hood.
 
 ```bash
@@ -64,23 +63,23 @@ terraform init -from-module github.com/dcos/terraform-dcos//gcp
 terraform apply -var gcp_project="your_existing_project"
 ```
 
-### Custom terraform-dcos variables
+### Custom `terraform-dcos` variables
 
-The default variables are tracked in the [variables.tf](https://github.com/dcos/terraform-dcos/blob/master/gcp/variables.tf) file. Since this file can be overwritten during updates when you may run `terraform get --update` when you want to fetch new releases of DC/OS to upgrade too, its best to use the [desired_cluster_profile.tfvars](https://github.com/dcos/terraform-dcos/blob/master/gcp/desired_cluster_profile.tfvars.example) and set your custom terraform and DC/OS flags there. This way you can keep track of a single file that you can use manage the lifecycle of your cluster.
+The default variables are tracked in the [variables.tf](https://github.com/dcos/terraform-dcos/blob/master/gcp/variables.tf) file. This file can be overwritten during updates when you may run `terraform get --update` when you want to fetch new releases of DC/OS to upgrade to. Therefore, it is best to use the [desired_cluster_profile.tfvars](https://github.com/dcos/terraform-dcos/blob/master/gcp/desired_cluster_profile.tfvars.example) and set your custom terraform and DC/OS flags there. This way you can keep track of a single file that you can use to manage the lifecycle of your cluster.
 
 For a list of supported operating systems for this repo, see the ones that DC/OS recommends [here](https://docs.mesosphere.com/1.10/installing/oss/custom/system-requirements/). You can find the list that Terraform supports [here](http://github.com/bernadinm/tf_dcos_core).
 
-To apply the configuration file, you can use this command below.
+To apply the configuration file, run the following command:
 
 ```bash
 terraform apply -var-file desired_cluster_profile.tfvars
 ```
 
-#### Advance YAML Configuration
+#### Advanced YAML configuration
 
-We have designed this project to be flexible. Here are the example working variables that allows very deep customization by using a single `tfvars` file.
+We have designed this project to be flexible. In the following example, the working variables allow customization by using a single `tfvars` file.
 
-For advance users with stringent requirements, here are the DC/OS flags examples where you can simply paste your YAML configuration in your desired_cluster_profile.tfvars. The alternative to YAML is to convert it to JSON.
+For advanced users with stringent requirements, here are the DC/OS flag examples where you can simply paste your YAML configuration in your `desired_cluster_profile.tfvars`. The alternative to YAML is to convert it to JSON.
 
 ```bash
 $ cat desired_cluster_profile.tfvars
@@ -125,36 +124,36 @@ dcos_cluster_docker_credentials = <<EOF
 EOF
 gcp_ssh_pub_key_file = "INSERT_PUBLIC_KEY_PATH_HERE"
 ```
-_Note: The YAML comment is required for the DC/OS specific YAML settings._
+**Note:** The YAML comment is required for the DC/OS specific YAML settings.
 
 ## Upgrading DC/OS
 
-You can upgrade your DC/OS cluster with a single command. This terraform script was built to perform installs and upgrades from the inception of this project. With the upgrade procedures below, you can also have finer control on how masters or agents upgrade at a given time. This will give you the ability to change the parallelism of master or agent upgrades.
+You can upgrade your DC/OS cluster with a single command. This Terraform script was built to perform installs and upgrades from the inception of this project. With the upgrade procedures below, you can also have finer control on how masters or agents upgrade at a given time. This will allow you to change the parallelism of master or agent upgrades.
 
 ### DC/OS Upgrades
 
-#### Rolling Upgrade
-###### Supported upgraded by dcos.io
+#### Rolling upgrade
 
-##### Masters Sequentially, Agents Parellel:
+Supported upgraded by dcos.io
+
+##### Masters sequential, agents parallel:
 ```bash
 terraform apply -var-file desired_cluster_profile.tfvars -var state=upgrade -target null_resource.bootstrap -target null_resource.master -parallelism=1
 terraform apply -var-file desired_cluster_profile.tfvars -var state=upgrade
 ```
 
-##### All Roles Simultaniously
-###### Not supported by dcos.io but it works without dcos_skip_checks enabled.
+##### All roles simultaneously
+This command is not supported by dcos.io, but it works without `dcos_skip_checks` enabled.
 
 ```bash
 terraform apply -var-file desired_cluster_profile.tfvars -var state=upgrade
 ```
 
-
 ## Maintenance
 
-If you would like to add or remove (private) agents or public agents from your cluster, you can do so by telling terraform your desired state and it will make sure it gets you there. For example, if I have 2 private agents and 1 public agent in my `-var-file` I can always override that flag by specifying the `-var` flag. It has higher priority than the `-var-file`.
+If you would like to add or remove private or public agents from your cluster, you can do so by telling Terraform your desired state and it will make the required changes. For example, if you have two private agents and one public agent in your `-var-file`,  you can override that flag by specifying the `-var` flag. The `var` flag has higher priority than the `-var-file`.
 
-### Adding Agents
+### Adding agents
 
 ```bash
 terraform apply \
@@ -163,7 +162,8 @@ terraform apply \
 -var num_of_public_agents=3
 ```
 
-### Removing Agents
+### Removing agents
+**Important**: Always remember to save your desired state in your `desired_cluster_profile.tfvars` before removing an agent.
 
 ```bash
 terraform apply \
@@ -172,42 +172,40 @@ terraform apply \
 -var num_of_public_agents=1
 ```
 
-**Important**: Always remember to save your desired state in your `desired_cluster_profile.tfvars`
+## Redeploy an existing master
 
-## Redeploy an existing Master
+If you want to redeploy a problematic master (for example, your storage has filled up, the cluster is not responsive, etc.), you can tell Terraform to redeploy during the next cycle.
 
-If you want to redeploy a problematic master (ie. storage filled up, not responsive, etc), you can tell terraform to redeploy during the next cycle.
-
-**NOTE:** This only applies to DC/OS clusters that have set their `dcos_master_discovery` to `master_http_loadbalancer` and not `static`.
+**Note:** This only applies to DC/OS clusters that have set their `dcos_master_discovery` to `master_http_loadbalancer` and not `static`.
 
 ### Master Node
 
-#### Taint Master Node
+#### Taint master node
 
 ```bash
 terraform taint google_compute_instance.master.0 # The number represents the agent in the list
 ```
 
-#### Redeploy Master Node
+#### Redeploy master node
 
 ```bash
 terraform apply -var-file desired_cluster_profile.tfvars
 ```
 
-## Redeploy an existing Agent
+## Redeploy an existing agent
 
-If you want to redeploy a problematic agent (i.e., storage filled up, not responsive, etc.), you can tell terraform to redeploy during the next cycle.
+If you want to redeploy a problematic agent, you can tell Terraform to redeploy during the next cycle.
 
 
 ### Private Agents
 
-#### Taint Private Agent
+#### Taint private agent
 
 ```bash
 terraform taint google_compute_instance.agent.0 # The number represents the agent in the list
 ```
 
-#### Redeploy Agent
+#### Redeploy agent
 
 ```bash
 terraform apply -var-file desired_cluster_profile.tfvars
@@ -216,27 +214,27 @@ terraform apply -var-file desired_cluster_profile.tfvars
 
 ### Public Agents
 
-#### Taint Private Agent
+#### Taint private agent
 
 ```bash
 terraform taint google_compute_instance.public-agent.0 # The number represents the agent in the list
 ```
 
-#### Redeploy Agent
+#### Redeploy agent
 
 ```bash
 terraform apply -var-file desired_cluster_profile.tfvars
 ```
 
-### Experimental
+### Experimental [experimental type="inline" size="large" /]
 
-#### Adding GPU Private Agents
+#### Adding GPU private agents
 
 Coming soon!
 
-### Destroy Cluster
+### Destroying a cluster
 
-You can shutdown/destroy all resources from your environment by running this command below:
+You can shut down and/or destroy all resources from your environment by running this command:
 
 ```bash
 terraform destroy -var-file desired_cluster_profile.tfvars


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25874

The GCE installation procedure for 1.11 is incorrect; the correct version should be based on the GCE installation docs for 1.10. Before we edit 1.11, however, I have gone through and edited the 1.10 docs for clarity. Once the 1.10 docs are correct, we can use them as the basis for the 1.11 corrections.


## Urgency
- [x] Medium
