### PR TITLE
ss/DCOS-40671 Replacing /installing/oss/ links with correct links.

### DIFF
--- a/pages/1.11/administering-clusters/add-a-node/index.md
+++ b/pages/1.11/administering-clusters/add-a-node/index.md
@@ -11,18 +11,18 @@ enterprise: false
 
 
 
-Agent nodes are designated as [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) during installation. By default, they are designated as private during [GUI][1] or [CLI][2] installation.
+Agent nodes are designated as [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) during installation. By default, they are designated as private during the GUI or CLI [installation](/1.11/installing/evaluation/cloud-installation/) method.
 
 ### Prerequisites:
 
-*   DC/OS is installed using the [custom](/1.11/installing/oss/custom/) installation method.
-*   The archived DC/OS installer file (`dcos-install.tar`) from your [installation](/1.11/installing/oss/custom/gui/#backup).
-*   Available agent nodes that satisfy the [system requirements](/1.11/installing/oss/custom/system-requirements/).
+*   DC/OS is installed using the [custom](/1.11/installing/production/deploying-dcos/installation/) installation method.
+*   The archived DC/OS installer file (`dcos-install.tar`) from your [installation](/1.11/installing/evaluation/cloud-installation/#backup).
+*   Available agent nodes that satisfy the [system requirements](/1.11/installing/production/system-requirements/).
 *   The CLI JSON processor [jq](https://github.com/stedolan/jq/wiki/Installation).
 *   SSH installed and configured. This is required for accessing nodes in the DC/OS cluster.
 
 ### Install DC/OS agent nodes
-Copy the archived DC/OS installer file (`dcos-install.tar`) to the agent node. This archive is created during the GUI or CLI [installation](/1.11/installing/oss/custom/gui/#backup) method.
+Copy the archived DC/OS installer file (`dcos-install.tar`) to the agent node. This archive is created during the GUI or CLI [installation](/1.11/installing/evaluation/cloud-installation/) method.
 
 1.  Copy the files to your agent node. For example, you can use Secure Copy (scp) to copy `dcos-install.tar` to your home directory:
 
@@ -76,5 +76,4 @@ Copy the archived DC/OS installer file (`dcos-install.tar`) to the agent node. T
         dcos node --json | jq --raw-output '.[] | select(.reserved_resources.slave_public != null) | .id' | wc -l
         ```
 
- [1]: /1.11/installing/oss/custom/gui/
- [2]: /1.11/installing/oss/custom/cli/
+

--- a/pages/1.11/administering-clusters/convert-agent-type/index.md
+++ b/pages/1.11/administering-clusters/convert-agent-type/index.md
@@ -8,18 +8,13 @@ excerpt: Learn to convert agent nodes to public or private agent nodes.
 enterprise: false
 ---
 
-<!-- The source repo for this topic is https://github.com/dcos/dcos-docs -->
-
-
-You can convert agent nodes to public or private for an existing DC/OS cluster.
-
-Agent nodes are designated as [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) during installation. By default, they are designated as private during [GUI][1] or [CLI][2] installation.
+You can convert agent nodes to public or private for an existing DC/OS cluster. Agent nodes are designated as [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) during installation. By default, they are designated as private during [installation](1.11/installing/evaluation/cloud-installation/).
 
 ### Prerequisites:
 These steps must be performed on a machine that is configured as a DC/OS node. Any tasks that are running on the node will be terminated during this conversion process.
 
-*   DC/OS is installed using the [custom](/1.11/installing/oss/custom/) installation method and you have deployed at least one [master](/1.11/overview/concepts/#master) and one [private](/1.11/overview/concepts/#private-agent-node) agent node.
-*   The archived DC/OS installer file (`dcos-install.tar`) from your [installation](/1.11/installing/oss/custom/gui/#backup).     
+*   DC/OS is installed using the [custom](/1.11/installing/production/deploying-dcos/installation/) installation method and you have deployed at least one [master](/1.11/overview/concepts/#master) and one [private](/1.11/overview/concepts/#private-agent-node) agent node.
+*   The archived DC/OS installer file (`dcos-install.tar`) from your [installation](/1.11/installing/production/deploying-dcos/installation/).     
 *   The CLI JSON processor [jq](https://github.com/stedolan/jq/wiki/Installation).
 *   SSH installed and configured. This is required for accessing nodes in the DC/OS cluster.
 
@@ -62,7 +57,7 @@ You can determine the node type by running this command from the DC/OS CLI.
     ```
 
 ### Install DC/OS and convert agent node
-Copy the archived DC/OS installer file (`dcos-install.tar`) to the node that that is being converted. This archive is created during the GUI or CLI [installation](/1.11/installing/oss/custom/gui/#backup) method.
+Copy the archived DC/OS installer file (`dcos-install.tar`) to the node that that is being converted. This archive is created during the GUI or CLI [installation](/1.11/installing/evaluation/cloud-installation/) method.
 
 1.  Copy the files to your agent node. For example, you can use Secure Copy (scp) to copy `dcos-install.tar` to your home directory:
 
@@ -102,5 +97,3 @@ Copy the archived DC/OS installer file (`dcos-install.tar`) to the node that tha
     sudo bash /opt/dcos_install_tmp/dcos_install.sh slave_public
     ```
 
- [1]: /1.11/installing/oss/custom/gui/
- [2]: /1.11/installing/oss/custom/cli/

--- a/pages/1.11/administering-clusters/managing-aws/index.md
+++ b/pages/1.11/administering-clusters/managing-aws/index.md
@@ -3,11 +3,10 @@ layout: layout.pug
 navigationTitle:  Managing AWS
 title: Managing AWS
 menuWeight: 9
-excerpt: Learn to scale your AWS cluster or change the number of agent nodes.
+excerpt: Learn to scale your AWS cluster or change the number of agent nodes
 enterprise: false
 ---
 
-<!-- The source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 You can scale your AWS cluster or change the number of agent nodes.
 
@@ -19,16 +18,14 @@ The DC/OS AWS CloudFormation template is optimized to run DC/OS, but you might w
 
 To change the number of agent nodes with AWS:
 
-1.  From [AWS CloudFormation Management][3] page, select your DC/OS cluster and click **Update Stack**.
+1.  From the [AWS CloudFormation Management][3] page, select your DC/OS cluster and click **Update Stack**.
 2.  Click through to the **Specify Parameters** page, and you can specify new values for the **PublicSlaveInstanceCount** and **SlaveInstanceCount**.
 3.  On the **Options** page, accept the defaults and click **Next**. **Tip:** You can choose whether to rollback on failure. By default this option is set to **Yes**.
 4.  On the **Review** page, check the acknowledgement box and then click **Create**.
 
 Your new machines will take a few minutes to initialize; you can watch them in the EC2 console. The DC/OS web interface will update as soon as the new nodes register.
 
-<!-- ## Upgrading
 
-See the upgrade [documentation](/1.11/installing/oss/cloud/aws/upgrading/). -->
 
- [2]: /1.11/installing/oss/cloud/aws/
+
  [3]: https://console.aws.amazon.com/cloudformation/home

--- a/pages/1.11/administering-clusters/recovering-agent-disk-space/index.md
+++ b/pages/1.11/administering-clusters/recovering-agent-disk-space/index.md
@@ -7,12 +7,11 @@ excerpt: Learn to recover space on an agent node volume.
 enterprise: false
 ---
 
-<!-- The source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 If tasks fill up the reserved volume of an agent node, there are a few options to recover space:
 
 - Check each component's healthiness and restart each component.
 
-- If the work directory is on a separate volume (as recommended in [Agent nodes](/1.11/installing/oss/custom/system-requirements/#agent-nodes)), then you can empty this volume and restart the agent.
+- If the work directory is on a separate volume (as recommended in [Agent nodes](/1.11/installing/production/system-requirements/#agent-nodes)), then you can empty this volume and restart the agent.
 
 If neither of these approaches work, you may need to re-image the node.

--- a/pages/1.11/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.11/administering-clusters/securing-your-cluster/index.md
@@ -88,4 +88,4 @@ Authenticated users are authorized to perform arbitrary actions in their
 cluster. That is, there is currently no fine-grained access control in DC/OS
 besides having access or not having access to services.
 
-See the [Security Administrator's Guide](/1.11/security/) for more information.
+See the [Security section](/1.11/security/) for more information.

--- a/pages/1.11/deploying-jobs/examples/index.md
+++ b/pages/1.11/deploying-jobs/examples/index.md
@@ -12,7 +12,7 @@ These examples provide common usage scenarios for jobs.
 
 **Prerequisite:**
 
-- [DC/OS](/1.11/installing/oss/) and the [DC/OS CLI installed](/1.11/cli/install/).
+- [DC/OS](/1.11/installing/) and the [DC/OS CLI installed](/1.11/cli/install/).
 
 # <a name="create-job"></a>Creating a Simple Job
 

--- a/pages/1.11/deploying-services/creating-services/deploy-docker-app/index.md
+++ b/pages/1.11/deploying-services/creating-services/deploy-docker-app/index.md
@@ -138,7 +138,7 @@ In this tutorial, you create a custom Docker image and deploy it to DC/OS.
     /hello-nginx   64  0.1    1/1    N/A       ---      False      MESOS    N/A
     ```
 
-1.  If you used the [AWS CloudFormation templates](/1.11/installing/oss/cloud/aws/) to expose the app to the port specified in your app definition (e.g. port 80), you must reconfigure the health check on the public ELB.
+1.  If you used the [AWS CloudFormation templates](/1.11/installing/evaluation/cloud-installation/aws/) to expose the app to the port specified in your app definition (e.g. port 80), you must reconfigure the health check on the public ELB.
     1. In CloudFormation, check the checkbox next to your stack.
     2. Click the **Resources** tab.
     3. Search for **PublicSlaveLoadBalancer**.
@@ -158,5 +158,5 @@ Learn how to load balance your app on a public node using [Marathon-LB](/1.11/ne
 
  [1]: https://www.docker.com
  [2]: https://hub.docker.com
- [3]: /1.11/installing/oss/
+ [3]: /1.11/installing/evaluation/cloud-installation/aws/
  [4]: /1.11/cli/install/

--- a/pages/1.11/deploying-services/expose-service/index.md
+++ b/pages/1.11/deploying-services/expose-service/index.md
@@ -9,13 +9,13 @@ enterprise: false
 ---
 
 
-DC/OS agent nodes can be designated as [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) during [installation](/1.11/installing/oss/). Public agent nodes provide access from outside of the cluster via infrastructure networking to your DC/OS services. By default, services are launched on private agent nodes and are not accessible from outside the cluster.
+DC/OS agent nodes can be designated as [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) during [installation](/1.11/installing/). Public agent nodes provide access from outside of the cluster via infrastructure networking to your DC/OS services. By default, services are launched on private agent nodes and are not accessible from outside the cluster.
 
 To launch a service on a public node, you must create a Marathon app definition with the `"acceptedResourceRoles":["slave_public"]` parameter specified and configure an edge load balancer and service discovery mechanism.
 
 **Prerequisites:**
 
-* DC/OS is [installed](/1.11/installing/oss/)
+* DC/OS is [installed](/1.11/installing/)
 * DC/OS CLI is [installed](/1.11/cli/install/)
 
 1.  Create a Marathon app definition with the required `"acceptedResourceRoles":["slave_public"]` parameter specified. For example:
@@ -59,7 +59,7 @@ To launch a service on a public node, you must create a Marathon app definition 
 
     If this is added successfully, there is no output.
 
-     **Tip:** You can also add your app by using the **Services** tab of DC/OS [GUI](/1.11/gui/services/).
+     **Note:** You can also add your app by using the **Services** tab of DC/OS [GUI](/1.11/gui/services/).
 
 1.  Verify that the app is added with this command:
 
@@ -74,11 +74,11 @@ To launch a service on a public node, you must create a Marathon app definition 
     /myApp   64  0.1    0/1    ---      scale       DOCKER   None
     ```
 
-    **Tip:** You can also view deployed apps by using the **Services** tab of DC/OS [GUI](/1.11/gui/services/).
+    **Note:** You can also view deployed apps by using the **Services** tab of DC/OS [GUI](/1.11/gui/services/).
 
 1.  Configure an edge load balancer and service discovery mechanism.
 
-    - AWS users: If you installed DC/OS by using the [AWS CloudFormation templates](/1.11/installing/oss/cloud/aws/), an ELB is included. However, you must reconfigure the health check on the public ELB to expose the app to the port specified in your app definition (e.g. port 80).
+    - AWS users: If you installed DC/OS by using the [AWS CloudFormation templates](/1.11/installing/evaluation/cloud-installation/aws/), an ELB is included. However, you must reconfigure the health check on the public ELB to expose the app to the port specified in your app definition (e.g. port 80).
     - All other users: You can use [Marathon-LB](/1.11/networking/marathon-lb/), a rapid proxy and load balancer that is based on HAProxy.
 
 1.  Go to your public agent to see the site running and to find your public agent IP. Type it into your browser.

--- a/pages/1.11/deploying-services/faq/index.md
+++ b/pages/1.11/deploying-services/faq/index.md
@@ -39,7 +39,7 @@ A comprehensive overview of a few common service discovery implementations is av
 
 ## Is it possible to span my cluster over different cloud providers?
 
-This is not currently supported. For more information, see [this document](/1.11/installing/oss/high-availability/).
+This is not currently supported. For more information, see [this document](/1.11/installing/production/advanced-configuration/configuring-zones-regions/).
 
 ## How can I upload files to Spark driver/executor?
 

--- a/pages/1.11/deploying-services/gpu/index.md
+++ b/pages/1.11/deploying-services/gpu/index.md
@@ -20,18 +20,18 @@ GPUs must be enabled during DC/OS installation. Follow the instructions below to
 ## Custom DC/OS Installation with GPUs
 
 1.  Install the [NVIDIA Management Library (NVML)](https://developer.nvidia.com/nvidia-management-library-nvml) on each node of your cluster that has GPUs. The minimum required NVIDIA driver version is 340.29. For detailed installation instructions, see the [Mesos GPU support documentation](http://mesos.apache.org/documentation/latest/gpu-support/#external-dependencies).
-1.  Install DC/OS using the [custom advanced installation instructions](/1.11/installing/oss/custom/advanced/). Here are the GPU-specific configuration parameters:
+1.  Install DC/OS using the [custom advanced installation instructions](/1.11/installing/production/deploying-dcos/installation/). Here are the GPU-specific configuration parameters:
 
     -  **enable_gpu_isolation**: Indicates whether to enable GPU support in DC/OS. By default, this is set to `enable_gpu_isolation: 'true'`.
     -  **gpus_are_scarce**: Indicates whether to treat GPUs as a scarce resource in the cluster. By default, this is set to `gpus_are_scarce: 'true'`, which means DC/OS reserves GPU nodes exclusively for services that are configured to consume GPU resources. It's important to note that this setting will influence which agent nodes a GPU-aware framework will be deployed on DC/OS. This setting does not influence the individual tasks which the frameworks might launch while the framework is running. It is possible for a framework to schedule a non-GPU task on an agent node where GPU's are present.
 
-    For more information, see the [configuration parameter documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/#enable-gpu-isolation) and Mesos [Nvidia GPU Support documentation](http://mesos.apache.org/documentation/latest/gpu-support/#external-dependencies).
+    For more information, see the [configuration parameter documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#enable-gpu-isolation) and Mesos [Nvidia GPU Support documentation](http://mesos.apache.org/documentation/latest/gpu-support/#external-dependencies).
 
 ## AWS EC2 DC/OS Installation with GPUs
 
 ###  Prerequisites
-- The AWS DC/OS advanced template [system requirements](/1.11/installing/oss/cloud/aws/advanced/).
-- The `zen.sh` script copied to your local machine. The script and instructions are [here](/1.11/installing/oss/cloud/aws/advanced/).
+- The AWS DC/OS advanced template [system requirements](1.11/installing/evaluation/cloud-installation/aws/advanced/).
+- The `zen.sh` script copied to your local machine. The script and instructions are [here](/1.11/installing/evaluation/cloud-installation/aws/advanced/).
 
 ### Create Dependencies
 
@@ -43,7 +43,7 @@ GPUs must be enabled during DC/OS installation. Follow the instructions below to
 
    **Important:** You must run the `zen.sh` script before performing the next steps.
 
-1. Follow the instructions [here](/1.11/installing/oss/cloud/aws/advanced/) to create a cluster with advanced AWS templates, using the following GPU-specific configuration.
+1. Follow the instructions [here](1.11/installing/evaluation/cloud-installation/aws/advanced/) to create a cluster with advanced AWS templates, using the following GPU-specific configuration.
 
 1. On the **Create Stack** > **Specify Details** page, specify your stack information and click **Next**. Here are the GPU-specific settings.
 

--- a/pages/1.11/deploying-services/pods/examples/index.md
+++ b/pages/1.11/deploying-services/pods/examples/index.md
@@ -551,7 +551,7 @@ For an example of a pod that uses a persistent volume, see [Create a pod with a 
 
 ## IP-per-Pod Networking
 
-The following pod definition specifies a virtual (user) network named `dcos`. The `networks:mode:container` field creates the virtual network. The `name` field is optional. If you have installed DC/OS using [our AWS templates](/1.11/installing/oss/cloud/aws/), the default virtual network name is `dcos`. <!-- Validated by suzanne 6-23-17 -->
+The following pod definition specifies a virtual (user) network named `dcos`. The `networks:mode:container` field creates the virtual network. The `name` field is optional. If you have installed DC/OS using [our AWS templates](/1.11/installing/evaluation/cloud-installation/aws/), the default virtual network name is `dcos`. <!-- Validated by suzanne 6-23-17 -->
 
 ```json
 {

--- a/pages/1.11/deploying-services/pods/quickstart/index.md
+++ b/pages/1.11/deploying-services/pods/quickstart/index.md
@@ -9,7 +9,7 @@ enterprise: false
 
 
 ### Prerequisites
-- DC/OS [installed](/1.11/installing/oss/)
+- DC/OS [installed](/1.11/installing/)
 - DC/OS CLI [installed](/1.11/cli/install/)
 
 # Launching a pod from the DC/OS CLI

--- a/pages/1.11/deploying-services/pods/technical-overview/index.md
+++ b/pages/1.11/deploying-services/pods/technical-overview/index.md
@@ -21,7 +21,7 @@ You configure a pod via a pod definition, which is similar to a Marathon applica
 # Networking
 Marathon pods only support the [DC/OS Universal container runtime](/1.11/deploying-services/containerizers/), which supports multiple image formats, including Docker.
 
-The Universal container runtime simplifies networking by allowing the containers of each pod instance to share a network namespace and communicate over a VLAN or private network. If you specify a container network without a name in a pod definition, it will be assigned to the default network. If you have installed DC/OS using [AWS templates](/1.11/installing/oss/cloud/aws/), the default network is `dcos`.
+The Universal container runtime simplifies networking by allowing the containers of each pod instance to share a network namespace and communicate over a VLAN or private network. If you specify a container network without a name in a pod definition, it will be assigned to the default network. If you have installed DC/OS using [AWS templates](/1.11/installing/evaluation/cloud-installation/aws/), the default network is `dcos`.
 
 If other applications need to communicate with your pod, specify an endpoint in your pod definition. Other applications will communicate with your pod by addressing those endpoints. See [the Examples section](/1.11/deploying-services/pods/examples/) for more information.
 

--- a/pages/1.11/monitoring/logging/access-component-logs/index.md
+++ b/pages/1.11/monitoring/logging/access-component-logs/index.md
@@ -18,7 +18,7 @@ Here is the [permission](/1.11/security/ent/perms-reference/) that is required t
 
 **Prerequisites:**
 
-- DC/OS and DC/OS CLI are [installed](/1.11/installing/oss/) and you are logged in as a superuser.
+- DC/OS and DC/OS CLI are [installed](/1.11/installing/) and you are logged in as a superuser.
 
 # Via the DC/OS GUI
 

--- a/pages/1.11/monitoring/logging/access-task-logs/index.md
+++ b/pages/1.11/monitoring/logging/access-task-logs/index.md
@@ -32,7 +32,7 @@ Here is an overview of the [permissions](/1.11/security/ent/perms-reference/) th
 
 **Prerequisites:**
 
-- DC/OS and DC/OS CLI are [installed](/1.11/installing/oss/) and you are logged in as a superuser.
+- DC/OS and DC/OS CLI are [installed](/1.11/installing/) and you are logged in as a superuser.
 
 # Via the DC/OS GUI
 

--- a/pages/1.11/monitoring/logging/logging-api-examples/index.md
+++ b/pages/1.11/monitoring/logging/logging-api-examples/index.md
@@ -18,7 +18,7 @@ Here are some common usage examples for the Logging API.
 - [Bash](https://www.gnu.org/software/bash/)
 - [Curl](https://curl.haxx.se/)
 - [jq](https://stedolan.github.io/jq/)
-- [DC/OS](/1.11/installing/oss/)
+- [DC/OS](/1.11/installing/)
 - [DC/OS CLI](/1.11/cli/) must be installed, configured, and logged in.
 - Extract `DCOS_URL` and `DCOS_AUTH_TOKEN` from the DC/OS CLI:
 

--- a/pages/1.11/monitoring/logging/quickstart/index.md
+++ b/pages/1.11/monitoring/logging/quickstart/index.md
@@ -12,7 +12,7 @@ Use this guide to get started with DC/OS logging.
 
 **Prerequisites:**
 
-- You must have DC/OS and the DC/OS CLI [installed](/1.11/installing/oss/).
+- You must have DC/OS and the DC/OS CLI [installed](/1.11/installing/).
 - You must be logged in as as a superuser or have been granted user access to logging. For more information, see [Accessing system and component logs](/1.11/monitoring/logging/access-component-logs/) and [Accessing task logs](/1.11/monitoring/logging/access-task-logs/).
 
 # Deploy a sample app

--- a/pages/1.11/networking/DNS/mesos-dns/service-naming/index.md
+++ b/pages/1.11/networking/DNS/mesos-dns/service-naming/index.md
@@ -237,7 +237,7 @@ If a service launches multiple tasks with the same name, the DNS lookup will ret
 
 You can get a comprehensive list of the apps running on your DC/OS cluster nodes.
 
-**Prerequisites:** [DC/OS and DC/OS CLI](/1.11/installing/oss/) are installed.
+**Prerequisites:** [DC/OS and DC/OS CLI](/1.11/installing/) are installed.
 
 1.  SSH into your node. For example, use this CLI command to SSH to your master:
 

--- a/pages/1.11/networking/DNS/mesos-dns/troubleshooting/index.md
+++ b/pages/1.11/networking/DNS/mesos-dns/troubleshooting/index.md
@@ -29,7 +29,7 @@ Check that port 53 and port 8123 are available and not in use by other processes
 
 # How do I configure my DC/OS cluster to communicate with external hosts and services?
 
-For DNS requests for hostnames or services outside the DC/OS cluster, Mesos-DNS will query an external nameserver. By default, Google's nameserver with IP address 8.8.8.8 will be used. If you need to configure a custom external name server, use the [`resolvers` parameter][1] when you first install DC/OS.
+For DNS requests for hostnames or services outside the DC/OS cluster, Mesos-DNS will query an external nameserver. By default, Google's nameserver with IP address 8.8.8.8 will be used. If you need to configure a custom external name server, use the [`resolvers` parameter](/1.11/installing/production/advanced-configuration/configuration-reference/) when you first install DC/OS.
 
 **Important:** External nameservers can only be set when you install DC/OS. They cannot be changed after installation.
 
@@ -41,4 +41,3 @@ If you try to connect to `master.mesos` using HTTP, you will be automatically re
 
 However, if you try to query or connect to `master.mesos` using any method other than HTTP, the results will be unpredictable because the name will resolve to a random master node. For example, a service that attempts to register with `master.mesos` may communicate with a non-leading master node and will be unable to register as a service on the cluster.
 
- [1]: /1.11/installing/oss/custom/configuration/configuration-parameters/

--- a/pages/1.11/networking/load-balancing-vips/index.md
+++ b/pages/1.11/networking/load-balancing-vips/index.md
@@ -30,7 +30,7 @@ When you launch a set of tasks, DC/OS distributes them to a set of nodes in the 
 
 -  Do not firewall traffic between the nodes (allow all TCP/UDP).
 -  Do not change the default value of `net.ipv4.ip_local_port_range` sysctl parameter. It should be in the range of 32768 to 60999.
--  You must use a supported [operating system](/1.11/installing/oss/custom/system-requirements/).
+-  You must use a supported [operating system](/1.11/installing/production/system-requirements/).
 
 #### Persistent Connections
 Keep long-running persistent connections, otherwise, you can quickly fill up the TCP socket table. The default local port range on Linux allows source connections from 32768 to 61000. This allows 28232 connections to be established between a given source IP and a destination address and port pair. TCP connections must go through the time wait state prior to being reclaimed. The Linux kernel's default TCP time wait period is 120 seconds. Without persistent connections, you would exhaust the connection table by only making 235 new connections per second.

--- a/pages/1.11/overview/architecture/components/index.md
+++ b/pages/1.11/overview/architecture/components/index.md
@@ -105,7 +105,7 @@ DC/OS provides a way to view and operate a large number of individual machine-le
 <p>
   <strong>See Also:</strong>
   <ul>
-    <li><a href="/1.11/installing/oss/">Documentation</a></li>
+    <li><a href="/1.11/installing/">Documentation</a></li>
     <li><a href="https://github.com/dcos/dcos">Source</a></li>
   </ul>
 </p>
@@ -387,7 +387,7 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
 <div data-role="collapsible">
 <h2 id="dcos-signal">DC/OS Signal</h2>
 <div>
-<p><strong>Description:</strong> The DC/OS Signal service reports cluster telemetry and analytics to help improve DC/OS. Administrators can <a href="/1.11/installing/oss/opt-out/#telemetry">opt-out of telemetry</a> at install time.</p>
+<p><strong>Description:</strong> The DC/OS Signal service reports cluster telemetry and analytics to help improve DC/OS. Administrators can <a href="/1.11/installing/production/deploying-dcos/opt-out/#telemetry">opt-out of telemetry</a> at install time.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>

--- a/pages/1.11/overview/concepts/index.md
+++ b/pages/1.11/overview/concepts/index.md
@@ -102,10 +102,10 @@ A bootstrap machine is the machine on which the DC/OS installer artifacts are co
 
 - The bootstrap machine is not technically considered part of the cluster since it does not have DC/OS installed on it (this may change in the future). For most installation methods, the bootstrap node must be accessible to and from the machines in the cluster via infrastructure networking.
 - The bootstrap machine is sometimes used as a jumpbox to control SSH access into other nodes in the cluster for added security and logging.
-- One method of allowing master nodes to change IPs involves running ZooKeeper with Exhibitor on the bootstrap machine. Other alternatives include using S3, DNS, or static IPs, with various tradeoffs. For more information, see [configuring the exhibitor storage backend](/1.11/installing/oss/custom/configuration/configuration-parameters/#exhibitor-storage-backend).
+- One method of allowing master nodes to change IPs involves running ZooKeeper with Exhibitor on the bootstrap machine. Other alternatives include using S3, DNS, or static IPs, with various tradeoffs. For more information, see [configuring the exhibitor storage backend](/1.11/installing/production/advanced-configuration/configuration-reference/#exhibitor-storage-backend).
 - If a bootstrap machine is not required for managing master node IP changes or as an SSH jumpbox, it can be shut down after bootstrapping and spun up on demand to [add new nodes](/1.11/administering-clusters/add-a-node/) to the cluster.
 
-For more information, see the [system requirements](/1.11/installing/oss/custom/system-requirements/#bootstrap-node).
+For more information, see the [system requirements](/1.11/installing/production/system-requirements/#bootstrap-node).
 
 # <a name="dcos-service"></a>Service
 
@@ -227,7 +227,7 @@ The [Universal Container Runtime](#mesos-containerizer-universal-container-runti
 
 A cloud template is an infrastructure-specific method of declaratively describing a DC/OS cluster.
 
-For more information, see [Cloud Installation Options](/1.11/installing/oss/cloud/).
+For more information, see [Cloud Installation Options](/1.11/installing/evaluation/cloud-installation/).
 
 
 # <a name="mesos-concepts"></a>Mesos Concepts

--- a/pages/1.11/overview/high-availability/index.md
+++ b/pages/1.11/overview/high-availability/index.md
@@ -35,7 +35,7 @@ Fault domain isolation is an important part of building HA systems. To correctly
  * Physical domains: this includes machine, rack, datacenter, region, and availability zone.
  * Network domains: machines within the same network may be subject to network partitions. For example, a shared network switch may fail or have invalid configuration.
 
-With DC/OS, you can distribute masters across racks for HA. Agents can be distributed across regions, and it is recommended that you tag agents with attributes to describe their location. Synchronous services like ZooKeeper should also remain within the same region to reduce network latency. For more information, see the Configuring High Availability [documentation](/1.11/installing/oss/high-availability/).
+With DC/OS, you can distribute masters across racks for HA. Agents can be distributed across regions, and it is recommended that you tag agents with attributes to describe their location. Synchronous services like ZooKeeper should also remain within the same region to reduce network latency. For more information, see the Configuring High Availability [documentation](/1.11/installing/production/advanced-configuration/configuring-zones-regions/).
 
 Applications which require HA should be distributed across fault domains. Marathon can  accomplish this by using the [`UNIQUE`  and `GROUP_BY` constraints operator](https://mesosphere.github.io/marathon/docs/constraints.html).
 

--- a/pages/1.11/overview/telemetry/index.md
+++ b/pages/1.11/overview/telemetry/index.md
@@ -288,4 +288,4 @@ The DC/OS UI sends two types of notifications to [Segment](https://segment.com/d
 
 ## Opt-Out
 
-You can also choose to opt out of the telemetry features. For more information, see the [documentation](/1.11/installing/oss/opt-out/).
+You can also choose to opt out of the telemetry features. For more information, see the [documentation](/1.11/installing/production/deploying-dcos/opt-out/).

--- a/pages/1.11/release-notes/1.11.0/index.md
+++ b/pages/1.11/release-notes/1.11.0/index.md
@@ -47,7 +47,7 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 - Edge-LB 1.0. [View the documentation](https://docs.mesosphere.com/services/edge-lb/1.0/) [enterprise type="inline" size="small" /]
 - IPv6 is now supported for Docker containers.
 - Performance improvements to the DC/OS network stack - All networking components (minuteman, navstar, spartan) are aggregated into a single systemd unit called `dcos-net`. Please read this [note](/1.11/networking/#a-note-on-software-re-architecture) to learn more about the re-factoring of the network stack.
-- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/#dns-forward-zones) to understand its usage.
+- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#dns-forward-zones) to understand its usage.
 
 [enterprise]
 ### Security

--- a/pages/1.11/release-notes/1.11.1/index.md
+++ b/pages/1.11/release-notes/1.11.1/index.md
@@ -88,7 +88,7 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 - Edge-LB 1.0. [View the documentation](https://docs.mesosphere.com/services/edge-lb/1.0/) [enterprise type="inline" size="small" /]
 - IPv6 is now supported for Docker containers.
 - Performance improvements to the DC/OS network stack - All networking components (minuteman, navstar, spartan) are aggregated into a single systemd unit called `dcos-net`. Please read this [note](/1.11/networking/#a-note-on-software-re-architecture) to learn more about the re-factoring of the network stack.
-- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/#dns-forward-zones) to understand its usage.
+- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#dns-forward-zones) to understand its usage.
 
 [enterprise]
 ### Security

--- a/pages/1.11/release-notes/1.11.2/index.md
+++ b/pages/1.11/release-notes/1.11.2/index.md
@@ -81,7 +81,7 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 - Edge-LB 1.0. [View the documentation](https://docs.mesosphere.com/services/edge-lb/1.0/). [enterprise type="inline" size="small" /]
 - IPv6 is now supported for Docker containers.
 - Performance improvements to the DC/OS network stack - All networking components (minuteman, navstar, spartan) are aggregated into a single systemd unit called `dcos-net`.  Read this [note](/1.11/networking/#a-note-on-software-re-architecture) to learn more about the re-factoring of the network stack.
-- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/#dns-forward-zones) to understand its usage.
+- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#dns-forward-zones) to understand its usage.
 
 [enterprise]
 ### Security

--- a/pages/1.11/release-notes/1.11.3/index.md
+++ b/pages/1.11/release-notes/1.11.3/index.md
@@ -68,7 +68,7 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 - Edge-LB 1.0. [View the documentation](https://docs.mesosphere.com/services/edge-lb/1.0/). [enterprise type="inline" size="small" /]
 - IPv6 is now supported for Docker containers.
 - Performance improvements to the DC/OS network stack - All networking components (minuteman, navstar, spartan) are aggregated into a single systemd unit called `dcos-net`.  Read this [note](/1.11/networking/#a-note-on-software-re-architecture) to learn more about the re-factoring of the network stack.
-- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/#dns-forward-zones) to understand its usage.
+- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#dns-forward-zones) to understand its usage.
 
 [enterprise]
 ### Security

--- a/pages/1.11/release-notes/1.11.4/index.md
+++ b/pages/1.11/release-notes/1.11.4/index.md
@@ -81,7 +81,7 @@ Provide feedback on the new features and services at: [support.mesosphere.com](h
 - Edge-LB 1.0. [View the documentation](https://docs.mesosphere.com/services/edge-lb/1.0/). [enterprise type="inline" size="small" /]
 - IPv6 is now supported for Docker containers.
 - Performance improvements to the DC/OS network stack - All networking components (minuteman, navstar, spartan) are aggregated into a single systemd unit called `dcos-net`.  Read this [note](/1.11/networking/#a-note-on-software-re-architecture) to learn more about the re-factoring of the network stack.
-- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/#dns-forward-zones) to understand its usage.
+- The configuration parameter `dns_forward_zones` now takes a list of objects instead of nested lists ([DCOS_OSS-1733](https://jira.mesosphere.com/browse/DCOS_OSS-1733)). [View the documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#dns-forward-zones) to understand its usage.
 
 [enterprise]
 ### Security

--- a/pages/1.11/security/oss/add-user-script/index.md
+++ b/pages/1.11/security/oss/add-user-script/index.md
@@ -11,7 +11,7 @@ You can add users to your DC/OS cluster from a terminal by using the `dcos_add_u
 
 **Prerequisites:**
 
-- DC/OS is [installed](/1.11/installing/oss/)
+- DC/OS is [installed](/1.11/installing/)
 
 
 1.  [SSH](/1.11/administering-clusters/sshcluster/) to a master node and run this command, where `<email>` is the user's email:

--- a/pages/1.11/security/oss/managing-authentication/index.md
+++ b/pages/1.11/security/oss/managing-authentication/index.md
@@ -115,16 +115,16 @@ sudo journalctl -u dcos-oauth.service
 
 ## Authentication opt-out
 
-If you are doing an [advanced installation](/1.11/installing/oss/custom/advanced/), you can opt out of
-Auth0-based authentication by adding this parameter to your configuration file (`genconf/config.yaml`). For more information, see the configuration [documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/).
+If you are doing an [advanced installation](/1.11/installing/production/deploying-dcos/installation/), you can opt out of
+Auth0-based authentication by adding this parameter to your configuration file (`genconf/config.yaml`). For more information, see the configuration [documentation](/1.11/installing/production/advanced-configuration/configuration-reference/).
 
 ```yaml
 oauth_enabled: 'false'
 ```
 
-If you are doing a cloud installation on [AWS](/1.11/installing/oss/cloud/aws/), you can set the `OAuthEnabled` option to `false` on the **Specify Details** step to disable authentication.
+If you are doing a cloud installation on [AWS](1.11/installing/evaluation/cloud-installation/aws/), you can set the `OAuthEnabled` option to `false` on the **Specify Details** step to disable authentication.
 
-If you are doing a cloud installation on [Azure](/1.11/installing/oss/cloud/azure/), you currently cannot disable authentication. This will be added in a future release along with other
+If you are doing a cloud installation on [Azure](/1.11/installing/evaluation/cloud-installation/azure/), you currently cannot disable authentication. This will be added in a future release along with other
 options to customize authentication.
 
 Note that if you’ve already installed your cluster and would like to disable this in-place, you can go through an upgrade with the same parameter set.

--- a/pages/1.11/tutorials/iot_pipeline/index.md
+++ b/pages/1.11/tutorials/iot_pipeline/index.md
@@ -47,7 +47,7 @@ The following graphic illustrates the data flow:
 
 ## Prerequisites
 
-*  [DC/OS](/1.10/installing/oss/) or [DC/OS Enterprise](/1.10/installing/ent/) installed with at least 5 [private agents][6] and 1 [public agent][6].
+*  [DC/OS](/1.10/installing/) or [DC/OS Enterprise](/1.10/installing/ent/) installed with at least 5 [private agents][6] and 1 [public agent][6].
 
     **Tip** If you are running this tutorial using a DC/OS Enterprise cluster, you will want to make sure [security mode](/1.10/installing/ent/custom/configuration/configuration-parameters/#security-enterprise) is set to permissive or strict. DC/OS installs in permissive security mode by default.
 

--- a/pages/1.11/tutorials/stateful-services/index.md
+++ b/pages/1.11/tutorials/stateful-services/index.md
@@ -149,6 +149,6 @@ dcos marathon app remove postgres
 For further information on stateful services in DC/OS, visit the [Storage section of the documentation](/1.11/storage/).
 
 
-[1]: /1.11/installing/oss/
+[1]: /1.11/installing/
 [2]: /1.11/cli/install/
 [4]: postgres.marathon.json


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-40671
Remove/fix all references to /installing/ent/ or /installing/oss/ remaining in 1.11 docs.

Although the redirects page will take users to the correct page when they click on these outdated links, it is a good practice to make sure the correct links are in our own documents on our own site. There is no need to do anything to the redirect pages.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrections made ONLY to 1.11 docs.