### PR TITLE
ss/DCOS-25729 Replacing variable name in Troubleshooting sections.

### DIFF
--- a/pages/services/kafka/2.0.1-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.1-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <broker-id>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/2.0.2-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.2-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <broker-id>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/2.0.3-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.3-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <broker-id>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/2.0.4-1.0.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.4-1.0.0/troubleshooting/index.md
@@ -1,6 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle: 
+navigationTitle:
 excerpt:
 title: Troubleshooting
 menuWeight: 90
@@ -9,7 +9,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <broker-id>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/v1.1.19.1-0.10.1.0/troubleshooting/index.md
+++ b/pages/services/kafka/v1.1.19.1-0.10.1.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <broker-id>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 
@@ -39,7 +39,7 @@ GET /service/kafka/v1/plan HTTP/1.1
             ]
         },
         {
-            
+
             "id": "226a780e-132f-4fea-b584-7712b07cf357",
             "name": "Update to: 72cecf77-dbc5-4ae6-8f91-c88702b9a6a8",
             "steps": [
@@ -65,7 +65,7 @@ GET /service/kafka/v1/plan HTTP/1.1
             "status": "COMPLETE"
         }
     ],
-    
+
     <b>"errors": [
         "Validation error on field \"BROKER_COUNT\": Decreasing this value (from 3 to 2) is not supported."
     ],</b>
@@ -80,4 +80,3 @@ If a machine has permanently failed, manual intervention is required to replace 
 In the example below, the broker with id `0` will be replaced on new machine as long as cluster resources are sufficient to satisfy the service’s placement constraints and resource requirements.
 
     dcos kafka broker replace 0
-

--- a/pages/services/kafka/v2.0.0-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/v2.0.0-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <broker-id>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25729



via Community Slack: https://dcos-community.slack.com/archives/C132NTZJN/p1508943125000320

The current Service Docs for Kafka at https://docs.mesosphere.com/service-docs/kafka/2.0.2-0.11.0/troubleshooting/ state that a broker can be replaced with dcos kafka broker replace <broker_i> which is incorrect and must instead be dcos kafka pod replace <name> as corrected by Nicholas Parker - https://dcos-community.slack.com/archives/C132NTZJN/p1508950250000087

Please fix.


## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected in following versions:

1.1.19.1-0.10-0
2.0.0-0.11.0
2.0.1-0.11.0
2.0.2-0.11.0
2.0.3-0.11.0
2.0.4-1.0.0

 
