### PR TITLE
COPS-3321 FIRST DRAFT new include file on building a local universe.

### DIFF
--- a/pages/services/edge-lb/1.0/installing/index.md
+++ b/pages/services/edge-lb/1.0/installing/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Installing Edge-LB
 title: Installing Edge-LB
 menuWeight: 10
 excerpt:
-
+model: /services/edge-lb/data.yml
+render: mustache
 enterprise: false
 ---
 
@@ -12,9 +13,10 @@ Configure a service account and install the Edge-LB package using the instructio
 
 **Prerequisites:**
 
-- [DC/OS CLI installed](/latest/cli/install/) and be logged in as a superuser.
-- The [DC/OS Enterprise CLI installed](https://docs.mesosphere.com/1.10/cli/enterprise-cli/).
-- Access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
+- [DC/OS CLI is installed](/latest/cli/install/)
+- You are logged in as a superuser
+- The [DC/OS Enterprise CLI is installed](https://docs.mesosphere.com/1.10/cli/enterprise-cli/).
+- You have access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
 
 **Limitations**
 - Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/latest/security/ent/#security-modes). It does not work with disabled mode.
@@ -32,6 +34,12 @@ dcos package repo add --index=0 edgelb-aws \
 dcos package repo add --index=0 edgelb-pool-aws \
   https://<AWS S3 bucket>/stub-universe-edgelb-pool.json
 ```
+
+[enterprise]
+# Build your own local Universe
+[/enterprise]
+
+#include /services/include/build-local-universe-ee-only.tmpl
 
 # Create a service account
 The Edge-LB API server needs to be associated with a service account so that it can launch Edge-LB pools on public and private nodes, based on user requests.

--- a/pages/services/edge-lb/data.yml
+++ b/pages/services/edge-lb/data.yml
@@ -1,0 +1,34 @@
+# Common values:
+
+packageName: edge-lb
+serviceName: edgelb
+techName: Edge-LB
+techShortName: Edge-LB
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: three
+  nodeDescription: with three Apache Cassandra nodes
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/cassandra/cass-auth/
+
+managing:
+  podType: node
+  taskType: server
+
+supportedVersions:
+  techExampleVersion: 3.0.13
+  techLink:
+
+security:
+  plaintext:  |
+    , "allow_plaintext": <true|false default false>
+
+operations:
+  complete-deploy: |
+    deploy (serial strategy) (COMPLETE)
+    └─ node-deploy (serial strategy) (COMPLETE)
+       ├─ node-0:[server] (COMPLETE)
+       ├─ node-0:[init_system_keyspaces] (COMPLETE)
+       ├─ node-1:[server] (COMPLETE)
+       └─ node-2:[server] (COMPLETE)

--- a/pages/services/edge-lb/index.md
+++ b/pages/services/edge-lb/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Edge-LB
 title: Edge-LB
 menuWeight: 30
 excerpt:
+model: /services/edge-lb/data.yml
+render: mustache
 
 enterprise: false
 ---

--- a/pages/services/include/build-local-universe-ee-only.tmpl
+++ b/pages/services/include/build-local-universe-ee-only.tmpl
@@ -1,0 +1,311 @@
+Here's how you can add a package like {{ model.techName }} to a local universe.
+
+1. If you are using the latest stable release of DC/OS, download the [local-universe](https://downloads.mesosphere.com/universe/public/local-universe.tar.gz) container to each of your masters. Otherwise, you will need to build the container for your DC/OS version. See the section on [Building Your Own](#building-your-own) and copy it to each of your masters.
+
+1. Load the container into the local docker instance on each master:
+
+    ```bash
+    $ docker load < local-universe.tar.gz
+    ```
+
+1. Add the [`dcos-local-universe-http.service`](dcos-local-universe-http.service) definition to each of your masters at `/etc/systemd/system/dcos-local-universe-http.service` and then start it.
+
+    ```bash
+    $ cp dcos-local-universe-http.service /etc/systemd/system/dcos-local-universe-http.service
+    $ systemctl daemon-reload
+    $ systemctl start dcos-local-universe-http
+    ```
+
+1. Add the [`dcos-local-universe-registry.service`](dcos-local-universe-registry.service) definition to each of your masters at `/etc/systemd/system/dcos-local-universe-registry.service` and then start it.
+
+    ```bash
+    $ cp dcos-local-universe-registry.service /etc/systemd/system/dcos-local-universe-registry.service
+    $ systemctl daemon-reload
+    $ systemctl start dcos-local-universe-registry
+    ```
+
+1. Remove the built in repositories from the host that you have the DCOS CLI installed on (alternatively, these can be removed from the DCOS UI under **System>Repositories**).
+
+    ```bash
+    $ dcos package repo remove Universe
+    $ dcos package repo remove Universe-1.7
+    ```
+
+1. Add the local repository using the DCOS CLI.
+
+    ```bash
+    $ dcos package repo add local-universe http://master.mesos:8082/repo
+    ```
+
+1. To pull from this new repository, you will need to set up the docker daemon on every agent to have a valid SSL certificate. To do this, on every agent in your cluster, run the following:
+
+    ```bash
+    $ mkdir -p /etc/docker/certs.d/master.mesos:5000
+    $ curl -o /etc/docker/certs.d/master.mesos:5000/ca.crt http://master.mesos:8082/certs/domain.crt
+    $ systemctl restart docker
+    ```
+
+**Note:** You may use the instructions for insecure registries instead of this step. We don't recommend this.
+
+<a name="building-your-own"></a>
+## Building Your Own
+
+1. Both nginx and the docker registry are bundled into the same container. This requires building the "universe-base" container before you actually compile the universe container.
+
+    ```bash
+    $ sudo make base
+    ```
+
+1. Once you've built the "universe-base" container, you will be able to create a local-universe one. To keep size and time down, it is common to select only what you'd like to see. By default, `selected` applications are the only ones included. You can pass a list in if you'd like to see something more than that.
+
+    ```bash
+    $ sudo make DCOS_VERSION=<your DC/OS version> local-universe
+    ```
+
+    If you want to specify the set of package names and versions that get included in the image you can use the `DCOS_PACKAGE_INCLUDE variable. For example, to include two versions for Cassandra and one version of {{ model.techName }} you can execute the following command.
+
+    ```bash
+    $ sudo make DCOS_VERSION=<your DC/OS version> DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,cassandra:1.0.24-3.0.10,{{ model.packageName }}:1.4.2" local-universe
+    ```
+
+<a name="building-your-own-staticbase"></a>
+### Building Your Own, off a non-changing universe-static base image.
+
+Mesosphere provides a `mesosphere/universe-static` Docker image, which has all of the core requirements to run a local universe.  All that must be added are your own certificates and rep contents.
+
+1. Use the `make` command to download the static image:
+
+    ```bash
+    $ sudo make static-online
+    ## Will pull and re-tag mesosphere/universe-static to universe-static
+    ```
+
+1. Create your certs (either use `make certs` or generate your own), and add them to the static image to create a `universe-base` image:
+
+    ```bash
+    $ sudo make static-base
+    ## Will add certs to universe-static and create universe-base
+    ```
+
+1. Add content (see above):
+
+    ```bash
+    $ sudo make DCOS_VERSION=<your DC/OS version> local-universe
+    ```
+
+To generate your own static image, use and/or modify the make target `static-build` (e.g., `make static-build` instead of `make static-online`)
+
+This leaves three options:
+
+```bash
+make base
+make DCOS_VERSION=<your DC/OS version> local-universe
+```
+
+```bash
+make static-online
+make static-base
+make DCOS_VERSION=<your DC/OS version> local-universe
+```
+
+```bash
+make static-build
+make static-base
+make DCOS_VERSION=<your DC/OS version> local-universe
+```
+
+<a name="building-old-version"></a>
+### Building an old version of Local Universe
+The latest version of Local Universe has changed directory structure in a way that is not compatible with the old version of Local Universe. If you are interested in creating an old version of Local Universe with the old directory structure you must use the following command instead of the `local-universe` make target describe previously.
+
+```bash
+$ sudo make DCOS_VERSION=<your DC/OS version> old-local-universe
+```
+
+<a name="outside-resources"></a>
+### Outside Resources
+
+As a workaround for the image and CLI resource issues in [the FAQ](#faq), you can place those assets outside of the cluster.
+
+1. Place your CLI and image resources on a web server accessible to CLI and web UI users.
+
+2. Edit the URLs in the `resource.json` file of your package of interest to point to each of those resources, in the `images` and `cli` sections.
+
+3. Edit Makefile so the call to `local-universe.py` includes arguments `--nonlocal_images` and `--nonlocal_cli`.
+
+4. Proceed with [Building Your Own](#building-your-own) as above.
+
+<a name="running-local"></a>
+## Running Local Universe as a Marathon Service
+
+Instead of deploying to each of your masters, you can easily run a local universe as a regular Marathon service.
+
+1. Edit Makefile so the call to `local-universe.py` includes the `--server_url` argument indicating your choice of internal service name and port. For example, if you want dev-universe, then add `--server_url http://dev-universe.marathon.mesos:8085`.
+
+2. Build a container as per [Building Your Own](#building-your-own) above.
+
+3. Deploy the container to your cluster as you would one of your regular apps.
+
+4. Launch a single instance of your universe service, specifying health checks. Here's an example Marathon app:
+
+```json
+{
+  "id": "/dev-universe",
+  "instances": 1,
+  "cpus": 0.25,
+  "mem": 128,
+  "requirePorts": true,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "network": "BRIDGE",
+      "image": "your_image_location:latest",
+      "forcePullImage": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 8085,
+          "protocol": "tcp"
+        }
+      ]
+    },
+    "volumes": []
+  },
+  "cmd": "nginx -g 'daemon off;'",
+  "fetch": [ ],
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 30,
+      "maxConsecutiveFailures": 3,
+      "path": "/repo-empty-v3.json",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 5
+    }
+  ],
+  "constraints": [
+    [
+      "hostname",
+      "UNIQUE"
+    ]
+  ]
+}
+```
+
+<a name="making-changes"></a>
+## Making changes...
+
+###  ...to the `universe-static` image
+
+1. Update `Dockerfile.static` with the changes
+1. Bump the default value of `static_version` in `Makefile`
+1. Create a pull request with the above changes
+1. Once it is merged, run the [Publish universe-static image](https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Universe_2_PublishUniverseStaticImage&branch_Oss_Universe_2=%3Cdefault%3E&tab=buildTypeStatusDiv) build, providing the new version number when prompted
+1. Submit a pull request that updates the `FROM universe-static:...` line in
+`Dockerfile.static.base` to use the new version
+
+<a name="adding-stubs"></a>
+## Adding Stub Universes (Custom Universe Packages)
+
+If you've been provided stub universe json files (such as for {{ model.techName }}), you can add them to the local universe with the `add-stub-universe.sh` script.
+
+You can specify a local stub universe json definition with `-j <path-to-json-file>` or a URL for stub universe json definition with `-u <url-for-json-file>`
+
+Each run of the add-stub-universe.sh will process the json file and generate the necessary json and mustache files, and add them to `stub-repo/packages/<X>/<packagename>`.  Once all of your stub universe packages have been added into `stub-repo`, you can merge them into the primary `universe/repo/packages` and specify them in any of the standard local universe scripts.
+
+For example:
+```bash
+bash add-stub-universe.sh -j stub-universe-custom.json
+bash add-stub-universe.sh -u https://<url-path>/online-stub-universe.json
+```
+
+From there, they can be merged into the primary `universe/repo/packages` directory:
+
+```bash
+cp -rpv stub-repo/packages/* ../../repo/packages
+```
+
+Then, you could potentially build the rest of your universe with the regular workflow:
+
+```bash
+sudo make DCOS_VERSION=<your DC/OS version> DCOS_PACKAGE_INCLUDE="<custom-package>:0.1,<other-custom-package>:0.5" local-universe
+```
+
+Here's a full example:
+```bash
+# bash add-stub-universe.sh -j stub-universe-custom.json
+Building repo structure for custom...
+
+Full stub-repo contents:
+total 40
+drwxr-xr-x  7 userdirectory  staff   238B Jan 18 23:31 .
+drwxr-xr-x  3 userdirectory  staff   102B Jan 18 23:31 ..
+-rw-r--r--  1 userdirectory  staff   144B Jan 18 23:31 command.json
+-rw-r--r--  1 userdirectory  staff   1.7K Jan 18 23:31 config.json
+-rw-r--r--  1 userdirectory  staff   1.5K Jan 18 23:31 marathon.json.mustache
+-rw-r--r--  1 userdirectory  staff   384B Jan 18 23:31 package.json
+-rw-r--r--  1 userdirectory  staff   1.7K Jan 18 23:31 resource.json
+
+# bash add-stub-universe.sh -u https://<url-path>/online-stub-universe.json
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 13449  100 13449    0     0  22012      0 --:--:-- --:--:-- --:--:-- 22011
+Building repo structure for custom-online...
+
+Full stub-repo contents:
+stub-repo/packages/C/custom-online/0:
+total 48
+drwxr-xr-x  7 userdirectory  staff   238B Jan 18 23:31 .
+drwxr-xr-x  3 userdirectory  staff   102B Jan 18 23:31 ..
+-rw-r--r--  1 userdirectory  staff   149B Jan 18 23:31 command.json
+-rw-r--r--  1 userdirectory  staff   4.5K Jan 18 23:31 config.json
+-rw-r--r--  1 userdirectory  staff   3.4K Jan 18 23:31 marathon.json.mustache
+-rw-r--r--  1 userdirectory  staff   411B Jan 18 23:31 package.json
+-rw-r--r--  1 userdirectory  staff   2.2K Jan 18 23:31 resource.json
+
+stub-repo/packages/C/custom/0:
+total 40
+drwxr-xr-x@ 7 userdirectory  staff   238B Jan 18 23:31 .
+drwxr-xr-x@ 3 userdirectory  staff   102B Jan 18 23:31 ..
+-rw-r--r--@ 1 userdirectory  staff   144B Jan 18 23:31 command.json
+-rw-r--r--@ 1 userdirectory  staff   1.7K Jan 18 23:31 config.json
+-rw-r--r--@ 1 userdirectory  staff   1.5K Jan 18 23:31 marathon.json.mustache
+-rw-r--r--@ 1 userdirectory  staff   384B Jan 18 23:31 package.json
+-rw-r--r--@ 1 userdirectory  staff   1.7K Jan 18 23:31 resource.json
+
+# cp -rpv stub-repo/packages/* ../../repo/packages
+stub-repo/packages/C -> ../../repo/packages/E
+stub-repo/packages/C/custom -> ../../repo/packages/C/custom
+stub-repo/packages/C/custom/0 -> ../../repo/packages/C/custom/0
+stub-repo/packages/C/custom/0/command.json -> ../../repo/packages/C/custom/0/command.json
+stub-repo/packages/C/custom/0/config.json -> ../../repo/packages/C/custom/0/config.json
+stub-repo/packages/C/custom/0/marathon.json.mustache -> ../../repo/packages/C/custom/0/marathon.json.mustache
+stub-repo/packages/C/custom/0/package.json -> ../../repo/packages/C/custom/0/package.json
+stub-repo/packages/C/custom/0/resource.json -> ../../repo/packages/C/custom/0/resource.json
+stub-repo/packages/C/custom-online -> ../../repo/packages/C/custom-online
+stub-repo/packages/C/custom-online/0 -> ../../repo/packages/C/custom-online/0
+stub-repo/packages/C/custom-online/0/command.json -> ../../repo/packages/C/custom-online/0/command.json
+stub-repo/packages/C/custom-online/0/config.json -> ../../repo/packages/C/custom-online/0/config.json
+stub-repo/packages/C/custom-online/0/marathon.json.mustache -> ../../repo/packages/C/custom-online/0/marathon.json.mustache
+stub-repo/packages/C/custom-online/0/package.json -> ../../repo/packages/C/custom-online/0/package.json
+stub-repo/packages/C/custom-online/0/resource.json -> ../../repo/packages/C/custom-online/0/resource.json
+
+# sudo make DCOS_VERSION=1.10.4 DCOS_PACKAGE_INCLUDE="custom:0.1,custom-online:0.5" local-universe
+... Local universe build output here ...
+```
+
+<a name="faq"></a>
+## FAQ
+
+- I can't install CLI subcommands.
+
+    Packages are being hosted at `master.mesos:8082`. If you cannot resolve (or connect) to that from your DC/OS CLI install, you won't be able to install subcommands. If you're able to connect to port 8082 on your masters, the easiest way around this to add the IP for one of the masters to `/etc/hosts`.  See also [Outside Resources](#outside-resources).
+
+- The images are broken!
+
+    We host everything from inside your cluster, including the images. They're getting served up by `master.mesos:8082`. If you have connectivity to that IP, you can add it to `/etc/hosts` and get the images working.   See also [Outside Resources](#outside-resources).
+
+- I don't see the package I was looking for!
+
+    By default, we only bundle the `selected` packages. If you'd like to include something else, please see the [Building Your Own](#building-your-own) section.


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

This is a FIRST DRAFT of a new section in the Edge-LB documentation explaining how to build a local universe. I created a new template in the /include/ directory, build-local-universe-ee-only.tmpl, which includes variables so that it can be used in more than one page. This material is based on Justin Lee's  [Docker README](https://github.com/mesosphere/universe/tree/version-3.x/docker/local-universe#adding-stub-universes-custom-universe-packages). It almost certainly needs to be revised to be more "generic".