### PR TITLE
COPS-3391 fixed image broken link installing/ent/custom/advanced

### DIFF
--- a/pages/1.11/installing/ent/custom/advanced/index.md
+++ b/pages/1.11/installing/ent/custom/advanced/index.md
@@ -308,7 +308,7 @@ To install DC/OS:
 
 8.  Enter your administrator username and password.
 
-    ![alt text](/1.11/img/ui-installer-auth2.png)
+    ![Auth page](/1.11/img/ui-installer-auth2.png)
 
     You are done!
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-3391

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

Verified presence of image in /img/ directory.
Fixed broken link to image in /1.11/installing/ent/custom/advanced/#install-dcos
This image appeared only in /ent/ docs. No other versions affected.