### PR TITLE
DCOS-29992 Corrected spacing error in /managing/index.md wherever found.

### DIFF
--- a/pages/services/beta-cassandra/1.0.32-3.0.14-beta/managing/index.md
+++ b/pages/services/beta-cassandra/1.0.32-3.0.14-beta/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/) installed and available
++ [The DC/OS CLI](/1.10/cli/install/)  installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-cassandra`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-cassandra/2.1.0-3.0.15-beta/managing/index.md
+++ b/pages/services/beta-cassandra/2.1.0-3.0.15-beta/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/) installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-cassandra`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/managing/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/managing/index.md
@@ -34,7 +34,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-dse/2.1.0-5.1.2-beta/managing/index.md
+++ b/pages/services/beta-dse/2.1.0-5.1.2-beta/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-dse/2.1.2-5.1.2-beta/managing/index.md
+++ b/pages/services/beta-dse/2.1.2-5.1.2-beta/managing/index.md
@@ -30,7 +30,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-elastic/2.0.0-5.5.1/managing/index.md
+++ b/pages/services/beta-elastic/2.0.0-5.5.1/managing/index.md
@@ -33,7 +33,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli elastic`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-elastic/2.1.0-5.6.4-beta/managing/index.md
+++ b/pages/services/beta-elastic/2.1.0-5.6.4-beta/managing/index.md
@@ -33,7 +33,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-elastic`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-elastic/2.1.1-5.6.5-beta/managing/index.md
+++ b/pages/services/beta-elastic/2.1.1-5.6.5-beta/managing/index.md
@@ -32,7 +32,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-elastic`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-elastic/2.1.2-5.6.5-beta/managing/index.md
+++ b/pages/services/beta-elastic/2.1.2-5.6.5-beta/managing/index.md
@@ -32,7 +32,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-elastic`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/managing/index.md
+++ b/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/managing/index.md
@@ -32,7 +32,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-hdfs`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/managing/index.md
+++ b/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-hdfs`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-hdfs/v2.0.0-2.6.0-cdh5.11.0/managing/index.md
+++ b/pages/services/beta-hdfs/v2.0.0-2.6.0-cdh5.11.0/managing/index.md
@@ -32,7 +32,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-hdfs`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-kafka/1.1.27-0.11.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/1.1.27-0.11.0-beta/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-kafka/2.1.0-1.0.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/2.1.0-1.0.0-beta/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-kafka/2.1.1-1.0.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/2.1.1-1.0.0-beta/managing/index.md
@@ -30,7 +30,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/beta-kafka/2.1.2-1.0.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/2.1.2-1.0.0-beta/managing/index.md
@@ -30,7 +30,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli beta-kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/cassandra/2.0.1-3.0.14/managing/index.md
+++ b/pages/services/cassandra/2.0.1-3.0.14/managing/index.md
@@ -29,7 +29,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli cassandra`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/cassandra/2.0.2-3.0.14/managing/index.md
+++ b/pages/services/cassandra/2.0.2-3.0.14/managing/index.md
@@ -30,7 +30,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli cassandra`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/cassandra/2.0.3-3.0.14/managing/index.md
+++ b/pages/services/cassandra/2.0.3-3.0.14/managing/index.md
@@ -29,7 +29,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli cassandra`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/cassandra/v2.0.0-3.0.14/managing/index.md
+++ b/pages/services/cassandra/v2.0.0-3.0.14/managing/index.md
@@ -29,7 +29,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli cassandra`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/confluent-kafka/2.0.1-3.3.0e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.1-3.3.0e/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli confluent-kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/confluent-kafka/2.0.1.1-3.3.0e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.1.1-3.3.0e/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli confluent-kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/confluent-kafka/2.0.2-3.3.0e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.2-3.3.0e/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/confluent-kafka/2.0.3-3.3.1e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.3-3.3.1e/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/latest/cli/install/)installed and available
++ [The DC/OS CLI](/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli confluent-kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/2.0.2-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.2-5.1.2/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/2.0.3-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.3-5.1.2/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/2.0.4-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.4-5.1.2/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/2.0.5-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.5-5.1.2/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/v2.0.0-5.1.2/managing/index.md
+++ b/pages/services/dse/v2.0.0-5.1.2/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/kafka/2.0.1-0.11.0/managing/index.md
+++ b/pages/services/kafka/2.0.1-0.11.0/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/kafka/2.0.2-0.11.0/managing/index.md
+++ b/pages/services/kafka/2.0.2-0.11.0/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/kafka/2.0.3-0.11.0/managing/index.md
+++ b/pages/services/kafka/2.0.3-0.11.0/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/kafka/2.0.4-1.0.0/managing/index.md
+++ b/pages/services/kafka/2.0.4-1.0.0/managing/index.md
@@ -27,7 +27,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](https://docs.mesosphere.com/latest/cli/install/)installed and available
++ [The DC/OS CLI](https://docs.mesosphere.com/latest/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/kafka/v2.0.0-0.11.0/managing/index.md
+++ b/pages/services/kafka/v2.0.0-0.11.0/managing/index.md
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/)installed and available
++ [The DC/OS CLI](/1.10/cli/install/) installed and available 
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli kafka`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-29992
1. In managing.md (e.g. elastic, hdfs) there are references to NODEPOD which should have been replaced from the template documentation.
2.     In managing.md (e.g https://docs.mesosphere.com/service-docs/elastic/v2.0.0-5.5.1/managing/) in the "Recreating options.json (optional)" section, the numbering of the steps with CLI examples is broken due to incorrect indentation of the code blocks. This seems the case for ALL frameworks. (For HDFS: https://docs.mesosphere.com/service-docs/hdfs/v2.0.0-2.6.0-cdh5.11.0/managing/ the numbering is correct, but the code blocks are not).
3.     In managing.md the numbering in the section "Open Source DC/OS, Enterprise DC/OS 1.9 and Earlier" is incorrect.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Response:

    

1. These pages do not call a template, in any version, so I am not sure what replacement was supposed to have been made. Please clarify. Also, there are no pages in this doc suite called 'manage.md'. I have checked as many /managing/index.md pages as I could find.
2.     Cannot reproduce. The numbering is correct in all versions which have the /managing/index.md page in Elastic, HDFS, DSE, Percona-Mongo, NiFi, Cassandra, Beta-Cassandra, Beta Confluent Kafka, Beta DSE, Beta Elastic, Beta HDFS, and Beta Kafka. However, I did find some minor formatting errors in /managing/index.md which I fixed.
3.     This was fixed three months ago by Josh Earlenbaugh.

