### PR TITLE
Fix Kafka version number for pages in 2.3.0-1.1.0

### DIFF
--- a/pages/services/kafka/2.3.0-1.1.0/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/index.md
@@ -1,8 +1,8 @@
 ---
 layout: layout.pug
-navigationTitle: Kafka 2.3.0-1.0.0
+navigationTitle: Kafka 2.3.0-1.1.0
 excerpt:
-title: Kafka 2.3.0-1.0.0
+title: Kafka 2.3.0-1.1.0
 menuWeight: 8
 model: /services/kafka/data.yml
 render: mustache


### PR DESCRIPTION
Missed updating the meta version number for the 1st page.