### PR TITLE
ss/COPS-2883 Replaced older JSON file with newer version.

### DIFF
--- a/pages/1.11/networking/SDN/usage/index.md
+++ b/pages/1.11/networking/SDN/usage/index.md
@@ -25,7 +25,7 @@ To use a virtual network in a Marathon app definition, specify the `"network": "
 
 # Example
 
-The following Marathon application definition specifies a network named `dcos-1`, which refers to the target DC/OS virtual network of the same name.
+The following Marathon application definition specifies a network named `dcos`, which refers to the target DC/OS virtual network of the same name.
 
 ```json
 {

--- a/pages/1.11/networking/SDN/usage/index.md
+++ b/pages/1.11/networking/SDN/usage/index.md
@@ -29,30 +29,30 @@ The following Marathon application definition specifies a network named `dcos-1`
 
 ```json
 {
-   "id":"my-networking",
-   "cmd":"env; ip -o addr; sleep 30",
-   "cpus":0.10,
-   "mem":64,
-   "instances":1,
-   "backoffFactor":1.14472988585,
-   "backoffSeconds":5,
-   "ipAddress":{
-      "networkName":"dcos-1"
-   },
-   "container":{
-      "type":"DOCKER",
-      "docker":{
-         "network":"USER",
-         "image":"busybox",
-         "portMappings":[
-            {
-               "containerPort":123,
-               "servicePort":80,
-               "name":"foo"
-            }
-         ]
+  "id": "/my-networking",
+  "cmd": "env; ip -o addr; sleep 30",
+  "container": {
+    "portMappings": [
+      {
+        "containerPort": 123,
+        "servicePort": 80,
+        "name": "foo"
       }
-   }
+    ],
+    "type": "DOCKER",
+    "docker": {
+      "image": "busybox"
+    }
+  },
+  "cpus": 0.1,
+  "instances": 1,
+  "mem": 64,
+  "networks": [
+    {
+      "name": "dcos",
+      "mode": "container"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-2883

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Here is the page:

https://docs.mesosphere.com/1.11/networking/SDN/usage/

I think the portMappings section should be under container, not under docker.

And the network section under docker isn't allowed.

I've been able to deploy an app by changing the location of the portMappings section and by removing the network section. It seems to work well this way...We need to do it only on DC/OS 1.11 docs.