### PR TITLE
ss/DCOS-40444 Removing phrase about not working in disabled mode from…

### DIFF
--- a/pages/services/edge-lb/1.0/installing/index.md
+++ b/pages/services/edge-lb/1.0/installing/index.md
@@ -17,7 +17,7 @@ To configure a service account and install the Edge-LB package, use the instruct
 - You have access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
 
 **Limitations**
-- Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/latest/security/ent/#security-modes). It does not work in disabled mode.
+- Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/latest/security/ent/#security-modes). 
 
 # Add Edge-LB package repositories
 The Edge-LB package comprises two components:

--- a/pages/services/edge-lb/1.1/installing/index.md
+++ b/pages/services/edge-lb/1.1/installing/index.md
@@ -17,7 +17,7 @@ To configure a service account and install the Edge-LB package, use the instruct
 - You have access to [the remote Edge-LB repositories](https://support.mesosphere.com/hc/en-us/articles/213198586).
 
 **Limitations**
-- Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/latest/security/ent/#security-modes). It does not work in disabled mode.
+- Currently, Edge-LB works only with DC/OS Enterprise in permissive mode on DC/OS 1.10, and permissive or strict mode on DC/OS 1.11 [security mode](/latest/security/ent/#security-modes). 
 
 # Add Edge-LB package repositories
 The Edge-LB package comprises two components:


### PR DESCRIPTION
… install pages.

## Description
https://jira.mesosphere.com/browse/DCOS-40444
On this page: https://docs.mesosphere.com/services/edge-lb/1.1/installing/, in the "Limitations" section, remove this phrase:

"It does not work in disabled mode."
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

Removed phrase from 1.0 and 1.1 versions. Seth states that there shouldn't be any customers on 0.1 so don't bother updating.