### PR TITLE
kubernetes: make merge scripts work on osx

### DIFF
--- a/scripts/service-update-scripts/kubernetes-merge-branch.sh
+++ b/scripts/service-update-scripts/kubernetes-merge-branch.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-#
+
+# sed needs different args to -i depending on the flavor of the tool that is installed
+sedi () {
+    sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
+}
+
 echo "------------------------------"
 echo " Merging Kubernetes"
 echo "------------------------------"
@@ -32,12 +37,12 @@ git fetch dcos-kubernetes > /dev/null 2>&1
 git checkout dcos-kubernetes/$branch docs/package
 
 # checkout each file in the merge list from dcos-kubernetes/master
-for p in `find docs/$package -type f`; do
+for p in `find docs/package -type f`; do
   echo $p
   # markdown files only
   if [ ${p: -3} == ".md" ]; then
     # remove any dodgy control characters - sometimes copied in from commands
-    sed -i -e 's/ *//g' $p
+    sedi -e 's/ *//g' $p
 
     # insert tag ( markdown files only )
     awk -v n=2 '/---/ { if (++count == n) sub(/---/, "---\n\n<!-- This source repo for this topic is https://github.com/mesosphere/dcos-kubernetes -->\n"); } 1{print}' $p > tmp && mv tmp $p
@@ -65,7 +70,7 @@ for p in `find docs/$package -type f`; do
 done
 
 # Fix up relative links after prettifying structure above
-sed -i -e 's/](\(.*\)\.md)/](..\/\1)/' $(find docs/package/ -name '*.md')
+sedi -e 's/](\(.*\)\.md)/](..\/\1)/' $(find docs/package/ -name '*.md')
 
 cp -r docs/package/* ./pages/services/kubernetes/$directory
 
@@ -74,14 +79,14 @@ rm -rf docs/
 
 # Add version information to latest index file
 
-sed -i -e "s/^navigationTitle: .*$/navigationTitle: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
-sed -i -e "s/^title: .*$/title: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
+sedi -e "s/^navigationTitle: .*$/navigationTitle: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
+sedi -e "s/^title: .*$/title: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
 
 # Update sort order of index files
 
 weight=10
 for i in $( ls -r ./pages/services/kubernetes/*/index.md ); do
-  sed -i "s/^menuWeight:.*$/menuWeight: ${weight}/" $i
+  sedi "s/^menuWeight:.*$/menuWeight: ${weight}/" $i
   weight=$(expr ${weight} + 10)
 done
 

--- a/scripts/service-update-scripts/kubernetes-merge.sh
+++ b/scripts/service-update-scripts/kubernetes-merge.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-#
+
+# sed needs different args to -i depending on the flavor of the tool that is installed
+sedi () {
+    sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
+}
+
 echo "------------------------------"
 echo " Merging Kubernetes"
 echo "------------------------------"
@@ -37,7 +42,7 @@ for p in `find docs/package -type f`; do
   # markdown files only
   if [ ${p: -3} == ".md" ]; then
     # remove any dodgy control characters - sometimes copied in from commands
-    sed -i -e 's/ *//g' $p
+    sedi -e 's/ *//g' $p
 
     # insert tag ( markdown files only )
     awk -v n=2 '/---/ { if (++count == n) sub(/---/, "---\n\n<!-- This source repo for this topic is https://github.com/mesosphere/dcos-kubernetes -->\n"); } 1{print}' $p > tmp && mv tmp $p
@@ -65,7 +70,7 @@ for p in `find docs/package -type f`; do
 done
 
 # Fix up relative links after prettifying structure above
-sed -i -e 's/](\(.*\)\.md)/](..\/\1)/' $(find docs/package/ -name '*.md')
+sedi -e 's/](\(.*\)\.md)/](..\/\1)/' $(find docs/package/ -name '*.md')
 
 cp -r docs/package/* ./pages/services/kubernetes/$directory
 
@@ -74,14 +79,14 @@ rm -rf docs/
 
 # Add version information to latest index file
 
-sed -i -e "s/^navigationTitle: .*$/navigationTitle: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
-sed -i -e "s/^title: .*$/title: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
+sedi -e "s/^navigationTitle: .*$/navigationTitle: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
+sedi -e "s/^title: .*$/title: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
 
 # Update sort order of index files
 
 weight=10
 for i in $( ls -r ./pages/services/kubernetes/*/index.md ); do
-  sed -i "s/^menuWeight:.*$/menuWeight: ${weight}/" $i
+  sedi "s/^menuWeight:.*$/menuWeight: ${weight}/" $i
   weight=$(expr ${weight} + 10)
 done
 


### PR DESCRIPTION
The current `kubernetes-merge*.sh` scripts don't work on OSX because `sed` expects an extension to be provided to `-i` in order to create a backup file. This PR updates the scripts in order to detect the OS and use appropriate parameters for `sed`.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
