### PR TITLE
Add docs for DSE 2.3.0-5.1.2

### DIFF
--- a/pages/services/dse/2.3.0-5.1.2/advanced/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/advanced/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Advanced
+menuWeight: 80
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/advanced.tmpl

--- a/pages/services/dse/2.3.0-5.1.2/api-reference/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/api-reference/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: API Reference
+menuWeight: 90
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/api-reference.tmpl

--- a/pages/services/dse/2.3.0-5.1.2/configuration/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/configuration/index.md
@@ -1,0 +1,188 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Configuration
+menuWeight: 20
+model: /services/dse/data.yml
+render: mustache
+---
+
+
+#include /services/include/configuration-install-with-options.tmpl
+
+## Datastax Opscenter
+The DC/OS Datastax Opscenter can be installed from the `datastax-ops` package. It is managed identically to datastax-dse. This guide primarily covers `datastax-dse` for conciseness. See the later sections of the guide for any configuration specifics of Opscenter.
+
+#include /services/include/configuration-service-settings.tmpl
+
+## Best Practices
+
+- Use Mesosphere Enterprise DC/OS's placement rules to map your DSE cluster nodes or DC to different availability zones to achieve high resiliency.
+- Set up a routine backup service using OpsCenter to back up your business critical data on a regular basis. The data can be stored on the DSE nodes themselves, or on AWS S3 buckets, depending on your IT policy or business needs.
+- Set up a routine repair service using OpsCenter to ensure that all data on a replica is consistent within your DSE clusters.
+
+
+
+
+
+## Node Settings
+The following settings may be adjusted to customize the amount of resources allocated to each DSE Node. Datastax's minimum system requirements must be taken into consideration when adjusting these values. Reducing these values may result in adverse performance and possibly even task failures.
+
+Each of the following settings may be customized under the **dsenode** configuration section.
+
+### Node Count
+Customize the `Node Count` setting (default 3). Consult the DSE docs for minimum node requirements.
+
+### CPU
+The amount of CPU allocated to each DSE Node may be customized. A value of `1.0` equates to one full CPU core on a machine. This value may be customized by editing the **cpus** value under the **dsenode** configuration section.
+
+### Memory
+The amount of RAM allocated to each DSE Node may be customized. This value may be customized by editing the **mem** value (in MB) under the **dsenode** configuration section.
+
+If the allocated memory is customized, you must also update the **heap** value under that section as well. As a rule of thumb we recommend that **heap** be set to half of **mem**. For example, for a **mem** value of `32000`, **heap** should be `16000`. If you do not do this, you may see restarted `dse-#-node` tasks due to memory errors.
+
+### Ports
+Each port exposed by DSE components may be customized via the service configuratiton. If you wish to install multiple instances of DSE and have them colocate on the same machines, you must ensure that **no** ports are common between those instances. Customizing ports is only needed if you require multiple instances sharing a single machine. This customization is optional otherwise.
+
+Each component's ports may be customized in the following configuration sections:
+- DSE Nodes (as a group): `Node placement constraint` under **dsenode**.
+- OpsCenter (if built-in instance is enabled): `OpsCenter placement constraint` under **opscenter**.
+
+Note that in a multi-DC environment, all DSE DCs within a DSE Cluster **must** share the same port configuration. As such, co-location of DSE nodes within the same DSE Cluster is not supported.
+
+### Storage Volumes
+The DSE DC/OS service supports two volume types:
+- `ROOT` volumes are effectively an isolated _directory_ on the root volume, sharing IO/spindles with the rest of the host system.
+- `MOUNT` volumes are a dedicated device or partition on a separate volume, with dedicated IO/spindles.
+
+`MOUNT` volumes require [additional configuration on each DC/OS agent system](/latest/storage/mount-disk-resources/), so the service currently uses `ROOT` volumes by default. To ensure reliable and consistent performance in a production environment, you must configure **two MOUNT volumes** on the machines which will run DSE in your cluster, and then configure the following as `MOUNT` volumes under **dsenode**:
+- Persistent data volume type = `MOUNT`
+- Persistent Solr volume type (if `DSE Search` is enabled) = `MOUNT`
+Using `ROOT` volumes for these is not supported in production.
+
+### Separate volume for commit log data
+If you are using non-magnetic disks, then a good approach is to keep your commit log data files on the same volume as your dse data. This is the default configuration.  If for whatever reason you need to keep commit log data on a separate volume, you can do so.  The service install provides options for enabling that feature and provisioning a separate mount point for commit log data.  Just be warned that if you choose to use a separate volume, you will not be able to change it back later.
+
+### Placement Constraints
+Placement constraints allow you to customize where a DSE instance is deployed in the DC/OS cluster. Placement constraints may be configured separately for each of the node types in the following locations:
+
+  - DSE Nodes (as a group): `Node placement constraint` under **dsenode**.
+  - OpsCenter (if built-in instance is enabled): `OpsCenter placement constraint` under **opscenter**.
+
+Placement constraints support all [Marathon operators (reference)](http://mesosphere.github.io/marathon/docs/constraints.html) with this syntax: `field:OPERATOR[:parameter]`. For example, if the reference lists `[["hostname", "UNIQUE"]]`, you should  use `hostname:UNIQUE`.
+
+A common task is to specify a list of whitelisted systems to deploy to. To achieve this, use the following syntax for the placement constraint:
+```
+hostname:LIKE:10.0.0.159|10.0.1.202|10.0.3.3
+```
+
+You must include spare capacity in this list so that if one of the whitelisted systems goes down, there is still enough room to repair your service without that system.
+
+## Rack-Aware Placement
+
+DSE's "rack"-based fault domain support may be enabled by specifying a placement constraint that uses the `@zone` key. For example, one could spread DSE nodes across a minimum of three different zones/racks by specifying the constraint `@zone:GROUP_BY:3`. When a placement constraint specifying `@zone` is used, DSE nodes will be automatically configured with `rack`s that match the names of the zones. If no placement constraint referencing `@zone` is configured, all nodes will be configured with a default rack of `rack1`.
+
+
+### dse.yaml and cassandra.yaml settings
+Nearly all settings for `dse.yaml` and `cassandra.yaml` are exposed as configuration options, allowing them to be deployed and updated automatically by the service.
+
+- `dse.yaml` options are listed under the **dse** section
+- `cassandra.yaml` options are listed under the **cassandra** section
+
+For more information on each setting, view Datastax's documentation for [dse.yaml](https://docs.datastax.com/en/latest-dse/datastax_enterprise/config/configDseYaml.html) and [cassandra.yaml](https://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html).
+
+## Use Built-In or External OpsCenter
+DSE DC/OS provides the **datastax-ops** package, which you can install to get a default OpsCenter dashboard.  If you prefer to use an external OpsCenter instance, you can configure the **dse** service to point to an externally managed OpsCenter.
+
+Follow these steps to configure **dse** to use an external **opscenter** (in the OpsCenter section of the **dse** installation screen).
+
+1. Check the **ENABLE DATASTAX OPSCENTER** checkbox.
+1. Set the **OPSCENTER HOST NAME** field to the hostname of your external OpsCenter instance.
+
+If you choose to run an instance of the **datastax-ops** package, this field can be populated as `opscenter-0-node.<service-name>.autoip.dcos.thisdcos.directory`. For example `opscenter-0-node.datastax-ops-1.autoip.dcos.thisdcos.directory` if the **datastax-ops** service is named `datastax-ops-1`
+
+## Installation with DSE Multi-Datacenter
+Each DSE Datacenter must be configured with the seed nodes of the other DSE Datacenters. For example, let's deploy three Datacenters (as separate DC/OS services in DC/OS terms), named `datastax-dse-1`, `datastax-dse-2`, and `datastax-dse-3`, and then link them all together. Here is an example timeline from start to finish:
+
+**Note:** These instructions are an example and should be vetted by Datastax for the correct ordering of operations (when to add seed nodes, etc.).
+
+### DC/OS 1.10 and later
+
+Follow these instructions for DC/OS 1.10 and later. If you are using DC/OS 1.9 or earlier, follow [these instructions](#1.9-and-earlier).
+
+1. Add a DSE service from the DC/OS Universe. Deploy `datastax-dse-1` with the following customizations:
+    - In **service**, set `Service Name` = `datastax-dse-1`
+    - In **cluster**, set `DSE Datacenter` = `dc_datastax_1`
+1. Wait for `datastax-dse-1` to finish deploying before continuing with the other DCs.
+1. Add a second DSE service from the DC/OS Universe. Deploy `datastax-dse-2` with the following customizations:
+    - In **service**, set:
+        - `Service Name` = `datastax-dse-2`
+    - In **cluster**, set:
+        - `DSE Datacenter` = `dc_datastax_2`
+        - `External Seed Nodes` = `dse-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-2` to `datastax-dse-1`'s seeds)
+    - In **opscenter**, set:
+        - `OPSCENTER HOSTNAME` = `opscenter-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-2` to `datastax-dse-1`'s OpsCenter)
+1. Add a third DSE service from the DC/OS Universe. Deploy `datastax-dse-3` with the following customizations:
+    - In **service**, set:
+        - `Service Name` = `datastax-dse-3`
+    - In **cluster**, set:
+        - `DSE Datacenter` = `dc_datastax_3`
+        - `External Seed Nodes` = `dse-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-3` to `datastax-dse-1`'s seeds)
+    - In **opscenter**, set:
+        - `OPSCENTER HOSTNAME` = `opscenter-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-3` to `datastax-dse-1`'s OpsCenter)
+1. Wait for `datastax-dse-2` and `datastax-dse-3` to finish deploying. Then, update the seed nodes across all the instances:
+    1. Create a local file called `dse-1-options.json`. Paste the following into the file.
+
+       ```json
+       {
+         "cluster": {
+           "external_seeds": "dse-0-node.datastax-dse-2.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-2.autoip.dcos.thisdcos.directory,dse-0-node.datastax-dse-3.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-3.autoip.dcos.thisdcos.directory"
+         },
+       }
+       ```
+       This points `datastax-dse-1` to `datastax-dse-2` and `datastax-dse-3`.
+
+    1. From the DC/OS CLI, update the service to the new configuration.
+
+       ```json
+       dcos datastax-dse update start --options=dse-1-options.json
+       ```
+
+    1. Wait for the seed update to roll out across `datastax-dse-1` nodes.
+    1. Perform the same operation for `datastax-dse-2` and `datastax-dse-3`.
+       - For `datastax-dse-2`, set `cluster.external_seeds` to `dse-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-0-node.datastax-dse-3.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-3.autoip.dcos.thisdcos.directory`.
+       - For `datastax-dse-3`, set `cluster.external_seeds` to `dse-0-node.datastax-dse-2.autoip.dcos.thisdcos.directory,dse-2-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-0-node.datastax-dse-3.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-3.autoip.dcos.thisdcos.directory`.
+
+1. Now, each of the three DCs has seed nodes configured for the other DCs. Because we used `.autoip.dcos.thisdcos.directory` hostnames, which automatically update to follow the tasks, we won't need to reconfigure seeds if they're moved between systems in the DC/OS cluster.
+
+<a name="1.9-and-earlier"></a>
+
+1. Add a DSE service from the DC/OS Universe. Deploy `datastax-dse-1` with the following customizations:
+    - In **service**, set `Service Name` = `datastax-dse-1`
+    - In **cluster**, set `DSE Datacenter` = `dc_datastax_1`
+1. Wait for `datastax-dse-1` to finish deploying before continuing with the other DCs.
+1. Add a second DSE service from the DC/OS Universe. Deploy `datastax-dse-2` with the following customizations:
+    - In **service**, set:
+        - `Service Name` = `datastax-dse-2`
+    - In **cluster**, set:
+        - `DSE Datacenter` = `dc_datastax_2`
+        - `External Seed Nodes` = `dse-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-2` to `datastax-dse-1`'s seeds)
+    - In **opscenter**, set:
+        - `OPSCENTER HOSTNAME` = `opscenter-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-2` to `datastax-dse-1`'s OpsCenter)
+1. Add a third DSE service from the DC/OS Universe. Deploy `datastax-dse-3` with the following customizations:
+    - In **service**, set:
+        - `Service Name` = `datastax-dse-3`
+    - In **cluster**, set:
+        - `DSE Datacenter` = `dc_datastax_3`
+        - `External Seed Nodes` = `dse-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-3` to `datastax-dse-1`'s seeds)
+    - In **opscenter**, set:
+        - `OPSCENTER HOSTNAME` = `opscenter-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory` (point `datastax-dse-3` to `datastax-dse-1`'s OpsCenter)
+1. Wait for `datastax-dse-2` and `datastax-dse-3` to finish deploying. Then, update the seed nodes across all the instances:
+    1. Go to the service view of `datastax-dse-1` in the DC/OS UI. Click the menu in the upper right and then choose **Edit**. Go to the **Environment** tab and set `DSE_EXTERNAL_SEEDS` = `dse-0-node.datastax-dse-2.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-2.autoip.dcos.thisdcos.directory,dse-0-node.datastax-dse-3.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-3.autoip.dcos.thisdcos.directory` (point `datastax-dse-1` to `datastax-dse-2` and `datastax-dse-3`).
+    1. Wait for the seed update to roll out across `datastax-dse-1` nodes.
+    1. Go to the service view of `datastax-dse-2` in the DC/OS UI. Click the menu in the upper right and then choose **Edit**. Go to the **Environment** tab and update `DSE_EXTERNAL_SEEDS` = `dse-0-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-0-node.datastax-dse-3.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-3.autoip.dcos.thisdcos.directory` (point `datastax-dse-2` to `datastax-dse-1` and `datastax-dse-3`).
+    1. Wait for the seed update to roll out across `datastax-dse-2` nodes.
+    1. Go to the service view of `datastax-dse-3` in the DC/OS UI. Click the menu in the upper right and then choose **Edit**. Go to the **Environment** tab and update `DSE_EXTERNAL_SEEDS` = `dse-0-node.datastax-dse-2.autoip.dcos.thisdcos.directory,dse-2-node.datastax-dse-1.autoip.dcos.thisdcos.directory,dse-0-node.datastax-dse-3.autoip.dcos.thisdcos.directory,dse-1-node.datastax-dse-3.autoip.dcos.thisdcos.directory` (point `datastax-dse-3` to `datastax-dse-1` and `datastax-dse-2`).
+    1. Wait for the seed update to roll out across `datastax-dse-3` nodes.
+1. Now, each of the three DCs has seed nodes configured for the other DCs. Because we used `.autoip.dcos.thisdcos.directory` hostnames, which automatically update to follow the tasks, we won't need to reconfigure seeds if they're moved between systems in the DC/OS cluster.

--- a/pages/services/dse/2.3.0-5.1.2/configuration/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/configuration/index.md
@@ -12,7 +12,7 @@ render: mustache
 #include /services/include/configuration-install-with-options.tmpl
 
 ## Datastax Opscenter
-The DC/OS Datastax Opscenter can be installed from the `datastax-ops` package. It is managed identically to datastax-dse. This guide primarily covers `datastax-dse` for conciseness. See the later sections of the guide for any configuration specifics of Opscenter.
+The DC/OS Datastax Opscenter can be installed from the `datastax-ops` package. It is managed identically to `datastax-dse`. This guide primarily covers `datastax-dse` for conciseness. See the later sections of the guide for any configuration specifics of Opscenter.
 
 #include /services/include/configuration-service-settings.tmpl
 
@@ -21,9 +21,6 @@ The DC/OS Datastax Opscenter can be installed from the `datastax-ops` package. I
 - Use Mesosphere Enterprise DC/OS's placement rules to map your DSE cluster nodes or DC to different availability zones to achieve high resiliency.
 - Set up a routine backup service using OpsCenter to back up your business critical data on a regular basis. The data can be stored on the DSE nodes themselves, or on AWS S3 buckets, depending on your IT policy or business needs.
 - Set up a routine repair service using OpsCenter to ensure that all data on a replica is consistent within your DSE clusters.
-
-
-
 
 
 ## Node Settings
@@ -43,13 +40,13 @@ The amount of RAM allocated to each DSE Node may be customized. This value may b
 If the allocated memory is customized, you must also update the **heap** value under that section as well. As a rule of thumb we recommend that **heap** be set to half of **mem**. For example, for a **mem** value of `32000`, **heap** should be `16000`. If you do not do this, you may see restarted `dse-#-node` tasks due to memory errors.
 
 ### Ports
-Each port exposed by DSE components may be customized via the service configuratiton. If you wish to install multiple instances of DSE and have them colocate on the same machines, you must ensure that **no** ports are common between those instances. Customizing ports is only needed if you require multiple instances sharing a single machine. This customization is optional otherwise.
+Each port exposed by DSE components may be customized via the service configuration. If you wish to install multiple instances of DSE and have them colocate on the same machines, you must ensure that **no** ports are common between those instances. Customizing ports is only needed if you require multiple instances sharing a single machine. This customization is optional otherwise.
 
 Each component's ports may be customized in the following configuration sections:
 - DSE Nodes (as a group): `Node placement constraint` under **dsenode**.
 - OpsCenter (if built-in instance is enabled): `OpsCenter placement constraint` under **opscenter**.
 
-Note that in a multi-DC environment, all DSE DCs within a DSE Cluster **must** share the same port configuration. As such, co-location of DSE nodes within the same DSE Cluster is not supported.
+**Note:** In a multi-DC environment, all DSE DCs within a DSE Cluster **must** share the same port configuration. Co-location of DSE nodes within the same DSE Cluster is not supported.
 
 ### Storage Volumes
 The DSE DC/OS service supports two volume types:
@@ -62,7 +59,7 @@ The DSE DC/OS service supports two volume types:
 Using `ROOT` volumes for these is not supported in production.
 
 ### Separate volume for commit log data
-If you are using non-magnetic disks, then a good approach is to keep your commit log data files on the same volume as your dse data. This is the default configuration.  If for whatever reason you need to keep commit log data on a separate volume, you can do so.  The service install provides options for enabling that feature and provisioning a separate mount point for commit log data.  Just be warned that if you choose to use a separate volume, you will not be able to change it back later.
+If you are using non-magnetic disks, then a good approach is to keep your commit log data files on the same volume as your dse data. This is the default configuration.  If you need to keep commit log data on a separate volume, you can do so.  The service install provides options for enabling that feature and provisioning a separate mount point for commit log data.  Just be warned that if you choose to use a separate volume, you will not be able to change it back later.
 
 ### Placement Constraints
 Placement constraints allow you to customize where a DSE instance is deployed in the DC/OS cluster. Placement constraints may be configured separately for each of the node types in the following locations:
@@ -81,7 +78,7 @@ You must include spare capacity in this list so that if one of the whitelisted s
 
 ## Rack-Aware Placement
 
-DSE's "rack"-based fault domain support may be enabled by specifying a placement constraint that uses the `@zone` key. For example, one could spread DSE nodes across a minimum of three different zones/racks by specifying the constraint `@zone:GROUP_BY:3`. When a placement constraint specifying `@zone` is used, DSE nodes will be automatically configured with `rack`s that match the names of the zones. If no placement constraint referencing `@zone` is configured, all nodes will be configured with a default rack of `rack1`.
+DSE's "rack"-based fault domain support may be enabled by specifying a placement constraint that uses the `@zone` key. For example, you  could spread DSE nodes across a minimum of three different zones/racks by specifying the constraint `@zone:GROUP_BY:3`. When a placement constraint specifying `@zone` is used, DSE nodes will be automatically configured with `rack`s that match the names of the zones. If no placement constraint referencing `@zone` is configured, all nodes will be configured with a default rack of `rack1`.
 
 
 ### dse.yaml and cassandra.yaml settings

--- a/pages/services/dse/2.3.0-5.1.2/getting-started/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/getting-started/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Getting Started
+menuWeight: 10
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/getting-started.tmpl

--- a/pages/services/dse/2.3.0-5.1.2/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/index.md
@@ -1,0 +1,25 @@
+---
+layout: layout.pug
+navigationTitle: DSE 2.3.0-5.1.2
+title: DSE 2.3.0-5.1.2
+menuWeight: 9
+excerpt:
+
+---
+
+DataStax Enterprise (DSE) Service is an automated service that makes it easy to deploy and manage DataStax Enterprise clusters on Mesosphere DC/OS, eliminating nearly all of the complexity traditionally associated with managing a DataStax cluster. DataStax Enterprise helps customers of all sizes build and run cloud-native applications at epic scale.  Our customers have been using our technology to build personalization, IoT, Customer 360 type applications, just to name a few.  Inside DataStax Enterprise, you will find Solr to power our Search capability, Spark for Analytics, and a graph database for highly connected data sets. Multiple DataStax clusters can be installed on DC/OS and managed independently, so you can offer DataStax Enterprise as a managed service to your organization.
+
+## Features
+
+- Auto-configured OpsCenter (datastax-ops package) or point to external OpsCenter.
+- Multiple instances sharing the same physical systems (requires custom port configuration).
+- Vertical (resource) and horizontal (node count) scaling.
+- Easy redeployment to new systems upon scheduled or unscheduled outages.
+- Consistent DNS addresses regardless of where nodes are located in the cluster.
+- Node placement may be customized via Placement Constraints.
+
+
+## Terms of Use
+
+- Customers will be at their own risk if any failure arises when using a non-default DSE package settings without a service engagement with DataStax.
+- This integration is DataStax licensed and for DataStax Enterprise customers only.

--- a/pages/services/dse/2.3.0-5.1.2/limitations/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/limitations/index.md
@@ -1,0 +1,29 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Limitations
+menuWeight: 100
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/limitations.tmpl
+#include /services/include/limitations-zones.tmpl
+
+## Service Limits
+- Multiple DSE Instances on a host is not supported in production.
+- Stopping or restarting a DSE node from OpsCenter is not supported. Use `dcos pod restart` to restart DSE nodes from the DC/OS CLI.
+- A single OpsCenter cannot manage multiple DSE clusters, but can manage multiple DCs in the same cluster.
+- A DSE node will restart if its associated DSE Agent process crashes.
+- Point-in-time restore functionality through the OpsCenter UI is not supported.
+
+## Automatic failed node recovery
+
+A manual `nodetool removenode` call is currently required when replacing nodes. This is planned to be automated in a future release.
+
+Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes or build your own ruleset and automation to perform this operation automatically.
+
+## Rack-aware replication
+
+Rack awareness within the DC/OS DSE Service is not currently supported, but is planned to be supported with a future release of DC/OS.

--- a/pages/services/dse/2.3.0-5.1.2/operations/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/operations/index.md
@@ -1,0 +1,17 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Operations
+menuWeight: 30
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/operations.tmpl
+
+## DSE OpsCenter Backup Service
+
+**Regular backups should be performed via the DSE OpsCenter Backup Service in production environments.  Backups and restores should be tested in a staging environment.**
+
+The [OpsCenter Backup Service](https://docs.datastax.com/en/latest-opscenter/opsc/online_help/services/opscBackupService.html) allows you to create automatic or manual backups of your cluster data, from all the keyspaces in a cluster to specific keyspaces. You can perform both local and remote backups, and restoration ("cloning") to a different cluster. Backup data is stored locally on each node, and optionally in cloud-based storage services like Amazon S3.

--- a/pages/services/dse/2.3.0-5.1.2/release-notes/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/release-notes/index.md
@@ -1,0 +1,157 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Release Notes
+menuWeight: 120
+model: /services/dse/data.yml
+render: mustache
+---
+
+# Version 2.3.0-5.1.2
+
+## New Features
+
+- DataStax DSE and DataStax OpsCenter now isolate their `/tmp` task directories by making them Mesos [`SANDBOX_PATH` volume sources](https://github.com/apache/mesos/blob/master/docs/container-volume.md#sandbox_path-volume-source). ([#2467](https://github.com/mesosphere/dcos-commons/pull/2467) and [#2486](https://github.com/mesosphere/dcos-commons/pull/2486))
+
+## Improvements
+
+- The SDK tests now validate missing values for `svc.yml` Mustache variables. ([#2527](https://github.com/mesosphere/dcos-commons/pull/2527))
+
+# Version 2.2.0-5.1.2
+
+## New Features
+- Support for deploying the service in a remote region.
+
+## Bug Fixes
+- Default the RLimits to the recommended defaults.
+- Allow the service to run as the root user.
+
+# Version 2.1.2-5.1.2
+
+## New Features
+
+- Ability to pause a service pod for debugging and recovery purposes. ([#1989](https://github.com/mesosphere/dcos-commons/pull/1989))
+- Support for starting/stopping Cassandra for PIT backup/restore support via OpsCenter.
+- Support for the automated provisioning of TLS artifacts to secure service communication.
+
+## Updates
+
+- Upgraded JRE to 1.8u162. ([#2135](https://github.com/mesosphere/dcos-commons/pull/2135))
+- Marks all DSE tasks as non-essential: the DSE agent and DSE node may now fail independently (without the entire pod failing).
+- Major Improvements to the stability and performance of service orchestration
+- The service now uses the Mesos V1 API. The service can be set back to the V0 API using the service property `service.mesos_api_version`.
+
+# Version 2.0.5-5.1.2
+
+## Bug Fixes
+* Uninstall now handles failed tasks correctly.
+
+# Version 2.0.4-5.1.2
+
+## Bug Fixes
+
+- Permission denied error when attempting to create a backup in OpsCenter
+
+## Improvements
+
+- Exposed additional OpsCenter agent options to the DSE DC/OS service
+- Exposed commitlog_archiving.properties file and associated options to the DSE DC/OS service
+
+## Breaking Changes
+
+- None
+
+## Upgrade Steps
+
+- Follow the upgrade steps in the [DCOS DSE service guide](https://docs.mesosphere.com/services/dse/2.0.4-5.1.2/managing/#upgrading-or-downgrading-a-service).
+
+
+# Version 2.0.3-5.1.2
+
+## Bug Fixes
+
+- Tomcat not deploying Solr admin web app.
+- `OPSC_DEFINITIONS_AUTO_UPDATE` environment variable not taking affect.
+
+## Improvements
+
+- Upgraded to the latest stable release of the dcos-commons SDK.
+- Better support for configuring/using DSE Unified Authentication. See the [authentication documentation](https://docs.mesosphere.com/services/dse/2.0.3-5.1.2/dse-authentication).
+
+## Breaking Changes
+
+- New authentication configuration options have been added, and one existing option (`ldap.default_scheme`) has been moved.  Follow the steps in the Upgrade section, below, to prepare your configuration options and perform the upgrade.
+
+## Upgrade Steps
+
+- Upgrade to the latest version of the CLI: `dcos package install --cli datastax-dse --package-version=2.0.3-5.1.2`.
+
+### On DC/OS 1.10 Enterprise:
+  1. Save your current configuration: `dcos datastax-dse describe > $HOME/options.json`.
+  1. Update your configuration. Add the following options to your `$HOME/options.json` file just before the "ldap" section.
+
+    ```
+    "authentication_options_enabled": false,
+    "authentication_options_default_scheme": "internal",
+    "authentication_options_scheme_permissions": true,
+    "authentication_options_allow_digest_with_kerberos": true,
+    "authentication_options_plain_text_without_ssl": "warn",
+    "authentication_options_transitional_mode": "disabled",
+    "role_management_options_mode": "internal",
+    "authorization_options_enabled": false,
+    "authorization_options_transitional_mode": "disabled",
+    "authorization_options_allow_row_level_security": false,
+    ```
+
+  1. The location of `ldap.default_scheme` has been changed. Record the current value and then delete that option from the ldap section. The new option is named `authentication_options_default_scheme`. Set this value to the value you just recorded.
+  1. Set your authentication and authorization options according to your needs. See the [authentication documentation](https://docs.mesosphere.com/services/dse/2.0.3-5.1.2/dse-authentication).
+  1. Save your changes to that file and run the following command: `dcos datastax-dse update start --replace --options=$HOME/options.json --package-version=2.0.3-5.1.2`.
+  1. After the service performs a rolling restart of each node, the upgrade is complete.
+
+ ### On DC/OS 1.9 and DC/OS Open Source
+
+  1. Create an `options.json` file with your existing installation options. If you saved a copy during initial install, you can use that. If you don't have it, follow the steps in the "Recreating options.json" section of the [management docs](https://docs.mesosphere.com/services/dse/2.0.3-5.1.2/managing/#enterprise-dcos-1.10). When you have obtained your `options.json` file, place a copy of it in `$HOME/options.json`.
+  1. Update your configuration. Add the following options to your `$HOME/options.json` file just before the "ldap" section.
+
+     ```
+     "authentication_options_enabled": false,
+     "authentication_options_default_scheme": "internal",
+     "authentication_options_scheme_permissions": true,
+     "authentication_options_allow_digest_with_kerberos": true,
+     "authentication_options_plain_text_without_ssl": "warn",
+     "authentication_options_transitional_mode": "disabled",
+     "role_management_options_mode": "internal",
+     "authorization_options_enabled": false,
+     "authorization_options_transitional_mode": "disabled",
+     "authorization_options_allow_row_level_security": false,
+     ```
+
+  1. The location of ldap.default_scheme has been changed. Record the current value and then delete that option from the ldap section. The new option is named authentication_options_default_scheme. Set this value to the value you just recorded.
+  1. The location of `ldap.default_scheme` has been changed. Record the current value and then delete that option from the ldap section. The new option is named `authentication_options_default_scheme`. Set this value to the value you just recorded.
+  1. Set your authentication and authorization options according to your needs. See the [authentication documentation](https://docs.mesosphere.com/services/dse/2.0.3-5.1.2/dse-authentication).
+  1. Save your changes to that file
+  1. Get the marathon app id for dse: `marathon app list`.
+  1. Remove the app: `marathon app remove <dse-app-id-here>`.
+  1. Wait 30 seconds and then confirm the dse app is no longer present: `marathon app list`.
+  1. Install the latest version: `dcos package install --options=$HOME/options.json --package-version=2.0.3-5.1.2`.
+  1. After the service performs a rolling restart of each node, the upgrade is complete.
+
+# Version 2.0.2-5.1.2
+
+## Bug Fixes
+* Tasks will correctly bind on DC/OS 1.10.
+
+# Version 2.0.0-5.1.2
+
+## Improvements
+- Based on the latest stable release of the dcos-commons SDK, which provides numerous benefits:
+  -Integration with DC/OS features such as virtual networking and integration with DC/OS access controls.
+  - Orchestrated software and configuration updates, enforcement of version upgrade paths, and ability to pause/resume updates.
+  - Placement constraints for pods.
+  - Uniform user experience across a variety of services.
+- Upgrade to version 5.1.2 of DataStax Enterprise.
+- Upgrade to version 6.1.2 of DataStax Enterprise Opscenter.
+
+## Breaking Changes
+- This is a major release available for DC/OS 1.9 or higher. You cannot upgrade to version 2.0.0-5.1.2 from any previous versions of the  package. This is due to the separation of the core DSE nodes from Opscenter.

--- a/pages/services/dse/2.3.0-5.1.2/security/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/security/index.md
@@ -1,0 +1,115 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Security
+menuWeight: 50
+model: /services/dse/data.yml
+render: mustache
+---
+
+# DC/OS {{ model.techName }} Security
+
+The DC/OS {{ model.techName }} service supports {{ model.techShortName }}'s native transport encryption mechanisms. The service provides automation and orchestration to simplify the usage of these important features.
+
+*Note*: These security features are only available on DC/OS Enterprise 1.10 and above.
+
+## Transport Encryption
+
+#include /services/include/security-transport-encryption-lead-in.tmpl
+
+#include /services/include/security-configure-transport-encryption.tmpl
+
+#include /services/include/security-transport-encryption-clients.tmpl
+
+## DSE Authentication/Authorization Schemes
+DSE in DC/OS currently supports both internal and ldap authentication/authorization schemes.  You can configure both schemes and then select the order in which they are used, or you can configure just one, in which case only that scheme will be used.  DSE will try to authenticate with the default scheme first and fall back to the alternate scheme if it has been configured. More information about how DSE handles this can be found in [DataStax's documentation](http://docs.datastax.com/en/dse/5.1/dse-admin/datastax_enterprise/security/secDSEUnifiedAuthAbout.html)
+
+## Enabling DSE Authentication/Authorization
+To enable DSE authentication/authorization, follow these steps:
+   1. In Advanced Installation wizard, configure the following fields:
+      ```
+      In "cassandra" tab,
+      Set authenticator to com.datastax.bdp.cassandra.auth.DseAuthenticator
+      Set authorizer to com.datastax.bdp.cassandra.auth.DseAuthorizer
+      Set role_manager to com.datastax.bdp.cassandra.auth.DseRoleManager
+
+      In "dse" tab,
+      Check AUTHENTICATION_OPTIONS_ENABLED checkbox
+      Set AUTHENTICATION_OPTIONS_DEFAULT_SCHEME to either internal or ldap, depending on which sheme you want as the default
+      Set AUTHENTICATION_OPTIONS_OTHER_SCHEMES to either internal or ldap (optional to configure the fallback)
+      Set ROLE_MANAGEMENT_OPTIONS_MODE to either internal or ldap, according to your needs
+      Check AUTHORIZATION_OPTIONS_ENABLED checkbox (optional to enable authorization)
+      ```
+   1. If you are using only internal auth, no further configuration is required for DSE. If you are also using ldap, then follow the sections below to configure ldap based on your needs.
+
+## DSE LDAP Configuration
+When you enable LDAP authentication in DataStax Enterprise, users and groups that are managed by external LDAP servers can be authenticated by DataStax Enterprise.  To enable LDAP authentication with your DSE cluster, you need to configure the followings:
+
+   1. In Advanced Installation wizard, you need to configure the following fields according to your LDAP settings:
+      ```
+      In "dse" tab,
+      Check ldap's enabled checkbox
+      Set server_host to your LDAP server FQDN or IP address
+      Set server_port of your LDAP server port (default is 389)
+      Set search_dn  ex. cn=admin,dc=example,dc=org
+      Set search_password  ex. secret
+      Set user_search_base  ex. ou=People,dc=example,dc=org
+      Set user_search_filter  ex. (uid={0})
+      Set user_memberof_attribute  ex. memberof
+      Set group_search_type  ex. memberof_search
+      Set group_search_base  ex. ou=Groups,dc=example,dc=org
+      Set group_search_filter  ex. (uniquemember={0})
+      Set group_name_attribute  (default is 0)
+      Set credentials_validity_in_ms  (default is 0)
+      Set search_validity_in_seconds  (default is 0)
+      Set connection_pool_max_active  (default is 8)
+      Set connection_pool_max_idle  (default is 8)
+      ```
+
+   1. You will need to run the following CQL statements to grant relevant permission to your LDAP roles
+      ```
+      cqlsh> CREATE ROLE <role-name> WITH LOGIN = TRUE;  (role-name is the corresponding role inside your LDAP)
+
+      cqlsh> GRANT EXECUTE ON ALL AUTHENTICATION SCHEMES TO <role-name>;  OR
+      cqlsh> GRANT EXECUTE ON (INTERNAL|LDAP) SCHEME TO <role-name>;
+      ```
+    Please refer to [DataStax's documentation](http://docs.datastax.com/en/latest-dse/datastax_enterprise/sec/authLdapConfig.html) for more detailed description of each field above.
+
+## OpsCenter LDAP Configuration
+Configure LDAP (Lightweight Directory Access Protocol) for users accessing OpsCenter.
+
+   1. In Advanced Installation wizard, you need to configure the following fields according to your LDAP settings:
+      ```
+      In "opscenter" tab,
+      Check Authentication Configuration's checkbox
+      Set login_user to a LDAP user's uid belonging to one or more LDAP groups in "admin_group_name" field below
+      Set login_password (the password associated with the login_user field above)
+      Set method to LDAP
+      Check LDAP Configuration's checkbox
+      Set server_host to your LDAP server FQDN or IP address
+      Set server_port of your LDAP server port (default is 389)
+      Set search_dn  ex. cn=admin,dc=example,dc=org
+      Set search_password  ex. secret
+      Set user_search_base  ex. ou=People,dc=example,dc=org
+      Set user_search_filter  ex. (uid={0})
+      Set user_memberof_attribute  ex. memberof
+      Set group_search_type  ex. directory_search
+      Set group_search_base  ex. ou=Groups,dc=example,dc=org
+      Set group_search_filter_with_dn  ex. (member={0})
+      Set group_name_attribute  ex. cn
+      Set admin_group_name  ex. mygroup, manager, developer
+      ```
+      Please refer to [DataStax's documentation](https://docs.datastax.com/en/latest-opsc/opsc/configure/opscConfigLDAP.html) for more detailed description of each field above.
+      Once your DSE Package service instance is ready, you can use your LDAP account to log in to OpsCenter to manage your DSE cluster.
+
+## OpsCenter Internal Authentication Configuraton
+
+   1. In Advanced Installation wizard, you need to configure the following fields:
+      ```
+      In "opscenter" tab,
+      Check Authentication Configuration's checkbox
+      Leave login_user as admin (when you install the package the first time)
+      Leave login_password as admin (when you install the package the first time)
+      ```
+      Once your DSE Package service instance is ready, you can use "admin" and "admin" as the username and the password to log into OpsCenter to start managing your DSE cluster.

--- a/pages/services/dse/2.3.0-5.1.2/support-policy/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/support-policy/index.md
@@ -1,0 +1,18 @@
+---
+layout: layout.pug
+navigationTitle:
+title: Support Policy
+menuWeight: 110
+excerpt:
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/support-policy.tmpl
+
+
+## Contacting DataStax Technical Support
+To start a support case for issues related to DataStax, please email support@datastax.com.
+
+## Contacting Mesosphere Technical Support
+To start a support case for issues related to DC/OS or the integration of DSE with DC/OS, please email support@mesosphere.com.

--- a/pages/services/dse/2.3.0-5.1.2/troubleshooting/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/troubleshooting/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Troubleshooting
+menuWeight: 70
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/troubleshooting.tmpl

--- a/pages/services/dse/2.3.0-5.1.2/uninstall/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/uninstall/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Uninstall
+menuWeight: 60
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/uninstall.tmpl

--- a/pages/services/dse/2.3.0-5.1.2/updates/index.md
+++ b/pages/services/dse/2.3.0-5.1.2/updates/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: Updates
+menuWeight: 40
+model: /services/dse/data.yml
+render: mustache
+---
+
+#include /services/include/update.tmpl


### PR DESCRIPTION
## Description
Release docs of DataStax 2.3.0 including:
- `datastax-dse`: `2.3.0-5.1.2`
- `datastax-ops`: `2.3.0-6.1.2`

https://jira.mesosphere.com/browse/DCOS-38715

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
