### PR TITLE
Create new docs for Kafka 1.1.0 upgrade

### DIFF
--- a/pages/services/kafka/2.3.0-1.1.0/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/index.md
@@ -1,0 +1,38 @@
+---
+layout: layout.pug
+navigationTitle: Kafka 2.3.0-1.0.0
+excerpt:
+title: Kafka 2.3.0-1.0.0
+menuWeight: 8
+model: /services/kafka/data.yml
+render: mustache
+---
+
+<!-- Imported from https://github.com/mesosphere/dcos-commons.git:sdk-0.40 -->
+
+DC/OS Apache Kafka is an automated service that makes it easy to deploy and manage Apache Kafka on Mesosphere DC/OS, eliminating nearly all of the complexity traditionally associated with managing a Kafka cluster. Apache Kafka is a distributed high-throughput publish-subscribe messaging system with strong ordering guarantees. Kafka clusters are highly available, fault tolerant, and very durable. For more information on Apache Kafka, see the Apache Kafka [documentation](http://kafka.apache.org/documentation.html). DC/OS Kafka gives you direct access to the Kafka API so that existing producers and consumers can interoperate. You can configure and install DC/OS Kafka in moments. Multiple Kafka clusters can be installed on DC/OS and managed independently, so you can offer Kafka as a managed service to your organization.
+
+## Benefits
+
+DC/OS Kafka offers the following benefits of a semi-managed service:
+
+*   Easy installation
+*   Multiple Kafka clusters
+*   Elastic scaling of brokers
+*   Replication and graceful shutdown for high availability
+*   Kafka cluster and broker monitoring
+
+## Features
+
+DC/OS Kafka provides the following features:
+
+*   Single-command installation for rapid provisioning
+*   Multiple clusters for multiple tenancy with DC/OS
+*   High availability runtime configuration and software updates
+*   Storage volumes for enhanced data durability, known as Mesos Dynamic Reservations and Persistent Volumes
+*   Integration with syslog-compatible logging services for diagnostics and troubleshooting
+*   Integration with statsd-compatible metrics services for capacity and performance monitoring
+
+# Related Services
+
+*   [DC/OS Spark](/services/spark/)

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_0-getting-started/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_0-getting-started/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Getting Started
+menuWeight: 10
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/getting-started.tmpl

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_1-configuration/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_1-configuration/index.md
@@ -1,0 +1,55 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Configuration
+menuWeight: 20
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/configuration-install-with-options.tmpl
+#include /services/include/configuration-service-settings.tmpl
+#include /services/include/configuration-regions.tmpl
+
+## Configuring the ZooKeeper Connection.
+
+{{ model.techName }} requires a running ZooKeeper ensemble to perform its own internal accounting. By default, the DC/OS {{ model.techName }} Service uses the ZooKeeper ensemble made available on the Mesos masters of a DC/OS cluster at `master.mesos:2181/dcos-service-<servicename>`. At install time, you can configure an alternate ZooKeeper for {{ model.techName }} to use. This enables you to increase {{ model.techName }}'s capacity and removes the DC/OS System ZooKeeper ensemble's involvement in running it.
+
+To configure an alternate Zookeeper instance:
+
+1. Create a file named `options.json` with the following contents.
+
+**Note:** If you are using the [DC/OS Apache ZooKeeper service](/services/{{ model.kafka.zookeeperPackageName }}), use the DNS addresses provided by the `dcos {{ model.kafka.zookeeperPackageName }} endpoints clientport` command as the value of `kafka_zookeeper_uri`. Here is an example `options.json` which points to a `{{ model.kafka.zookeeperPackageName }}` instance named `{{ model.kafka.zookeeperServiceName }}`:
+
+```json
+{
+  "kafka": {
+    "kafka_zookeeper_uri": "zookeeper-0-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140"
+  }
+}
+```
+
+1. Install {{ model.techName }} with the options file you created.
+
+```bash
+$ dcos package install {{ model.packageName }} --options="options.json"
+```
+
+You can also update an already-running {{ model.techName }} instance from the DC/OS CLI, in case you need to migrate your ZooKeeper data elsewhere.
+
+**Note:** Before performing this configuration change, you must first copy the data from your current ZooKeeper ensemble to the new ZooKeeper ensemble. The new location must have the same data as the previous location during the migration.
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} update start --options=options.json
+```
+
+## Extend the Kill Grace Period
+
+When performing a requested restart or replace of a running broker, the Kafka service will wait a default of `30` seconds for a broker to exit, before killing the process. This grace period may be customized via the `brokers.kill_grace_period` setting. In this example we will use the DC/OS CLI to increase the grace period delay to `60` seconds. This example assumes that the Kafka service instance is named `{{ model.serviceName }}`.
+
+During the configuration update, each of the Kafka broker tasks are restarted. During the shutdown portion of the task restart, the previous configuration value for `brokers.kill_grace_period` is in effect. Following the shutdown, each broker task is launched with the new effective configuration value. Take care to monitor the amount of time Kafka brokers take to cleanly shut down by observing their logs.
+
+### Replacing a Broker with Grace
+
+The grace period must also be respected when a broker is shut down before replacement. While it is not ideal that a broker must respect the grace period even if it is going to lose persistent state, this behavior will be improved in future versions of the SDK. Broker replacement generally requires complex and time-consuming reconciliation activities at startup if there was not a graceful shutdown, so the respect of the grace kill period still provides value in most situations. We recommend setting the kill grace period only sufficiently long enough to allow graceful shutdown. Monitor the Kafka broker clean shutdown times in the broker logs to keep this value tuned to the scale of data flowing through the Kafka service.

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_10-support-policy/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_10-support-policy/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+title: Support Policy
+menuWeight: 110
+excerpt:
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/support-policy.tmpl

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_11-release-notes/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_11-release-notes/index.md
@@ -1,0 +1,88 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Release Notes
+menuWeight: 120
+model: /services/kafka/data.yml
+render: mustache
+---
+
+
+## Version 2.3.0-1.1.0
+
+### Updates
+- Upgrade Kafka base tech to version 1.1.0. See [Kafka's Release Notes](https://www.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html) for details.
+
+## Version 2.3.0-1.0.0
+
+### New Features
+- Support for configuring Kafka transport encryption ciphers with secure defaults.
+
+## Version 2.2.0-1.0.0
+
+### New Features
+- Support for using a custom top level domain to facilitate exposing the service securely outside of the cluster. Details [here](/services/kafka/2.3.0-1.0.0/security/#securely-exposing-dcos-apache-kafka-outside-the-cluster).
+- Support for launching the service in a remote region.
+
+## Version 2.1.0-1.0.0
+
+### New Features
+- Support for the automated provisioning of TLS artifacts to secure Kafka communication.
+- Support for Kerberos and SSL authorization and authentication.
+- Support for `Zone` placement constraints in DC/OS 1.11 (beta versions of DC/OS 1.11 coming soon).
+- Ability to pause a service pod for debugging and recovery purposes.
+
+### Updates
+- Major improvements to the stability and performance of service orchestration.
+- Protocol and log version defaults are also set to `1.0`.
+- Improve Kafka's ZK library to enable re-resolution as required on virtual networks
+- Upgrade the JRE to 1.8u162
+- The service now uses the Mesos V1 API. The service can be set back to the V0 API using the service property `service.mesos_api_version`.
+
+## Version 2.0.4-1.0.0
+
+### Updates
+- Upgraded to Kafka v1.0.0. **Note:** Protocol and log version defaults are set to 0.11.0. After upgrading to this version, they may be set to 1.0.0.
+
+# Version 2.0.3-0.11.0
+
+### Bug Fixes
+* Uninstall now handles failed tasks correctly.
+* Fixed a timing issue in the broker readiness check that caused brokers to be stuck in STARTING when the service is allocated more than 2 CPUs per broker.
+
+# Version 2.0.2-0.11.0
+
+### Bug Fixes
+
+- Dynamic ports are no longer sticky across pod replaces
+- Further fixes to scheduler behavior during task status transitions.
+
+#### Improvements
+
+- Updated JRE version to 8u144.
+- Improved handling of error codes in service CLI.
+
+# Version 2.0.1-0.11.0
+
+### Bug Fixes
+* Tasks will correctly bind on DC/OS 1.10.
+
+### Documentation
+* Updated post-install links for package.
+* Updated `limitations.md`.
+* Ensured previous `version-policy.md` content is present.
+
+# Version 2.0.0-0.11.0
+
+## Improvements
+- Based on the latest stable release of the dcos-commons SDK, which provides numerous benefits:
+  - Integration with DC/OS features such as virtual networking and integration with DC/OS access controls.
+  - Orchestrated software and configuration update, enforcement of version upgrade paths, and ability to pause/resume updates.
+  - Placement constraints for pods.
+  - Uniform user experience across a variety of services.
+- Graceful shutdown for brokers.
+- Update to 0.11.0.0 version of Apache Kafka (including log and protocol versions).
+
+## Breaking Changes
+- This is a major release.  You cannot upgrade to version 2.0.0-0.11.0 from a 1.0.x version of the package. To upgrade, you must perform a fresh install and replicate data across clusters.

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_2-operations/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_2-operations/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Operations
+menuWeight: 30
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/operations.tmpl

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_3-updates/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_3-updates/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Updates
+menuWeight: 40
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/update.tmpl

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_4-security/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_4-security/index.md
@@ -1,0 +1,259 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Security
+menuWeight: 50
+model: /services/kafka/data.yml
+render: mustache
+---
+
+
+# DC/OS {{ model.techName }} Security
+
+The DC/OS {{ model.techName }} service supports {{ model.techShortName }}'s native transport encryption, authentication, and authorization mechanisms. The service provides automation and orchestration to simplify the usage of these important features.
+
+A good overview of these features can be found [here](https://www.confluent.io/blog/apache-kafka-security-authorization-authentication-encryption/), and {{ model.techShortName }}'s security documentation can be found [here](http://kafka.apache.org/documentation/#security).
+
+*Note*: These security features are only available on DC/OS Enterprise 1.10 and above.
+
+## Transport Encryption
+
+#include /services/include/security-transport-encryption-lead-in.tmpl
+
+*Note*: Enabling transport encryption is _required_ to use [SSL authentication](#ssl-authentication) for [authentication](#authentication), but is optional for [Kerberos authentication](#kerberos-authentication).
+
+#include /services/include/security-configure-transport-encryption.tmpl
+
+*Note*: It is possible to update a running DC/OS {{ model.techName }} service to enable transport encryption after initial installation, but the service may be unavailable during the transition. Additionally, your {{ model.techShortName }} clients will need to be reconfigured unless `service.security.transport_encryption.allow_plaintext` is set to true.
+
+#### Verify Transport Encryption Enabled
+
+After service deployment completes, check the list of [{{ model.techShortName }} endpoints](../api-reference/#connection-information) for the endpoint `broker-tls`. If `service.security.transport_encryption.allow_plaintext` is `true`, then the `broker` endpoint will also be available.
+
+#include /services/include/security-transport-encryption-clients.tmpl
+
+## Authentication
+
+DC/OS {{ model.techName }} supports two authentication mechanisms, SSL and Kerberos. The two are supported independently and may not be combined. If both SSL and Kerberos authentication are enabled, the service will use Kerberos authentication.
+
+*Note*: Kerberos authentication can, however, be combined with transport encryption.
+
+### Kerberos Authentication
+
+Kerberos authentication relies on a central authority to verify that {{ model.techShortName }} clients (be it broker, consumer, or producer) are who they say they are. DC/OS {{ model.techName }} integrates with your existing Kerberos infrastructure to verify the identity of clients.
+
+#### Prerequisites
+- The hostname and port of a KDC reachable from your DC/OS cluster
+- Sufficient access to the KDC to create Kerberos principals
+- Sufficient access to the KDC to retrieve a keytab for the generated principals
+- [The DC/OS Enterprise CLI](/1.10/cli/enterprise-cli/#installing-the-dcos-enterprise-cli)
+- DC/OS Superuser permissions
+
+#### Configure Kerberos Authentication
+
+#### Create principals
+
+The DC/OS {{ model.techName }} service requires a Kerberos principal for each broker to be deployed. Each principal must be of the form
+```
+<service primary>/kafka-<broker index>-broker.<service subdomain>.autoip.dcos.thisdcos.directory@<service realm>
+```
+with:
+- `service primary = service.security.kerberos.primary`
+- `broker index = 0 up to brokers.count - 1`
+- `service subdomain = service.name with all `/`'s removed`
+- `service realm = service.security.kerberos.realm`
+
+For example, if installing with these options:
+```json
+{
+    "service": {
+        "name": "a/good/example",
+        "security": {
+            "kerberos": {
+                "primary": "example",
+                "realm": "EXAMPLE"
+            }
+        }
+    },
+    "brokers": {
+        "count": 3
+    }
+}
+```
+then the principals to create would be:
+```
+example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+example/kafka-1-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+example/kafka-2-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+```
+#include /services/include/security-kerberos-ad.tmpl
+
+#include /services/include/security-service-keytab.tmpl
+
+#### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own:
+```json
+{
+    "service": {
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "enabled_for_zookeeper": <true|false default false>,
+                "kdc": {
+                    "hostname": "<kdc host>",
+                    "port": <kdc port>
+                },
+                "primary": "<service primary default kafka>",
+                "realm": "<realm>",
+                "keytab_secret": "<path to keytab secret>",
+                "debug": <true|false default false>
+            }
+        }
+    }
+}
+```
+
+*Note*: If `service.kerberos.enabled_for_zookeeper` is set to true, then the additional setting `kafka.kafka_zookeeper_uri` must be configured to point at a kerberized {{ model.kafka.zookeeperTechName }} as follows:
+```json
+{
+    "kafka": {
+        "kafka_zookeeper_uri": <list of zookeeper hosts>
+    }
+}
+```
+The DC/OS {{ model.kafka.zookeeperTechName }} service (`{{ model.kafka.zookeeperPackageName }}` package) is intended for this purpose and supports Kerberos.
+
+*Note*: It is possible to enable Kerberos after initial installation but the service may be unavailable during the transition. Additionally, your {{ model.techShortName }} clients will need to be reconfigured.
+
+
+### SSL Authentication
+
+SSL authentication requires that all clients be they brokers, producers, or consumers present a valid certificate from which their identity can be derived. DC/OS {{ model.techName }} uses the `CN` of the SSL certificate as the principal for a given client. For example, from the certificate `CN=bob@example.com,OU=,O=Example,L=London,ST=London,C=GB` the principal `bob@example.com` will be extracted.
+
+#### Prerequisites
+- Completion of the section [Transport Encryption](#transport-encryption) above
+
+#### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own:
+```json
+{
+    "service": {
+        "service_account": "<service-account>",
+        "service_account_secret": "<secret path>",
+        "security": {
+            "transport_encryption": {
+                "enabled": true
+            },
+            "ssl_authentication": {
+                "enabled": true
+            }
+        }
+    }
+}
+```
+
+*Note*: It is possible to enable SSL authentication after initial installation, but the service may be unavailable during the transition. Additionally, your {{ model.techShortName }} clients will need to be reconfigured.
+
+#### Authenticating a Client
+
+To authenticate a client against DC/OS {{ model.techName }}, you will need to configure it to use a certificate signed by the DC/OS CA. After generating a [certificate signing request](https://www.ssl.com/how-to/manually-generate-a-certificate-signing-request-csr-using-openssl/), you can issue it to the DC/OS CA by calling the API `<dcos-cluster>/ca/api/v2/sign`. Using `curl` the request would look like:
+```bash
+$ curl -X POST \
+    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
+    <dcos-cluster>/ca/api/v2/sign \
+    -d '{"certificate_request": "<json-encoded-value-of-request.csr>"}'
+```
+
+The response will contain a signed public certificate. Full details on the DC/OS CA API can be found [here](/latest/security/ent/tls-ssl/ca-api/).
+
+## Authorization
+
+The DC/OS {{ model.techName }} service supports {{ model.techShortName }}'s [ACL-based](https://docs.confluent.io/current/kafka/authorization.html#using-acls) authorization system. To use {{ model.techShortName }}'s ACLs, either SSL or Kerberos authentication must be enabled as detailed above.
+
+### Enable Authorization
+
+#### Prerequisites
+- Completion of either [SSL](#ssl-authentication) or [Kerberos](#kerberos-authentication) authentication above.
+
+#### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own (remember, either SSL authentication or Kerberos _must_ be enabled):
+```json
+{
+    "service": {
+        "security": {
+            "authorization": {
+                "enabled": true,
+                "super_users": "<list of super users>",
+                "allow_everyone_if_no_acl_found": <true|false default false>
+            }
+        }
+    }
+}
+```
+
+`service.security.authorization.super_users` should be set to a semi-colon delimited list of principals to treat as super users (all permissions). The format of the list is `User:<user1>;User:<user2>;...`. Using Kerberos authentication, the "user" value is the Kerberos primary, and for SSL authentication the "user" value is the `CN` of the certificate. The {{ model.techShortName }} brokers themselves are automatically designated as super users.
+
+<!-- TODO. @Evan, did you write something for this already? Or am I mis-remembering? -->
+*Note*:  It is possible to enable Authorization after initial installation, but the service may be unavailable during the transition. Additionally, {{ model.techShortName }} clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition `service.security.authorization.allow_everyone_if_no_acl_found` can be set to `true` to prevent clients from being failing until their ACLs can be set correctly. After the transition, `service.security.authorization.allow_everyone_if_no_acl_found` should be reversed to `false`
+
+
+## Securely Exposing DC/OS {{ model.techName }} Outside the Cluster.
+
+Both transport encryption and Kerberos are tightly coupled to the DNS hosts of the Kafka brokers. As such, exposing a secure {{ model.techName }} service outside of the cluster requires additional setup.
+
+### Broker to Client Connection
+
+To expose a secure {{ model.techName }} service outside of the cluster, any client connecting to it must be able to access all brokers of the service via the IP address assigned to the broker. This IP address will be one of: an IP address on a virtual network or the IP address of the agent the broker is running on.
+
+### Forwarding DNS and Custom Domain
+
+Every DC/OS cluster has a unique cryptographic ID which can be used to forward DNS queries to that Cluster. To securely expose the service outside the cluster, external clients must have an upstream resolver configured to forward DNS queries to the DC/OS cluster of the service as described [here](https://docs.mesosphere.com/latest/networking/DNS/mesos-dns/expose-mesos-zone/).
+
+With only forwarding configured, DNS entries within the DC/OS cluster will be resolvable at `<task-domain>.autoip.dcos.<cryptographic-id>.dcos.directory`. However, if you configure a DNS alias, you can use a custom domain. For example, `<task-domain>.cluster-1.acmeco.net`. In either case, the DC/OS {{ model.techName }} service will need to be installed with an additional security option:
+```json
+{
+    "service": {
+        "security": {
+            "custom_domain": "<custom-domain>"
+        }
+    }
+}
+```
+where `<custom-domain>` is one of `autoip.dcos.<cryptographic-id>.dcos.directory` or your organization specific domain (e.g., `cluster-1.acmeco.net`).
+
+As a concrete example, using the custom domain of `cluster-1.acmeco.net` the broker 0 task would have a host of `kafka-0-broker.<service-name>.cluster-1.acmeco.net`.
+
+### Kerberos Principal Changes
+
+Transport encryption alone does not require any additional changes. Endpoint discovery will work as normal, and clients will be able to connect securely with the custom domain as long as they are configured as described [here](#transport-encryption-for-clients).
+
+Kerberos, however, does require slightly different configuration. As noted in the section [Create Principals](#create-principals), the principals of the service depend on the hostname of the service. When creating the Kerberos principals, be sure to use the correct domain.
+
+For example, if installing with these settings:
+```json
+{
+    "service": {
+        "name": "a/good/example",
+        "security": {
+            "custom_domain": "cluster-1.example.net",
+            "kerberos": {
+                "primary": "example",
+                "realm": "EXAMPLE"
+            }
+        }
+    },
+    "brokers": {
+        "count": 3
+    }
+}
+```
+then the principals to create would be:
+```
+example/kafka-0-broker.agoodexample.cluster-1.example.net@EXAMPLE
+example/kafka-1-broker.agoodexample.cluster-1.example.net@EXAMPLE
+example/kafka-2-broker.agoodexample.cluster-1.example.net@EXAMPLE
+```

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_5-uninstall/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_5-uninstall/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Uninstall
+menuWeight: 60
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/uninstall.tmpl

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_6-troubleshooting/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_6-troubleshooting/index.md
@@ -1,0 +1,23 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Troubleshooting
+menuWeight: 70
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/troubleshooting.tmpl
+
+## Partition replication
+
+Kafka may become unhealthy when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos {{ model.packageName }} --name={{ model.serviceName }} topic under_replicated_partitions` and `dcos {{ model.packageName }} --name={{ model.serviceName }} topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
+
+Possible repair actions include [restarting the affected broker](#restarting-a-node) and [destructively replacing the affected broker](#replacing-a-permanently-failed-node). The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+
+
+## Broker Shutdown
+
+If the Kafka brokers are not completing the clean shutdown within the configured
+`brokers.kill_grace_period` (Kill Grace Period), extend the Kill Grace Period.

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_7-advanced/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_7-advanced/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Advanced
+menuWeight: 80
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/advanced.tmpl

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_8-api-reference/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_8-api-reference/index.md
@@ -1,0 +1,271 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: API Reference
+menuWeight: 90
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/api-reference.tmpl
+
+# Topic Operations
+
+These operations mirror what is available with `bin/kafka-topics.sh`.
+
+## List Topics
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic list
+[
+  "topic1",
+  "topic0"
+]
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics"
+[
+  "topic1",
+  "topic0"
+]
+```
+
+## Describe Topic
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic describe topic1
+{
+  "partitions": [
+  {
+    "0": {
+      "controller_epoch": 1,
+      "isr": [
+        0,
+        1,
+        2
+      ],
+      "leader": 0,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "1": {
+      "controller_epoch": 1,
+      "isr": [
+        1,
+        2,
+        0
+      ],
+      "leader": 1,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "2": {
+      "controller_epoch": 1,
+      "isr": [
+        2,
+        0,
+        1
+      ],
+      "leader": 2,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  }
+  ]
+}
+```
+
+```bash
+$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1"
+{
+  "partitions": [
+  {
+    "0": {
+      "controller_epoch": 1,
+      "isr": [
+        0,
+        1,
+        2
+      ],
+      "leader": 0,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "1": {
+      "controller_epoch": 1,
+      "isr": [
+        1,
+        2,
+        0
+      ],
+      "leader": 1,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "2": {
+      "controller_epoch": 1,
+      "isr": [
+        2,
+        0,
+        1
+      ],
+      "leader": 2,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  }
+  ]
+}
+
+```
+
+## Create Topic
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic create topic1 --partitions=3 --replication=3
+{
+  "message": "Output: Created topic \"topic1\"\n"
+}
+```
+
+```bash
+$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1?partitions=3&replication=3"
+{
+  "message": "Output: Created topic \"topic1\"\n"
+}
+```
+
+## View Topic Offsets
+
+There is an optional `--time` parameter which may be set to either "first", "last", or a timestamp in milliseconds as [described in the Kafka documentation][15].
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic offsets topic1 --time=last
+[
+  {
+    "2": "334"
+  },
+  {
+    "1": "333"
+  },
+  {
+    "0": "333"
+  }
+]
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1/offsets?time=-1"
+[
+  {
+    "2": "334"
+  },
+  {
+    "1": "333"
+  },
+  {
+    "0": "333"
+  }
+]
+```
+
+## Alter Topic Partition Count
+
+```
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic partitions topic1 2
+{
+  "message": "Output: WARNING: If partitions are increased for a topic that has a key, the partition logic or ordering of the messages will be affectednAdding partitions succeeded!n"
+}
+```
+
+```bash
+$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1?operation=partitions&partitions=2"
+{
+  "message": "Output: WARNING: If partitions are increased for a topic that has a key, the partition logic or ordering of the messages will be affectednAdding partitions succeeded!n"
+}
+```
+
+## Run Producer Test on Topic
+
+```
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic producer_test topic1 10
+{
+  "message": "10 records sent, 70.422535 records/sec (0.07 MB/sec), 24.20 ms avg latency, 133.00 ms max latency, 13 ms 50th, 133 ms 95th, 133 ms 99th, 133 ms 99.9th.n"
+}
+
+```bash
+$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1?operation=producer-test&messages=10"
+{
+  "message": "10 records sent, 70.422535 records/sec (0.07 MB/sec), 24.20 ms avg latency, 133.00 ms max latency, 13 ms 50th, 133 ms 95th, 133 ms 99th, 133 ms 99.9th.n"
+}
+```
+
+This runs the equivalent of the following command from the machine running the Kafka Scheduler:
+```bash
+$ kafka-producer-perf-test.sh \
+  --topic <topic> \
+  --num-records <messages> \
+  --throughput 100000 \
+  --record-size 1024 \
+  --producer-props bootstrap.servers=<current broker endpoints>
+```
+
+## Delete Topic
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic delete topic1
+{
+  "message": "Topic topic1 is marked for deletion.nNote: This will have no impact if delete.topic.enable is not set to true.n"
+}
+```
+
+```bash
+$ curl -X DELETE -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1"
+{
+  "message": "Topic topic1 is marked for deletion.nNote: This will have no impact if delete.topic.enable is not set to true.n"
+}
+```
+
+Note the warning in the output from the commands above. You can change the indicated "delete.topic.enable" configuration value as a configuration change.
+
+## List Under Replicated Partitions
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic under_replicated_partitions
+{
+  "message": ""
+}
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/under_replicated_partitions"
+{
+  "message": ""
+}
+```
+
+## List Unavailable Partitions
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic unavailable_partitions
+{
+  "message": ""
+}
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/unavailable_partitions"
+{
+  "message": ""
+}
+```

--- a/pages/services/kafka/2.3.0-1.1.0/ordr_9-limitations/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/ordr_9-limitations/index.md
@@ -1,0 +1,38 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Limitations
+menuWeight: 100
+model: /services/kafka/data.yml
+render: mustache
+---
+
+#include /services/include/limitations.tmpl
+#include /services/include/limitations-zones.tmpl
+#include /services/include/limitations-regions.tmpl
+
+## Log Retention Bytes
+
+The "disk" configuration value is denominated in MB. We recommend you set the configuration value `log_retention_bytes` to a value smaller than the indicated "disk" configuration. See the Configuration section for instructions for customizing these values.
+
+## Security
+
+### Kafka CLI
+
+When any security functions are enabled, the Kafka service CLI sub-command `topic` will not function. While the service CLI convenience functions will not work, the tooling bundled with [Apache Kafka](https://cwiki.apache.org/confluence/display/KAFKA/System+Tools) and other tools that support the enabled security modes will of course work.
+
+
+### Kerberos
+
+When Kerberos is enabled, the broker VIP is disabled as Kerberized clients will not be able to use it. This is because each Kafka broker uses a specific Kerberos principal and cannot accept connections from a single unified principal which the VIP would require.
+
+### Toggling Kerberos
+
+Kerberos authentication can be toggled (enabled / disabled), but this triggers a rolling restart of the cluster. Clients configured with the old security settings will lose connectivity during and after this process. It is recommended that backups are made and downtime is scheduled.
+
+### Toggling Transport Encryption
+
+Transport encryption using TLS can be toggled (enabled / disabled), but will trigger a rolling restart of the cluster. As each broker restarts, a client may lose connectivity based on its security settings and the value of the `service.security.transport_encryption.allow_plaintext` configuration option. It is recommended that backups are made and downtime is scheduled.
+
+In order to enable TLS, a service account and corresponding secret is required. Since it is not possible to change the service account used by a service, it is recommended that the service is deployed with an explicit service account to allow for TLS to be enabled at a later stage.


### PR DESCRIPTION
## Description
[DCOS-37640](https://jira.mesosphere.com/browse/DCOS-37640)

There is now a DCOS `2.3.0-1.1.0`.

Note: The only change I made was add a new line in the release notes
page pointing to Kafka's own release notes. The rest is just a copy of
folder 2.3.0-1.0.0.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
