### PR TITLE
ss/DCOS-39518 Deleting extra backslashes in commands.

### DIFF
--- a/pages/services/edge-lb/1.0/installing/index.md
+++ b/pages/services/edge-lb/1.0/installing/index.md
@@ -31,11 +31,11 @@ The Edge-LB package is composed of two components: the Edge-LB API server and th
 2. Once you have the links to the artifacts for the Edge-LB API server and Edge-LB pool repos, use the following command to add them to the universe package repository:
 
 ```bash
-dcos package repo add --index=0 edgelb \ https://<insert download link>/stub-universe-edgelb.json
+dcos package repo add --index=0 edgelb  https://<insert download link>/stub-universe-edgelb.json
 ```
 
 ```bash
-dcos package repo add --index=0 edgelb-pool \ https://<insert download link>/stub-universe-edgelb-pool.json
+dcos package repo add --index=0 edgelb-pool https://<insert download link>/stub-universe-edgelb-pool.json
 ```
 
 [enterprise]


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-39518
Spurious backslash found in two commands:
dcos package repo add --index=0 edgelb \ https://<insert download link>/stub-universe-edgelb.json
dcos package repo add --index=0 edgelb-pool \ https://<insert download link>/stub-universe-edgelb-pool.json

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Deleted both backslashes.