### PR TITLE
ss/DCOS-25929 Corrected links between Limitations and Managing pages …

### DIFF
--- a/pages/services/dse/2.0.2-5.1.2/limitations/index.md
+++ b/pages/services/dse/2.0.2-5.1.2/limitations/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 A manual `nodetool removenode` call is currently required when replacing nodes. This is planned to be automated in a future release.
 
-Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](#managing), or build your own ruleset and automation to perform this operation automatically.
+Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](/services/dse/2.0.2-5.1.2/managing/), or build your own ruleset and automation to perform this operation automatically.
 
 ## Rack-aware replication
 

--- a/pages/services/dse/2.0.2-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.2-5.1.2/managing/index.md
@@ -19,7 +19,7 @@ After making a change, the scheduler will be restarted, and it will automaticall
 
 Nodes are configured with a "Readiness check" to ensure that the underlying service appears to be in a healthy state before continuing with applying a given change to the next node in the sequence. However, this basic check is not foolproof and reasonable care should be taken to ensure that a given configuration change will not negatively affect the behavior of the service.
 
-Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](#limitations).
+Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](/services/dse/2.0.2-5.1.2/limitations/).
 
 The instructions below describe how to update the configuration for a running DC/OS service.
 
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/) installed and available 
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/2.0.3-5.1.2/limitations/index.md
+++ b/pages/services/dse/2.0.3-5.1.2/limitations/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 A manual `nodetool removenode` call is currently required when replacing nodes. This is planned to be automated in a future release.
 
-Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](#managing), or build your own ruleset and automation to perform this operation automatically.
+Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](/services/dse/2.0.3-5.1.2/managing/), or build your own ruleset and automation to perform this operation automatically.
 
 ## Rack-aware replication
 

--- a/pages/services/dse/2.0.3-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.3-5.1.2/managing/index.md
@@ -19,7 +19,7 @@ After making a change, the scheduler will be restarted, and it will automaticall
 
 Nodes are configured with a "Readiness check" to ensure that the underlying service appears to be in a healthy state before continuing with applying a given change to the next node in the sequence. However, this basic check is not foolproof and reasonable care should be taken to ensure that a given configuration change will not negatively affect the behavior of the service.
 
-Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](#limitations).
+Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](/services/dse/2.0.3-5.1.2/limitations/).
 
 The instructions below describe how to update the configuration for a running DC/OS service.
 
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/) installed and available 
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/2.0.4-5.1.2/limitations/index.md
+++ b/pages/services/dse/2.0.4-5.1.2/limitations/index.md
@@ -21,7 +21,7 @@ enterprise: false
 
 A manual `nodetool removenode` call is currently required when replacing nodes. This is planned to be automated in a future release.
 
-Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](#managing), or build your own ruleset and automation to perform this operation automatically.
+Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](/services/dse/2.0.4-5.1.2/managing/), or build your own ruleset and automation to perform this operation automatically.
 
 ## Rack-aware replication
 

--- a/pages/services/dse/2.0.4-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.4-5.1.2/managing/index.md
@@ -19,7 +19,7 @@ After making a change, the scheduler will be restarted, and it will automaticall
 
 Nodes are configured with a "Readiness check" to ensure that the underlying service appears to be in a healthy state before continuing with applying a given change to the next node in the sequence. However, this basic check is not foolproof and reasonable care should be taken to ensure that a given configuration change will not negatively affect the behavior of the service.
 
-Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](#limitations).
+Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](/services/dse/2.0.4-5.1.2/limitations/).
 
 The instructions below describe how to update the configuration for a running DC/OS service.
 
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/) installed and available 
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/2.0.5-5.1.2/limitations/index.md
+++ b/pages/services/dse/2.0.5-5.1.2/limitations/index.md
@@ -21,7 +21,7 @@ enterprise: false
 
 A manual `nodetool removenode` call is currently required when replacing nodes. This is planned to be automated in a future release.
 
-Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](#managing), or build your own ruleset and automation to perform this operation automatically.
+Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](/services/dse/2.0.5-5.1.2/managing/), or build your own ruleset and automation to perform this operation automatically.
 
 ## Rack-aware replication
 

--- a/pages/services/dse/2.0.5-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.5-5.1.2/managing/index.md
@@ -19,7 +19,7 @@ After making a change, the scheduler will be restarted, and it will automaticall
 
 Nodes are configured with a "Readiness check" to ensure that the underlying service appears to be in a healthy state before continuing with applying a given change to the next node in the sequence. However, this basic check is not foolproof and reasonable care should be taken to ensure that a given configuration change will not negatively affect the behavior of the service.
 
-Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](#limitations).
+Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](/services/dse/2.0.5-5.1.2/limitations/).
 
 The instructions below describe how to update the configuration for a running DC/OS service.
 
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/) installed and available 
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.

--- a/pages/services/dse/v2.0.0-5.1.2/limitations/index.md
+++ b/pages/services/dse/v2.0.0-5.1.2/limitations/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 A manual `nodetool removenode` call is currently required when replacing nodes. This is planned to be automated in a future release.
 
-Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](#managing), or build your own ruleset and automation to perform this operation automatically.
+Nodes are not automatically replaced by the service in the event a system goes down. You may either manually replace nodes as described under [Managing](/services/dse/v2.0.0-5.1.2/managing/), or build your own ruleset and automation to perform this operation automatically.
 
 ## Rack-aware replication
 

--- a/pages/services/dse/v2.0.0-5.1.2/managing/index.md
+++ b/pages/services/dse/v2.0.0-5.1.2/managing/index.md
@@ -19,7 +19,7 @@ After making a change, the scheduler will be restarted, and it will automaticall
 
 Nodes are configured with a "Readiness check" to ensure that the underlying service appears to be in a healthy state before continuing with applying a given change to the next node in the sequence. However, this basic check is not foolproof and reasonable care should be taken to ensure that a given configuration change will not negatively affect the behavior of the service.
 
-Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](#limitations).
+Some changes, such as decreasing the number of nodes or changing volume requirements, are not supported after initial deployment. See [Limitations](/services/dse/v2.0.0-5.1.2/limitations/).
 
 The instructions below describe how to update the configuration for a running DC/OS service.
 
@@ -31,7 +31,7 @@ Enterprise DC/OS 1.10 introduces a convenient command line option that allows fo
 
 + Enterprise DC/OS 1.10 or newer
 + Service with a version greater than 2.0.0-x
-+ [The DC/OS CLI](/1.10/cli/install/) installed and available 
++ [The DC/OS CLI](/1.10/cli/install/) installed and available
 + The service's subcommand available and installed on your local machine
   + You can install just the subcommand CLI by running `dcos package install --cli datastax-dse`.
   + If you are running an older version of the subcommand CLI that doesn't have the `update` command, uninstall and reinstall your CLI.


### PR DESCRIPTION
…for each version below 2.1.0.

## Description
https://jira.mesosphere.com/browse/DCOS-25929
URL: http://docs2-staging.mesosphere.com/services/dse/v2.0.0-5.1.2/limitations/
Description:

Malformed link 

http://docs2-staging.mesosphere.com/services/dse/v2.0.0-5.1.2/limitations/#managing

Should be

http://docs2-staging.mesosphere.com/services/dse/v2.0.0-5.1.2/managing
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Correct link is (/services/dse/<version>/managing/). Also fixed malformed link from Managing to Limitations: (/services/dse/<version>/limitations/)

Fixed versions:

- [x] 2.0.0-5.1.2
- [x] 2.0.2-5.1.2
- [x] 2.0.3-5.1.2
- [x] 2.0.4-5.1.2
- [x] 2.0.5-5.1.2