### PR TITLE
DCOS-38576: Fixes to old janitor documentation

### DIFF
--- a/pages/1.10/deploying-services/uninstall/index.md
+++ b/pages/1.10/deploying-services/uninstall/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 
 
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources that were unable to be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
+Services can be uninstalled from the CLI. If a Universe service has any reserved resources that could not be be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
 # Uninstalling Universe services
 
@@ -30,17 +30,19 @@ dcos package uninstall chronos
 
 ## Web interface
 
-From the DC/OS web interface you can uninstall services from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
+You can uninstall services from the DC/OS web interface from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
 1.  Navigate to the [**Services**](/1.10/gui/services/) tab in the DC/OS web interface.
 1.  Select your service, click the vertical ellipsis at the far right, and select **Delete**.
 
     ![Destroy app](/1.10/img/service-delete.png)
+    Figure 1. Delete service
+
 1.  Copy and run the displayed command.
 
 ## Troubleshooting
 
-It's possible for an uninstall to fail with the following error message:
+It is possible for an uninstall to fail with the following error message:
 
 ```
 Incomplete uninstall of package [chronos] due to Mesos unavailability
@@ -74,7 +76,7 @@ For more information, see the [command reference](/1.10/cli/command-reference/dc
 
 ### Web interface
 
-From the DC/OS web interface you can uninstall services from the **Services**. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
+You can uninstall services from the DC/OS web interface, from the **Services**. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
 ### Services tab
 
@@ -86,7 +88,7 @@ From the DC/OS web interface you can uninstall services from the **Services**. T
 
 ### About the cleanup
 
-If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed unintall.** The package's documentation may have its own additional information in an "Uninstall" section.
+If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner Docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed uninstall.** The package's documentation may have its own additional information in an "Uninstall" section.
 
 There are two ways to run the framework cleaner script. The preferred method is via the DC/OS CLI. If the CLI is unavailable, you can also run the image as a self-deleting Marathon task.
 
@@ -103,7 +105,7 @@ The command would be run as follows:
 docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name>
 ```
 
-Users of strict-mode clusters will need to provide additional arguments providing credentials to perform the cleanup:
+If you have a strict-mode cluster, you must provide additional arguments providing credentials to perform the cleanup:
 * `-a`: Token to be used for authentication
 * `--username` and `--password`: Username and password to be used for authentication
 
@@ -145,7 +147,7 @@ From the DC/OS [**Services**](/1.10/gui/) tab, use the JSON editor to add the fo
       }
     }
 
-When the framework cleaner has completed its work, it will automatically remove itself from Marathon to ensure that it's only run once. This removal will often result in a `TASK_KILLED` or even a `TASK_FAILED` outcome for the janitor task, even if it finished successfully. The janitor task will also quickly disappear from both the Services and Dashboard tab.
+When the framework cleaner has completed its work, it will automatically remove itself from Marathon to ensure that it only runs once. This removal will often result in a `TASK_KILLED` or even a `TASK_FAILED` outcome for the janitor task, even if it finished successfully. The janitor task will also quickly disappear from both the Services and Dashboard tab.
 
 ### Verifying the outcome
 
@@ -163,7 +165,7 @@ To view the script's outcome, go to Mesos (`http://your-cluster.com/mesos`) and 
 
 ### Sample result
 
-Here's an example of the output for a successful run for a sample installation:
+Here is an example of the output for a successful run for a sample installation:
 
     your-machine$ dcos node ssh --master-proxy --leader
 

--- a/pages/1.10/deploying-services/uninstall/index.md
+++ b/pages/1.10/deploying-services/uninstall/index.md
@@ -37,7 +37,7 @@ You can uninstall services from the DC/OS web interface from the **Services** ta
 
     ![Destroy app](/1.10/img/service-delete.png)
     
-    Figure 1. Delete service
+    Figure 1. Delete Services
 
 1.  Copy and run the displayed command.
 

