### PR TITLE
CLI install doc fixes

### DIFF
--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -143,7 +143,7 @@ In this step, you create a YAML configuration file that is customized for your e
     - <agent-private-ip-4>
     - <agent-private-ip-5>
     public_agent_list:
-    - <private-agent-private-ip>
+    - <public-agent-private-ip>
     customer_key: <customer-key>
     # Choose your security mode: permissive, strict, or disabled.
     security: <security-mode>

--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -106,7 +106,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
    
     The CLI installer uses these default configuration values, which you may override in your configuration:
 
@@ -150,13 +150,6 @@ In this step, you create a YAML configuration file that is customized for your e
     # ssh_user must have passwordless sudo
     ssh_user: <username>
     superuser_username: <username>
-    # A custom proxy is optional. For details see the config documentation.
-    use_proxy: 'true'
-    http_proxy: http://<user>:<pass>@<proxy_host>:<http_proxy_port>
-    https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>
-    no_proxy: 
-    - 'foo.bar.com'         
-    - '.baz.com'    
     ```
 
 1.  From your home directory, run this command to create a hashed password for superuser [authentication](/1.10/security/ent/perms-reference/#superuser). The hashed password is automatically appended to `config.yaml`.

--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -106,11 +106,12 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. If your servers are installed with a domain name in your `/etc/resolv.conf`, you should add `dns_search` to your `config.yaml` file. For parameters, descriptions, and configuration examples, see the [documentation][3].
+    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. For parameters, descriptions, and configuration examples, see the [documentation][3].
    
     **Tips:** 
     
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
+    - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
     ```bash

--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -111,7 +111,7 @@ In this step, you create a YAML configuration file that is customized for your e
     **Tips:** 
     
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
-    - If you specify `master_discovery: static`, you must also create a script to map internal IPs to public IPs on your bootstrap node (e.g., `/genconf/ip-detect-public`). This script is then referenced in `ip_detect_public_filename: <path-to-ip-script>`.    
+    - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
     ```bash
     agent_list:

--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -119,7 +119,7 @@ In this step, you create a YAML configuration file that is customized for your e
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
-    ```bash
+    ```yaml
     cluster_name: <cluster-name>
     # Only override this value if you're hosting the contents of genconf/serve/
     # at a custom location. The CLI installer will automatically distribute

--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -106,7 +106,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][3].
    
     The CLI installer uses these default configuration values, which you may override in your configuration:
 

--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -108,38 +108,45 @@ In this step, you create a YAML configuration file that is customized for your e
     
     You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
    
+    The CLI installer uses these default configuration values, which you may override in your configuration:
+
+    - `ssh_port`: `22`
+      - Only override this value if SSH on cluster nodes is available at a different port.
+    - `process_timeout`: `120`
+
     **Tips:** 
     
-    - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
     ```bash
+    cluster_name: <cluster-name>
+    # Only override this value if you're hosting the contents of genconf/serve/
+    # at a custom location. The CLI installer will automatically distribute
+    # its contents to this location on all cluster nodes prior to install.
+    bootstrap_url: file:///opt/dcos_install_tmp
+    master_discovery: static
+    exhibitor_storage_backend: static
+    # If Google DNS is not available, you can replace these servers with your
+    # local DNS servers.
+    resolvers:
+    - 8.8.8.8
+    - 8.8.4.4
+    master_list:
+    - <master-private-ip-1>
+    - <master-private-ip-2>
+    - <master-private-ip-3>
     agent_list:
     - <agent-private-ip-1>
     - <agent-private-ip-2>
     - <agent-private-ip-3>
     - <agent-private-ip-4>
     - <agent-private-ip-5>
-    # Use this bootstrap_url value unless you have moved the DC/OS installer assets.   
-    bootstrap_url: file:///opt/dcos_install_tmp
-    customer_key: <customer-key>
-    cluster_name: <cluster-name>
-    exhibitor_storage_backend: static
-    master_discovery: static 
-    ip_detect_public_filename: <path-to-ip-script>
-    master_list:
-    - <master-private-ip-1>
-    - <master-private-ip-2>
-    - <master-private-ip-3>
     public_agent_list:
     - <private-agent-private-ip>
-    resolvers:
-    - 8.8.4.4
-    - 8.8.8.8 
+    customer_key: <customer-key>
     # Choose your security mode: permissive, strict, or disabled.
     security: <security-mode>
