### PR TITLE
ss/DCOS_OSS-3872 Corrected MenuWeight value for Prometheus docs in Se…

### DIFF
--- a/pages/services/prometheus/index.md
+++ b/pages/services/prometheus/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Prometheus
 title: Prometheus
-menuWeight: 20
+menuWeight: 87
 excerpt:
 featureMaturity:
 enterprise: false


### PR DESCRIPTION
…rvice docs list.

## Description
https://jira.mesosphere.com/browse/DCOS_OSS-3872

The Prometheus docs are out of alphabetical order on the Service Docs page because the MenuWeight metadata field in the index.md page is 20, the same as DataStax Enterprise. To fix, change the MenuWeight value to 87 so that it will appear below Percona-Mongo.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium


Corrected MenuWeight.