--- a/pages/1.10/deploying-services/uninstall/index.md
+++ b/pages/1.10/deploying-services/uninstall/index.md
@@ -3,15 +3,14 @@ layout: layout.pug
 navigationTitle:  Uninstalling Services
 title: Uninstalling Services
 menuWeight: 7
-excerpt:
+excerpt: Uninstalling DC/OS services from the CLI
 
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources, you also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
+Services can be uninstalled from the CLI. If a Universe service has any reserved resources that were unable to be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
 # Uninstalling Universe services
 
@@ -83,11 +82,11 @@ From the DC/OS web interface you can uninstall services from the **Services**. T
 2.  Click on the **Installed** tab to see your installed services.
 3.  Hover your cursor over the name of the package you wish to uninstall and you will see a red "Uninstall" link to the right. Click this link to uninstall the package.
 
-## <a name="framework-cleaner"></a>Cleaning up ZooKeeper
+## <a name="framework-cleaner"></a>Cleaning up Resources and ZooKeeper
 
-### About Cleaning up ZooKeeper
+### About the cleanup
 
-If your service has reserved resources, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it.
+If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed unintall.** The package's documentation may have its own additional information in an "Uninstall" section.
 
 There are two ways to run the framework cleaner script. The preferred method is via the DC/OS CLI. If the CLI is unavailable, you can also run the image as a self-deleting Marathon task.
 
@@ -96,34 +95,23 @@ There are two ways to run the framework cleaner script. The preferred method is 
 The script takes the following flags:
 
 * `-r`: The role of the resources to be deleted
-* `-p`: The principal of the resources to be deleted
 * `-z`: The configuration zookeeper node to be deleted
 
-These are some examples of default configurations (these will vary depending on selected task name, etc):
+The command would be run as follows:
 
-* Cassandra default:
+```bash
+docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name>
+```
 
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r cassandra-role -p cassandra-principal -z dcos-service-cassandra
-  ```
+Users of strict-mode clusters will need to provide additional arguments providing credentials to perform the cleanup:
+* `-a`: Token to be used for authentication
+* `--username` and `--password`: Username and password to be used for authentication
 
-* HDFS default:
+For example, the command could be run with an auth token included as follows:
 
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r hdfs-role -p hdfs-principal -z dcos-service-hdfs
-  ```
-
-* Kafka default:
-
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r kafka-role -p kafka-principal -z dcos-service-kafka
-  ```
-
-* Custom values:
-
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r <custom_role> -p <custom_principal> -z dcos-service-<custom_service_name>
-  ```
+```bash
+docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name> -a <content of "dcos config show core.dcos_acs_token">
+```
 
 ### Running from the DC/OS CLI
 
@@ -133,17 +121,17 @@ Connect to the leader and start the script:
 
         your-machine$ dcos node ssh --master-proxy --leader
 
-1. Run the `mesosphere/janitor` image with the role, principal, and zookeeper nodes that were configured for your service:
+1. Run the `mesosphere/janitor` image with the role and zookeeper node that were configured for your service, along with an auth token if on a strict mode cluster:
 
-        docker run mesosphere/janitor /janitor.py -r sample-role -p sample-principal -z sample-zk
+        docker run mesosphere/janitor /janitor.py -r sample-role -z sample-zk [-a auth-token]
 
 ### Running from Marathon
 
