### PR TITLE
DCOS_OSS-3734: Add redirect for webinterface for all versions since it was renamed gui

### DIFF
--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -494,7 +494,7 @@
 /1.10/usage/tutorials/registry/ https://github.com/dcos/examples/tree/master/registry/1.8;
 /1.10/usage/tutorials/stateful-services/ /1.10/tutorials/stateful-services/;
 /1.10/usage/tutorials/task-labels/ /1.10/tutorials/task-labels/;
-/1.10/usage/webinterface/ /1.10/gui/;
+/1.([1-9]\d+)/usage/webinterface/ /1.$1/gui/;
 /1.7/administration/dcosarchitecture/security/ /1.7/overview/;
 /1.7/administration/installing/custom/automated-installer/system-requirements/ /1.7/administration/installing/custom/system-requirements/;
 /1.7/administration/installing/img/digitalocean_help_link.png/ /1.7/administration/img/digitalocean_help_link.png/;


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-3734

- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).