### PR TITLE
ss/DCOS-25881 Correcting package install section for /oss/ and /ent/ …

### DIFF
--- a/pages/1.8/administration/installing/ent/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.8/administration/installing/ent/deploying-a-local-dcos-universe/index.md
@@ -129,11 +129,8 @@ interface.
     sudo make DCOS_VERSION=1.8 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-4.  Perform steps from 2 to 7 of [Installing the default Universe packages][5] section, except step 6. Run the following command instead:
+4.  Perform all of the steps in the [Installing the default Universe packages](#build) section. But instead of using the default local-package container, use the package file you just built.
 
-    ```bash
-    dcos package repo add local-universe http://master.mesos:8082/repo
-    ```
 
  [1]: https://downloads.mesosphere.com/universe/public/local-universe.tar.gz
  [2]: https://raw.githubusercontent.com/mesosphere/universe/version-3.x/docker/local-universe/dcos-local-universe-http.service

--- a/pages/1.8/administration/installing/oss/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.8/administration/installing/oss/deploying-a-local-dcos-universe/index.md
@@ -125,11 +125,9 @@ interface.
     sudo make DCOS_VERSION=1.8 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-4.  Perform steps from 2 to 7 of [Installing the default Universe packages][5] section, except step 6. Run the following command instead:
+4.  Perform all of the steps in the [Installing the default Universe packages](#build) section. But instead of using the default local-package container, use the package file you just built.
 
-    ```bash
-    dcos package repo add local-universe http://master.mesos:8082/repo
-    ```
+    
 
  [1]: https://downloads.mesosphere.com/universe/public/local-universe.tar.gz
  [2]: https://raw.githubusercontent.com/mesosphere/universe/version-3.x/docker/local-universe/dcos-local-universe-http.service


### PR DESCRIPTION
…versions of 1.8 only.

## Description
https://jira.mesosphere.com/browse/DCOS-25881



The last step in this page currently reads like this:

Perform steps from 2 to 7 of Installing the default Universe packages section exept of the 6th one. Run the following command instead:

$ dcos package repo add local-universe http://master.mesos:8082/repo

But it is out-dated. It should be modified to this:

Perform all of the steps in the Installing the default Universe packages section. But instead of using the default local-package container, use the package file you just built.

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrections made to /oss/ and /ent/ versions of 1.8 only. 