-From the DC/OS [**Services**](/1.10/gui/) tab, use the JSON editor to add the following as a Marathon task. Replace the values passed to `-r`/`-p`/`-z` according to what needs to be cleaned up.
+From the DC/OS [**Services**](/1.10/gui/) tab, use the JSON editor to add the following as a Marathon task. Replace the values passed to `-r`/`-z` according to what needs to be cleaned up.
 
     {
       "id": "janitor",
-      "cmd": "/janitor.py -r sample-role -p sample-principal -z sample",
+      "cmd": "/janitor.py -r sample-role -z dcos-service-sample",
       "cpus": 1,
       "mem": 128,
       "disk": 1,
@@ -175,39 +163,39 @@ To view the script's outcome, go to Mesos (`http://your-cluster.com/mesos`) and 
 
 ### Sample result
 
-Here's an example of the output for a successful run for a Cassandra installation:
+Here's an example of the output for a successful run for a sample installation:
 
     your-machine$ dcos node ssh --master-proxy --leader
 
-    leader-node$ docker run mesosphere/janitor /janitor.py -r cassandra_role -p cassandra_principal -z cassandra
+    leader-node$ docker run mesosphere/janitor /janitor.py -r sample_role -z dcos-service-sample
     [... docker download ...]
-    Master: http://leader.mesos:5050/master/ Exhibitor: http://leader.mesos:8181/ Role: cassandra_role Principal: cassandra_principal ZK Path: cassandra
+    Master: http://leader.mesos:5050/master/ Exhibitor: http://leader.mesos:8181/ Role: sample_role ZK Path: sample
 
     Destroying volumes...
     Mesos version: 0.28.1 => 28
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
     200
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
     200
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S3
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S2
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
     200
-    No reserved resources for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
+    No reserved resources for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
 
     Unreserving resources...
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
     200
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
     200
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S3
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S2
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
     200
-    No reserved resources for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
+    No reserved resources for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
 
     Deleting zk node...
-    Successfully deleted znode 'cassandra' (code=200), if znode existed.
+    Successfully deleted znode 'dcos-service-sample' (code=200), if znode existed.
     Cleanup completed successfully.
 
 If you run the script via Marathon, you will also see the following output:

--- a/pages/1.10/deploying-services/uninstall/index.md
+++ b/pages/1.10/deploying-services/uninstall/index.md
@@ -36,6 +36,7 @@ You can uninstall services from the DC/OS web interface from the **Services** ta
 1.  Select your service, click the vertical ellipsis at the far right, and select **Delete**.
 
     ![Destroy app](/1.10/img/service-delete.png)
+    
     Figure 1. Delete service
 
 1.  Copy and run the displayed command.

--- a/pages/1.11/deploying-services/uninstall/index.md
+++ b/pages/1.11/deploying-services/uninstall/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 
 
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources that were unable to be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
+Services can be uninstalled from the CLI. If a Universe service has any reserved resources that could not be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
 # Uninstalling Universe services
 
@@ -30,17 +30,20 @@ dcos package uninstall chronos
 
 ## Web interface
 
-From the DC/OS web interface you can uninstall services from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
+You can uninstall services from the DC/OS web interface, from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
 1.  Navigate to the [**Services**](/1.11/gui/services/) tab in the DC/OS web interface.
 1.  Select your service, click the vertical ellipsis at the far right, and select **Delete**.
 
     ![Destroy app](/1.11/img/service-delete.png)
+    
+    Figure 1. Delete Services
+    
 1.  Copy and run the displayed command.
 
 ## Troubleshooting
 
-It's possible for an uninstall to fail with the following error message:
+It is possible for an uninstall to fail with the following error message:
 
 ```
 Incomplete uninstall of package [chronos] due to Mesos unavailability
@@ -74,19 +77,19 @@ For more information, see the [command reference](/1.11/cli/command-reference/#d
 
 ### Web interface
 
-From the DC/OS web interface you can uninstall services from the **Services**. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
+You can uninstall services from the DC/OS web interface, from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
 ### Services tab
 
 1.  Navigate to the [**Services**](/1.11/gui/services/) tab in the DC/OS web interface.
 2.  Click on the **Installed** tab to see your installed services.
-3.  Hover your cursor over the name of the package you wish to uninstall and you will see a red "Uninstall" link to the right. Click this link to uninstall the package.
+3.  Hover your cursor over the name of the package you wish to uninstall; you will see a red "Uninstall" link to the right. Click this link to uninstall the package.
 
 ## <a name="framework-cleaner"></a>Cleaning up Resources and ZooKeeper
 
 ### About the cleanup
 
-If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed unintall.** The package's documentation may have its own additional information in an "Uninstall" section.
+If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed uninstall.** The package's documentation may have its own additional information in an "Uninstall" section.
 
 There are two ways to run the framework cleaner script. The preferred method is via the DC/OS CLI. If the CLI is unavailable, you can also run the image as a self-deleting Marathon task.
 
@@ -103,7 +106,7 @@ The command would be run as follows:
 docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name>
 ```
 
-Users of strict-mode clusters will need to provide additional arguments providing credentials to perform the cleanup:
+If you are using a strict-mode cluster, you must provide additional arguments providing credentials to perform the cleanup:
 * `-a`: Token to be used for authentication
 * `--username` and `--password`: Username and password to be used for authentication
 
@@ -145,7 +148,7 @@ From the DC/OS [**Services**](/1.11/gui/) tab, use the JSON editor to add the fo
       }
     }
 
