### PR TITLE
Increase the agent requirements for `/var` free space to 20 GB

### DIFF
--- a/pages/1.10/installing/ent/custom/system-requirements/index.md
+++ b/pages/1.10/installing/ent/custom/system-requirements/index.md
@@ -65,7 +65,7 @@ The table below shows the agent node hardware requirements.
 
 The agent nodes must also have:
 
-- A `/var` directory with 10 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.10/deploying-services/containerizers/).
+- A `/var` directory with 20 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.10/deploying-services/containerizers/).
 - Network Access to a public Docker repository or to an internal Docker registry.
 
 *   On RHEL 7 and CentOS 7, `firewalld` must be stopped and disabled. It is a known <a href="https://github.com/docker/docker/issues/16137" target="_blank">Docker issue</a> that `firewalld` interacts poorly with Docker. For more information, see the <a href="https://docs.docker.com/v1.6/installation/centos/#firewalld" target="_blank">Docker CentOS firewalld</a> documentation.

--- a/pages/1.10/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.10/installing/oss/custom/system-requirements/index.md
@@ -54,7 +54,7 @@ Here are the agent node hardware requirements.
 
 The agent nodes must also have:
 
-- A `/var` directory with 10 GB or more of free space. This directory is used by the sandbox for both the [Universal Container Runtime and Docker Engine](/1.10/deploying-services/containerizers/).
+- A `/var` directory with 20 GB or more of free space. This directory is used by the sandbox for both the [Universal Container Runtime and Docker Engine](/1.10/deploying-services/containerizers/).
 
 - The agent's work directory, `/var/lib/mesos/slave`, should be on a separate device. This protects all the other services from a task overflowing the disk.
 

--- a/pages/1.11/installing/ent/custom/system-requirements/index.md
+++ b/pages/1.11/installing/ent/custom/system-requirements/index.md
@@ -80,7 +80,7 @@ The table below shows the agent node hardware requirements.
 
 The agent nodes must also have:
 
-- A `/var` directory with 10 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.11/deploying-services/containerizers/).
+- A `/var` directory with 20 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.11/deploying-services/containerizers/).
 - Network Access to a public Docker repository or to an internal Docker registry.
 
 *   On RHEL 7 and CentOS 7, `firewalld` must be stopped and disabled. It is a known <a href="https://github.com/docker/docker/issues/16137" target="_blank">Docker issue</a> that `firewalld` interacts poorly with Docker. For more information, see the <a href="https://docs.docker.com/v1.6/installation/centos/#firewalld" target="_blank">Docker CentOS firewalld</a> documentation.

--- a/pages/1.11/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.11/installing/oss/custom/system-requirements/index.md
@@ -77,7 +77,7 @@ The table below shows the agent node hardware requirements.
 
 The agent nodes must also have:
 
-- A `/var` directory with 10 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.11/deploying-services/containerizers/).
+- A `/var` directory with 20 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.11/deploying-services/containerizers/).
 - Network Access to a public Docker repository or to an internal Docker registry.
 
 *   On RHEL 7 and CentOS 7, firewalld must be stopped and disabled. It is a known <a href="https://github.com/docker/docker/issues/16137" target="_blank">Docker issue</a> that firewalld interacts poorly with Docker. For more information, see the <a href="https://docs.docker.com/v1.6/installation/centos/#firewalld" target="_blank">Docker CentOS firewalld</a> documentation.


### PR DESCRIPTION
## Description

https://jira.mesosphere.com/browse/COPS-3375

The COPS issue refers to 1.10, so I changed 1.10+.

This increases the recommended free space in `/var` to 20 GB.
If approved, we will recommend @mikejennings 's customer from the `COPS` issue to give `/var` more free space.

However, this is not backed by tests.
As proposed by Gustav, this should be looked at by "Andrew Shahan or Justin Lee, etc" - @gpaul , please add anyone from "etc' to "Reviewers".
For one of  "Andrew Shahan or Justin Lee, etc" - please could you consider whether it is useful to do the following (also suggested by @gpaul ) and if so, do it - "Informally we could just ask how full /var is on a strict mode cluster at JPMC?".

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).