### PR TITLE
ss/COPS-1843 Correcting code in connecting-clients.

### DIFF
--- a/pages/services/cassandra/2.0.1-3.0.14/connecting-clients/index.md
+++ b/pages/services/cassandra/2.0.1-3.0.14/connecting-clients/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 50
-excerpt:
+excerpt: Using CQL to communicate with clients
 featureMaturity:
 enterprise: false
 ---
@@ -52,7 +52,7 @@ dcos node ssh --leader --master-proxy
 
 Then, use the `cassandra` Docker image to run `cqlsh`, passing as an argument the address of one of the Apache Cassandra nodes in the cluster:
 ```
-docker run cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
+docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
 ```
 
 This will open an interactive shell from which you can issue queries and write to the cluster. To ensure that the `cqlsh` client and your cluster are using the same CQL version, be sure to use the version of the `cassandra` Docker image that corresponds to the version of Apache Cassandra being run in your cluster. The version installed by the DC/OS Apache Cassandra Service is 3.0.13.

--- a/pages/services/cassandra/2.0.2-3.0.14/connecting-clients/index.md
+++ b/pages/services/cassandra/2.0.2-3.0.14/connecting-clients/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 50
-excerpt:
+excerpt: Using CQL to communicate with clients
 featureMaturity:
 enterprise: false
 ---
@@ -52,7 +52,7 @@ dcos node ssh --leader --master-proxy
 
 Then, use the `cassandra` Docker image to run `cqlsh`, passing as an argument the address of one of the Apache Cassandra nodes in the cluster:
 ```
-docker run cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
+docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
 ```
 
 This will open an interactive shell from which you can issue queries and write to the cluster. To ensure that the `cqlsh` client and your cluster are using the same CQL version, be sure to use the version of the `cassandra` Docker image that corresponds to the version of Apache Cassandra being run in your cluster. The version installed by the DC/OS Apache Cassandra Service is 3.0.13.

--- a/pages/services/cassandra/2.0.3-3.0.14/connecting-clients/index.md
+++ b/pages/services/cassandra/2.0.3-3.0.14/connecting-clients/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 50
-excerpt:
+excerpt: Using CQL to communicate with clients
 featureMaturity:
 enterprise: false
 ---
@@ -52,7 +52,7 @@ dcos node ssh --leader --master-proxy
 
 Then, use the `cassandra` Docker image to run `cqlsh`, passing as an argument the address of one of the Apache Cassandra nodes in the cluster:
 ```
-docker run cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
+docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
 ```
 
 This will open an interactive shell from which you can issue queries and write to the cluster. To ensure that the `cqlsh` client and your cluster are using the same CQL version, be sure to use the version of the `cassandra` Docker image that corresponds to the version of Apache Cassandra being run in your cluster. The version installed by the DC/OS Apache Cassandra Service is 3.0.13.

--- a/pages/services/cassandra/v2.0.0-3.0.14/connecting-clients/index.md
+++ b/pages/services/cassandra/v2.0.0-3.0.14/connecting-clients/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 50
-excerpt:
+excerpt: Using CQL to communicate with clients
 featureMaturity:
 enterprise: false
 ---
@@ -52,7 +52,7 @@ dcos node ssh --leader --master-proxy
 
 Then, use the `cassandra` Docker image to run `cqlsh`, passing as an argument the address of one of the Apache Cassandra nodes in the cluster:
 ```
-docker run cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
+docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory
 ```
 
 This will open an interactive shell from which you can issue queries and write to the cluster. To ensure that the `cqlsh` client and your cluster are using the same CQL version, be sure to use the version of the `cassandra` Docker image that corresponds to the version of Apache Cassandra being run in your cluster. The version installed by the DC/OS Apache Cassandra Service is 3.0.13.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-1843
The Cassandra 2.0.1-3.0.14 documentation at https://docs.mesosphere.com/service-docs/cassandra/2.0.1-3.0.14/connecting-clients/ needs the following edit:

Hi! We need to update this string `docker run cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory`; as it will not open up an interactive session. We need to add -it.

The correct string is `docker run -it cassandra:3.0.13 cqlsh node-0-server.cassandra.autoip.dcos.thisdcos.directory`



## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected code as specified in versions:

- [x] v.2.0.0 - 3.0.14
- [x] 2.0.1 - 3.0.14
- [x] 2.0.2. - 3.0.14
- [x] 2.0.3. - 3.0.14