### PR TITLE
Added redirect for Apache Ignite documentation.

### DIFF
--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -26,6 +26,7 @@
 /assets/images/webui-universe-install.png /1.11/img/webui-universe-install.png;
 /getting-started/ /latest/overview/;
 /getting-started/dcosarchitecture/ /latest/overview/architecture/;
+/getting-started/datacenter/install/ /latest/installing/;
 /img/hdfs-service-gui.gif /services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/img/hdfs-service-gui.gif;
 /img/hdfs-service-gui.png /services/hdfs/v2.0.0-2.6.0-cdh5.11.0/img/hdfs-service-gui.png;
 /img/hdfs-service-gui2.gif /services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/img/hdfs-service-gui2.gif;


### PR DESCRIPTION
Added redirect for Apache Ignite documentation

`old link` -https://docs.mesosphere.com/getting-started/datacenter/install/
`new link` - https://docs.mesosphere.com/latest/installing/

## Urgency
- [ ] Blocker <!-- Ping @sascala, @stbof, or @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
