### PR TITLE
ss/DCOS-25911 Added comment to expose-services doc 1.9, 1.10, 1.11

### DIFF
--- a/pages/1.10/deploying-services/expose-service/index.md
+++ b/pages/1.10/deploying-services/expose-service/index.md
@@ -80,10 +80,10 @@ To launch a service on a public node, you must create a Marathon app definition 
 
 1.  Configure an edge load balancer and service discovery mechanism.
 
-    - AWS users: If you installed DC/OS by using the [AWS CloudFormation templates](/1.10/installing/cloud/aws/), an ELB is included. However, you must reconfigure the health check on the public ELB to expose the app to the port specified in your app definition (e.g. port 80).
+    - AWS users: If you installed DC/OS by using the [AWS CloudFormation templates](/1.10/installing/cloud/aws/), an ELB is included. However, you must reconfigure the health check on the public ELB to expose the app to the port specified in your app definition (such as port 80).
     - All other users: You can use [Marathon-LB](/service-docs/marathon-lb/), a rapid proxy and load balancer that is based on HAProxy.
 
-1.  Go to your public agent to see the site running. For information about how to find your public agent IP, see the [documentation](/1.10/administering-clusters/locate-public-agent/).
+1.  Go to your public agent to see the site running and to find your public agent. Once you have identified your public agent IP, type it into your browser.
 
     You should see the following message in your browser:
 

--- a/pages/1.11/deploying-services/expose-service/index.md
+++ b/pages/1.11/deploying-services/expose-service/index.md
@@ -81,7 +81,7 @@ To launch a service on a public node, you must create a Marathon app definition 
     - AWS users: If you installed DC/OS by using the [AWS CloudFormation templates](/1.11/installing/oss/cloud/aws/), an ELB is included. However, you must reconfigure the health check on the public ELB to expose the app to the port specified in your app definition (e.g. port 80).
     - All other users: You can use [Marathon-LB](/1.11/networking/marathon-lb/), a rapid proxy and load balancer that is based on HAProxy.
 
-1.  Go to your public agent to see the site running. For information about how to find your public agent IP, see the [documentation](/1.11/administering-clusters/locate-public-agent/).
+1.  Go to your public agent to see the site running and to find your public agent IP. Type it into your browser.
 
     You should see the following message in your browser:
 

--- a/pages/1.9/deploying-services/expose-service/index.md
+++ b/pages/1.9/deploying-services/expose-service/index.md
@@ -12,7 +12,7 @@ enterprise: false
 
 
 DC/OS agent nodes can be designated as [public](/1.9/overview/concepts/#public-agent-node) or [private](/1.9/overview/concepts/#private-agent-node) during [installation](/1.9/installing/oss/). Public agent nodes provide access from outside of the cluster via infrastructure networking to your DC/OS services. By default, services are launched on private agent nodes and are not accessible from outside the cluster.
- 
+
 To launch a service on a public node, you must create a Marathon app definition with the `"acceptedResourceRoles":["slave_public"]` parameter specified and configure an edge load balancer and service discovery mechanism.
 
 **Prerequisites:**
@@ -51,35 +51,35 @@ To launch a service on a public node, you must create a Marathon app definition 
     ```
 
     If this is added successfully, there is no output.
-    
-     **Tip:** You can also add your app by using the **Services** tab of DC/OS [GUI](/1.9/gui/services/). 
+
+     **Tip:** You can also add your app by using the **Services** tab of DC/OS [GUI](/1.9/gui/services/).
 
 1.  Verify that the app is added with this command:
 
     ```bash
     dcos marathon app list
     ```
-    
+
     The output should look like this:
-    
+
     ```bash
      ID     MEM  CPUS  TASKS  HEALTH  DEPLOYMENT  CONTAINER  CMD
     /myApp   64  0.1    0/1    ---      scale       DOCKER   None
     ```
-    
+
     **Tip:** You can also view deployed apps by using the **Services** tab of DC/OS [GUI](/1.9/gui/services/).
 
-1.  Configure an edge load balancer and service discovery mechanism. 
+1.  Configure an edge load balancer and service discovery mechanism.
 
     - AWS users: If you installed DC/OS by using the [AWS CloudFormation templates](/1.9/installing/oss/cloud/aws/), an ELB is included. However, you must reconfigure the health check on the public ELB to expose the app to the port specified in your app definition (e.g. port 80).
-    - All other users: You can use [Marathon-LB](/1.9/networking/marathon-lb/), a rapid proxy and load balancer that is based on HAProxy. 
+    - All other users: You can use [Marathon-LB](/1.9/networking/marathon-lb/), a rapid proxy and load balancer that is based on HAProxy.
 
-1.  Go to your public agent to see the site running. For information about how to find your public agent IP, see the [documentation](/1.9/administering-clusters/locate-public-agent/).
+1.  Go to your public agent to see the site running and to find your public agent IP. Type it into your browser.
 
-    You should see the following message in your browser: 
-    
+    You should see the following message in your browser:
+
     ![Hello Brave World](/1.9/img/helloworld.png)
-    
+
 ## Next steps
 
 Learn how to load balance your app on a public node using [Marathon-LB](/1.9/networking/marathon-lb/marathon-lb-basic-tutorial/).


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25911
https://docs.mesosphere.com/1.10/deploying-services/expose-service/

In step 1, the page refers to a Marathon application that is not deployable. It needs to be updated to tell users to configure an existing Docker image.

This should link to info about how to configure the health check:

AWS users: If you installed DC/OS by using the AWS CloudFormation templates, an ELB is included. However, you must reconfigure the health check on the public ELB to expose the app to the port specified in your app definition (e.g. port 80).

That info is available here: https://docs.mesosphere.com/1.10/deploying-services/creating-services/deploy-docker-app/

This statement is followed by a screenshot that points to an application that wasn't discussed earlier:

You should see the following message in your browser

The screenshot should be updated or removed.


## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

I removed the `edge-lb-docs` label, since this affects only DCOS docs. 

Added message:

"Go to your public agent to see the site running and to find your public agent IP. Type it into your browser."

to final step. 

Versions corrected:

- [x] 1.9
- [x] 1.10
- [x] 1.11