-    ssh_port: 22
     # ssh_user must have passwordless sudo
     ssh_user: <username>
     superuser_username: <username>

--- a/pages/1.10/installing/ent/custom/cli/index.md
+++ b/pages/1.10/installing/ent/custom/cli/index.md
@@ -106,7 +106,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. For parameters, descriptions, and configuration examples, see the [documentation][3].
+    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
    
     **Tips:** 
     

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 
@@ -187,12 +187,6 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
     public_agent_list:
     - <public-agent-private-ip>
     ssh_user: <username>
-    use_proxy: 'true'
-    http_proxy: http://<proxy_host>:<http_proxy_port>
-    https_proxy: https://<proxy_host>:<https_proxy_port>
-    no_proxy:
-    - 'foo.bar.com'
-    - '.baz.com'
     ```
 
 3.  Copy your private SSH key to `genconf/ssh_key`. For more information, see the [ssh_key_path][6] parameter.

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. For parameters descriptions and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     **Tips:**
 

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -156,7 +156,6 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
 
     **Tips:**
 
-    - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -146,11 +146,12 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. If your servers are installed with a domain name in your `/etc/resolv.conf`, you should add `dns_search` to your `config.yaml` file. For parameters descriptions and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. For parameters descriptions and configuration examples, see the [documentation][6].
 
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
+    - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -160,7 +160,6 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
-    ---
     cluster_name: <cluster-name>
     # Only override this value if you're hosting the contents of genconf/serve/
     # at a custom location. The CLI installer will automatically distribute

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -146,7 +146,13 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+
+    The CLI installer uses these default configuration values, which you may override in your configuration:
+
+    - `ssh_port`: `22`
+      - Only override this value if SSH on cluster nodes is available at a different port.
+    - `process_timeout`: `120`
 
     **Tips:**
 
@@ -156,28 +162,30 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
 
     ```yaml
     ---
+    cluster_name: <cluster-name>
+    # Only override this value if you're hosting the contents of genconf/serve/
+    # at a custom location. The CLI installer will automatically distribute
+    # its contents to this location on all cluster nodes prior to install.
+    bootstrap_url: file:///opt/dcos_install_tmp
+    master_discovery: static
+    exhibitor_storage_backend: static
+    # If Google DNS is not available, you can replace these servers with your
+    # local DNS servers.
+    resolvers:
+    - 8.8.8.8
+    - 8.8.4.4
+    master_list:
+    - <master-private-ip-1>
+    - <master-private-ip-2>
+    - <master-private-ip-3>
     agent_list:
     - <agent-private-ip-1>
     - <agent-private-ip-2>
     - <agent-private-ip-3>
     - <agent-private-ip-4>
     - <agent-private-ip-5>
-    # Use this bootstrap_url value unless you have moved the DC/OS installer assets.
-    bootstrap_url: file:///opt/dcos_install_tmp
-    cluster_name: <cluster-name>
-    exhibitor_storage_backend: static
-    master_discovery: static
-    ip_detect_public_filename: <path-to-ip-script>
-    master_list:
-    - <master-private-ip-1>
-    - <master-private-ip-2>
-    - <master-private-ip-3>
     public_agent_list:
     - <public-agent-private-ip>
-    resolvers:
-    - 8.8.4.4
-    - 8.8.8.8
-    ssh_port: 22
     ssh_user: <username>
     use_proxy: 'true'
     http_proxy: http://<proxy_host>:<http_proxy_port>

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.10/overview/concepts/#private-agent-node) agents, 1 [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.10/overview/concepts/#private-agent-node) agents, one [public](/1.10/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 

