### PR TITLE
DCOS-25934 Correcting Spark minimal install command

### DIFF
--- a/pages/services/spark/2.1.0-2.2.0-1/install/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,12 +101,13 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
+
 
 # Multiple Installations
 

--- a/pages/services/spark/2.1.0-2.2.1-1/install/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/install/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: 
-excerpt:
+navigationTitle:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 title: Install and Customize
 menuWeight: 0
 featureMaturity:
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/overview/security/security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/usage/webinterface/#universe
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,12 +101,13 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
+
 
 # Multiple Installations
 

--- a/pages/services/spark/2.3.0-2.2.1-2/install/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/install/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: 
-excerpt:
+navigationTitle:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 title: Install and Customize
 menuWeight: 0
 featureMaturity:
@@ -43,7 +43,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/usage/webinterface/#universe
 
 ## Spark CLI
 You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need
-the Spark CLI. 
+the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS
 CLI.
@@ -102,9 +102,7 @@ configuration variables:
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -115,12 +113,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-**Note**: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache
-Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install
-DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 
@@ -186,14 +182,14 @@ to follow these steps to install and run Spark.
     $ dcos security org service-accounts create -p <your-public-key>.pem -d "Spark service account" <service-account>
     ```
 
-    For example: 
+    For example:
 
     ```bash
     dcos security org service-accounts create -p public-key.pem -d "Spark service account" spark-principal
-    
+
     ```
 
-    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here. 
+    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here.
 
     **Note** You can verify your new service account using the following command.
 
@@ -236,7 +232,7 @@ cluster:
     instances of Spark without modifying this default. If you want to override the default Spark role, you must modify
     these code samples accordingly. We use `spark-service-role` to designate the role used below.
 
-Permissions can also be assigned through the UI. 
+Permissions can also be assigned through the UI.
 
 1.  Run the following to create the required permissions for Spark:
     ```bash
@@ -244,16 +240,16 @@ Permissions can also be assigned through the UI.
     $ dcos security org users grant <service-account> dcos:mesos:master:framework:role:<spark-service-role> create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     $ dcos security org users grant <service-account> dcos:mesos:master:task:app_id:/<service_name> create --description "Allows reading of the task state"
     ```
-    
+
     Note that above the `dcos:mesos:master:task:app_id:/<service_name>` will likely be `dcos:mesos:master:task:app_id:/spark`
 
     For example, continuing from above:
-    
+
     ```bash
     dcos security org users grant spark-principal dcos:mesos:master:task:user:root create --description "Allows the Linux user to execute tasks"
     dcos security org users grant spark-principal dcos:mesos:master:framework:role:* create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     dcos security org users grant spark-principal dcos:mesos:master:task:app_id:/spark create --description "Allows reading of the task state"
-    
+
     ```
 
     Note that here we're using the service account `spark-principal` and the user `root`.
@@ -265,11 +261,11 @@ Permissions can also be assigned through the UI.
     dcos security org users grant dcos_marathon dcos:mesos:master:task:user:root create --description "Allow Marathon to launch containers as root"
     ```
 
-## Install Spark with necessary configuration 
+## Install Spark with necessary configuration
 
 1.  Make a configuration file with the following before installing Spark, these settings can also be set through the UI:
     ```json
-    $ cat spark-strict-options.json 
+    $ cat spark-strict-options.json
     {
     "service": {
             "service_account": "<service-account-id>",
@@ -279,10 +275,10 @@ Permissions can also be assigned through the UI.
     }
     ```
 
-    A minimal example would be: 
+    A minimal example would be:
 
     ```json
-    { 
+    {
     "service": {
             "service_account": "spark-principal",
             "user": "root",
@@ -308,7 +304,7 @@ Permissions can also be assigned through the UI.
     --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
     ```
 
