### PR TITLE
DCOS-25764 Documentation styling is too wide in Firefox

### DIFF
--- a/scss/base/_content.scss
+++ b/scss/base/_content.scss
@@ -8,6 +8,7 @@ $sections-size: 20%;
     position: relative;
     display: flex;
     flex-direction: column;
+    min-width: 0;
   }
   &__header {
     z-index: 10;

--- a/scss/base/_content.scss
+++ b/scss/base/_content.scss
@@ -8,8 +8,6 @@ $sections-size: 20%;
     position: relative;
     display: flex;
     flex-direction: column;
-    flex: 1;
-    width: 100%;
   }
   &__header {
     z-index: 10;
@@ -122,8 +120,8 @@ $sections-size: 20%;
     }
     &__sections {
       position: relative;
-      display: block;
-      flex-basis: 20%;
+      display: flex;
+      align-items: flex-start;
       min-width: 150px;
       margin-left: 2rem;
       padding-left: 1.5rem;

--- a/scss/base/_global.scss
+++ b/scss/base/_global.scss
@@ -1,10 +1,8 @@
 html {
-  height: 100%;
-  width: 100%;
+  width: 100vw;
 }
 
 body {
-  height: 100%;
   margin: 0;
   padding: 0;
 }

--- a/scss/components/_prism.scss
+++ b/scss/components/_prism.scss
@@ -28,6 +28,7 @@ pre {
     background: transparent;
     // font-size: 0.8rem;
     font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    margin-right: 15px;
   }
 }
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25764
## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
