### PR TITLE
ss/DCOS-39731 Adding service.mesosProtocol info to install docs.

### DIFF
--- a/pages/services/edge-lb/1.0/installing/index.md
+++ b/pages/services/edge-lb/1.0/installing/index.md
@@ -201,6 +201,7 @@ Other useful configurable service parameters include:
 * `service.logLevel`: `"info"`. Can be one of `debug`, `info`, `warn`, or `error`
 * `service.cpus`: `1.0`
 * `service.mem`: `1024`
+* `service.mesosProtocol`: `"https"` (default) for Permissive and Strict security modes, `"http"` for Disabled security mode
 
 Save the file with a meaningful name, such as `edge-lb-options.json`. Keep this file in source control so that you can quickly update configuration at a later time.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-39731

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium



On the following page: https://docs.mesosphere.com/services/edge-lb/1.0/installing/#create-a-configuration-file-for-service-authentication

 

Add a 5th bullet (beneath service.mem) that says:

    service.mesosProtocol: "https" (default) for Permissive and Strict security modes, "http" for Disabled security mode.

=====
Done.