### PR TITLE
Update jq usage in docs for Updating User Service

### DIFF
--- a/pages/1.10/deploying-services/update-user-service/index.md
+++ b/pages/1.10/deploying-services/update-user-service/index.md
@@ -38,16 +38,16 @@ The entire [`env` field][1] can also be updated by specifying a JSON file in a c
 First, save the existing environment variables to a file:
 
 ```bash
-dcos marathon app show test-app | jq .env >env_vars.json
+dcos marathon app show test-app | jq '{env}' > env_vars.json
 ```
 
 The file will contain the JSON for the `env` field:
 
 ```json
-{ "SCHEDULER_DRIVER_PORT": "25501", }
+{ "env" : { "SCHEDULER_DRIVER_PORT" : "25501" } }
 ```
 
-Now edit the `env_vars.json` file. Make the JSON a valid object by enclosing the file contents with `{ "env" :}` and add your update:
+Now edit the `env_vars.json` file and add your updated env variables:
 
 ```json
 { "env" : { "APISERVER_PORT" : "25502", "SCHEDULER_DRIVER_PORT" : "25501" } }

--- a/pages/1.11/deploying-services/update-user-service/index.md
+++ b/pages/1.11/deploying-services/update-user-service/index.md
@@ -36,16 +36,16 @@ The [`env` field][1] can also be updated by specifying a JSON file in a command 
 First, save the existing environment variables to a file:
 
 ```bash
-dcos marathon app show test-app | jq .env >env_vars.json
+dcos marathon app show test-app | jq '{env}' > env_vars.json
 ```
 
 The file will contain the JSON for the `env` field:
 
 ```json
-{ "SCHEDULER_DRIVER_PORT": "25501", }
+{ "env" : { "SCHEDULER_DRIVER_PORT" : "25501" } }
 ```
 
-Now edit the `env_vars.json` file. Make the JSON a valid object by enclosing the file contents with `{ "env" :}` and add your update:
+Now edit the `env_vars.json` file and add your updated env variables:
 
 ```json
 { "env" : { "APISERVER_PORT" : "25502", "SCHEDULER_DRIVER_PORT" : "25501" } }

--- a/pages/1.7/usage/tutorials/marathon/inline-update/index.md
+++ b/pages/1.7/usage/tutorials/marathon/inline-update/index.md
@@ -32,16 +32,16 @@ The [Marathon `env` variable][1] can also be updated by specifying a JSON file i
 First, save the existing environment variables to a file:
 
 ```bash
-dcos marathon app show test-app | jq .env >env_vars.json
+dcos marathon app show test-app | jq '{env}' > env_vars.json
 ```
 
 The file will look like this:
 
 ```json
-{ "SCHEDULER_DRIVER_PORT": "25501", }
+{ "env" : { "SCHEDULER_DRIVER_PORT" : "25501" } }
 ```
 
-Now edit the `env_vars.json` file. Make the JSON a valid object by enclosing the file contents with `{ "env" :}` and add your update:
+Now edit the `env_vars.json` file and add your updated env variables:
 
 ```json
 { "env" : { "APISERVER_PORT" : "25502", "SCHEDULER_DRIVER_PORT" : "25501" } }

--- a/pages/1.8/usage/managing-services/update-user-service/index.md
+++ b/pages/1.8/usage/managing-services/update-user-service/index.md
@@ -38,16 +38,16 @@ The entire [`env` field][1] can also be updated by specifying a JSON file in a c
 First, save the existing environment variables to a file:
 
 ```bash
-dcos marathon app show test-app | jq .env >env_vars.json
+dcos marathon app show test-app | jq '{env}' > env_vars.json
 ```
 
 The file will contain the JSON for the `env` field:
 
 ```json
-{ "SCHEDULER_DRIVER_PORT": "25501", }
+{ "env" : { "SCHEDULER_DRIVER_PORT" : "25501" } }
 ```
 
-Now edit the `env_vars.json` file. Make the JSON a valid object by enclosing the file contents with `{ "env" :}` and add your update:
+Now edit the `env_vars.json` file and add your updated env variables:
 
 ```json
 { "env" : { "APISERVER_PORT" : "25502", "SCHEDULER_DRIVER_PORT" : "25501" } }

--- a/pages/1.9/deploying-services/update-user-service/index.md
+++ b/pages/1.9/deploying-services/update-user-service/index.md
@@ -38,16 +38,16 @@ The entire [`env` field][1] can also be updated by specifying a JSON file in a c
 First, save the existing environment variables to a file:
 
 ```bash
-dcos marathon app show test-app | jq .env >env_vars.json
+dcos marathon app show test-app | jq '{env}' > env_vars.json
 ```
 
 The file will contain the JSON for the `env` field:
 
 ```json
-{ "SCHEDULER_DRIVER_PORT": "25501", }
+{ "env" : { "SCHEDULER_DRIVER_PORT" : "25501" } }
 ```
 
-Now edit the `env_vars.json` file. Make the JSON a valid object by enclosing the file contents with `{ "env" :}` and add your update:
+Now edit the `env_vars.json` file and add your updated env variables:
 
 ```json
 { "env" : { "APISERVER_PORT" : "25502", "SCHEDULER_DRIVER_PORT" : "25501" } }


### PR DESCRIPTION
## Description
This PR updates the `jq` usage example in the "Updating a User-Created Service" docs to reduce the need for manually add the `{ "env": {…} }` wrapper.

## Urgency
- [ ] Blocker
- [ ] High
- [ ] Medium
- [x] Low

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
