### PR TITLE
Moved * against CoreOS 1688.5.3.

### DIFF
--- a/pages/version-policy/index.md
+++ b/pages/version-policy/index.md
@@ -55,8 +55,8 @@ The below matrix provides guidance as to which platform components and operating
     <th><strong>DC/OS 1.9</strong></th>
     </tr>
     <tr>
-       <td>CoreOS 1688.5.3</td>
-       <td><p style="text-align: center;">⚫</p><p style="text-align: center;">Docker Engine 17.12.1<sup>*</sup></p></td>
+       <td>CoreOS 1688.5.3<sup>*</sup></td>
+       <td><p style="text-align: center;">⚫</p><p style="text-align: center;">Docker Engine 17.12.1</p></td>
        <td>                    </td>
        <td>                    </td>
     </tr>


### PR DESCRIPTION
Updated compatibility matrix as per Senthil's suggestion on #dcos-release channel. 

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
