### PR TITLE
Add information about the new install-time param: `mesosAuthNZ`

### DIFF
--- a/pages/services/edge-lb/1.0/installing/index.md
+++ b/pages/services/edge-lb/1.0/installing/index.md
@@ -194,7 +194,7 @@ In the file, specify the service account secret (`dcos-edgelb/edge-lb-secret`) t
   }
 }
 ```
-EdgeLB also needs following options to be specified. Their values depend on the security mode of the cluster it is running on:
+EdgeLB also needs the following options to be specified. Their values depend on the security mode of the cluster it is running on:
 
 * `service.mesosProtocol`: `"https"` for Permissive and Strict security modes, `"http"` (default) for Disabled security mode
 * `service.mesosAuthNZ`: `true` (default) for Permissive and Strict security modes, `false` for Disabled security mode. Parameter is available begining version v1.1.

--- a/pages/services/edge-lb/1.0/installing/index.md
+++ b/pages/services/edge-lb/1.0/installing/index.md
@@ -194,6 +194,10 @@ In the file, specify the service account secret (`dcos-edgelb/edge-lb-secret`) t
   }
 }
 ```
+EdgeLB also needs following options to be specified. Their values depend on the security mode of the cluster it is running on:
+
+* `service.mesosProtocol`: `"https"` for Permissive and Strict security modes, `"http"` (default) for Disabled security mode
+* `service.mesosAuthNZ`: `true` (default) for Permissive and Strict security modes, `false` for Disabled security mode. Parameter is available begining version v1.1.
 
 Other useful configurable service parameters include:
 
@@ -201,7 +205,6 @@ Other useful configurable service parameters include:
 * `service.logLevel`: `"info"`. Can be one of `debug`, `info`, `warn`, or `error`
 * `service.cpus`: `1.0`
 * `service.mem`: `1024`
-* `service.mesosProtocol`: `"https"` (default) for Permissive and Strict security modes, `"http"` for Disabled security mode
 
 Save the file with a meaningful name, such as `edge-lb-options.json`. Keep this file in source control so that you can quickly update configuration at a later time.
 

--- a/pages/services/edge-lb/1.0/upgrading/index.md
+++ b/pages/services/edge-lb/1.0/upgrading/index.md
@@ -47,6 +47,12 @@ Perform an Edge-LB upgrade by following this procedure.
     dcos package install --options=edgelb-options.json edgelb
     ```
 
+EdgeLB also needs following options to be specified. Their values depend on the security mode of the cluster it is running on:
+
+* `service.mesosProtocol`: `"https"` for Permissive and Strict security modes, `"http"` (default) for Disabled security mode
+* `service.mesosAuthNZ`: `true` (default) for Permissive and Strict security modes, `false` for Disabled security mode. Parameter is available begining version v1.1.
+
+
 1. Upgrade each pool.
 
     ```bash

--- a/pages/services/edge-lb/1.0/upgrading/index.md
+++ b/pages/services/edge-lb/1.0/upgrading/index.md
@@ -47,7 +47,7 @@ Perform an Edge-LB upgrade by following this procedure.
     dcos package install --options=edgelb-options.json edgelb
     ```
 
-EdgeLB also needs following options to be specified. Their values depend on the security mode of the cluster it is running on:
+EdgeLB also needs the following options to be specified. Their values depend on the security mode of the cluster it is running on:
 
 * `service.mesosProtocol`: `"https"` for Permissive and Strict security modes, `"http"` (default) for Disabled security mode
 * `service.mesosAuthNZ`: `true` (default) for Permissive and Strict security modes, `false` for Disabled security mode. Parameter is available begining version v1.1.


### PR DESCRIPTION
## Description
This PR adds a description for the newly introduced package option for EdgeLB: `mesosAuthNZ`. It enables users to install EdgeLB on 1.10 cluster working in security mode `Disabled`.

@SarahStegall @masonse @GoelDeepak  Please feel free to edit this PR the way you like, and treat my work just as a draft. I have marked it as Blocker as we need to get it out ASAP, as EdgeLb v1.1 is out today.

## Urgency
- [x] Blocker
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
