### PR TITLE
Ss/dcos 25934

### DIFF
--- a/pages/services/edge-lb/1.0/installing/index.md
+++ b/pages/services/edge-lb/1.0/installing/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Installing Edge-LB
 title: Installing Edge-LB
 menuWeight: 10
 excerpt:
-
+model: /services/edge-lb/data.yml
+render: mustache
 enterprise: false
 ---
 
@@ -12,9 +13,10 @@ Configure a service account and install the Edge-LB package using the instructio
 
 **Prerequisites:**
 
-- [DC/OS CLI installed](/latest/cli/install/) and be logged in as a superuser.
-- The [DC/OS Enterprise CLI installed](https://docs.mesosphere.com/1.10/cli/enterprise-cli/).
-- Access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
+- [DC/OS CLI is installed](/latest/cli/install/)
+- You are logged in as a superuser
+- The [DC/OS Enterprise CLI is installed](https://docs.mesosphere.com/1.10/cli/enterprise-cli/).
+- You have access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
 
 **Limitations**
 - Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/latest/security/ent/#security-modes). It does not work with disabled mode.
@@ -32,6 +34,12 @@ dcos package repo add --index=0 edgelb-aws \
 dcos package repo add --index=0 edgelb-pool-aws \
   https://<AWS S3 bucket>/stub-universe-edgelb-pool.json
 ```
+
+[enterprise]
+# Build your own local Universe
+[/enterprise]
+
+#include /services/include/build-local-universe-ee-only.tmpl
 
 # Create a service account
 The Edge-LB API server needs to be associated with a service account so that it can launch Edge-LB pools on public and private nodes, based on user requests.

--- a/pages/services/edge-lb/data.yml
+++ b/pages/services/edge-lb/data.yml
@@ -1,0 +1,34 @@
+# Common values:
+
+packageName: edge-lb
+serviceName: edgelb
+techName: Edge-LB
+techShortName: Edge-LB
+
+# Values specific to certain templates:
+
+install:
+  minNodeCount: three
+  nodeDescription: with three Apache Cassandra nodes
+  serviceAccountInstructionsUrl: https://docs.mesosphere.com/services/cassandra/cass-auth/
+
+managing:
+  podType: node
+  taskType: server
+
+supportedVersions:
+  techExampleVersion: 3.0.13
+  techLink:
+
+security:
+  plaintext:  |
+    , "allow_plaintext": <true|false default false>
+
+operations:
+  complete-deploy: |
+    deploy (serial strategy) (COMPLETE)
+    └─ node-deploy (serial strategy) (COMPLETE)
+       ├─ node-0:[server] (COMPLETE)
+       ├─ node-0:[init_system_keyspaces] (COMPLETE)
+       ├─ node-1:[server] (COMPLETE)
+       └─ node-2:[server] (COMPLETE)

--- a/pages/services/edge-lb/index.md
+++ b/pages/services/edge-lb/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Edge-LB
 title: Edge-LB
 menuWeight: 30
 excerpt:
+model: /services/edge-lb/data.yml
+render: mustache
 
 enterprise: false
 ---

--- a/pages/services/include/build-local-universe-ee-only.tmpl
+++ b/pages/services/include/build-local-universe-ee-only.tmpl
@@ -1,0 +1,311 @@
+Here's how you can add a package like {{ model.techName }} to a local universe.
+
+1. If you are using the latest stable release of DC/OS, download the [local-universe](https://downloads.mesosphere.com/universe/public/local-universe.tar.gz) container to each of your masters. Otherwise, you will need to build the container for your DC/OS version. See the section on [Building Your Own](#building-your-own) and copy it to each of your masters.
+
+1. Load the container into the local docker instance on each master:
+
+    ```bash
+    $ docker load < local-universe.tar.gz
+    ```
+
+1. Add the [`dcos-local-universe-http.service`](dcos-local-universe-http.service) definition to each of your masters at `/etc/systemd/system/dcos-local-universe-http.service` and then start it.
+
+    ```bash
+    $ cp dcos-local-universe-http.service /etc/systemd/system/dcos-local-universe-http.service
+    $ systemctl daemon-reload
+    $ systemctl start dcos-local-universe-http
+    ```
+
+1. Add the [`dcos-local-universe-registry.service`](dcos-local-universe-registry.service) definition to each of your masters at `/etc/systemd/system/dcos-local-universe-registry.service` and then start it.
+
+    ```bash
+    $ cp dcos-local-universe-registry.service /etc/systemd/system/dcos-local-universe-registry.service
+    $ systemctl daemon-reload
+    $ systemctl start dcos-local-universe-registry
+    ```
+
+1. Remove the built in repositories from the host that you have the DCOS CLI installed on (alternatively, these can be removed from the DCOS UI under **System>Repositories**).
+
+    ```bash
+    $ dcos package repo remove Universe
+    $ dcos package repo remove Universe-1.7
+    ```
+
+1. Add the local repository using the DCOS CLI.
+
+    ```bash
+    $ dcos package repo add local-universe http://master.mesos:8082/repo
+    ```
+
+1. To pull from this new repository, you will need to set up the docker daemon on every agent to have a valid SSL certificate. To do this, on every agent in your cluster, run the following:
+
+    ```bash
+    $ mkdir -p /etc/docker/certs.d/master.mesos:5000
+    $ curl -o /etc/docker/certs.d/master.mesos:5000/ca.crt http://master.mesos:8082/certs/domain.crt
+    $ systemctl restart docker
+    ```
+
+**Note:** You may use the instructions for insecure registries instead of this step. We don't recommend this.
+
+<a name="building-your-own"></a>
+## Building Your Own
+
+1. Both nginx and the docker registry are bundled into the same container. This requires building the "universe-base" container before you actually compile the universe container.
+
+    ```bash
+    $ sudo make base
+    ```
+
+1. Once you've built the "universe-base" container, you will be able to create a local-universe one. To keep size and time down, it is common to select only what you'd like to see. By default, `selected` applications are the only ones included. You can pass a list in if you'd like to see something more than that.
+
+    ```bash
+    $ sudo make DCOS_VERSION=<your DC/OS version> local-universe
+    ```
+
+    If you want to specify the set of package names and versions that get included in the image you can use the `DCOS_PACKAGE_INCLUDE variable. For example, to include two versions for Cassandra and one version of {{ model.techName }} you can execute the following command.
+
+    ```bash
+    $ sudo make DCOS_VERSION=<your DC/OS version> DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,cassandra:1.0.24-3.0.10,{{ model.packageName }}:1.4.2" local-universe
+    ```
+
+<a name="building-your-own-staticbase"></a>
+### Building Your Own, off a non-changing universe-static base image.
+
+Mesosphere provides a `mesosphere/universe-static` Docker image, which has all of the core requirements to run a local universe.  All that must be added are your own certificates and rep contents.
+
+1. Use the `make` command to download the static image:
+
+    ```bash
+    $ sudo make static-online
+    ## Will pull and re-tag mesosphere/universe-static to universe-static
+    ```
+
+1. Create your certs (either use `make certs` or generate your own), and add them to the static image to create a `universe-base` image:
+
+    ```bash
+    $ sudo make static-base
+    ## Will add certs to universe-static and create universe-base
+    ```
+
+1. Add content (see above):
+
+    ```bash
+    $ sudo make DCOS_VERSION=<your DC/OS version> local-universe
+    ```
+
+To generate your own static image, use and/or modify the make target `static-build` (e.g., `make static-build` instead of `make static-online`)
+
+This leaves three options:
+
+```bash
+make base
+make DCOS_VERSION=<your DC/OS version> local-universe
+```
+
+```bash
+make static-online
+make static-base
+make DCOS_VERSION=<your DC/OS version> local-universe
+```
+
+```bash
+make static-build
+make static-base
+make DCOS_VERSION=<your DC/OS version> local-universe
+```
+
+<a name="building-old-version"></a>
+### Building an old version of Local Universe
+The latest version of Local Universe has changed directory structure in a way that is not compatible with the old version of Local Universe. If you are interested in creating an old version of Local Universe with the old directory structure you must use the following command instead of the `local-universe` make target describe previously.
+
+```bash
+$ sudo make DCOS_VERSION=<your DC/OS version> old-local-universe
+```
+
+<a name="outside-resources"></a>
+### Outside Resources
+
+As a workaround for the image and CLI resource issues in [the FAQ](#faq), you can place those assets outside of the cluster.
+
+1. Place your CLI and image resources on a web server accessible to CLI and web UI users.
+
+2. Edit the URLs in the `resource.json` file of your package of interest to point to each of those resources, in the `images` and `cli` sections.
+
+3. Edit Makefile so the call to `local-universe.py` includes arguments `--nonlocal_images` and `--nonlocal_cli`.
+
+4. Proceed with [Building Your Own](#building-your-own) as above.
+
+<a name="running-local"></a>
+## Running Local Universe as a Marathon Service
+
+Instead of deploying to each of your masters, you can easily run a local universe as a regular Marathon service.
+
+1. Edit Makefile so the call to `local-universe.py` includes the `--server_url` argument indicating your choice of internal service name and port. For example, if you want dev-universe, then add `--server_url http://dev-universe.marathon.mesos:8085`.
+
+2. Build a container as per [Building Your Own](#building-your-own) above.
+
+3. Deploy the container to your cluster as you would one of your regular apps.
+
+4. Launch a single instance of your universe service, specifying health checks. Here's an example Marathon app:
+
+```json
+{
+  "id": "/dev-universe",
+  "instances": 1,
+  "cpus": 0.25,
+  "mem": 128,
+  "requirePorts": true,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "network": "BRIDGE",
+      "image": "your_image_location:latest",
+      "forcePullImage": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 8085,
+          "protocol": "tcp"
+        }
+      ]
+    },
+    "volumes": []
+  },
+  "cmd": "nginx -g 'daemon off;'",
+  "fetch": [ ],
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 30,
+      "maxConsecutiveFailures": 3,
+      "path": "/repo-empty-v3.json",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 5
+    }
+  ],
+  "constraints": [
+    [
+      "hostname",
+      "UNIQUE"
+    ]
+  ]
+}
+```
+
+<a name="making-changes"></a>
+## Making changes...
+
+###  ...to the `universe-static` image
+
+1. Update `Dockerfile.static` with the changes
+1. Bump the default value of `static_version` in `Makefile`
+1. Create a pull request with the above changes
+1. Once it is merged, run the [Publish universe-static image](https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Universe_2_PublishUniverseStaticImage&branch_Oss_Universe_2=%3Cdefault%3E&tab=buildTypeStatusDiv) build, providing the new version number when prompted
+1. Submit a pull request that updates the `FROM universe-static:...` line in
+`Dockerfile.static.base` to use the new version
+
+<a name="adding-stubs"></a>
+## Adding Stub Universes (Custom Universe Packages)
+
+If you've been provided stub universe json files (such as for {{ model.techName }}), you can add them to the local universe with the `add-stub-universe.sh` script.
+
+You can specify a local stub universe json definition with `-j <path-to-json-file>` or a URL for stub universe json definition with `-u <url-for-json-file>`
+
+Each run of the add-stub-universe.sh will process the json file and generate the necessary json and mustache files, and add them to `stub-repo/packages/<X>/<packagename>`.  Once all of your stub universe packages have been added into `stub-repo`, you can merge them into the primary `universe/repo/packages` and specify them in any of the standard local universe scripts.
+
+For example:
+```bash
+bash add-stub-universe.sh -j stub-universe-custom.json
+bash add-stub-universe.sh -u https://<url-path>/online-stub-universe.json
+```
+
+From there, they can be merged into the primary `universe/repo/packages` directory:
+
+```bash
+cp -rpv stub-repo/packages/* ../../repo/packages
+```
+
+Then, you could potentially build the rest of your universe with the regular workflow:
+
+```bash
+sudo make DCOS_VERSION=<your DC/OS version> DCOS_PACKAGE_INCLUDE="<custom-package>:0.1,<other-custom-package>:0.5" local-universe
+```
+
+Here's a full example:
+```bash
+# bash add-stub-universe.sh -j stub-universe-custom.json
+Building repo structure for custom...
+
+Full stub-repo contents:
+total 40
+drwxr-xr-x  7 userdirectory  staff   238B Jan 18 23:31 .
+drwxr-xr-x  3 userdirectory  staff   102B Jan 18 23:31 ..
+-rw-r--r--  1 userdirectory  staff   144B Jan 18 23:31 command.json
+-rw-r--r--  1 userdirectory  staff   1.7K Jan 18 23:31 config.json
+-rw-r--r--  1 userdirectory  staff   1.5K Jan 18 23:31 marathon.json.mustache
+-rw-r--r--  1 userdirectory  staff   384B Jan 18 23:31 package.json
+-rw-r--r--  1 userdirectory  staff   1.7K Jan 18 23:31 resource.json
+
+# bash add-stub-universe.sh -u https://<url-path>/online-stub-universe.json
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 13449  100 13449    0     0  22012      0 --:--:-- --:--:-- --:--:-- 22011
+Building repo structure for custom-online...
+
+Full stub-repo contents:
+stub-repo/packages/C/custom-online/0:
+total 48
+drwxr-xr-x  7 userdirectory  staff   238B Jan 18 23:31 .
+drwxr-xr-x  3 userdirectory  staff   102B Jan 18 23:31 ..
+-rw-r--r--  1 userdirectory  staff   149B Jan 18 23:31 command.json
+-rw-r--r--  1 userdirectory  staff   4.5K Jan 18 23:31 config.json
+-rw-r--r--  1 userdirectory  staff   3.4K Jan 18 23:31 marathon.json.mustache
+-rw-r--r--  1 userdirectory  staff   411B Jan 18 23:31 package.json
+-rw-r--r--  1 userdirectory  staff   2.2K Jan 18 23:31 resource.json
+
+stub-repo/packages/C/custom/0:
+total 40
+drwxr-xr-x@ 7 userdirectory  staff   238B Jan 18 23:31 .
+drwxr-xr-x@ 3 userdirectory  staff   102B Jan 18 23:31 ..
+-rw-r--r--@ 1 userdirectory  staff   144B Jan 18 23:31 command.json
+-rw-r--r--@ 1 userdirectory  staff   1.7K Jan 18 23:31 config.json
+-rw-r--r--@ 1 userdirectory  staff   1.5K Jan 18 23:31 marathon.json.mustache
+-rw-r--r--@ 1 userdirectory  staff   384B Jan 18 23:31 package.json
+-rw-r--r--@ 1 userdirectory  staff   1.7K Jan 18 23:31 resource.json
+
+# cp -rpv stub-repo/packages/* ../../repo/packages
+stub-repo/packages/C -> ../../repo/packages/E
+stub-repo/packages/C/custom -> ../../repo/packages/C/custom
+stub-repo/packages/C/custom/0 -> ../../repo/packages/C/custom/0
+stub-repo/packages/C/custom/0/command.json -> ../../repo/packages/C/custom/0/command.json
+stub-repo/packages/C/custom/0/config.json -> ../../repo/packages/C/custom/0/config.json
+stub-repo/packages/C/custom/0/marathon.json.mustache -> ../../repo/packages/C/custom/0/marathon.json.mustache
+stub-repo/packages/C/custom/0/package.json -> ../../repo/packages/C/custom/0/package.json
+stub-repo/packages/C/custom/0/resource.json -> ../../repo/packages/C/custom/0/resource.json
+stub-repo/packages/C/custom-online -> ../../repo/packages/C/custom-online
+stub-repo/packages/C/custom-online/0 -> ../../repo/packages/C/custom-online/0
+stub-repo/packages/C/custom-online/0/command.json -> ../../repo/packages/C/custom-online/0/command.json
+stub-repo/packages/C/custom-online/0/config.json -> ../../repo/packages/C/custom-online/0/config.json
+stub-repo/packages/C/custom-online/0/marathon.json.mustache -> ../../repo/packages/C/custom-online/0/marathon.json.mustache
+stub-repo/packages/C/custom-online/0/package.json -> ../../repo/packages/C/custom-online/0/package.json
+stub-repo/packages/C/custom-online/0/resource.json -> ../../repo/packages/C/custom-online/0/resource.json
+
+# sudo make DCOS_VERSION=1.10.4 DCOS_PACKAGE_INCLUDE="custom:0.1,custom-online:0.5" local-universe
+... Local universe build output here ...
+```
+
+<a name="faq"></a>
+## FAQ
+
+- I can't install CLI subcommands.
+
+    Packages are being hosted at `master.mesos:8082`. If you cannot resolve (or connect) to that from your DC/OS CLI install, you won't be able to install subcommands. If you're able to connect to port 8082 on your masters, the easiest way around this to add the IP for one of the masters to `/etc/hosts`.  See also [Outside Resources](#outside-resources).
+
+- The images are broken!
+
+    We host everything from inside your cluster, including the images. They're getting served up by `master.mesos:8082`. If you have connectivity to that IP, you can add it to `/etc/hosts` and get the images working.   See also [Outside Resources](#outside-resources).
+
+- I don't see the package I was looking for!
+
+    By default, we only bundle the `selected` packages. If you'd like to include something else, please see the [Building Your Own](#building-your-own) section.

--- a/pages/services/spark/2.1.0-2.2.0-1/install/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,10 +101,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 

--- a/pages/services/spark/2.1.0-2.2.1-1/install/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/install/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: 
-excerpt:
+navigationTitle:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 title: Install and Customize
 menuWeight: 0
 featureMaturity:
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/overview/security/security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/usage/webinterface/#universe
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,10 +101,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 

--- a/pages/services/spark/2.3.0-2.2.1-2/install/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/install/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: 
-excerpt:
+navigationTitle:
+excerpt: Install Spark with either the web interface or the DC/OS CLI
 title: Install and Customize
 menuWeight: 0
 featureMaturity:
@@ -43,7 +43,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/usage/webinterface/#universe
 
 ## Spark CLI
 You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need
-the Spark CLI. 
+the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS
 CLI.
@@ -102,9 +102,7 @@ configuration variables:
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -115,7 +113,7 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
+   dcos spark run --class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
    ```
 
 **Note**: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache
@@ -186,14 +184,14 @@ to follow these steps to install and run Spark.
     $ dcos security org service-accounts create -p <your-public-key>.pem -d "Spark service account" <service-account>
     ```
 
-    For example: 
+    For example:
 
     ```bash
     dcos security org service-accounts create -p public-key.pem -d "Spark service account" spark-principal
-    
+
     ```
 
-    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here. 
+    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here.
 
     **Note** You can verify your new service account using the following command.
 
@@ -217,7 +215,7 @@ to follow these steps to install and run Spark.
     dcos security secrets create-sa-secret --strict private-key.pem spark-principal spark/spark-secret
     ```
 
-    **Note* You can verify the secrets were created with:
+    **Note** You can verify the secrets were created with:
 
     ```bash
     $ dcos security secrets list /
@@ -236,7 +234,7 @@ cluster:
     instances of Spark without modifying this default. If you want to override the default Spark role, you must modify
     these code samples accordingly. We use `spark-service-role` to designate the role used below.
 
-Permissions can also be assigned through the UI. 
+Permissions can also be assigned through the UI.
 
 1.  Run the following to create the required permissions for Spark:
     ```bash
@@ -244,16 +242,16 @@ Permissions can also be assigned through the UI.
     $ dcos security org users grant <service-account> dcos:mesos:master:framework:role:<spark-service-role> create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     $ dcos security org users grant <service-account> dcos:mesos:master:task:app_id:/<service_name> create --description "Allows reading of the task state"
     ```
-    
+
     Note that above the `dcos:mesos:master:task:app_id:/<service_name>` will likely be `dcos:mesos:master:task:app_id:/spark`
 
     For example, continuing from above:
-    
+
     ```bash
     dcos security org users grant spark-principal dcos:mesos:master:task:user:root create --description "Allows the Linux user to execute tasks"
     dcos security org users grant spark-principal dcos:mesos:master:framework:role:* create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     dcos security org users grant spark-principal dcos:mesos:master:task:app_id:/spark create --description "Allows reading of the task state"
-    
+
     ```
 
     Note that here we're using the service account `spark-principal` and the user `root`.
@@ -265,11 +263,11 @@ Permissions can also be assigned through the UI.
     dcos security org users grant dcos_marathon dcos:mesos:master:task:user:root create --description "Allow Marathon to launch containers as root"
     ```
 
-## Install Spark with necessary configuration 
+## Install Spark with necessary configuration
 
 1.  Make a configuration file with the following before installing Spark, these settings can also be set through the UI:
     ```json
-    $ cat spark-strict-options.json 
+    $ cat spark-strict-options.json
     {
     "service": {
             "service_account": "<service-account-id>",
@@ -279,10 +277,10 @@ Permissions can also be assigned through the UI.
     }
     ```
 
-    A minimal example would be: 
+    A minimal example would be:
 
     ```json
-    { 
+    {
     "service": {
             "service_account": "spark-principal",
             "user": "root",
@@ -308,7 +306,7 @@ Permissions can also be assigned through the UI.
     --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
     ```
 
-If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable: 
+If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable:
 
     ```bash
     $ dcos spark run --verbose --submit-args="\

--- a/pages/services/spark/2.3.1-2.2.1-2/install/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/install/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: 
-excerpt:
+navigationTitle:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 title: Install and Customize
 menuWeight: 0
 featureMaturity:
@@ -40,7 +40,7 @@ You can also [install Spark via the DC/OS GUI](https://docs.mesosphere.com/1.9/u
 
 ## Spark CLI
 You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need
-the Spark CLI. 
+the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS
 CLI.
@@ -99,9 +99,7 @@ configuration variables:
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -112,7 +110,7 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
+   dcos spark run --class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
    ```
 
 **Note**: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache
@@ -183,14 +181,14 @@ to follow these steps to install and run Spark.
     $ dcos security org service-accounts create -p <your-public-key>.pem -d "Spark service account" <service-account>
     ```
 
-    For example: 
+    For example:
 
     ```bash
     dcos security org service-accounts create -p public-key.pem -d "Spark service account" spark-principal
-    
+
     ```
 
-    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here. 
+    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here.
 
     **Note** You can verify your new service account using the following command.
 
@@ -233,7 +231,7 @@ cluster:
     instances of Spark without modifying this default. If you want to override the default Spark role, you must modify
     these code samples accordingly. We use `spark-service-role` to designate the role used below.
 
-Permissions can also be assigned through the UI. 
+Permissions can also be assigned through the UI.
 
 1.  Run the following to create the required permissions for Spark:
     ```bash
@@ -241,16 +239,16 @@ Permissions can also be assigned through the UI.
     $ dcos security org users grant <service-account> dcos:mesos:master:framework:role:<spark-service-role> create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     $ dcos security org users grant <service-account> dcos:mesos:master:task:app_id:/<service_name> create --description "Allows reading of the task state"
     ```
-    
+
     Note that above the `dcos:mesos:master:task:app_id:/<service_name>` will likely be `dcos:mesos:master:task:app_id:/spark`
 
     For example, continuing from above:
-    
+
     ```bash
     dcos security org users grant spark-principal dcos:mesos:master:task:user:root create --description "Allows the Linux user to execute tasks"
     dcos security org users grant spark-principal dcos:mesos:master:framework:role:* create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     dcos security org users grant spark-principal dcos:mesos:master:task:app_id:/spark create --description "Allows reading of the task state"
-    
+
     ```
 
     Note that here we're using the service account `spark-principal` and the user `root`.
@@ -262,11 +260,11 @@ Permissions can also be assigned through the UI.
     dcos security org users grant dcos_marathon dcos:mesos:master:task:user:root create --description "Allow Marathon to launch containers as root"
     ```
 
-## Install Spark with necessary configuration 
+## Install Spark with necessary configuration
 
 1.  Make a configuration file with the following before installing Spark, these settings can also be set through the UI:
     ```json
-    $ cat spark-strict-options.json 
+    $ cat spark-strict-options.json
     {
     "service": {
             "service_account": "<service-account-id>",
@@ -276,10 +274,10 @@ Permissions can also be assigned through the UI.
     }
     ```
 
-    A minimal example would be: 
+    A minimal example would be:
 
     ```json
-    { 
+    {
     "service": {
             "service_account": "spark-principal",
             "user": "root",
@@ -305,7 +303,7 @@ Permissions can also be assigned through the UI.
     --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
     ```
 
-If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable: 
+If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable:
 
     ```bash
     $ dcos spark run --verbose --submit-args="\

--- a/pages/services/spark/v1.1.0-2.1.1/install/index.md
+++ b/pages/services/spark/v1.1.0-2.1.1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Spark can be installed by using either the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -72,9 +72,7 @@ DC/OS Spark does not support arbitrary Spark distributions, but Mesosphere does 
 
 For development purposes, you may wish to install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -82,9 +80,9 @@ For development purposes, you may wish to install Spark on a local DC/OS cluster
 
 1. Run a simple Job:
 
-        $ dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+        $ dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 

--- a/pages/services/spark/v1.1.1-2.2.0/install/index.md
+++ b/pages/services/spark/v1.1.1-2.2.0/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Spark can be installed by using either the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,10 +101,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 

--- a/pages/services/spark/v2.0.0-2.2.0-1/install/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,10 +101,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 

--- a/pages/services/spark/v2.0.1-2.2.0-1/install/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Install Spark using the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,10 +101,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25934

[https://docs.mesosphere.com/service-docs/spark/v1.1.0-2.1.1/install/]

Minimal Installation step 3 fails. There&[#039|https://mesosphere.zendesk.com/agent/tickets/039];s an SSL error on the URL, which causes the Spark job to fail to pull the jar down.

$ dcos spark run --submit-args=&quot;--class org.apache.spark.examples.SparkPi [https://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar\|https://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar%5C]"

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrections made to install docs on:

- [x] 1.1.0-2.1.1
- [x] 1.1.1-2.2.0
- [x] 2.0.0-2.2.0-1
- [x] 2.0.1-2.2.0-1
- [x] 2.1.0-2.2.0-1
- [x] 2.1.0-2.2.1-1
- [x] 2.3.0-2.2.1-2
- [x] 2.3.1-2.2.1-2