--- a/pages/1.10/installing/oss/custom/cli/index.md
+++ b/pages/1.10/installing/oss/custom/cli/index.md
@@ -151,7 +151,7 @@ Your cluster must meet the software and hardware [requirements](/1.10/installing
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
-    - If you specify `master_discovery: static`, you must also create a script to map internal IPs to public IPs on your bootstrap node (e.g., `/genconf/ip-detect-public`). This script is then referenced in `ip_detect_public_filename: <path-to-ip-script>`.
+    - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
     ---

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -110,7 +110,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
 
-    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 
@@ -153,13 +153,6 @@ In this step, you create a YAML configuration file that is customized for your e
     # ssh_user must have passwordless sudo
     ssh_user: <username>
     superuser_username: <username>
-    # A custom proxy is optional. For details see the config documentation.
-    use_proxy: 'true'
-    http_proxy: http://<user>:<pass>@<proxy_host>:<http_proxy_port>
-    https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>
-    no_proxy:
-    - 'foo.bar.com'         
-    - '.baz.com'
     # Fault domain entry required for DC/OS Enterprise 1.11+.
     fault_domain_enabled: false
     # If IPv6 is disabled in your kernel, you must disable it in the config.yaml.

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -147,7 +147,7 @@ In this step, you create a YAML configuration file that is customized for your e
     - <agent-private-ip-4>
     - <agent-private-ip-5>
     public_agent_list:
-    - <private-agent-private-ip>
+    - <public-agent-private-ip>
     # Choose your security mode: permissive, strict, or disabled.
     security: <security-mode>
     # ssh_user must have passwordless sudo

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -110,7 +110,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
 
-    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][3].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -192,6 +192,8 @@ In this step, you create a YAML configuration file that is customized for your e
 
         cp <path-to-key> genconf/ssh_key && chmod 0600 genconf/ssh_key
 
+5.  Create a [license file][16] containing the license key from the email you received from your Authorized Support Contact and save it as `genconf/license.txt`.
+
 
 # <a name="install-bash"></a>Install DC/OS
 
@@ -405,3 +407,4 @@ After DC/OS is installed and deployed across your cluster, you can add more agen
  [13]: #hardware
  [14]: #software
  [15]: #two
+ [16]: /1.11/administering-clusters/licenses/

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -156,7 +156,7 @@ In this step, you create a YAML configuration file that is customized for your e
     # Fault domain entry required for DC/OS Enterprise 1.11+.
     fault_domain_enabled: false
     # If IPv6 is disabled in your kernel, you must disable it in the config.yaml.
-    enable_ipv6: 'false'
+    enable_ipv6: false
     ```
 
 1.  From your home directory, run this command to create a hashed password for superuser [authentication](/1.11/security/#superuser). The hashed password is automatically appended to `config.yaml`.

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -112,38 +112,44 @@ In this step, you create a YAML configuration file that is customized for your e
 
     You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
+    The CLI installer uses these default configuration values, which you may override in your configuration:
+
+    - `ssh_port`: `22`
+      - Only override this value if SSH on cluster nodes is available at a different port.
+    - `process_timeout`: `120`
+
     **Tips:**
 
-    - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```bash
+    cluster_name: <cluster-name>
+    # Only override this value if you're hosting the contents of genconf/serve/
+    # at a custom location. The CLI installer will automatically distribute
+    # its contents to this location on all cluster nodes prior to install.
+    bootstrap_url: file:///opt/dcos_install_tmp
+    master_discovery: static
+    exhibitor_storage_backend: static
+    # If Google DNS is not available, you can replace these servers with your
+    # local DNS servers.
+    resolvers:
+    - 8.8.8.8
+    - 8.8.4.4
+    master_list:
+    - <master-private-ip-1>
+    - <master-private-ip-2>
+    - <master-private-ip-3>
     agent_list:
     - <agent-private-ip-1>
     - <agent-private-ip-2>
     - <agent-private-ip-3>
     - <agent-private-ip-4>
     - <agent-private-ip-5>
-    # bootstrap_url should define where you can get the DC/OS installer assets.
-    # This is generally the bootstrap IP and a port but it can also be a local file.
-    bootstrap_url: http://<bootstrap_ip>:<your_port>
-    cluster_name: <cluster-name>
-    exhibitor_storage_backend: static
-    master_discovery: static
-    ip_detect_public_filename: <path-to-ip-script>
-    master_list:
-    - <master-private-ip-1>
-    - <master-private-ip-2>
-    - <master-private-ip-3>
     public_agent_list:
     - <private-agent-private-ip>
-    resolvers:
-    - 8.8.4.4
-    - 8.8.8.8
     # Choose your security mode: permissive, strict, or disabled.
     security: <security-mode>
