### PR TITLE
COPS-3327 Removed references to Velocity from text of storage/nfs doc…

### DIFF
--- a/pages/1.10/storage/nfs/index.md
+++ b/pages/1.10/storage/nfs/index.md
@@ -8,7 +8,7 @@ menuWeight: 1
 
 # Overview
 
-For some stateful services, such as Jenkins/Velocity, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
+For some stateful services, such as Jenkins, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
 
 **Note:** This example uses CoreOS and systemd and has not been tested in other environments.
 

--- a/pages/1.11/storage/nfs/index.md
+++ b/pages/1.11/storage/nfs/index.md
@@ -10,7 +10,7 @@ menuWeight: 1
 
 # Overview
 
-For some stateful services, such as Jenkins/Velocity, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
+For some stateful services, such as Jenkins, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
 
 **Note:** This example uses CoreOS and systemd and has not been tested in other environments.
 

--- a/pages/1.7/administration/storage/nfs/index.md
+++ b/pages/1.7/administration/storage/nfs/index.md
@@ -8,7 +8,7 @@ menuWeight: 1
 
 # Overview
 
-For some stateful services, such as Jenkins/Velocity, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
+For some stateful services, such as Jenkins, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
 
 **Note:** This example uses CoreOS and systemd and has not been tested in other environments.
 

--- a/pages/1.8/administration/storage/nfs/index.md
+++ b/pages/1.8/administration/storage/nfs/index.md
@@ -8,7 +8,7 @@ menuWeight: 1
 
 # Overview
 
-For some stateful services, such as Jenkins/Velocity, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
+For some stateful services, such as Jenkins, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
 
 **Note:** This example uses CoreOS and systemd and has not been tested in other environments.
 

--- a/pages/1.9/storage/nfs/index.md
+++ b/pages/1.9/storage/nfs/index.md
@@ -8,7 +8,7 @@ menuWeight: 1
 
 # Overview
 
-For some stateful services, such as Jenkins/Velocity, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
+For some stateful services, such as Jenkins, it can be convenient to mount a shared network drive to every node. A shared network drive makes it possible to launch the task on a new node if the node in use becomes unavailable.
 
 **Note:** This example uses CoreOS and systemd and has not been tested in other environments.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-3327

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Removed all mention of Velocity from Mesosphere core docs in the following versions:

- [x]  1.7
- [x]  1.8
- [x]  1.9
- [x]  1.10
- [x]  1.11


The word "velocity", linked with "jenkins", is part of the filename for several images which are referenced in tutorials and service docs (i.e,. "/services/jenkins/img/**velocity**-jobdsl-seed-job.png"). The filename is visible to users only if they  hover the mouse over the picture; otherwise it is invisible. Unless there is a compelling reason to rename these image filenames, which would entail adding redirects for broken links and editing every doc in which the images appear, I suggest we leave the image filenames as they are.

