### PR TITLE
ss/DCOS-40529 Fixing menuweight in Edge-LB docs.

### DIFF
--- a/pages/services/edge-lb/index.md
+++ b/pages/services/edge-lb/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Edge-LB
 title: Edge-LB
-menuWeight: 1
+menuWeight: 30
 excerpt: Edge-LB proxies and load balances traffic to all services that run on DC/OS.
 
 enterprise: false


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-40529

Fixing order of service docs.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected menuweight value of Edge-LB docs.