### PR TITLE
Kubernetes service docs layout

### DIFF
--- a/pages/services/kubernetes/1.0.0-1.9.3/advanced-install/index.md
+++ b/pages/services/kubernetes/1.0.0-1.9.3/advanced-install/index.md
@@ -139,12 +139,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -159,7 +159,7 @@ a [service account](/latest/security/service-auth/custom-service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/1.0.1-1.9.4/advanced-install/index.md
+++ b/pages/services/kubernetes/1.0.1-1.9.4/advanced-install/index.md
@@ -139,12 +139,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -159,7 +159,7 @@ a [service account](/latest/security/service-auth/custom-service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/1.0.2-1.9.6/advanced-install/index.md
+++ b/pages/services/kubernetes/1.0.2-1.9.6/advanced-install/index.md
@@ -139,12 +139,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -159,7 +159,7 @@ a [service account](/latest/security/service-auth/custom-service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/1.0.2-1.9.6/release-notes/index.md
+++ b/pages/services/kubernetes/1.0.2-1.9.6/release-notes/index.md
@@ -32,7 +32,7 @@ excerpt:
 
 ## Bug Fixes
 
-* Fix support for air-gapped clusters which use [local universe](https://docs.mesosphere.com/1.11/administering-clusters/deploying-a-local-dcos-universe/).
+* Fix support for air-gapped clusters which use [local universe](/1.11/administering-clusters/deploying-a-local-dcos-universe/).
 
 ## Documentation
 

--- a/pages/services/kubernetes/1.0.3-1.9.7/advanced-install/index.md
+++ b/pages/services/kubernetes/1.0.3-1.9.7/advanced-install/index.md
@@ -142,12 +142,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -162,7 +162,7 @@ a [service account](/latest/security/service-auth/custom-service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/1.1.0-1.10.3/advanced-install/index.md
+++ b/pages/services/kubernetes/1.1.0-1.10.3/advanced-install/index.md
@@ -140,12 +140,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -160,7 +160,7 @@ a [service account](/latest/security/service-auth/custom-service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/1.1.1-1.10.4/advanced-install/index.md
+++ b/pages/services/kubernetes/1.1.1-1.10.4/advanced-install/index.md
@@ -176,12 +176,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -196,7 +196,7 @@ a [service account](/latest/security/service-auth/custom-service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/1.1.1-1.10.4/exposing-the-kubernetes-api/index.md
+++ b/pages/services/kubernetes/1.1.1-1.10.4/exposing-the-kubernetes-api/index.md
@@ -29,7 +29,7 @@ build a fully-secured setup.
 
 In order for a user to follow the examples successfully, their DC/OS cluster
 **MUST** have at least one
-[public agent](https://docs.mesosphere.com/1.11/overview/architecture/node-types/#public-agent-nodes)
+[public agent](/1.11/overview/architecture/node-types/#public-agent-nodes)
 (i.e. an agent that is on a network that allows ingress from outside the
 cluster). In the examples, `<ip-of-public-agent>` represents the IP address at
 which this public agent can be reached. The user  **MUST** also have access to

--- a/pages/services/kubernetes/1.2.0-1.10.5/advanced-install/index.md
+++ b/pages/services/kubernetes/1.2.0-1.10.5/advanced-install/index.md
@@ -176,12 +176,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -192,11 +192,11 @@ implement TLS on Open DC/OS? The answer comes in the form of the diagram below:
 ### Leveraging Enterprise DC/OS PKI
 
 In order to fully leverage the DC/OS Enterprise PKI infrastructure when setting up TLS,
-a [service account](https://docs.mesosphere.com/1.11/security/ent/service-auth/)
+a [service account](/1.11/security/ent/service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem
@@ -207,7 +207,7 @@ dcos security secrets create-sa-secret private-key.pem kubernetes kubernetes/sa
 dcos security org groups add_user superusers kubernetes
 ```
 
-Next, you need to [grant](https://docs.mesosphere.com/1.11/security/ent/perms-management/)
+Next, you need to [grant](/1.11/security/ent/perms-management/)
 the service account the correct permissions.
 
 The required permissions are:

--- a/pages/services/kubernetes/1.2.0-1.10.5/exposing-the-kubernetes-api/index.md
+++ b/pages/services/kubernetes/1.2.0-1.10.5/exposing-the-kubernetes-api/index.md
@@ -31,7 +31,7 @@ Alternately, if you are running Marathon-LB and/or Edge-LB in your DC/OS cluster
 
 In order for a user to follow the examples successfully, their DC/OS cluster
 **MUST** have at least one
-[public agent](https://docs.mesosphere.com/1.11/overview/architecture/node-types/#public-agent-nodes)
+[public agent](/1.11/overview/architecture/node-types/#public-agent-nodes)
 (i.e. an agent that is on a network that allows ingress from outside the
 cluster). In the examples, `<ip-of-public-agent>` represents the IP address at
 which this public agent can be reached. The user  **MUST** also have access to

--- a/pages/services/kubernetes/1.2.0-1.10.5/install/index.md
+++ b/pages/services/kubernetes/1.2.0-1.10.5/install/index.md
@@ -51,11 +51,11 @@ where you will install your service.
 
 **Recommendation:** Store your custom configuration in source control.
 
-For more information on building the `options.json` file, see [DC/OS documentation](https://docs.mesosphere.com/1.11/deploying-services/config-universe-service/).
+For more information on building the `options.json` file, see [DC/OS documentation](/1.11/deploying-services/config-universe-service/).
 
 # Installing from the DC/OS Web Interface
 
-You can [install Kubernetes from the DC/OS web interface](https://docs.mesosphere.com/1.11/deploying-services/install/). If you install Kubernetes from the web interface, you must install the DC/OS Kubernetes CLI subcommands separately.
+You can [install Kubernetes from the DC/OS web interface](/1.11/deploying-services/install/). If you install Kubernetes from the web interface, you must install the DC/OS Kubernetes CLI subcommands separately.
 From the DC/OS CLI, enter:
 
 ```shell

--- a/pages/services/kubernetes/1.2.1-1.10.6/advanced-install/index.md
+++ b/pages/services/kubernetes/1.2.1-1.10.6/advanced-install/index.md
@@ -205,12 +205,12 @@ For this trust establishment to happen, one needs a [Public Key Infrastructure o
 In the past, this package supported TLS in full only when running atop DC/OS Enterprise because
 only this version provides the mechanisms needed for PKI:
 
-- [DC/OS CA](https://docs.mesosphere.com/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
+- [DC/OS CA](/1.11/security/ent/tls-ssl/) - a centralized certificate-authority
   (CA) for validating and, eventually, signing certificate signing requests (CSRs).
-- [DC/OS Secrets](https://docs.mesosphere.com/1.11/security/ent/secrets/) - a centralized and secure way
+- [DC/OS Secrets](/1.11/security/ent/secrets/) - a centralized and secure way
   to distribute TLS artifacts to package components, such as the Kubernetes components, and other
   applications living in the same DC/OS cluster.
-- [DC/OS Service Accounts](https://docs.mesosphere.com/1.11/security/ent/service-auth/) - needed for
+- [DC/OS Service Accounts](/1.11/security/ent/service-auth/) - needed for
   our package and applications to authenticate against the services named above.
 
 As you may have guessed by now, Open doesn't provide such functionality. So the question is how did we
@@ -221,11 +221,11 @@ implement TLS on Open DC/OS? The answer comes in the form of the diagram below:
 ### Leveraging Enterprise DC/OS PKI
 
 In order to fully leverage the DC/OS Enterprise PKI infrastructure when setting up TLS,
-a [service account](https://docs.mesosphere.com/1.11/security/ent/service-auth/)
+a [service account](/1.11/security/ent/service-auth/)
 with permissions to manage CA and secrets is required. It **must** be provisioned before installing
 the Kubernetes package.
 
-In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](https://docs.mesosphere.com/1.11/cli/enterprise-cli/). Then, run the following:
+In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/). Then, run the following:
 
 ```shell
 dcos security org service-accounts keypair private-key.pem public-key.pem
@@ -236,7 +236,7 @@ dcos security secrets create-sa-secret private-key.pem kubernetes kubernetes/sa
 dcos security org groups add_user superusers kubernetes
 ```
 
-Next, you need to [grant](https://docs.mesosphere.com/1.11/security/ent/perms-management/)
+Next, you need to [grant](/1.11/security/ent/perms-management/)
 the service account the correct permissions.
 
 The required permissions are:

--- a/pages/services/kubernetes/1.2.1-1.10.6/exposing-the-kubernetes-api/index.md
+++ b/pages/services/kubernetes/1.2.1-1.10.6/exposing-the-kubernetes-api/index.md
@@ -31,7 +31,7 @@ Alternately, if you are running Marathon-LB and/or Edge-LB in your DC/OS cluster
 
 In order for a user to follow the examples successfully, their DC/OS cluster
 **MUST** have at least one
-[public agent](https://docs.mesosphere.com/1.11/overview/architecture/node-types/#public-agent-nodes)
+[public agent](/1.11/overview/architecture/node-types/#public-agent-nodes)
 (i.e. an agent that is on a network that allows ingress from outside the
 cluster). In the examples, `<ip-of-public-agent>` represents the IP address at
 which this public agent can be reached. The user  **MUST** also have access to

--- a/pages/services/kubernetes/1.2.1-1.10.6/install/index.md
+++ b/pages/services/kubernetes/1.2.1-1.10.6/install/index.md
@@ -115,11 +115,11 @@ where you will install your service.
 
 **Recommendation:** Store your custom configuration in source control.
 
-For more information on building the `options.json` file, see [DC/OS documentation](https://docs.mesosphere.com/1.11/deploying-services/config-universe-service/).
+For more information on building the `options.json` file, see [DC/OS documentation](/1.11/deploying-services/config-universe-service/).
 
 # Installing from the DC/OS Web Interface
 
-You can [install Kubernetes from the DC/OS web interface](https://docs.mesosphere.com/1.11/deploying-services/install/). If you install Kubernetes from the web interface, you must install the DC/OS Kubernetes CLI subcommands separately.
+You can [install Kubernetes from the DC/OS web interface](/1.11/deploying-services/install/). If you install Kubernetes from the web interface, you must install the DC/OS Kubernetes CLI subcommands separately.
 From the DC/OS CLI, enter:
 
 ```shell

--- a/scripts/service-update-scripts/kubernetes-merge-branch.sh
+++ b/scripts/service-update-scripts/kubernetes-merge-branch.sh
@@ -2,7 +2,7 @@
 
 # sed needs different args to -i depending on the flavor of the tool that is installed
 sedi () {
-    sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
+    sed --version >/dev/null 2>&1 && sed -i "$@" || sed -i "" "$@"
 }
 
 echo "------------------------------"

--- a/scripts/service-update-scripts/kubernetes-merge-branch.sh
+++ b/scripts/service-update-scripts/kubernetes-merge-branch.sh
@@ -9,19 +9,10 @@ echo "------------------------------"
 echo " Merging Kubernetes"
 echo "------------------------------"
 
-# Get values for branch and directory variable
-
+# Get value for branch
 branch=$1
 if [ -z "$1" ]; then echo "Enter a branch as the first argument."; exit 1; fi
-directory=$2
-if [ -z "$2" ]; then echo "Enter a directory name as the second argument."; exit 1; fi
-
-# Create directory structure
-
-echo "Creating new directories"
-mkdir -p ./pages/services/kubernetes/$directory
-mkdir -p ./pages/services/kubernetes/$directory/img
-echo "New directories created: pages/services/kubernetes/$directory and pages/services/kubernetes/$directory/img"
+skip=$2
 
 # Move to the top level of the repo
 
@@ -36,51 +27,46 @@ git fetch dcos-kubernetes > /dev/null 2>&1
 # checkout
 git checkout dcos-kubernetes/$branch docs/package
 
-# checkout each file in the merge list from dcos-kubernetes/master
-for p in `find docs/package -type f`; do
-  echo $p
-  # markdown files only
-  if [ ${p: -3} == ".md" ]; then
-    # remove any dodgy control characters - sometimes copied in from commands
-    sedi -e 's/ *//g' $p
+# remove any user specified directories 
+if [ -n "$skip" ]; then 
+  echo "Skipping $skip"
+  for d in $(echo $skip | sedi "s/,/ /g"); do rm -rf docs/package/$d; done
+fi
 
-    # insert tag ( markdown files only )
-    awk -v n=2 '/---/ { if (++count == n) sub(/---/, "---\n\n<!-- This source repo for this topic is https://github.com/mesosphere/dcos-kubernetes -->\n"); } 1{print}' $p > tmp && mv tmp $p
-    # remove https://docs.mesosphere.com from links
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/1.9\//,"/1.9/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.10/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.11/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/latest\//,"/latest/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/service-docs\//,"/services/");}{print}' $p > tmp && mv tmp $p
+# always remove lates/ directory it will never be copied
+rm -rf docs/package/latest
 
-    # add full path for images
-    awk -v directory="$directory" '{gsub(/\(img/,"(/services/kubernetes/"directory"/img");}{print;}' $p > tmp && mv tmp $p
-    
-    # if it's not an index file, make a directory from the filename, rename file to "index.md"
-    if [ ${p: -8} != "index.md" ]; then
-      directory_from_filename=$p
-      tmp_val=$(echo "$directory_from_filename" | sed 's/...$//')
-      directory_from_filename=$tmp_val
-      mkdir -p $directory_from_filename
-      mv $p $directory_from_filename/index.md
+# checkout each file in the merge list from dcos-kubernetes/$branch
+for d in docs/package/*/; do
+  echo $d
+  for p in `find $d -type f`; do
+    echo $p
+    # markdown files only
+    if [ ${p: -3} == ".md" ]; then
+      # remove any dodgy control characters - sometimes copied in from commands
+      sedi -e 's/ *//g' $p
+
+      # remove https://docs.mesosphere.com from links
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.9\//,"/1.9/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.10/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.11\//,"/1.11/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.12\//,"/1.12/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/latest\//,"/latest/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/service-docs\//,"/services/");}{print}' $p > tmp && mv tmp $p
+
+      # add full path for images
+      awk -v directory=$(basename $d) '{gsub(/\([.][.]\/img/,"(/services/kubernetes/"directory"/img");}{print;}' $p > tmp && mv tmp $p  
     fi
-    
-  fi
-
+  done
 done
 
 # Fix up relative links after prettifying structure above
 sedi -e 's/](\(.*\)\.md)/](..\/\1)/' $(find docs/package/ -name '*.md')
 
-cp -r docs/package/* ./pages/services/kubernetes/$directory
+cp -r docs/package/* ./pages/services/kubernetes
 
 git rm -rf docs/
 rm -rf docs/
-
-# Add version information to latest index file
-
-sedi -e "s/^navigationTitle: .*$/navigationTitle: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
-sedi -e "s/^title: .*$/title: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
 
 # Update sort order of index files
 

--- a/scripts/service-update-scripts/kubernetes-merge.sh
+++ b/scripts/service-update-scripts/kubernetes-merge.sh
@@ -9,19 +9,10 @@ echo "------------------------------"
 echo " Merging Kubernetes"
 echo "------------------------------"
 
-# Get values for version and directory variable
-
-version=$1
+# Get values for version
+branch=$1
 if [ -z "$1" ]; then echo "Enter a version tag as the first argument."; exit 1; fi
-directory=$2
-if [ -z "$2" ]; then echo "Enter a directory name as the second argument."; exit 1; fi
-
-# Create directory structure
-
-echo "Creating new directories"
-mkdir -p ./pages/services/kubernetes/$directory
-mkdir -p ./pages/services/kubernetes/$directory/img
-echo "New directories created: pages/services/kubernetes/$directory and pages/services/kubernetes/$directory/img"
+skip=$2
 
 # Move to the top level of the repo
 
@@ -36,51 +27,46 @@ git fetch dcos-kubernetes > /dev/null 2>&1
 # checkout
 git checkout tags/$version docs/package
 
-# checkout each file in the merge list from dcos-kubernetes/master
-for p in `find docs/package -type f`; do
-  echo $p
-  # markdown files only
-  if [ ${p: -3} == ".md" ]; then
-    # remove any dodgy control characters - sometimes copied in from commands
-    sedi -e 's/ *//g' $p
+# remove any user specified directories 
+if [ -n "$skip" ]; then 
+  echo "Skipping $skip"
+  for d in $(echo $skip | sedi "s/,/ /g"); do rm -rf docs/package/$d; done
+fi
 
-    # insert tag ( markdown files only )
-    awk -v n=2 '/---/ { if (++count == n) sub(/---/, "---\n\n<!-- This source repo for this topic is https://github.com/mesosphere/dcos-kubernetes -->\n"); } 1{print}' $p > tmp && mv tmp $p
-    # remove https://docs.mesosphere.com from links
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/1.9\//,"/1.9/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.10/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.11/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/latest\//,"/latest/");}{print}' $p > tmp && mv tmp $p
-    awk '{gsub(/https:\/\/docs.mesosphere.com\/service-docs\//,"/services/");}{print}' $p > tmp && mv tmp $p
+# always remove lates/ directory it will never be copied
+rm -rf docs/package/latest
 
-    # add full path for images
-    awk -v directory="$directory" '{gsub(/\(img/,"(/services/kubernetes/"directory"/img");}{print;}' $p > tmp && mv tmp $p
-    
-    # if it's not an index file, make a directory from the filename, rename file to "index.md"
-    if [ ${p: -8} != "index.md" ]; then
-      directory_from_filename=$p
-      tmp_val=$(echo "$directory_from_filename" | sed 's/...$//')
-      directory_from_filename=$tmp_val
-      mkdir -p $directory_from_filename
-      mv $p $directory_from_filename/index.md
+# checkout each file in the merge list from dcos-kubernetes/$branch
+for d in docs/package/*/; do
+  echo $d
+  for p in `find $d -type f`; do
+    echo $p
+    # markdown files only
+    if [ ${p: -3} == ".md" ]; then
+      # remove any dodgy control characters - sometimes copied in from commands
+      sedi -e 's/ *//g' $p
+
+      # remove https://docs.mesosphere.com from links
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.9\//,"/1.9/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.10/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.11\//,"/1.11/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/1.12\//,"/1.12/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/latest\//,"/latest/");}{print}' $p > tmp && mv tmp $p
+      awk '{gsub(/https:\/\/docs.mesosphere.com\/service-docs\//,"/services/");}{print}' $p > tmp && mv tmp $p
+
+      # add full path for images
+      awk -v directory=$(basename $d) '{gsub(/\([.][.]\/img/,"(/services/kubernetes/"directory"/img");}{print;}' $p > tmp && mv tmp $p  
     fi
-    
-  fi
-
+  done
 done
 
 # Fix up relative links after prettifying structure above
 sedi -e 's/](\(.*\)\.md)/](..\/\1)/' $(find docs/package/ -name '*.md')
 
-cp -r docs/package/* ./pages/services/kubernetes/$directory
+cp -r docs/package/* ./pages/services/kubernetes
 
 git rm -rf docs/
 rm -rf docs/
-
-# Add version information to latest index file
-
-sedi -e "s/^navigationTitle: .*$/navigationTitle: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
-sedi -e "s/^title: .*$/title: Kubernetes $directory/g" ./pages/services/kubernetes/$directory/index.md
 
 # Update sort order of index files
 

--- a/scripts/service-update-scripts/kubernetes-merge.sh
+++ b/scripts/service-update-scripts/kubernetes-merge.sh
@@ -2,7 +2,7 @@
 
 # sed needs different args to -i depending on the flavor of the tool that is installed
 sedi () {
-    sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
+    sed --version >/dev/null 2>&1 && sed -i "$@" || sed -i "" "$@"
 }
 
 echo "------------------------------"


### PR DESCRIPTION
## Description
Changes for [docs layout proposal](https://docs.google.com/document/d/1IyD9rZOUgsSSG6O1f119tedJKyYqSgGGlbi1YQGydZc/edit)

PR https://github.com/mesosphere/dcos-kubernetes/pull/643 must be merged to support the new scripts.

- [x] Parameters are changed - [code](https://github.com/mesosphere/dcos-docs-site/commit/4c474661334aadff74f200879daf9f2157eabcc5#diff-c9fc6608bef18e3a98310bc4892a783fR30)
```
./scripts/service-update-scripts/kubernetes-merge-branch.sh $BRANCH [comma separated versions to skip when copying]
```
- [x] `awk https://docs.mesosphere.com` - [code](https://github.com/mesosphere/dcos-docs-site/commit/4c474661334aadff74f200879daf9f2157eabcc5#diff-c9fc6608bef18e3a98310bc4892a783fR52)
  - This looked like a bug?

Existing code - moved 1.10 to 1.11 references and was missing for 1.12
```
# remove https://docs.mesosphere.com from links
awk '{gsub(/https:\/\/docs.mesosphere.com\/1.9\//,"/1.9/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.10/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.11/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/latest\//,"/latest/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/service-docs\//,"/services/");}{print}' $p > tmp && mv tmp $p
```
Proposed code
```
# remove https://docs.mesosphere.com from links
awk '{gsub(/https:\/\/docs.mesosphere.com\/1.9\//,"/1.9/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/1.10\//,"/1.10/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/1.11\//,"/1.11/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/1.12\//,"/1.12/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/latest\//,"/latest/");}{print}' $p > tmp && mv tmp $p
awk '{gsub(/https:\/\/docs.mesosphere.com\/service-docs\//,"/services/");}{print}' $p > tmp && mv tmp $p
```

- [x] `sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"` seems to be incorrect
```
docker run -v $(pwd):/docs -v /Users/dkoshkin/.ssh:/root/.ssh -it mesosphere/dcos-kubernetes-ci bash

root@b897c546687c:/docs# ./scripts/service-update-scripts/kubernetes-merge-branch.sh release-1.x 2.0.0-1.10.6
------------------------------
 Merging Kubernetes
------------------------------
Creating new directories
New directories created: pages/services/kubernetes/2.0.0-1.10.6 and pages/services/kubernetes/2.0.0-1.10.6/img
Enter passphrase for key '/root/.ssh/id_rsa':
docs/package/uninstall.md
sed: -e expression #1, char 1: unknown command: `-'
sed: can't read : No such file or directory
```

After removing `--` the script runs without errors.

- [x] Other changes to support new structure
- [x] Commit to modify the docs to use relative links

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
