### PR TITLE
DCOS-26632 Fixing formatting error in installing/int/ docs. Removed 1…

### DIFF
--- a/pages/1.10/overview/architecture/components/index.md
+++ b/pages/1.10/overview/architecture/components/index.md
@@ -865,13 +865,3 @@ dcos-spartan.service
 dcos-spartan-watchdog.service
 dcos-spartan-watchdog.timer
 ```
-
-
-# Changes Since DC/OS 1.9
-
-- [Admin Router](#admin-router) - Admin Router now performs dynamic DNS resolution. The external `dcos-adminrouter-reload` service and timer were removed.
-- [DC/OS Backup](#dcos-backup) - DC/OS Backup service and socket were added in DC/OS 1.10.0 for the [backup and restore](/1.10/administering-clusters/backup-and-restore/) feature. [enterprise type="inline" size="small" /]
-- [DC/OS Component Package Manager](#dcos-component-package-manager) - To avoid a race condition during DC/OS upgrades, the DC/OS Component Package Manager socket file is now managed by [gunicorn](http://gunicorn.org/) instead of systemd.
-- [DC/OS Identity and Access Manager](#dcos-iam) - For improved storage performance, DC/OS Identity and Access Manager now uses CockroachDB instead of ZooKeeper as the default store. To retain ZooKeeper as the store, you can use the `dcos-bouncer-legacy` service. [enterprise type="inline" size="small" /]
-- [CockroachDB](#cockroachdb) - CockroachDB was added in DC/OS 1.10.0 as the new store for DC/OS Identity and Access Manager. [enterprise type="inline" size="small" /]
-- [DC/OS Secrets](#dcos-secrets) - For improved security, DC/OS Secrets now uses a socket instead of a port. [enterprise type="inline" size="small" /]

--- a/pages/1.11/installing/ent/local/index.md
+++ b/pages/1.11/installing/ent/local/index.md
@@ -2,13 +2,8 @@
 layout: layout.pug
 navigationTitle:  Local
 title: Install DC/OS Locally
-
-menuWeight: 3
-excerpt: Automating local installation of DC/OS for development and testing
-
 menuWeight: 2
-
-
+excerpt: Automating local installation of DC/OS for development and testing
 enterprise: true
 ---
 

--- a/pages/1.11/installing/ent/patching/index.md
+++ b/pages/1.11/installing/ent/patching/index.md
@@ -3,7 +3,8 @@ layout: layout.pug
 navigationTitle: Patching
 title: Patching
 menuWeight: 3
-excerpt:
+excerpt: Understanding cluster patches
+enterprise: false
 ---
 
 # Patching live clusters with no downtime

--- a/pages/1.11/installing/oss/patching/index.md
+++ b/pages/1.11/installing/oss/patching/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Patching
 title: Patching
 menuWeight: 3
-excerpt:
+excerpt: Understanding cluster patches
 ---
 
 # Patching live clusters with no downtime

--- a/pages/1.11/overview/architecture/components/index.md
+++ b/pages/1.11/overview/architecture/components/index.md
@@ -816,13 +816,3 @@ dcos-spartan.service
 dcos-spartan-watchdog.service
 dcos-spartan-watchdog.timer
 ```
-
-
-# Changes Since DC/OS 1.9
-
-- [Admin Router](#admin-router) - Admin Router now performs dynamic DNS resolution. The external `dcos-adminrouter-reload` service and timer were removed.
-- [DC/OS Backup](#dcos-backup) - DC/OS Backup service and socket were added in DC/OS 1.10.0 for the [backup and restore](/1.10/administering-clusters/backup-and-restore/) feature. [enterprise type="inline" size="small" /]
-- [DC/OS Component Package Manager](#dcos-component-package-manager) - To avoid a race condition during DC/OS upgrades, the DC/OS Component Package Manager socket file is now managed by [gunicorn](http://gunicorn.org/) instead of systemd.
-- [DC/OS Identity and Access Manager](#dcos-iam) - For improved storage performance, DC/OS Identity and Access Manager now uses CockroachDB instead of ZooKeeper as the default store. To retain ZooKeeper as the store, you can use the `dcos-bouncer-legacy` service. [enterprise type="inline" size="small" /]
-- [CockroachDB](#cockroachdb) - CockroachDB was added in DC/OS 1.10.0 as the new store for DC/OS Identity and Access Manager. [enterprise type="inline" size="small" /]
-- [DC/OS Secrets](#dcos-secrets) - For improved security, DC/OS Secrets now uses a socket instead of a port. [enterprise type="inline" size="small" /]


### PR DESCRIPTION
….9 material from /architecture/components docs.

## Description
https://jira.mesosphere.com/browse/DCOS-26632

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