-    ssh_port: 22
     # ssh_user must have passwordless sudo
     ssh_user: <username>
     superuser_username: <username>

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -115,7 +115,7 @@ In this step, you create a YAML configuration file that is customized for your e
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
-    - If you specify `master_discovery: static`, you must also create a script to map internal IPs to public IPs on your bootstrap node (e.g., `/genconf/ip-detect-public`). This script is then referenced in `ip_detect_public_filename: <path-to-ip-script>`.    
+    - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```bash
     agent_list:

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -110,7 +110,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
 
-    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. For parameters, descriptions, and configuration examples, see the [documentation][3].
+    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     **Tips:**
 

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -110,11 +110,12 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
 
-    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. If your servers are installed with a domain name in your `/etc/resolv.conf`, you should add `dns_search` to your `config.yaml` file. For parameters, descriptions, and configuration examples, see the [documentation][3].
+    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. For parameters, descriptions, and configuration examples, see the [documentation][3].
 
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
+    - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```bash

--- a/pages/1.11/installing/ent/custom/cli/index.md
+++ b/pages/1.11/installing/ent/custom/cli/index.md
@@ -123,7 +123,7 @@ In this step, you create a YAML configuration file that is customized for your e
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
-    ```bash
+    ```yaml
     cluster_name: <cluster-name>
     # Only override this value if you're hosting the contents of genconf/serve/
     # at a custom location. The CLI installer will automatically distribute

--- a/pages/1.11/installing/oss/custom/cli/index.md
+++ b/pages/1.11/installing/oss/custom/cli/index.md
@@ -160,7 +160,6 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
-    ---
     cluster_name: <cluster-name>
     # Only override this value if you're hosting the contents of genconf/serve/
     # at a custom location. The CLI installer will automatically distribute

--- a/pages/1.11/installing/oss/custom/cli/index.md
+++ b/pages/1.11/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.11/overview/concepts/#private-agent-node) agents, one [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 

--- a/pages/1.11/installing/oss/custom/cli/index.md
+++ b/pages/1.11/installing/oss/custom/cli/index.md
@@ -151,7 +151,7 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
-    - If you specify `master_discovery: static`, you must also create a script to map internal IPs to public IPs on your bootstrap node (e.g., `/genconf/ip-detect-public`). This script is then referenced in `ip_detect_public_filename: <path-to-ip-script>`.
+    - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
     ---

--- a/pages/1.11/installing/oss/custom/cli/index.md
+++ b/pages/1.11/installing/oss/custom/cli/index.md
@@ -146,11 +146,12 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. If your servers are installed with a domain name in your `/etc/resolv.conf`, you should add `dns_search` to your `config.yaml` file. For parameters descriptions and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. For parameters descriptions and configuration examples, see the [documentation][6].
 
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
+    - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml

--- a/pages/1.11/installing/oss/custom/cli/index.md
+++ b/pages/1.11/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. For parameters descriptions and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     **Tips:**
 

--- a/pages/1.11/installing/oss/custom/cli/index.md
+++ b/pages/1.11/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 
@@ -186,12 +186,6 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
     public_agent_list:
     - <public-agent-private-ip>
     ssh_user: <username>