-If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable: 
+If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable:
 
     ```bash
     $ dcos spark run --verbose --submit-args="\

--- a/pages/services/spark/2.3.1-2.2.1-2/install/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/install/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: 
-excerpt:
+navigationTitle:
+excerpt: Install Spark using either the web interface or the DC/OS CLI
 title: Install and Customize
 menuWeight: 0
 featureMaturity:
@@ -40,7 +40,7 @@ You can also [install Spark via the DC/OS GUI](https://docs.mesosphere.com/1.9/u
 
 ## Spark CLI
 You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need
-the Spark CLI. 
+the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS
 CLI.
@@ -99,9 +99,7 @@ configuration variables:
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -112,14 +110,13 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-**Note**: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache
-Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install
-DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
+
 
 # Multiple Installations
 
@@ -183,14 +180,14 @@ to follow these steps to install and run Spark.
     $ dcos security org service-accounts create -p <your-public-key>.pem -d "Spark service account" <service-account>
     ```
 
-    For example: 
+    For example:
 
     ```bash
     dcos security org service-accounts create -p public-key.pem -d "Spark service account" spark-principal
-    
+
     ```
 
-    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here. 
+    In the Mesos parlance a `service-account` is called a `principal` and so we use the terms interchangeably here.
 
     **Note** You can verify your new service account using the following command.
 
@@ -233,7 +230,7 @@ cluster:
     instances of Spark without modifying this default. If you want to override the default Spark role, you must modify
     these code samples accordingly. We use `spark-service-role` to designate the role used below.
 
-Permissions can also be assigned through the UI. 
+Permissions can also be assigned through the UI.
 
 1.  Run the following to create the required permissions for Spark:
     ```bash
@@ -241,16 +238,16 @@ Permissions can also be assigned through the UI.
     $ dcos security org users grant <service-account> dcos:mesos:master:framework:role:<spark-service-role> create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     $ dcos security org users grant <service-account> dcos:mesos:master:task:app_id:/<service_name> create --description "Allows reading of the task state"
     ```
-    
+
     Note that above the `dcos:mesos:master:task:app_id:/<service_name>` will likely be `dcos:mesos:master:task:app_id:/spark`
 
     For example, continuing from above:
-    
+
     ```bash
     dcos security org users grant spark-principal dcos:mesos:master:task:user:root create --description "Allows the Linux user to execute tasks"
     dcos security org users grant spark-principal dcos:mesos:master:framework:role:* create --description "Allows a framework to register with the Mesos master using the Mesos default role"
     dcos security org users grant spark-principal dcos:mesos:master:task:app_id:/spark create --description "Allows reading of the task state"
-    
+
     ```
 
     Note that here we're using the service account `spark-principal` and the user `root`.
@@ -262,11 +259,11 @@ Permissions can also be assigned through the UI.
     dcos security org users grant dcos_marathon dcos:mesos:master:task:user:root create --description "Allow Marathon to launch containers as root"
     ```
 
-## Install Spark with necessary configuration 
+## Install Spark with necessary configuration
 
 1.  Make a configuration file with the following before installing Spark, these settings can also be set through the UI:
     ```json
