### PR TITLE
Fixed checkpointed resources removal omission.

### DIFF
--- a/pages/1.11/storage/mount-disk-resources/index.md
+++ b/pages/1.11/storage/mount-disk-resources/index.md
@@ -58,6 +58,12 @@ In this example, a disk resource is added to a DC/OS agent post-install on a run
         sudo rm -f /var/lib/mesos/slave/meta/slaves/latest
         ```
 
+    1. Remove checkpointed agent resources with this command:
+
+      ```bash
+      sudo rm -f /var/lib/mesos/slave/meta/resources
+      ```
+
 5. Create a 200 MB loopback device.
 
     ```bash

--- a/pages/1.11/storage/mount-disk-resources/index.md
+++ b/pages/1.11/storage/mount-disk-resources/index.md
@@ -17,7 +17,9 @@ When a DC/OS agent starts, it scans for volumes that match the pattern `/dcos/vo
 
 # Example using loopback device
 
-In this example, a disk resource is added to a DC/OS agent post-install on a running cluster. These same steps can be used pre-install without having to stop services or clear the agent state.
+In this example, a disk resource is added to a DC/OS agent post-install on a running cluster. These same steps can be used pre-install without having to stop services or clear the agent state. 
+
+Please note that this example handles **adding** resources exclusively and can not get applied the same way when removing resources.
 
 ***Warning:*** This will terminate any running tasks or services on the node.
 
@@ -57,12 +59,6 @@ In this example, a disk resource is added to a DC/OS agent post-install on a run
         ```bash
         sudo rm -f /var/lib/mesos/slave/meta/slaves/latest
         ```
-
-    1. Remove checkpointed agent resources with this command:
-
-      ```bash
-      sudo rm -f /var/lib/mesos/slave/meta/resources
-      ```
 
 5. Create a 200 MB loopback device.
 


### PR DESCRIPTION
## Description
Documentation on mount disk resources is outdated and incomplete.

When the user changes the agent resources, there is one step missing in the guide; removing the agent's checkpointed resources

https://jira.mesosphere.com/browse/DCOS_OSS-3713

## Urgency
- [x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).