-    use_proxy: 'true'
-    http_proxy: http://<proxy_host>:<http_proxy_port>
-    https_proxy: https://<proxy_host>:<https_proxy_port>
-    no_proxy:
-    - 'foo.bar.com'
-    - '.baz.com'
     ```
 
 3.  Copy your private SSH key to `genconf/ssh_key`. For more information, see the [ssh_key_path][6] parameter.

--- a/pages/1.11/installing/oss/custom/cli/index.md
+++ b/pages/1.11/installing/oss/custom/cli/index.md
@@ -146,38 +146,45 @@ Your cluster must meet the software and hardware [requirements](/1.11/installing
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.11/overview/concepts/#private-agent-node) agents, 1 [public](/1.11/overview/concepts/#public-agent-node) agent, static master discovery list, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+
+    The CLI installer uses these default configuration values, which you may override in your configuration:
+
+    - `ssh_port`: `22`
+      - Only override this value if SSH on cluster nodes is available at a different port.
+    - `process_timeout`: `120`
 
     **Tips:**
 
-    - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
     ---
+    cluster_name: <cluster-name>
+    # Only override this value if you're hosting the contents of genconf/serve/
+    # at a custom location. The CLI installer will automatically distribute
+    # its contents to this location on all cluster nodes prior to install.
+    bootstrap_url: file:///opt/dcos_install_tmp
+    master_discovery: static
+    exhibitor_storage_backend: static
+    # If Google DNS is not available, you can replace these servers with your
+    # local DNS servers.
+    resolvers:
+    - 8.8.8.8
+    - 8.8.4.4
+    master_list:
+    - <master-private-ip-1>
+    - <master-private-ip-2>
+    - <master-private-ip-3>
     agent_list:
     - <agent-private-ip-1>
     - <agent-private-ip-2>
     - <agent-private-ip-3>
     - <agent-private-ip-4>
     - <agent-private-ip-5>
-    # Use this bootstrap_url value unless you have moved the DC/OS installer assets.
-    bootstrap_url: file:///opt/dcos_install_tmp
-    cluster_name: <cluster-name>
-    exhibitor_storage_backend: static
-    master_discovery: static
-    ip_detect_public_filename: <path-to-ip-script>
-    master_list:
-    - <master-private-ip-1>
-    - <master-private-ip-2>
-    - <master-private-ip-3>
     public_agent_list:
     - <public-agent-private-ip>
-    resolvers:
-    - 8.8.4.4
-    - 8.8.8.8
-    ssh_port: 22
     ssh_user: <username>
     use_proxy: 'true'
     http_proxy: http://<proxy_host>:<http_proxy_port>

--- a/pages/1.8/administration/installing/ent/custom/cli/index.md
+++ b/pages/1.8/administration/installing/ent/custom/cli/index.md
@@ -124,7 +124,7 @@ In this step, you create a YAML configuration file that is customized for your e
     - <master-private-ip-2>
     - <master-private-ip-3>
     public_agent_list:
-    - <private-agent-private-ip>
+    - <public-agent-private-ip>
     resolvers:
     - 8.8.4.4
     - 8.8.8.8 

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -107,7 +107,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][3].
     
     The CLI installer uses these default configuration values, which you may override in your configuration:
 

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -107,7 +107,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
     
     The CLI installer uses these default configuration values, which you may override in your configuration:
 
@@ -152,13 +152,6 @@ In this step, you create a YAML configuration file that is customized for your e
     # ssh_user must have passwordless sudo
     ssh_user: <username>
     superuser_username: <username>
-    # A custom proxy is optional. For details see the config documentation.
-    use_proxy: 'true'
-    http_proxy: http://<user>:<pass>@<proxy_host>:<http_proxy_port>
-    https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>
-    no_proxy: 
-    - 'foo.bar.com'         
-    - '.baz.com'    
     ```
 
 1.  From your home directory, run this command to create a hashed password for superuser [authentication](/1.9/security/ent/perms-reference/#superuser). The hashed password is automatically appended to `config.yaml`.

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -109,6 +109,12 @@ In this step, you create a YAML configuration file that is customized for your e
     
     You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
     
+    The CLI installer uses these default configuration values, which you may override in your configuration:
+
+    - `ssh_port`: `22`
+      - Only override this value if SSH on cluster nodes is available at a different port.
+    - `process_timeout`: `120`
+
     **Tips:** 
     
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
@@ -116,31 +122,33 @@ In this step, you create a YAML configuration file that is customized for your e
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
     ```bash
+    cluster_name: <cluster-name>
+    # Only override this value if you're hosting the contents of genconf/serve/
+    # at a custom location. The CLI installer will automatically distribute
+    # its contents to this location on all cluster nodes prior to install.
+    bootstrap_url: file:///opt/dcos_install_tmp
+    master_discovery: static
+    exhibitor_storage_backend: static
+    # If Google DNS is not available, you can replace these servers with your
+    # local DNS servers.
+    resolvers:
+    - 8.8.8.8
+    - 8.8.4.4
+    master_list:
+    - <master-private-ip-1>
+    - <master-private-ip-2>
+    - <master-private-ip-3>
     agent_list:
     - <agent-private-ip-1>
     - <agent-private-ip-2>
     - <agent-private-ip-3>
     - <agent-private-ip-4>
     - <agent-private-ip-5>
-    # Use this bootstrap_url value unless you have moved the DC/OS installer assets.   
-    bootstrap_url: http://<bootstrap_ip>:<your_port>
-    customer_key: <customer-key>
-    cluster_name: <cluster-name>
-    exhibitor_storage_backend: static
-    master_discovery: static 
-    ip_detect_public_filename: <path-to-ip-script>
-    master_list:
-    - <master-private-ip-1>
-    - <master-private-ip-2>
-    - <master-private-ip-3>
     public_agent_list:
     - <private-agent-private-ip>
-    resolvers:
-    - 8.8.4.4
-    - 8.8.8.8 
+    customer_key: <customer-key>
     # Choose your security mode: permissive, strict, or disabled.
     security: <security-mode>
-    ssh_port: 22
     # ssh_user must have passwordless sudo
     ssh_user: <username>
     superuser_username: <username>

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -107,7 +107,7 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. For parameters, descriptions, and configuration examples, see the [documentation][3].
+    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
     
     **Tips:** 
     

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -144,7 +144,7 @@ In this step, you create a YAML configuration file that is customized for your e
     - <agent-private-ip-4>
     - <agent-private-ip-5>
     public_agent_list:
-    - <private-agent-private-ip>
+    - <public-agent-private-ip>
     customer_key: <customer-key>
     # Choose your security mode: permissive, strict, or disabled.
     security: <security-mode>

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -120,7 +120,7 @@ In this step, you create a YAML configuration file that is customized for your e
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain.
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
-    ```bash
+    ```yaml
     cluster_name: <cluster-name>
     # Only override this value if you're hosting the contents of genconf/serve/
     # at a custom location. The CLI installer will automatically distribute

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -117,7 +117,6 @@ In this step, you create a YAML configuration file that is customized for your e
 
     **Tips:** 
     
-    - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain.
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -107,11 +107,12 @@ In this step, you create a YAML configuration file that is customized for your e
 
 1.  From your `genconf` directory, create a configuration file and save as `config.yaml`.
     
-    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. If your servers are installed with a domain name in your `/etc/resolv.conf`, you should add `dns_search` to your `config.yaml` file. For parameters, descriptions, and configuration examples, see the [documentation][3].
+    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, an optional custom proxy, and SSH configuration specified. For parameters, descriptions, and configuration examples, see the [documentation][3].
     
     **Tips:** 
     
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
+    - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain.
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
     ```bash

--- a/pages/1.9/installing/ent/custom/cli/index.md
+++ b/pages/1.9/installing/ent/custom/cli/index.md
@@ -112,7 +112,7 @@ In this step, you create a YAML configuration file that is customized for your e
     **Tips:** 
     
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
-    - If you specify `master_discovery: static`, you must also create a script to map internal IPs to public IPs on your bootstrap node (e.g., `/genconf/ip-detect-public`). This script is then referenced in `ip_detect_public_filename: <path-to-ip-script>`.  
+    - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
     
     ```bash
     agent_list:

--- a/pages/1.9/installing/oss/custom/cli/index.md
+++ b/pages/1.9/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. For parameters descriptions and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     **Tips:**
 

--- a/pages/1.9/installing/oss/custom/cli/index.md
+++ b/pages/1.9/installing/oss/custom/cli/index.md
@@ -146,38 +146,45 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+
+    The CLI installer uses these default configuration values, which you may override in your configuration:
+
+    - `ssh_port`: `22`
+      - Only override this value if SSH on cluster nodes is available at a different port.
+    - `process_timeout`: `120`
 
     **Tips:**
 
-    - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
     - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
     ---
+    cluster_name: <cluster-name>
+    # Only override this value if you're hosting the contents of genconf/serve/
+    # at a custom location. The CLI installer will automatically distribute
+    # its contents to this location on all cluster nodes prior to install.
+    bootstrap_url: file:///opt/dcos_install_tmp
+    master_discovery: static
+    exhibitor_storage_backend: static
+    # If Google DNS is not available, you can replace these servers with your
+    # local DNS servers.
+    resolvers:
+    - 8.8.8.8
+    - 8.8.4.4
+    master_list:
+    - <master-private-ip-1>
+    - <master-private-ip-2>
+    - <master-private-ip-3>
     agent_list:
     - <agent-private-ip-1>
     - <agent-private-ip-2>
     - <agent-private-ip-3>
     - <agent-private-ip-4>
     - <agent-private-ip-5>
-    # Use this bootstrap_url value unless you have moved the DC/OS installer assets.
-    bootstrap_url: http://<bootstrap_ip>:<your_port>
-    cluster_name: <cluster-name>
-    exhibitor_storage_backend: static
-    master_discovery: static
-    ip_detect_public_filename: <path-to-ip-script>
-    master_list:
-    - <master-private-ip-1>
-    - <master-private-ip-2>
-    - <master-private-ip-3>
     public_agent_list:
     - <public-agent-private-ip>
-    resolvers:
-    - 8.8.4.4
-    - 8.8.8.8
-    ssh_port: 22
     ssh_user: <username>
     use_proxy: 'true'
     http_proxy: http://<proxy_host>:<http_proxy_port>

--- a/pages/1.9/installing/oss/custom/cli/index.md
+++ b/pages/1.9/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies three masters, five [private](/1.9/overview/concepts/#private-agent-node) agents, one [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 

--- a/pages/1.9/installing/oss/custom/cli/index.md
+++ b/pages/1.9/installing/oss/custom/cli/index.md
@@ -151,7 +151,7 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
-    - If you specify `master_discovery: static`, you must also create a script to map internal IPs to public IPs on your bootstrap node (e.g., `/genconf/ip-detect-public`). This script is then referenced in `ip_detect_public_filename: <path-to-ip-script>`.
+    - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
     ---

--- a/pages/1.9/installing/oss/custom/cli/index.md
+++ b/pages/1.9/installing/oss/custom/cli/index.md
@@ -146,7 +146,7 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, a custom proxy, and SSH configuration specified. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, static master discovery list, and SSH configuration. You may use additional configuration parameters. For descriptions of all parameters and configuration examples, see the [documentation][6].
 
     The CLI installer uses these default configuration values, which you may override in your configuration:
 
@@ -186,12 +186,6 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
     public_agent_list:
     - <public-agent-private-ip>
     ssh_user: <username>
-    use_proxy: 'true'
-    http_proxy: http://<proxy_host>:<http_proxy_port>
-    https_proxy: https://<proxy_host>:<https_proxy_port>
-    no_proxy:
-    - 'foo.bar.com'
-    - '.baz.com'
     ```
 
 3.  Copy your private SSH key to `genconf/ssh_key`. For more information, see the [ssh_key_path][6] parameter.

--- a/pages/1.9/installing/oss/custom/cli/index.md
+++ b/pages/1.9/installing/oss/custom/cli/index.md
@@ -160,7 +160,6 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml
-    ---
     cluster_name: <cluster-name>
     # Only override this value if you're hosting the contents of genconf/serve/
     # at a custom location. The CLI installer will automatically distribute

--- a/pages/1.9/installing/oss/custom/cli/index.md
+++ b/pages/1.9/installing/oss/custom/cli/index.md
@@ -146,11 +146,12 @@ Your cluster must meet the software and hardware [requirements](/1.9/installing/
 
     In this step you create a YAML configuration file that is customized for your environment. DC/OS uses this configuration file during installation to generate your cluster installation files.
 
-    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. If your servers are installed with a domain name in your `/etc/resolv.conf`, you should add `dns_search` to your `config.yaml` file. For parameters descriptions and configuration examples, see the [documentation][6].
+    You can use this template to get started. This template specifies 3 masters, 5 [private](/1.9/overview/concepts/#private-agent-node) agents, 1 [public](/1.9/overview/concepts/#public-agent-node) agent, a custom proxy, and SSH configuration specified. For parameters descriptions and configuration examples, see the [documentation][6].
 
     **Tips:**
 
     - If Google DNS is not available in your country, you can replace the Google DNS servers `8.8.8.8` and `8.8.4.4` with your local DNS servers.
+    - If your servers are installed with a domain name in `/etc/resolv.conf`, you should specify `dns_search` with a value that includes that domain. 
     - If you set `master_discovery` to `static`, the IP addresses in `master_list` will be used for internal cluster communication. These IP addresses must be reachable from each other, as well as from the bootstrap host.
 
     ```yaml


### PR DESCRIPTION
## Description

https://jira.mesosphere.com/browse/COPS-3411

This PR fixes up the configuration section of CLI install docs to correct or clarify guidance, makes clear which config values are required, and explains default values specific to the CLI installer. See commits for a list of individual fixes.

Tested the 1.11 Enterprise doc manually.

## Urgency
- [x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
