### PR TITLE
ss/DCOS-25998 Fixing release note links for all versions; fixing menu…

### DIFF
--- a/pages/services/beta-spark/2.2.0-2.2.0-2-beta/index.md
+++ b/pages/services/beta-spark/2.2.0-2.2.0-2-beta/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for Apache DC/OS Spark Beta. For the latest information, see the [release notes](/services/beta-spark/2.2.0-2.2.0-2-beta/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/beta-spark/2.2.0-2.2.0-2-beta/release-notes/index.md
+++ b/pages/services/beta-spark/2.2.0-2.2.0-2-beta/release-notes/index.md
@@ -1,6 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle: 
+navigationTitle:
 title: Release Notes
 menuWeight: 140
 excerpt:
@@ -57,12 +57,12 @@ dispatcher use `dcos spark --name <dispatcher_app_id>`.
 ### Improvements
 * Upgrade to Spark 2.2.0
 * Spark driver now supports configurable failover_timeout. The default value is 0 when the configuration is not set.
-[SPARK-21456](https://issues.apache.org/jira/browse/SPARK-21456). 
+[SPARK-21456](https://issues.apache.org/jira/browse/SPARK-21456).
 
 ### Breaking change
 
 *  Spark CLI no longer supports -Dspark args.
 
-## Version 1.0.9-2.1.0-1 
+## Version 1.0.9-2.1.0-1
 
 - The history server has been removed from the "spark" package, and put into a dedicated "spark-history" package.

--- a/pages/services/beta-spark/2.2.1-2.2.0-2-beta/index.md
+++ b/pages/services/beta-spark/2.2.1-2.2.0-2-beta/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for Apache DC/OS Spark Beta. For the latest information, see the [release notes](/services/beta-spark/2.2.1-2.2.0-2-beta/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/beta-spark/2.3.0-2.2.0-2-beta/index.md
+++ b/pages/services/beta-spark/2.3.0-2.2.0-2-beta/index.md
@@ -11,7 +11,7 @@ featureMaturity:
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark Beta. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for Apache DC/OS Spark Beta. For the latest information, see the [release notes](/services/beta-spark/2.3.0-2.2.0-2-beta/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/beta-spark/2.3.1-2.2.1-2-beta/index.md
+++ b/pages/services/beta-spark/2.3.1-2.2.1-2-beta/index.md
@@ -11,7 +11,7 @@ featureMaturity:
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for Apache DC/OS Spark Beta. For the latest information, see the [release notes](/services/beta-spark/2.3.1-2.2.1-2-beta/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/2.1.0-2.2.0-1/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for DC/OS Apache Spark. For more information about new and changed features, see the [release notes](/services/spark/2.1.0-2.2.0-1/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/2.1.0-2.2.1-1/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for DC/OS Apache Spark. For more information about new and changed features, see the [release notes](/services/spark/2.1.0-2.2.1-1/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/2.3.0-2.2.1-2/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Spark 2.3.0-2.2.1-2
 navigationTitle: Spark 2.3.0-2.2.1-2
-menuWeight: 2
+menuWeight: 20
 excerpt:
 featureMaturity:
 
@@ -11,7 +11,7 @@ featureMaturity:
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for DC/OS Apache Spark. For more information about new and changed features, see the [release notes](/services/spark/2.3.0-2.2.1-2/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/2.3.1-2.2.1-2/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/index.md
@@ -2,13 +2,13 @@
 layout: layout.pug
 title: Spark 2.3.1-2.2.1-2
 navigationTitle: Spark 2.3.1-2.2.1-2
-menuWeight:
+menuWeight: 10
 excerpt:
 featureMaturity:
 
 ---
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for DC/OS Apache Spark. For more information about new and changed features, see the [release notes](/services/spark/2.3.1-2.2.1-2/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/v1.0.9-2.1.0-1/index.md
+++ b/pages/services/spark/v1.0.9-2.1.0-1/index.md
@@ -8,8 +8,7 @@ featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
-
+Welcome to the documentation for DC/OS Apache Spark.
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/v1.1.0-2.1.1/index.md
+++ b/pages/services/spark/v1.1.0-2.1.1/index.md
@@ -8,7 +8,7 @@ featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
+Welcome to the documentation for DC/OS Apache Spark.
 
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].

--- a/pages/services/spark/v1.1.1-2.2.0/index.md
+++ b/pages/services/spark/v1.1.1-2.2.0/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for DC/OS Apache Spark.
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/v2.0.0-2.2.0-1/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for DC/OS Apache Spark. For more information about new and changed features, see the [release notes](/services/spark/v2.0.0-2.2.0-1/release-notes/).
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 

--- a/pages/services/spark/v2.0.1-2.2.0-1/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/index.md
@@ -10,7 +10,8 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
 
-Welcome to the documentation for the DC/OS Apache Spark. For more information about new and changed features, see the [release notes](https://github.com/mesosphere/spark-build/releases/).
+Welcome to the documentation for DC/OS Apache Spark. For more information about new and changed features, see the [release notes](/services/spark/v2.0.1-2.2.0-1/release-notes/).
+
 
 Apache Spark is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including Spark SQL for SQL and DataFrames, MLlib for machine learning, GraphX for graph processing, and Spark Streaming for stream processing. For more information, see the [Apache Spark documentation][1].
 


### PR DESCRIPTION
…Weights to correct navmenu display.

## Description
https://jira.mesosphere.com/browse/DCOS-25998

There are a couple issues with this:

    Spark docs include release notes - so this is redundant
    General reference from PM bias toward not pushing customers to Github - though this is not a hard rule.

PM recommendation is to delete this entire sentence  - "Welcome to the documentation for the DC/OS Apache Spark Beta. For more information about new and changed features, see the release notes."

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [x] High
- [ ] Medium

Changed link in opening paragraph to correct release notes for each release of Beta-Spark and Spark that actually have release notes. Corrected menuWeights in metadata for Spark releases so that the navMenu shows the correct order. 