### PR TITLE
EdgeLB v1.1.0 release notes

### DIFF
--- a/pages/1.11/networking/load-balancing-vips/index.md
+++ b/pages/1.11/networking/load-balancing-vips/index.md
@@ -29,7 +29,7 @@ When you launch a set of tasks, DC/OS distributes them to a set of nodes in the 
 ### Requirements
 
 -  Do not firewall traffic between the nodes (allow all TCP/UDP).
--  Do not change `ip_local_port_range`.
+-  Do not change the default value of `net.ipv4.ip_local_port_range` sysctl parameter. It should be in the range of 32768 to 60999.
 -  You must use a supported [operating system](/1.11/installing/oss/custom/system-requirements/).
 
 #### Persistent Connections

--- a/pages/1.11/networking/load-balancing-vips/index.md
+++ b/pages/1.11/networking/load-balancing-vips/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- The source repo for this topic is https://github.com/dcos/dcos-docs-site -->
 
 
-DC/OS provides an east-west layer 4 load balancer (minuteman) that enables multi-tier microservices architectures.
+DC/OS provides an east-west layer 4 load balancer (Minuteman) that enables multi-tier microservices architectures.
 
 It acts as a TCP layer 4 load balancer and leverages load-balancing features within the Linux kernel to achieve near line-rate throughputs and latency.
 
@@ -42,7 +42,7 @@ Use Mesos health checks. Mesos health checks are surfaced to the load balancing 
  test "$(curl -4 -w '%{http_code}' -s http://localhost:${PORT0}/|cut -f1 -d" ")" == 200
  ```
 
- This ensures the HTTP status code returned is 200. It also assumes your application binds to localhost. The `${PORT0}` is set as a variable by Marathon. You should not use TCP health checks because they may provide misleading information about the liveness of a service.
+This ensures the HTTP status code returned is 200. It also assumes your application binds to localhost. The `${PORT0}` is set as a variable by Marathon. You should not use TCP health checks because they may provide misleading information about the liveness of a service.
 
 **Note:** Docker container command health checks are run inside the Docker container. For example, if cURL is used to check NGINX, the NGINX container must have cURL installed, or the container must mount `/opt/mesosphere` in RW mode.
 

--- a/pages/services/edge-lb/1.0/release-notes/index.md
+++ b/pages/services/edge-lb/1.0/release-notes/index.md
@@ -10,11 +10,57 @@ enterprise: false
 
 Release notes for Edge-LB.
 
+# v1.1.0
+
+## Noteworthy changes:
+
+- Updates HAProxy used by the pool servers to 1.8.12 from 1.7.6. Please check the [HAProxy CHANGELOG](http://git.haproxy.org/?p=haproxy-1.8.git;a=blob;f=CHANGELOG;hb=8a200c71bd0848752b71a1aed5727563962b3a1a) for details.
+- Pool server reloads are no longer blocked by persistent connections.
+- Stability, debuggability and reliability improvements in the pool server code.
+- The size of the pool container was reduced to 100MB from ~250MB
+- Transition to Master/Worker mode in HAProxy running on the pool server. If custom configuration templates are used, then they must be updated. Namely:
+  - template must not specify the daemon option
+  - template must specify the `expose-fd listeners` parameter in the `stats socket` option
+- Edge-Lb now uses the default CLI packages from the DC/OS SDK `edgelb-pool` cli subcommand. Compared to edge-lb native packages, they do not support the `version` subcommand.
+
+
+Shortlist:
+
+```
+$ git shortlog v1.0.3..HEAD | cat
+      sdk: Update SDK buildchain to 0.42.1
+      sdk: replace stub cli for edgelb-pool with a default one
+      sdk: Use SDK version in build.gradle from the env, localize it to `framework/` dir
+      Bump pip requirements
+      Force rebuilding of all the deps while checking if cli binary has changed
+      Permit specifying custom linker flags to build_go_exe.sh
+      Move dcos-commons tooling into git subrepo
+      Extra debugging in ci-setup.sh script
+      Add pytest cache to gitignore
+      Makefile and Dockerfile should not be sent as context during lbmgr cont. build
+      Update haproxy to 1.8.12
+      Be more verbose with logging in order to boost debugging
+      Use instance with more IOPS when running integration tests
+```
+
+## Known Limitations
+
+* Edge-LB does not currently support `Disabled` security mode.
+* Edge-LB does not currently support `Strict` security mode on DC/OS 1.10, but does work in DC/OS 1.11 strict mode.
+* Edge-LB does not currently support self-service configuration; all configuration must be handled centrally.
+
+## Known Issues
+
+* The steps presented in the UI to uninstall Edge-LB are currently incorrect. Follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.0/uninstalling/).
+* Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
+* If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion.  It must be removed manually.
+
 # v1.0.3
 
 ## Noteworthy changes:
 
-- Bumps SDK to version 0.42.1
+- Bumps DC/OS SDK to version 0.42.1
+- Fixes a bug which was causing configuration reloads to cause short downtimes of the services behind the load balancer.
 
 Shortlist:
 
@@ -34,7 +80,7 @@ Shortlist:
 ## Known Issues
 
 * The steps presented in the UI to uninstall Edge-LB are currently incorrect. Follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.0/uninstalling/).
-* Edge-LB running on a CentOS/RHEL 7.2 node where /var/lib/mesos is formatted with ext4 may have connection issues.
+* Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
 * If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion.  It must be removed manually.
 
 # v1.0.2
@@ -60,7 +106,7 @@ Shortlist:
 ## Known Issues
 
 * The steps presented in the UI to uninstall Edge-LB are currently incorrect. Follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.0/uninstalling/).
-* Edge-LB running on a CentOS/RHEL 7.2 node where /var/lib/mesos is formatted with ext4 may have connection issues.
+* Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
 * If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion.  It must be removed manually.
 
 # v1.0.1
@@ -87,7 +133,7 @@ Shortlist:
 
 * V2 API backend.service regex selectors do not work properly
 * The steps presented in the UI to uninstall Edge-LB are currently incorrect. Follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.0/uninstalling/).
-* Edge-LB running on a CentOS/RHEL 7.2 node where /var/lib/mesos is formatted with ext4 may have connection issues.
+* Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
 * If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion.  It must be removed manually.
 * Marathon-LB and Edge-LB pool servers cannot run on the same agent without changing the default ports because they both require 80/443 for serving traffic and 9090 for HAProxy statistics by default.
  An example is listed on [pool configuration with non-default ports](/services/edge-lb/1.0/pool-configuration/v2-examples/#internal-east-west-load-balancing/).
@@ -137,7 +183,7 @@ Shortlist:
 
 * A potentially serious situation exists in DC/OS 1.10 or 1.11 clusters for any Marathon application deployed using persistent volumes in conjunction with Edge-LB.  If Edge-LB is deployed on a public agent node, the schedulers may erroneously destroy one or more Marathon persistent volumes, potentially leading to data loss. This bug has been resolved in Edge-LB v1.0.1
 * The steps presented in the UI to uninstall Edge-LB are currently incorrect. Follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.0/uninstalling/).
-* Edge-LB running on a CentOS/RHEL 7.2 node where /var/lib/mesos is formatted with ext4 may have connection issues.
+* Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
 * If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion.  It must be removed manually.
 
 # v0.1.9
@@ -170,7 +216,7 @@ Shortlist:
 ## Known Issues
 
 * The steps presented in the UI to uninstall Edge-LB are currently incorrect. Follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/0.1/uninstalling/).
-* Edge-LB running on a CentOS/RHEL 7.2 node where /var/lib/mesos is formatted with ext4 may have connection issues.
+* Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
 * If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion.  It must be removed manually.
 
 # v0.1.8

--- a/pages/services/edge-lb/1.0/release-notes/index.md
+++ b/pages/services/edge-lb/1.0/release-notes/index.md
@@ -24,7 +24,7 @@ Release notes for Edge-LB.
 - Edge-Lb now uses the default CLI packages from the DC/OS SDK `edgelb-pool` cli subcommand. Compared to edge-lb native packages, they do not support the `version` subcommand.
 - provide `mesosAuthNZ` package install option, which when set to `false` enables EdgeLB to run on DC/OS 1.10 clusters in `disabled` security mode.
 
-Released on 9th of August 2018.
+Released on 9 August 2018.
 
 Shortlist:
 

--- a/pages/services/edge-lb/1.0/release-notes/index.md
+++ b/pages/services/edge-lb/1.0/release-notes/index.md
@@ -22,12 +22,14 @@ Release notes for Edge-LB.
   - template must not specify the daemon option
   - template must specify the `expose-fd listeners` parameter in the `stats socket` option
 - Edge-Lb now uses the default CLI packages from the DC/OS SDK `edgelb-pool` cli subcommand. Compared to edge-lb native packages, they do not support the `version` subcommand.
+- provide `mesosAuthNZ` package install option, which when set to `false` enables EdgeLB to run on DC/OS 1.10 clusters in `disabled` security mode.
 
+Released on 9th of August 2018.
 
 Shortlist:
 
 ```
