### PR TITLE
DCOS-26143 Remove double slash `//` redirect issue

### DIFF
--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -1,5 +1,4 @@
-~^([^.]*[^/])$ $1/;
-~^([^/]*)$ $1/;
+(^.*/[^.]*[^/])$ $1/;
 ~^/service-docs/(.*)$ /services/$1;
 /administration/admin-tutorials/installdatacenter/ /latest/tutorials/dcos-101/redis-package/;
 /administration/id-and-access-mgt/ /latest/security/ent/iam-api/;


### PR DESCRIPTION
Combine two regex and remove error. This regex adds a `/` to the
end of appropriate paths that don't already have them.

^.*/ => capture everything up to the last `/`
[^.]* => don't match when `.` in last section (eg: /assets/image.png)
[^/] => last character shouldn't already be a `/`

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