-    $ cat spark-strict-options.json 
+    $ cat spark-strict-options.json
     {
     "service": {
             "service_account": "<service-account-id>",
@@ -276,10 +273,10 @@ Permissions can also be assigned through the UI.
     }
     ```
 
-    A minimal example would be: 
+    A minimal example would be:
 
     ```json
-    { 
+    {
     "service": {
             "service_account": "spark-principal",
             "user": "root",
@@ -305,7 +302,7 @@ Permissions can also be assigned through the UI.
     --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
     ```
 
-If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable: 
+If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify the user through the `SPARK_USER` environment variable:
 
     ```bash
     $ dcos spark run --verbose --submit-args="\

--- a/pages/services/spark/v1.0.9-2.1.0-1/install/index.md
+++ b/pages/services/spark/v1.0.9-2.1.0-1/install/index.md
@@ -70,23 +70,26 @@ DC/OS Spark does not support arbitrary Spark distributions, but Mesosphere does 
 
 # Minimal Installation
 
-For development purposes, you may wish to install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
+For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
-        $ dcos package install spark
+   ```bash
+   dcos package install spark
+   ```
 
 1. Run a simple Job:
 
-        $ dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   ```bash
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
+
 
 # Multiple Installations
 

--- a/pages/services/spark/v1.1.0-2.1.1/install/index.md
+++ b/pages/services/spark/v1.1.0-2.1.1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Installing Spark with web interface or DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -70,23 +70,26 @@ DC/OS Spark does not support arbitrary Spark distributions, but Mesosphere does 
 
 # Minimal Installation
 
-For development purposes, you may wish to install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
+For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
-        $ dcos package install spark
+   ```bash
+   dcos package install spark
+   ```
 
 1. Run a simple Job:
 
-        $ dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   ```bash
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
+
 
 # Multiple Installations
 

--- a/pages/services/spark/v1.1.1-2.2.0/install/index.md
+++ b/pages/services/spark/v1.1.1-2.2.0/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Installing Spark with the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,10 +101,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 

--- a/pages/services/spark/v2.0.0-2.2.0-1/install/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Install Spark with either the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,12 +101,13 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
+
 
 # Multiple Installations
 

--- a/pages/services/spark/v2.0.1-2.2.0-1/install/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/install/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Install and Customize
 title: Install and Customize
 menuWeight: 0
-excerpt:
+excerpt: Install Spark with either the web interface or the DC/OS CLI
 featureMaturity:
 enterprise: false
 ---
@@ -17,7 +17,7 @@ Spark is available in the Universe and can be installed by using either the GUI 
 
 - [DC/OS and DC/OS CLI installed](/1.9/installing/).
 - Depending on your [security mode](/1.9/security/ent/#security-modes/), Spark requires service authentication for access to DC/OS. For more information, see [Configuring DC/OS Access for Spark](/services/spark/spark-auth/).
-  
+
   | Security mode | Service Account |
   |---------------|-----------------------|
   | Disabled      | Not available   |
@@ -37,7 +37,7 @@ You can also [install Spark via the DC/OS GUI](/1.9/gui/universe).
 
 
 ## Spark CLI
-You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI. 
+You can install the Spark CLI with this command. This is useful if you already have a Spark cluster running, but need the Spark CLI.
 
 **Important:** If you install Spark via the DC/OS GUI, you must install the Spark CLI as a separate step from the DC/OS CLI.
 
@@ -90,9 +90,7 @@ To use one of these distributions, select your Spark distribution from [here](ht
 
 For development purposes, you can install Spark on a local DC/OS cluster. For this, you can use [dcos-vagrant][16].
 
-1. Install DC/OS Vagrant:
-
-	Install a minimal DC/OS Vagrant according to the instructions [here][16].
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
 
 1. Install Spark:
 
@@ -103,10 +101,10 @@ For development purposes, you can install Spark on a local DC/OS cluster. For th
 1. Run a simple Job:
 
    ```bash
-   dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
+   dcos spark run --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar"
    ```
 
-NOTE: A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
+**Note:** A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS Apache Spark.  For example, unless you have enough resources to start up a 5-agent cluster, you will not be able to install DC/OS HDFS, and you thus won't be able to enable the history server.
 
 Also, a limited resource environment can restrict how you size your executors, for example with `spark.executor.memory`.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25934

[https://docs.mesosphere.com/service-docs/spark/v1.1.0-2.1.1/install/]

Minimal Installation step 3 fails. There is an SSL error on the URL, which causes the Spark job to fail to pull the jar down.

$ dcos spark run --submit-args=&quot;--class org.apache.spark.examples.SparkPi [https://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar\|https://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/spark-examples_2.10-1.5.0.jar%5C]"

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrections made to install docs on:

- [x] 1.0.9-2.1.0-1
- [x] 1.1.0-2.1.1
- [x] 1.1.1-2.2.0
- [x] 2.0.0-2.2.0-1
- [x] 2.0.1-2.2.0-1
- [x] 2.1.0-2.2.0-1
- [x] 2.1.0-2.2.1-1
- [x] 2.3.0-2.2.1-2
- [x] 2.3.1-2.2.1-2