### PR TITLE
Remove stale documentation from local universe deployment

### DIFF
--- a/pages/1.10/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.10/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -284,10 +284,6 @@ interface.
     sudo make DCOS_VERSION=1.10 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-4.  Perform all of the steps as described in [Deploying a local Universe containing Certified Universe packages][5], except step 27. Replace the command in step 27 with the following.
-
-    ```bash
-    dcos package repo add local-universe http://master.mesos:8082/repo
-    ```
+4.  Perform all of the steps as described in [Deploying a local Universe containing Certified Universe packages][5].
 
  [5]: #certified

--- a/pages/1.11/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.11/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -281,10 +281,6 @@ interface.
     sudo make DCOS_VERSION=1.10 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-4.  Perform all of the steps as described in [Deploying a local Universe containing Certified Universe packages][5], except step 27. Replace the command in step 27 with the following.
-
-    ```bash
-    dcos package repo add local-universe http://master.mesos:8082/repo
-    ```
+4.  Perform all of the steps as described in [Deploying a local Universe containing Certified Universe packages][5].
 
  [5]: #certified

--- a/pages/1.12/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.12/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -281,10 +281,6 @@ interface.
     sudo make DCOS_VERSION=1.10 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-4.  Perform all of the steps as described in [Deploying a local Universe containing Certified Universe packages][5], except step 27. Replace the command in step 27 with the following.
-
-    ```bash
-    dcos package repo add local-universe http://master.mesos:8082/repo
-    ```
+4.  Perform all of the steps as described in [Deploying a local Universe containing Certified Universe packages][5].
 
  [5]: #certified

--- a/pages/1.7/administration/installing/ent/custom/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.7/administration/installing/ent/custom/deploying-a-local-dcos-universe/index.md
@@ -104,10 +104,7 @@ To install your own set of packages you must build a customized local Universe D
         
         sudo make local-universe
 
-5.  Perform steps from 2 to 7 of [Installing the default Universe packages][5] section exept of the 6th one. Run the following command instead:
-
-        dcos package repo add local-universe-1.7 http://master.mesos:8082/repo-1.7
-        dcos package repo add local-universe http://master.mesos:8082/repo
+5.  Perform steps from 2 to 7 of [Installing the default Universe packages][5] section.
 
  [1]: https://downloads.mesosphere.com/universe/public/local-universe.tar.gz
  [2]: https://raw.githubusercontent.com/mesosphere/universe/version-3.x/docker/local-universe/dcos-local-universe-http.service

--- a/pages/1.9/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.9/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -273,11 +273,7 @@ interface.
     sudo make DCOS_VERSION=1.9 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-4.  Perform all of the steps as described in [Installing the default Universe packages][5] section, except step 27. Replace the command in step 27 with the following.
-
-    ```bash
-    dcos package repo add local-universe http://master.mesos:8082/repo
-    ```
+4.  Perform all of the steps as described in [Installing the default Universe packages][5].
 
  [1]: https://downloads.mesosphere.com/universe/public/local-universe.tar.gz
  [2]: https://raw.githubusercontent.com/mesosphere/universe/version-3.x/local/dcos-local-universe-http.service


### PR DESCRIPTION
## Description
[DCOS-38551](https://jira.mesosphere.com/browse/DCOS-38551)
- The instructions are referring to a step 27 that is supposed to be different from what they instruct, but it is the same command copied over again. Hence I removed the phrasing `.... except step 27. Replace the command in step 27 with the following.......`
- 1.8 already looks good so I did not touch those files.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