-$ git shortlog v1.0.3..HEAD | cat
+$ git shortlog v1.0.3..HEAD
       sdk: Update SDK buildchain to 0.42.1
       sdk: replace stub cli for edgelb-pool with a default one
       sdk: Use SDK version in build.gradle from the env, localize it to `framework/` dir
@@ -41,6 +43,9 @@ $ git shortlog v1.0.3..HEAD | cat
       Update haproxy to 1.8.12
       Be more verbose with logging in order to boost debugging
       Use instance with more IOPS when running integration tests
+      Do not wait for haproxy to finish reloading/for long-running connections
+      Disable gosec linter
+      Permit for disabling of Mesos Authorization via package-install option
 ```
 
 ## Known Limitations


### PR DESCRIPTION
## Description
This PR adds release notes for EdgeLB v1.1.0 plus some minor improvements to the existing docs.

**Please do not merge until EdgeLB v1.1.0 is released**

## Related Jiras
* https://jira.mesosphere.com/browse/DCOS-25625 `edgelb: upgrade HAProxy to version 1.8`
* https://jira.mesosphere.com/browse/DCOS-38061 `[Edge-lb]: Provide operator methods to update instances with long running connections`
* https://jira.mesosphere.com/browse/COPS-3463 `Timeout kill haproxy if it takes longer than X to reload`
* https://jira.mesosphere.com/browse/COPS-3462 `EdgeLB should be able to re-load even if one of the backends have long running connections`
* https://jira.mesosphere.com/browse/DCOS-37564 `edgelb: Iptables rules removal should be attempted only once.`
* https://jira.mesosphere.com/browse/COPS-3166 `Possible Recommendation/Bug Resolution for ELB Performance`
* https://jira.mesosphere.com/browse/DCOS-39135 `Method to update edge-lb instances with long running connections`

## Urgency
- [x] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
