### PR TITLE
ss/DCOS-25729 Correcting correction to Troubleshooting docs.

### DIFF
--- a/pages/services/kafka/2.0.1-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.1-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka pod replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/2.0.2-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.2-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka pod replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/2.0.3-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.3-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka pod replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/2.0.4-1.0.0/troubleshooting/index.md
+++ b/pages/services/kafka/2.0.4-1.0.0/troubleshooting/index.md
@@ -9,7 +9,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka pod replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/v1.1.19.1-0.10.1.0/troubleshooting/index.md
+++ b/pages/services/kafka/v1.1.19.1-0.10.1.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka pod replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 

--- a/pages/services/kafka/v2.0.0-0.11.0/troubleshooting/index.md
+++ b/pages/services/kafka/v2.0.0-0.11.0/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The Kafka service will be listed as "Unhealthy" when it detects any underreplicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos kafka topic under_replicated_partitions` and `dcos kafka topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
 
-Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka broker replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+Possible repair actions include `dcos kafka broker restart <broker-id>` and `dcos kafka pod replace <name>`. The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
 
 # Configuration Update Errors
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25729



via Community Slack: https://dcos-community.slack.com/archives/C132NTZJN/p1508943125000320

The current Service Docs for Kafka at https://docs.mesosphere.com/service-docs/kafka/2.0.2-0.11.0/troubleshooting/ state that a broker can be replaced with dcos kafka broker replace <broker_i> which is incorrect and must instead be dcos kafka pod replace <name> as corrected by Nicholas Parker - https://dcos-community.slack.com/archives/C132NTZJN/p1508950250000087

Please fix.


## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

My earlier fix was incorrect. This  fix replaces
`dcos kafka broker replace <broker-id>`
with 
`dcos kafka pod replace <name>' 
as requested.

Versions fixed:

- [x] 1.1.19-1-0.10.0
- [x] 2.0.0.-0.11.0
- [x] 2.0.1.-0.11.0
- [x] 2.0.2.-0.11.0
- [x] 2.0.3.-0.11.0
- [x] 2.0.4-1.0.0

