### PR TITLE
Fixing typos and correcting a few mistakes in 0.2.0 docs after QA

### DIFF
--- a/pages/services/percona-mongo/0.2.0-3.4.13/deploy-best-practice/index.md
+++ b/pages/services/percona-mongo/0.2.0-3.4.13/deploy-best-practice/index.md
@@ -78,11 +78,9 @@ NUMA *(Non-Uniform Memory Access)* Architecture should be disabled on the DC/OS 
 
 We recommend NUMA is disabled on the DC/OS Agent node. Please consult your operating system or system manual to do this.
 
-### Transparent HugePages *(Red Hat/CentOS only)*
+### Transparent HugePages
 
-*Note: this section does not apply to Debian/Ubuntu or CentOS/Red Hat 5 and lower.*
-
-Recent versions of CentOS and Red Hat enable a memory optimisation named Transparent HugePages. We recommend this is disabled as it does not perform optimally under MongoDB *(or most other)* workloads.
+Recent versions of Linux operating systems enable a memory optimisation named Transparent HugePages. We recommend this is disabled as it does not perform optimally under MongoDB *(or most other)* workloads.
 
 MongoDB will log the following warning if Transparent HugePages are enabled:
 

--- a/pages/services/percona-mongo/0.2.0-3.4.13/mongodb-administration/index.md
+++ b/pages/services/percona-mongo/0.2.0-3.4.13/mongodb-administration/index.md
@@ -205,7 +205,7 @@ dcos task exec --tty --interactive <task-id> /bin/bash
 
 The Percona-Mongo service contains several custom plans for modifying MongoDB Users via the Percona-Mongo CLI tool.
 
-All actions require the username ands password of the MongoDB clusterAdmin *(defined in service configuration)*.
+All actions require the username and password of the MongoDB clusterAdmin *(defined in service configuration)*.
 
 ### DC/OS Percona-Mongo System Users
 <a name="system-users"></a>

--- a/pages/services/percona-mongo/0.2.0-3.4.13/quick-start/index.md
+++ b/pages/services/percona-mongo/0.2.0-3.4.13/quick-start/index.md
@@ -86,4 +86,4 @@ enterprise: false
 # See Also
 
 - [Connecting clients][1].
- [1]: [https://docs.mesosphere.com/service-docs/<Template>/connecting-clients/](https://docs.mesosphere.com/service-docs/<Template>/connecting-clients/)
+ [1]: [https://docs.mesosphere.com/services/percona-mongo/0.2.0-3.4.13/connecting-clients/](https://docs.mesosphere.com/services/percona-mongo/0.2.0-3.4.13/connecting-clients/)

--- a/pages/services/percona-mongo/0.2.0-3.4.13/quick-start/index.md
+++ b/pages/services/percona-mongo/0.2.0-3.4.13/quick-start/index.md
@@ -42,7 +42,7 @@ enterprise: false
     ```
 1. Connect to MongoDB using the [mongo shell](https://docs.mongodb.com/manual/mongo/) tool and the *clusterAdmin* user *(replace username/password for your situation)*.
     ```shell
-    $ mongo mongodb://clusteruseradmin:clusteruseradminpassword@mongo-rs-0-mongod.percona-mongo.autoip.dcos.thisdcos.directory,mongo-rs-1-mongod.percona-mongo.autoip.dcos.thisdcos.directory,mongo-rs-2-mongod.percona-mongo.autoip.dcos.thisdcos.directory:27017/admin?replicaSet=rs
+    $ mongo mongodb://useradmin:useradminpassword@mongo-rs-0-mongod.percona-mongo.autoip.dcos.thisdcos.directory,mongo-rs-1-mongod.percona-mongo.autoip.dcos.thisdcos.directory,mongo-rs-2-mongod.percona-mongo.autoip.dcos.thisdcos.directory:27017/admin?replicaSet=rs
     ```
 1. Create a non-admin user for your application and exit the shell.
     ```shell
@@ -86,5 +86,4 @@ enterprise: false
 # See Also
 
 - [Connecting clients][1].
-
- [1]: https://docs.mesosphere.com/service-docs/<Template>/connecting-clients/
+ [1]: [https://docs.mesosphere.com/service-docs/<Template>/connecting-clients/](https://docs.mesosphere.com/service-docs/<Template>/connecting-clients/)


### PR DESCRIPTION
## Description
Internal Percona QA JIRAs (not public) identified a few typos or corrections needed in the docs:

1. Transparent HugePages isn't RedHat/CentOS only.
2. Wrong username in Quick Start example.
3. Typos.
4. Broken link.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
