### PR TITLE
ss/DCOS-40306 Pushed from DCOS-40326 updating link to spark walkthrou…

### DIFF
--- a/pages/services/spark/2.3.1-2.2.1-2/usage-examples/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/usage-examples/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
 navigationTitle: Usage Examples
-excerpt: Usage example
+excerpt: Usage examples
 title: Usage Examples
 menuWeight: 16
 featureMaturity:
@@ -29,8 +29,8 @@ Visit the Spark cluster dispatcher at `http://<dcos-url>/service/spark/` to view
 
 ## Advanced examples
 
-*   Run a Spark Streaming job with Kafka: Examples of Spark Streaming applications that connect to a secure Kafka cluster can be found at [spark-build](https://github.com/mesosphere/spark-build/blob/beta-2.1.1-2.2.0-2/tests/jobs/scala/src/main/scala/KafkaJobs.scala). As mentioned in the [Using Keberos-secured Kafka](/services/spark/2.3.1-2.2.1-2/kerberos/#using-kerberos-secured-kafka) section, Spark requires a JAAS file, the `krb5.conf`, and the keytab. An example of the JAAS file is: 
-        
+*   Run a Spark Streaming job with Kafka: Examples of Spark Streaming applications that connect to a secure Kafka cluster can be found at [spark-build](https://github.com/mesosphere/spark-build/blob/beta-2.1.1-2.2.0-2/tests/jobs/scala/src/main/scala/KafkaJobs.scala). As mentioned in the [Using Keberos-secured Kafka](/services/spark/2.3.1-2.2.1-2/kerberos/#using-kerberos-secured-kafka) section, Spark requires a JAAS file, the `krb5.conf`, and the keytab. An example of the JAAS file is:
+
         KafkaClient {
             com.sun.security.auth.module.Krb5LoginModule required
             useKeyTab=true
@@ -40,8 +40,8 @@ Visit the Spark cluster dispatcher at `http://<dcos-url>/service/spark/` to view
             serviceName="kafka"
             principal="client@LOCAL";
         };
-    
-    The corresponding `dcos spark` command would be: 
+
+    The corresponding `dcos spark` command would be:
 
         dcos spark run --submit-args="\
         --conf spark.mesos.containerizer=mesos \  # required for secrets
@@ -50,7 +50,7 @@ Visit the Spark cluster dispatcher at `http://<dcos-url>/service/spark/` to view
         --conf spark.mesos.driver.secret.filenames=kafka-client.keytab \
         --conf spark.mesos.executor.secret.names=spark/__dcos_base64___keytab \
         --conf spark.mesos.executor.secret.filenames=kafka-client.keytab \
-        --conf spark.mesos.task.labels=DCOS_SPACE:/spark \ 
+        --conf spark.mesos.task.labels=DCOS_SPACE:/spark \
         --conf spark.scheduler.minRegisteredResourcesRatio=1.0 \
         --conf spark.executorEnv.KRB5_CONFIG_BASE64=W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKCltyZWFsbXNdCiAgTE9DQUwgPSB7CiAgICBrZGMgPSBrZGMubWFyYXRob24uYXV0b2lwLmRjb3MudGhpc2Rjb3MuZGlyZWN0b3J5OjI1MDAKICB9Cg== \
         --conf spark.mesos.driverEnv.KRB5_CONFIG_BASE64=W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKCltyZWFsbXNdCiAgTE9DQUwgPSB7CiAgICBrZGMgPSBrZGMubWFyYXRob24uYXV0b2lwLmRjb3MudGhpc2Rjb3MuZGlyZWN0b3J5OjI1MDAKICB9Cg== \
@@ -58,4 +58,4 @@ Visit the Spark cluster dispatcher at `http://<dcos-url>/service/spark/` to view
 
 
 
-**Note:** There are additional walkthroughs available in the `docs/walkthroughs/` directory of Mesosphere's `spark-build` [repo](https://github.com/mesosphere/spark-build/docs/walkthroughs/)
+**Note:** There are additional walkthroughs available in the `docs/walkthroughs/` directory of Mesosphere's `spark-build` [repo](https://github.com/mesosphere/spark-build/tree/master/docs/walkthroughs).


### PR DESCRIPTION
…ghs.

## Description
https://jira.mesosphere.com/browse/DCOS-40306

Mike Jennings [12:50 PM]
https://docs.mesosphere.com/services/spark/2.3.1-2.2.1-2/usage-examples/
404 on the last link
https://github.com/mesosphere/spark-build/docs/walkthroughs/


## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Versions changed:

- [x] 2.3.1-2.2.1-2

- [x] 2.3.0-2.2.1-2
