### PR TITLE
ss/DCOS-39284 Correcting typo in setenforce command.

### DIFF
--- a/pages/1.11/installing/ent/custom/system-requirements/install-docker-RHEL/index.md
+++ b/pages/1.11/installing/ent/custom/system-requirements/install-docker-RHEL/index.md
@@ -95,7 +95,7 @@ The following instructions demonstrate how to prepare a RHEL 7.4 system for DC/O
 
     ```bash
     sed -i s/SELINUX=enforcing/SELINUX=permissive/g /etc/selinux/config
-    set enforce 0
+    setenforce 0
     ```
 
 1.  Disable DNSmasq (DC/OS requires access to port 53)


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-39284
URL: https://docs.mesosphere.com/1.11/installing/ent/custom/system-requirements/install-docker-RHEL/#installation-procedure

Typo in command. Currently command says "set enforce 0" but should be "setenforce 0".
## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Fixed typo in 1.11 docs. This doc does not appear in earlier versions of DC/OS.