### PR TITLE
ss/DCOS_OSS-1719 Fixing curl command bug.

### DIFF
--- a/pages/services/kafka/2.0.1-0.11.0/api-reference/index.md
+++ b/pages/services/kafka/2.0.1-0.11.0/api-reference/index.md
@@ -527,7 +527,7 @@ $ dcos kafka --name=kafka plan show deploy --json
 ```
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "$dcos_url/service/kafka/v1/plan/deploy"
+$ curl -H "Authorization: token=$auth_token" "$dcos_url/service/kafka/v1/plans/deploy"
 {
     "phases": [
     {

--- a/pages/services/kafka/2.0.2-0.11.0/api-reference/index.md
+++ b/pages/services/kafka/2.0.2-0.11.0/api-reference/index.md
@@ -527,7 +527,7 @@ $ dcos kafka --name=kafka plan show deploy --json
 ```
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "$dcos_url/service/kafka/v1/plan/deploy"
+$ curl -H "Authorization: token=$auth_token" "$dcos_url/service/kafka/v1/plans/deploy"
 {
     "phases": [
     {

--- a/pages/services/kafka/2.0.3-0.11.0/api-reference/index.md
+++ b/pages/services/kafka/2.0.3-0.11.0/api-reference/index.md
@@ -527,7 +527,7 @@ $ dcos kafka --name=kafka plan show deploy --json
 ```
 
 ```bash
-$ curl -H "Authorization: token=$auth_token" "$dcos_url/service/kafka/v1/plan/deploy"
+$ curl -H "Authorization: token=$auth_token" "$dcos_url/service/kafka/v1/plans/deploy"
 {
     "phases": [
     {


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-1719

There's a documentation bug in https://docs.mesosphere.com/service-docs/kafka/2.0.1-0.11.0/api-reference/#view-plan-status .  The curl command should be `curl -H "Authorization: token=$auth_token" "$dcos_url/service/kafka/v1/plans/deploy"`

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected in versions

- [x] 2.0.1-0.11.0
- [x] 2.0.2-0.11.0
- [x] 2.0.3-0.11.0