-When the framework cleaner has completed its work, it will automatically remove itself from Marathon to ensure that it's only run once. This removal will often result in a `TASK_KILLED` or even a `TASK_FAILED` outcome for the janitor task, even if it finished successfully. The janitor task will also quickly disappear from both the Services and Dashboard tab.
+When the framework cleaner has completed its work, it will automatically remove itself from Marathon to ensure that it only runs once. This removal will often result in a `TASK_KILLED` or even a `TASK_FAILED` outcome for the janitor task, even if it finished successfully. The janitor task will also quickly disappear from both the Services and Dashboard tab.
 
 ### Verifying the outcome
 
@@ -163,7 +166,7 @@ To view the script's outcome, go to Mesos (`http://your-cluster.com/mesos`) and 
 
 ### Sample result
 
-Here's an example of the output for a successful run for a sample installation:
+Here is an example of the output for a successful run for a sample installation:
 
     your-machine$ dcos node ssh --master-proxy --leader
 

--- a/pages/1.11/deploying-services/uninstall/index.md
+++ b/pages/1.11/deploying-services/uninstall/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 
 
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources, you also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
+Services can be uninstalled from the CLI. If a Universe service has any reserved resources that were unable to be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
 # Uninstalling Universe services
 
@@ -82,11 +82,11 @@ From the DC/OS web interface you can uninstall services from the **Services**. T
 2.  Click on the **Installed** tab to see your installed services.
 3.  Hover your cursor over the name of the package you wish to uninstall and you will see a red "Uninstall" link to the right. Click this link to uninstall the package.
 
-## <a name="framework-cleaner"></a>Cleaning up ZooKeeper
+## <a name="framework-cleaner"></a>Cleaning up Resources and ZooKeeper
 
-### About Cleaning up ZooKeeper
+### About the cleanup
 
-If your service has reserved resources, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it.
+If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed unintall.** The package's documentation may have its own additional information in an "Uninstall" section.
 
 There are two ways to run the framework cleaner script. The preferred method is via the DC/OS CLI. If the CLI is unavailable, you can also run the image as a self-deleting Marathon task.
 
@@ -95,34 +95,23 @@ There are two ways to run the framework cleaner script. The preferred method is 
 The script takes the following flags:
 
 * `-r`: The role of the resources to be deleted
-* `-p`: The principal of the resources to be deleted
 * `-z`: The configuration zookeeper node to be deleted
 
-These are some examples of default configurations (these will vary depending on selected task name, etc):
+The command would be run as follows:
 
-* Cassandra default:
+```bash
+docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name>
+```
 
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r cassandra-role -p cassandra-principal -z dcos-service-cassandra
-  ```
+Users of strict-mode clusters will need to provide additional arguments providing credentials to perform the cleanup:
+* `-a`: Token to be used for authentication
+* `--username` and `--password`: Username and password to be used for authentication
 
-* HDFS default:
+For example, the command could be run with an auth token included as follows:
 
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r hdfs-role -p hdfs-principal -z dcos-service-hdfs
-  ```
-
-* Kafka default:
-
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r kafka-role -p kafka-principal -z dcos-service-kafka
-  ```
-
-* Custom values:
-
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r <custom_role> -p <custom_principal> -z dcos-service-<custom_service_name>
-  ```
+```bash
+docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name> -a <content of "dcos config show core.dcos_acs_token">
+```
 
 ### Running from the DC/OS CLI
 
