### PR TITLE
Update iam.yaml

### DIFF
--- a/pages/1.11/api/iam.yaml
+++ b/pages/1.11/api/iam.yaml
@@ -910,8 +910,8 @@ paths:
         - name: type
           in: query
           description: >
-            If set to `services`, list only service accounts. If unset,
-            default to only listing user accounts members of a group.
+            If set to `service`, list only service accounts. If unset, or set to
+            `services` default to only listing user accounts members of a group.
           type: string
       responses:
         200:
@@ -1138,7 +1138,7 @@ paths:
     get:
       summary: List all user or service accounts.
       description: >
-        By default, returns all `User` objects. Passing the `services` parameter 
+        By default, returns all `User` objects. Passing the `service` parameter 
         returns all service accounts. 
       tags:
         - users
@@ -1146,7 +1146,7 @@ paths:
         - name: type
           in: query
           description: >
-            If set to `services`, list only service accounts. If unset,
+            If set to `service`, list only service accounts. If unset or set to `services`,
             default to only listing user accounts.
           type: string
       produces:


### PR DESCRIPTION
When you run `curl -v -X GET -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H "Content-Type: application/json" -k 'https://<cluster-ip>/acs/api/v1/users?type=service'` you will get a list of service accounts. The API docs mentions the use of `services` to get this output. However, using this line with `services` instead of `service`:

`curl -v -X GET -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H "Content-Type: application/json" -k 'https://<cluster-ip>/acs/api/v1/users?type=services'` just outputs the user, or superuser.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
