### PR TITLE
DCOS-26349 Correcting intro in both versions

### DIFF
--- a/pages/services/edge-lb/0.1/index.md
+++ b/pages/services/edge-lb/0.1/index.md
@@ -8,7 +8,7 @@ excerpt:
 enterprise: false
 ---
 
-Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides both North-South (external to internal) load balancing, while the [Minuteman component](/1.10/overview/architecture/components/#minuteman) provides East-West (internal to internal) load balancing.
+Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides North-South (external to internal) load balancing, while the [Minuteman component](/1.10/overview/architecture/components/#minuteman) provides East-West (internal to internal) load balancing.
 
 Edge-LB leverages HAProxy, which provides the core load balancing and proxying features, such as load balancing for TCP and HTTP-based applications, SSL support, and health checking. In addition, Edge-LB provides first class support for zero downtime service deployment strategies, such as blue/green deployment. Edge-LB subscribes to Mesos and updates HAProxy configuration in real time.
 

--- a/pages/services/edge-lb/1.0/index.md
+++ b/pages/services/edge-lb/1.0/index.md
@@ -8,7 +8,7 @@ excerpt:
 enterprise: false
 ---
 
-Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides both North-South (external to internal) load balancing, while the [Minuteman component](/latest/networking/load-balancing-vips/) provides East-West (internal to internal) load balancing.
+Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides North-South (external to internal) load balancing, while the [Minuteman component](/latest/networking/load-balancing-vips/) provides East-West (internal to internal) load balancing.
 
 Edge-LB leverages HAProxy, which provides the core load balancing and proxying features, such as load balancing for TCP and HTTP-based applications, SSL support, and health checking. In addition, Edge-LB provides first class support for zero downtime service deployment strategies, such as blue/green deployment. Edge-LB subscribes to Mesos and updates HAProxy configuration in real time.
 

--- a/pages/services/edge-lb/index.md
+++ b/pages/services/edge-lb/index.md
@@ -8,7 +8,7 @@ excerpt:
 enterprise: false
 ---
 
-Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides both North-South (external to internal) and East-West (internal to internal) load balancing.
+Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides North-South (external to internal) and East-West (internal to internal) load balancing.
 
 Edge-LB builds upon HAProxy. HAProxy provides base functionality, such as load balancing for TCP and HTTP-based applications, SSL support, and health checking. In addition, Edge-LB provides first class support for zero downtime service deployment strategies, such as blue/green deployment. Edge-LB subscribes to Mesos and updates HAProxy configuration in real time.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-26349

In the EdgeLB documentation introduction - the statement is ambiguous. 

"Edge-LB proxies and load balances traffic to all services that run on DC/OS. Edge-LB provides both North-South (external to internal) load balancing, while the Minuteman component provides East-West (internal to internal) load balancing."

 It should either say both North-south and East-West, or remove the word both.
## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected versions:

- [x] 0.1
- [x] 1.0