@@ -132,17 +121,17 @@ Connect to the leader and start the script:
 
         your-machine$ dcos node ssh --master-proxy --leader
 
-1. Run the `mesosphere/janitor` image with the role, principal, and zookeeper nodes that were configured for your service:
+1. Run the `mesosphere/janitor` image with the role and zookeeper node that were configured for your service, along with an auth token if on a strict mode cluster:
 
-        docker run mesosphere/janitor /janitor.py -r sample-role -p sample-principal -z sample-zk
+        docker run mesosphere/janitor /janitor.py -r sample-role -z sample-zk [-a auth-token]
 
 ### Running from Marathon
 
-From the DC/OS [**Services**](/1.11/gui/) tab, use the JSON editor to add the following as a Marathon task. Replace the values passed to `-r`/`-p`/`-z` according to what needs to be cleaned up.
+From the DC/OS [**Services**](/1.11/gui/) tab, use the JSON editor to add the following as a Marathon task. Replace the values passed to `-r`/`-z` according to what needs to be cleaned up.
 
     {
       "id": "janitor",
-      "cmd": "/janitor.py -r sample-role -p sample-principal -z sample",
+      "cmd": "/janitor.py -r sample-role -z dcos-service-sample",
       "cpus": 1,
       "mem": 128,
       "disk": 1,
@@ -174,39 +163,39 @@ To view the script's outcome, go to Mesos (`http://your-cluster.com/mesos`) and 
 
 ### Sample result
 
-Here's an example of the output for a successful run for a Cassandra installation:
+Here's an example of the output for a successful run for a sample installation:
 
     your-machine$ dcos node ssh --master-proxy --leader
 
-    leader-node$ docker run mesosphere/janitor /janitor.py -r cassandra_role -p cassandra_principal -z cassandra
+    leader-node$ docker run mesosphere/janitor /janitor.py -r sample_role -z dcos-service-sample
     [... docker download ...]
-    Master: http://leader.mesos:5050/master/ Exhibitor: http://leader.mesos:8181/ Role: cassandra_role Principal: cassandra_principal ZK Path: cassandra
+    Master: http://leader.mesos:5050/master/ Exhibitor: http://leader.mesos:8181/ Role: sample_role ZK Path: sample
 
     Destroying volumes...
     Mesos version: 0.28.1 => 28
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
     200
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
     200
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S3
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S2
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
     200
-    No reserved resources for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
+    No reserved resources for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
 
     Unreserving resources...
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
     200
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
     200
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S3
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S2
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
     200
-    No reserved resources for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
+    No reserved resources for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
 
     Deleting zk node...
-    Successfully deleted znode 'cassandra' (code=200), if znode existed.
+    Successfully deleted znode 'dcos-service-sample' (code=200), if znode existed.
     Cleanup completed successfully.
 
 If you run the script via Marathon, you will also see the following output:

--- a/pages/1.12/deploying-services/uninstall/index.md
+++ b/pages/1.12/deploying-services/uninstall/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 
 
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources that were unable to be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
+Services can be uninstalled from the CLI. If a Universe service has any reserved resources that could not be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
 # Uninstalling Universe services
 
@@ -36,11 +36,14 @@ From the DC/OS web interface you can uninstall services from the **Services** ta
 1.  Select your service, click the vertical ellipsis at the far right, and select **Delete**.
 
     ![Destroy app](/1.12/img/service-delete.png)
+    
+    Figure 1. Delete Services
+    
 1.  Copy and run the displayed command.
 
 ## Troubleshooting
 
-It's possible for an uninstall to fail with the following error message:
+It is possible for an uninstall to fail with the following error message:
 
 ```
 Incomplete uninstall of package [chronos] due to Mesos unavailability
@@ -74,7 +77,7 @@ For more information, see the [command reference](/1.12/cli/command-reference/#d
 
 ### Web interface
 
-From the DC/OS web interface you can uninstall services from the **Services**. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
+You can uninstall services from the DC/OS web interface, from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
 ### Services tab
 
@@ -86,7 +89,7 @@ From the DC/OS web interface you can uninstall services from the **Services**. T
 
 ### About the cleanup
 
-If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed unintall.** The package's documentation may have its own additional information in an "Uninstall" section.
+If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed uninstall.** The package's documentation may have its own additional information in an "Uninstall" section.
 
 There are two ways to run the framework cleaner script. The preferred method is via the DC/OS CLI. If the CLI is unavailable, you can also run the image as a self-deleting Marathon task.
 
@@ -103,7 +106,7 @@ The command would be run as follows:
 docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name>
 ```
 
-Users of strict-mode clusters will need to provide additional arguments providing credentials to perform the cleanup:
+If you are using a strict-mode cluster, you must provide additional arguments providing credentials to perform the cleanup:
 * `-a <token>`: Token to be used for authentication
 * `--username <username>` and `--password <password>`: Username and password to be used for authentication
 
@@ -163,7 +166,7 @@ To view the script's outcome, go to Mesos (`http://your-cluster.com/mesos`) and 
 
 ### Sample result
 
-Here's an example of the output for a successful run for a sample installation:
+Here is an example of the output for a successful run for a sample installation:
 
     your-machine$ dcos node ssh --master-proxy --leader
 

--- a/pages/1.12/deploying-services/uninstall/index.md
+++ b/pages/1.12/deploying-services/uninstall/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 
 
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources, you also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
+Services can be uninstalled from the CLI. If a Universe service has any reserved resources that were unable to be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
 # Uninstalling Universe services
 
@@ -32,10 +32,10 @@ dcos package uninstall chronos
 
 From the DC/OS web interface you can uninstall services from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
-1.  Navigate to the [**Services**](/1.11/gui/services/) tab in the DC/OS web interface.
+1.  Navigate to the [**Services**](/1.12/gui/services/) tab in the DC/OS web interface.
 1.  Select your service, click the vertical ellipsis at the far right, and select **Delete**.
 
-    ![Destroy app](/1.11/img/service-delete.png)
+    ![Destroy app](/1.12/img/service-delete.png)
 1.  Copy and run the displayed command.
 
 ## Troubleshooting
@@ -70,7 +70,7 @@ Uninstall a user-created service with this command:
 dcos marathon app remove [--force] <app-id>
 ```
 
-For more information, see the [command reference](/1.11/cli/command-reference/#dcos-marathon).
+For more information, see the [command reference](/1.12/cli/command-reference/#dcos-marathon).
 
 ### Web interface
 
@@ -78,15 +78,15 @@ From the DC/OS web interface you can uninstall services from the **Services**. T
 
 ### Services tab
 
-1.  Navigate to the [**Services**](/1.11/gui/services/) tab in the DC/OS web interface.
+1.  Navigate to the [**Services**](/1.12/gui/services/) tab in the DC/OS web interface.
 2.  Click on the **Installed** tab to see your installed services.
 3.  Hover your cursor over the name of the package you wish to uninstall and you will see a red "Uninstall" link to the right. Click this link to uninstall the package.
 
-## <a name="framework-cleaner"></a>Cleaning up ZooKeeper
+## <a name="framework-cleaner"></a>Cleaning up Resources and ZooKeeper
 
-### About Cleaning up ZooKeeper
+### About the cleanup
 
-If your service has reserved resources, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it.
+If your service has reserved resources and it did not completely clean itself up automatically, you can use the framework cleaner docker image, `mesosphere/janitor`, to simplify the process of removing your service instance from ZooKeeper and destroying all the data associated with it. **On DC/OS 1.10+ clusters, this should only be necessary in rare circumstances such as a failed unintall.** The package's documentation may have its own additional information in an "Uninstall" section.
 
 There are two ways to run the framework cleaner script. The preferred method is via the DC/OS CLI. If the CLI is unavailable, you can also run the image as a self-deleting Marathon task.
 
@@ -94,35 +94,24 @@ There are two ways to run the framework cleaner script. The preferred method is 
 
 The script takes the following flags:
 
-* `-r`: The role of the resources to be deleted
-* `-p`: The principal of the resources to be deleted
-* `-z`: The configuration zookeeper node to be deleted
+* `-r <role>`: The role of the resources to be deleted
+* `-z <zk-node>`: The configuration zookeeper node to be deleted
 
-These are some examples of default configurations (these will vary depending on selected task name, etc):
+The command would be run as follows:
 
-* Cassandra default:
+```bash
+docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name>
+```
 
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r cassandra-role -p cassandra-principal -z dcos-service-cassandra
-  ```
+Users of strict-mode clusters will need to provide additional arguments providing credentials to perform the cleanup:
+* `-a <token>`: Token to be used for authentication
+* `--username <username>` and `--password <password>`: Username and password to be used for authentication
 
-* HDFS default:
+For example, the command could be run with an auth token included as follows:
 
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r hdfs-role -p hdfs-principal -z dcos-service-hdfs
-  ```
-
-* Kafka default:
-
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r kafka-role -p kafka-principal -z dcos-service-kafka
-  ```
-
-* Custom values:
-
-  ```bash
-  docker run mesosphere/janitor /janitor.py -r <custom_role> -p <custom_principal> -z dcos-service-<custom_service_name>
-  ```
+```bash
+docker run mesosphere/janitor /janitor.py -r <service_name>-role -z dcos-service-<service_name> -a <content of "dcos config show core.dcos_acs_token">
+```
 
 ### Running from the DC/OS CLI
 
@@ -132,17 +121,17 @@ Connect to the leader and start the script:
 
         your-machine$ dcos node ssh --master-proxy --leader
 
-1. Run the `mesosphere/janitor` image with the role, principal, and zookeeper nodes that were configured for your service:
+1. Run the `mesosphere/janitor` image with the role and zookeeper node that were configured for your service, along with an auth token if on a strict mode cluster:
 
-        docker run mesosphere/janitor /janitor.py -r sample-role -p sample-principal -z sample-zk
+        docker run mesosphere/janitor /janitor.py -r sample-role -z sample-zk [-a auth-token]
 
 ### Running from Marathon
 
-From the DC/OS [**Services**](/1.11/gui/) tab, use the JSON editor to add the following as a Marathon task. Replace the values passed to `-r`/`-p`/`-z` according to what needs to be cleaned up.
+From the DC/OS [**Services**](/1.12/gui/) tab, use the JSON editor to add the following as a Marathon task. Replace the values passed to `-r`/`-z` according to what needs to be cleaned up.
 
     {
       "id": "janitor",
-      "cmd": "/janitor.py -r sample-role -p sample-principal -z sample",
+      "cmd": "/janitor.py -r sample-role -z dcos-service-sample",
       "cpus": 1,
       "mem": 128,
       "disk": 1,
@@ -174,39 +163,39 @@ To view the script's outcome, go to Mesos (`http://your-cluster.com/mesos`) and 
 
 ### Sample result
 
-Here's an example of the output for a successful run for a Cassandra installation:
+Here's an example of the output for a successful run for a sample installation:
 
     your-machine$ dcos node ssh --master-proxy --leader
 
-    leader-node$ docker run mesosphere/janitor /janitor.py -r cassandra_role -p cassandra_principal -z cassandra
+    leader-node$ docker run mesosphere/janitor /janitor.py -r sample_role -z dcos-service-sample
     [... docker download ...]
-    Master: http://leader.mesos:5050/master/ Exhibitor: http://leader.mesos:8181/ Role: cassandra_role Principal: cassandra_principal ZK Path: cassandra
+    Master: http://leader.mesos:5050/master/ Exhibitor: http://leader.mesos:8181/ Role: sample_role ZK Path: sample
 
     Destroying volumes...
     Mesos version: 0.28.1 => 28
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
     200
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
     200
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S3
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S2
-    Found 1 volume(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
+    Found 1 volume(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
     200
-    No reserved resources for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
+    No reserved resources for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
 
     Unreserving resources...
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S5, deleting...
     200
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S4, deleting...
     200
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S3
     No reserved resources for any role on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S2
-    Found 4 resource(s) for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
+    Found 4 resource(s) for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S1, deleting...
     200
-    No reserved resources for role 'cassandra_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
+    No reserved resources for role 'sample_role' on slave 3ce447e3-2894-4c61-bd0f-be97e4d99ee9-S0. Known roles are: [slave_public]
 
     Deleting zk node...
-    Successfully deleted znode 'cassandra' (code=200), if znode existed.
+    Successfully deleted znode 'dcos-service-sample' (code=200), if znode existed.
     Cleanup completed successfully.
 
 If you run the script via Marathon, you will also see the following output:

--- a/pages/services/include/uninstall.tmpl
+++ b/pages/services/include/uninstall.tmpl
@@ -27,7 +27,7 @@ If the service scheduler reports in its `stdout` that the uninstall is complete,
 
 #### Missing DC/OS agent
 
-The service will not complete the uninstall if it is not able to unreserve all the resources it has previously reserved. The common cause of this is a DC/OS agent that the service had reserved resources for, which is no longer part of the DC/OS cluster.
+The service will not complete the uninstall if it is not able to unreserve all the resources it has previously reserved. A common cause of this is a DC/OS agent that the service had reserved resources for, which is no longer part of the DC/OS cluster.
 
 - If the agent is only temporarily gone due to maintenance, the service will unreserve the resources when the agent returns to the cluster.
 
@@ -124,7 +124,7 @@ $ dcos node ssh --master-proxy --leader "docker run mesosphere/janitor /janitor.
     -z dcos-service-$MY_SERVICE_NAME"
 ```
 
-Users of Strict Mode clusters should also include either of the following credentials as `janitor.py` arguments:
+If you use a strict-mode clusters should also include either of the following credentials as `janitor.py` arguments:
 - `-a <token>`: Token to be used for authentication, such as the one printed by running `dcos config show core.dcos_acs_token` in the DC/OS CLI
 - `-u <username> -p <password>`: Username/password for a user which may be used to clean up the resources in question.
 

--- a/pages/services/include/uninstall.tmpl
+++ b/pages/services/include/uninstall.tmpl
@@ -110,9 +110,9 @@ If it is not possible to recover in other ways, then the service can be manually
 
 ## DC/OS 1.9 and earlier, or packages earlier than 2.0.0-x
 
-If you are running DC/OS 1.9 or earlier, or a version of the {{model.techName }} service that is earlier than 2.0.0-x, follow these steps:
+If you are running DC/OS 1.9 or earlier, or a version of the {{ model.techName }} service that is earlier than 2.0.0-x, follow these steps:
 
-1. Stop the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<service-name> {{model.packageName }}`.
+1. Stop the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<service-name> {{ model.packageName }}`.
 1. Clean up remaining reserved resources with the framework cleaner script, `janitor.py`.
 
 ```bash
@@ -123,5 +123,9 @@ $ dcos node ssh --master-proxy --leader "docker run mesosphere/janitor /janitor.
     -p $MY_SERVICE_NAME-principal \
     -z dcos-service-$MY_SERVICE_NAME"
 ```
+
+Users of Strict Mode clusters should also include either of the following credentials as `janitor.py` arguments:
+- `-a <token>`: Token to be used for authentication, such as the one printed by running `dcos config show core.dcos_acs_token` in the DC/OS CLI
+- `-u <username> -p <password>`: Username/password for a user which may be used to clean up the resources in question.
 
  See [DC/OS documentation](/latest/deploying-services/uninstall/#framework-cleaner) for more information about the framework cleaner script.


### PR DESCRIPTION
(Background: Before 1.10, janitor.py was how users needed to uninstall data services. As of 1.10+ they use a new flow which no longer requires running janitor.py)

Adds documentation for the -a/--username/--password arguments which are needed on strict mode clusters.

Also makes the following clarifications in older docs:
- This command should only rarely be needed on 1.10+ clusters, so 1.10+ docs have been updated to reflect that.
- Removes references to the unused `-p` argument, which is actually ignored by janitor.py.
- Updates examples to not make references to data services which no longer use janitor for uninstall.

## Description
https://jira.mesosphere.com/browse/DCOS-38576

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
