### PR TITLE
SITE-1610 Corrected misspelled word in template used by confluent-kaf…

### DIFF
--- a/pages/services/include/configuration-service-settings.tmpl
+++ b/pages/services/include/configuration-service-settings.tmpl
@@ -9,7 +9,7 @@ A common task is to specify a list of whitelisted systems to deploy to. To achie
 [["hostname", "LIKE", "10.0.0.159|10.0.1.202|10.0.3.3"]]
 ```
 
-**Note**: Be sure to include excess capacity in such a scenario so that if one of the whitelisted systems goes down, there is still enough capcaity to repair your service.
+**Note**: Be sure to include excess capacity in such a scenario so that if one of the whitelisted systems goes down, there is still enough capacity to repair your service.
 
 #### Updating Placement Constraints
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/SITE-1610

Misspelled word in service docs: "capcaity" -- should be "capacity". Affects all versions of confluent-kafka, cassandra, elastic, confluent-zookeeper, kafka, dse, hdfs, and kafka-zookeeper. This misspelled word is found in a template used by all these service docs, so fixing it once (as I have done here) fixes it in all renderings of those documents.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

