### PR TITLE
Update iam.yaml

### DIFF
--- a/pages/1.12/api/iam.yaml
+++ b/pages/1.12/api/iam.yaml
@@ -910,7 +910,7 @@ paths:
         - name: type
           in: query
           description: >
-            If set to `services`, list only service accounts. If unset,
+            If set to `service`, list only service accounts. If unset or set to `services`,
             default to only listing user accounts members of a group.
           type: string
       responses:
@@ -1138,15 +1138,15 @@ paths:
     get:
       summary: List all user or service accounts.
       description: >
-        By default, returns all `User` objects. Passing the `services` parameter 
-        returns all service accounts. 
+        By default, returns all `User` objects. Passing the `service` parameter 
+        returns all service accounts. Passing the `services` parameter returns all user accounts.
       tags:
         - users
       parameters:
         - name: type
           in: query
           description: >
-            If set to `services`, list only service accounts. If unset,
+            If set to `service`, list only service accounts. If unset or set to `services`,
             default to only listing user accounts.
           type: string
       produces:


### PR DESCRIPTION
When you run curl -v -X GET -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H "Content-Type: application/json" -k 'https:///acs/api/v1/users?type=service' you will get a list of service accounts. The API docs mentions the use of services to get this output. However, using this line with services instead of service:

curl -v -X GET -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H "Content-Type: application/json" -k 'https:///acs/api/v1/users?type=services' just outputs the user, or superuser.

## Description
n/a

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [X] High
- [ ] Medium

## Requirements
- Test all commands and procedures. -> OK
- Change all affected versions : 1.12-dev
