### PR TITLE
add kubernetes scheduler to the place Constraints

### DIFF
--- a/pages/services/kubernetes/1.2.1-1.10.6/advanced-install/index.md
+++ b/pages/services/kubernetes/1.2.1-1.10.6/advanced-install/index.md
@@ -157,7 +157,7 @@ Options example:
 }
 ```
 
-**Note**: Task anti-affinity at the agent level is enforced, meaning no task of same type, e.g. `kube-node-kube-proxy` will run on an agent where another `kube-node-kube-proxy` is running.
+**Note**: Task anti-affinity at the agent level is enforced, meaning no task of same type, e.g. `kube-node-kube-proxy` will run on an agent where another `kube-node-kube-proxy` is running. Kubernetes scheduler will install on the nodes with node_placement constraint
 
 ### Updating Placement Constraints
 


### PR DESCRIPTION
kubernetes scheduler task takes 1 CPU and if not accounted prevents kublets from installing

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
