### PR TITLE
COPS-405 Adding disk node setting warning to all versions, using .tmpl

### DIFF
--- a/pages/services/beta-cassandra/1.0.30-3.0.13-beta/node-settings/index.md
+++ b/pages/services/beta-cassandra/1.0.30-3.0.13-beta/node-settings/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Node Settings
 title: Node Settings
 menuWeight: 50
-excerpt:
+excerpt: Customize your node resource settings
 featureMaturity:
 enterprise: false
 ---
@@ -79,11 +79,12 @@ The service supports two volume types:
 
 Using `MOUNT` volumes requires [additional configuration on each DC/OS agent system](/1.9/storage/mount-disk-resources/), so the service currently uses `ROOT` volumes by default. To ensure reliable and consistent performance in a production environment, you should configure `MOUNT` volumes on the machines that will run the service in your cluster and then configure the following as `MOUNT` volumes:
 
-**Note:** It is not currently possible to change disk types on an existing deployment as data will not be migrated.  For an existing deployment, data should be backed up, the cluster re-deployed with the new disk type, and data restored.
-
 To configure the disk type:
 *   **In DC/OS CLI options.json**: `disk_type`: string (default: `ROOT`)
 *   **DC/OS web interface**: `CASSANDRA_DISK_TYPE`: `string`
+
+#include /services/include/node-disk-type-warning.tmpl
+
 
 # Placement Constraints
 

--- a/pages/services/beta-cassandra/1.0.31-3.0.13-beta/node-settings/index.md
+++ b/pages/services/beta-cassandra/1.0.31-3.0.13-beta/node-settings/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Node Settings
 title: Node Settings
 menuWeight: 50
-excerpt:
+excerpt: Customize your node resource settings
 featureMaturity:
 enterprise: false
 ---
@@ -82,6 +82,9 @@ Using `MOUNT` volumes requires [additional configuration on each DC/OS agent sys
 To configure the disk type:
 *   **In DC/OS CLI options.json**: `disk_type`: string (default: `ROOT`)
 *   **DC/OS web interface**: `CASSANDRA_DISK_TYPE`: `string`
+
+#include /services/include/node-disk-type-warning.tmpl
+
 
 # Placement Constraints
 

--- a/pages/services/beta-cassandra/1.0.32-3.0.14-beta/node-settings/index.md
+++ b/pages/services/beta-cassandra/1.0.32-3.0.14-beta/node-settings/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Node Settings
 title: Node Settings
 menuWeight: 50
-excerpt:
+excerpt: Customize your node resource settings
 featureMaturity:
 enterprise: false
 ---
@@ -84,6 +84,9 @@ Using `MOUNT` volumes requires [additional configuration on each DC/OS agent sys
 To configure the disk type:
 *   **In DC/OS CLI options.json**: `disk_type`: string (default: `ROOT`)
 *   **DC/OS web interface**: `CASSANDRA_DISK_TYPE`: `string`
+
+#include /services/include/node-disk-type-warning.tmpl
+
 
 ## Disk Scheduler
 

--- a/pages/services/beta-cassandra/2.1.0-3.0.15-beta/node-settings/index.md
+++ b/pages/services/beta-cassandra/2.1.0-3.0.15-beta/node-settings/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 title: Node Settings
 menuWeight: 27
-excerpt:
+excerpt: Customize your node resource settings
 featureMaturity:
 enterprise: false
 ---
@@ -84,6 +84,9 @@ Using `MOUNT` volumes requires [additional configuration on each DC/OS agent sys
 To configure the disk type:
 *   **In DC/OS CLI options.json**: `disk_type`: string (default: `ROOT`)
 *   **DC/OS web interface**: `CASSANDRA_DISK_TYPE`: `string`
+
+#include /services/include/node-disk-type-warning.tmpl
+
 
 ## Disk Scheduler
 

--- a/pages/services/beta-cassandra/2.1.1-3.0.15-beta/node-settings/index.md
+++ b/pages/services/beta-cassandra/2.1.1-3.0.15-beta/node-settings/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 title: Node Settings
 menuWeight: 27
-excerpt:
+excerpt: Customize your node resource settings
 featureMaturity:
 enterprise: false
 ---
@@ -83,6 +83,9 @@ Using `MOUNT` volumes requires [additional configuration on each DC/OS agent sys
 To configure the disk type:
 *   **In DC/OS CLI options.json**: `disk_type`: string (default: `ROOT`)
 *   **DC/OS web interface**: `CASSANDRA_DISK_TYPE`: `string`
+
+#include /services/include/node-disk-type-warning.tmpl
+
 
 ## Disk Scheduler
 

--- a/pages/services/beta-cassandra/2.1.2-3.0.15-beta/index.md
+++ b/pages/services/beta-cassandra/2.1.2-3.0.15-beta/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Beta Cassandra 2.1.2-3.0.15-beta
 title: Beta Cassandra 2.1.2-3.0.15-beta
 menuWeight: 10
-excerpt:
+excerpt: 
 featureMaturity:
 enterprise: false
 ---

--- a/pages/services/beta-cassandra/2.1.2-3.0.15-beta/node-settings/index.md
+++ b/pages/services/beta-cassandra/2.1.2-3.0.15-beta/node-settings/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 title: Node Settings
 menuWeight: 27
-excerpt:
+excerpt: Customize your node resource settings
 
 ---
 
@@ -83,6 +83,9 @@ Using `MOUNT` volumes requires [additional configuration on each DC/OS agent sys
 To configure the disk type:
 *   **In DC/OS CLI options.json**: `disk_type`: string (default: `ROOT`)
 *   **DC/OS web interface**: `CASSANDRA_DISK_TYPE`: `string`
+
+#include /services/include/node-disk-type-warning.tmpl
+
 
 ## Disk Scheduler
 

--- a/pages/services/beta-cassandra/index.md
+++ b/pages/services/beta-cassandra/index.md
@@ -3,9 +3,10 @@ layout: layout.pug
 navigationTitle:  Beta Cassandra
 title: Beta Cassandra
 menuWeight: 110
-excerpt:
+excerpt: DC/OS Apache Cassandra is an automated service that makes it easy to deploy and manage Apache Cassandra on DC/OS
 featureMaturity:
 enterprise: false
+beta: true
 ---
 
 Welcome to the documentation for the Apache DC/OS Cassandra Beta. Choose a version to get started!

--- a/pages/services/include/node-disk-type-warning.tmpl
+++ b/pages/services/include/node-disk-type-warning.tmpl
@@ -1,0 +1,1 @@
+**Node:** It is not currently possible to change disk types on an existing deployment as data will not be migrated. For an existing deployment, data should be backed up, the cluster re-deployed with the new disk type, and data restored.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-405

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Added note that changing disk types is not possible on an existing deployment, data will not be migrated for example from root to mount volume. For an existing deployment, data should be backed up, the cluster re-deployed with the new disk type, then data restored. I created this as a template, which deploys on every relevant page of each version to date.
