### PR TITLE
Introduce Tabbed Content Support

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -17,4 +17,5 @@ require('./js/swagger-ui.js');
 require('./js/toc-scroll.js');
 require('./js/analytics.js');
 require('./js/tooltip.js');
+require('./js/tabs.js');
 require('./js/ellipsis.js');

--- a/js/ellipsis.js
+++ b/js/ellipsis.js
@@ -15,6 +15,6 @@ const handleEllipsis = () => {
   }
 };
 
-window.onload = handleEllipsis;
-window.onresize = handleEllipsis;
+window.addEventListener('load', handleEllipsis);
+window.addEventListener('resize', handleEllipsis);
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
 // Initialize feather icon replacements
-if (feather) {
+if (typeof feather !== 'undefined') {
   feather.replace();
 }

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -11,7 +11,7 @@ if (sidebarDropdown && sidebarDropdownList) {
 if (sidebarItems.length) {
   sidebarItems.forEach((menu) => {
     const caret = menu.querySelector('svg');
-    caret.addEventListener('click', toggleMenu);
+    if (caret) caret.addEventListener('click', toggleMenu);
   });
 }
 

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,0 +1,145 @@
+/**
+ * Returns a click handler that activates the respective tab button and tab
+ * body. The `tabButtons` and `tabBodies` reference should point to an array
+ * that contain the references to the buttons and bodies.
+ *
+ * @param {array} tabButtons - A list of the buttons in the tab group
+ * @param {array} tabBodies - A list of the tab bodies in the tab group
+ * @returns - Returns a function that can be used as a click handler
+ */
+function createTabClickController(tabButtons, tabBodies) {
+  /**
+   * @param {index} - The index of the button to activate
+   * @param {event} - The click event argument
+   */
+  return function(index, event) {
+    // If we have an ID, append it on hash, without jumping on that
+    // hash, using the history service
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      try {
+        const buttonElm = $(event.target);
+        window.history.pushState(null, null, buttonElm.attr("href"));
+      } catch (e) {
+        // Some browsers might not support history
+      }
+    }
+
+    // Activate the selected tab
+    tabButtons.forEach(function(button, idx) {
+      if (idx === index) {
+        button.addClass("tabs__button__selected");
+      } else {
+        button.removeClass("tabs__button__selected");
+      }
+    });
+
+    // Activate the selected body
+    tabBodies.forEach(function(body, idx) {
+      if (idx === index) {
+        body.show();
+      } else {
+        body.hide();
+      }
+    });
+  };
+}
+
+/**
+ * Converts the heading structure into tabs, by performing the following steps:
+ */
+function convertHeadingToTab(heading) {
+  const isHeadingElement = /^h[0-9]$/i;
+  const tabs = {};
+  const headingLevel = parseInt(heading[0].tagName.substr(-1), 10);
+
+  const tabButtonContainer = $('<ul class="tabs__buttons"></ul>');
+  const tabBodyContainer = $('<div class="tabs__body"></div>')
+  let activeTabBody = null;
+
+  const tabButtons = [];
+  const tabBodies = [];
+  const clickController = createTabClickController(tabButtons, tabBodies);
+
+  // If the heading is empty, hide it
+  if (heading.text().trim() === "") heading.hide();
+
+  // Walk down the heading siblings and construct the tab interface
+  let elm = $(heading);
+  while ((elm = elm.next()).length) {
+    const tagName = elm[0].tagName;
+
+    //
+    // When we encounter a heading element we have three options:
+    //
+    if (tagName.match(isHeadingElement)) {
+      const level = parseInt(tagName.substr(-1), 10);
+
+      // 1. If the heading is the same or smaller than the `headingLevel`, we
+      //    should complete the tab conversion because we ran out of the scope.
+      if (level <= headingLevel) break;
+
+      // 2. If the heading is exactly one level deeper, we should start a new
+      //    tab capturing group.
+      if (level === headingLevel + 1) {
+        // If this is the first tab, we should inject here the bodies
+        if (activeTabBody == null) {
+          tabButtonContainer.insertBefore(elm);
+          tabBodyContainer.insertBefore(elm);
+        }
+
+        // Create a tab button and link it on the click controller
+        const tabId = elm.attr("id");
+        const tabTitle = elm.text();
+        const tabIndex = tabButtons.length;
+        const tabButton = $(
+          '<li class="tabs__button"><a href="#' +
+            tabId +
+            '">' +
+            tabTitle +
+            "</a></li>"
+        );
+        tabButton.click(clickController.bind(tabButton, tabIndex));
+        tabButton.appendTo(tabButtonContainer);
+        tabButtons.push(tabButton);
+
+        // Create and activate a new tab body
+        activeTabBody = $('<div class="tabs__body__tab"></div>');
+        activeTabBody.appendTo(tabBodyContainer);
+        tabBodies.push(activeTabBody);
+
+        // Hide the heading (we keep the element in the DOM just in case
+        // this header acts as an anchor)
+        elm.hide();
+        continue;
+      }
+
+      // 3. If the heading is more than one level deeper, it should be accounted
+      //    as a regular occurrence, and should be put into the active tab group.
+    }
+
+    // Every other encounter should be appended on the active tab body
+    if (activeTabBody != null) {
+      const popElm = elm;
+      elm = elm.prev();
+      popElm.appendTo(activeTabBody);
+    }
+  }
+
+  // If we followed a permalink to the specific tab, then the hash should contain
+  // the ID of the tab. Use this information to activate the correct tab.
+  let defaultActiveTab = Math.max(
+    0,
+    tabButtons.findIndex(function(elm) {
+      return elm.attr("href") === window.location.hash;
+    })
+  );
+  clickController(defaultActiveTab);
+}
+
+// Convert all headings with tabs at load time
+$("h1.tabs, h2.tabs, h3.tabs, h4.tabs").each(function(idx, elm) {
+  convertHeadingToTab($(elm));
+});

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,3 +1,5 @@
+const $ = global.$;
+
 /**
  * Returns a click handler that activates the respective tab button and tab
  * body. The `tabButtons` and `tabBodies` reference should point to an array
@@ -12,7 +14,7 @@ function createTabClickController(tabButtons, tabBodies) {
    * @param {index} - The index of the button to activate
    * @param {event} - The click event argument
    */
-  return function(index, event) {
+  return (index, event) => {
     // If we have an ID, append it on hash, without jumping on that
     // hash, using the history service
     if (event) {
@@ -21,23 +23,23 @@ function createTabClickController(tabButtons, tabBodies) {
 
       try {
         const buttonElm = $(event.target);
-        window.history.pushState(null, null, buttonElm.attr("href"));
+        window.history.pushState(null, null, buttonElm.attr('href'));
       } catch (e) {
         // Some browsers might not support history
       }
     }
 
     // Activate the selected tab
-    tabButtons.forEach(function(button, idx) {
+    tabButtons.forEach((button, idx) => {
       if (idx === index) {
-        button.addClass("tabs__button__selected");
+        button.addClass('tabs__button__selected');
       } else {
-        button.removeClass("tabs__button__selected");
+        button.removeClass('tabs__button__selected');
       }
     });
 
     // Activate the selected body
-    tabBodies.forEach(function(body, idx) {
+    tabBodies.forEach((body, idx) => {
       if (idx === index) {
         body.show();
       } else {
@@ -52,11 +54,10 @@ function createTabClickController(tabButtons, tabBodies) {
  */
 function convertHeadingToTab(heading) {
   const isHeadingElement = /^h[0-9]$/i;
-  const tabs = {};
   const headingLevel = parseInt(heading[0].tagName.substr(-1), 10);
 
   const tabButtonContainer = $('<ul class="tabs__buttons"></ul>');
-  const tabBodyContainer = $('<div class="tabs__body"></div>')
+  const tabBodyContainer = $('<div class="tabs__body"></div>');
   let activeTabBody = null;
 
   const tabButtons = [];
@@ -64,10 +65,12 @@ function convertHeadingToTab(heading) {
   const clickController = createTabClickController(tabButtons, tabBodies);
 
   // If the heading is empty, hide it
-  if (heading.text().trim() === "") heading.hide();
+  if (heading.text().trim() === '') heading.hide();
 
   // Walk down the heading siblings and construct the tab interface
   let elm = $(heading);
+
+  // eslint-disable-next-line
   while ((elm = elm.next()).length) {
     const tagName = elm[0].tagName;
 
@@ -91,15 +94,11 @@ function convertHeadingToTab(heading) {
         }
 
         // Create a tab button and link it on the click controller
-        const tabId = elm.attr("id");
+        const tabId = elm.attr('id');
         const tabTitle = elm.text();
         const tabIndex = tabButtons.length;
         const tabButton = $(
-          '<li class="tabs__button"><a href="#' +
-            tabId +
-            '">' +
-            tabTitle +
-            "</a></li>"
+          `<li class="tabs__button"><a href="#${tabId}">${tabTitle}</a></li>`,
         );
         tabButton.click(clickController.bind(tabButton, tabIndex));
         tabButton.appendTo(tabButtonContainer);
@@ -113,6 +112,8 @@ function convertHeadingToTab(heading) {
         // Hide the heading (we keep the element in the DOM just in case
         // this header acts as an anchor)
         elm.hide();
+
+        // eslint-disable-next-line
         continue;
       }
 
@@ -130,16 +131,17 @@ function convertHeadingToTab(heading) {
 
   // If we followed a permalink to the specific tab, then the hash should contain
   // the ID of the tab. Use this information to activate the correct tab.
-  let defaultActiveTab = Math.max(
-    0,
-    tabButtons.findIndex(function(elm) {
-      return elm.attr("href") === window.location.hash;
-    })
+  clickController(
+    Math.max(
+      0,
+      tabButtons.findIndex(
+        tabElm => tabElm.attr('href') === window.location.hash,
+      ),
+    ),
   );
-  clickController(defaultActiveTab);
 }
 
 // Convert all headings with tabs at load time
-$("h1.tabs, h2.tabs, h3.tabs, h4.tabs").each(function(idx, elm) {
+$('h1.tabs, h2.tabs, h3.tabs, h4.tabs').each((idx, elm) => {
   convertHeadingToTab($(elm));
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "devDependencies": {
     "algoliasearch": "^3.24.3",
     "autoprefixer": "^7.1.1",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-preset-env": "^1.7.0",
     "bootprint": "^1.0.0",
     "bootprint-openapi": "^1.1.0",
     "browser-sync": "^2.18.12",

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -1,0 +1,31 @@
+.tabs {
+  &__buttons {
+    display: flex;
+    margin-top: 2rem;
+    border-bottom: solid 1px $color-grey-medium;
+
+    list-style: none;
+    padding: 0;
+  }
+
+  &__button a {
+    display: block;
+    color: #101319;
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+  }
+  &__button {
+    display: inline-block;
+    margin-left: 0.5rem;
+
+    border: 1px solid transparent;
+    border-top-left-radius: .25rem;
+    border-top-right-radius: .25rem;
+    border-color: $color-grey-medium;
+    margin-bottom: -1px
+  }
+
+  &__button__selected {
+    border-color: $color-grey-medium $color-grey-medium #fff;
+  }
+}

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -37,6 +37,7 @@
 @import "components/grid-toc";
 @import "components/prism";
 @import "components/form";
+@import "components/tabs";
 
 /* Shortcodes */
 @import "shortcodes/message";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,14 @@ module.exports = {
           use: "css-loader"
         }),
       },
+      {
+        test: /\.js$/,
+        exclude: /(node_modules|vendor|assets)/,
+        loader: 'babel-loader',
+        options: {
+          presets: ['env'],
+        },
+      },
     ],
   },
   plugins: [


### PR DESCRIPTION
## Description
* [DCOS_OSS-4004](https://jira.mesosphere.com/browse/DCOS_OSS-4004)

This commit introduces a run-time extension to the docs page that automatically converts annotated headings into tabs. The PDF version of the documentation should not be affected by this PR.

This would greatly simplify some documentation updates that I am preparing for marathon, so if such PR matches to your standards, please merge it as soon as possible 😄 

_NOTE: I also performed some boy-scout clean-up in order to fix some problems that I encountered while debugging offline_

### Usage

To use this, append the class `{.tabs}` on the heading section of your choice
and the extension will automatically convert child headings into tabs. For example:

```md
...

## Some topic {.tabs}

Here is a preamble that does not participate in the tab creation.

### First tab

Here are the contents of the first tab.

#### Notice

Note that you can still use deeper heading nesting inside the tabs

### Second Tab

Here are the contents of the second tab.

### Third Tab

Here are the contents of the third tab.

...
```

Will produce this:

![tabs mov](https://user-images.githubusercontent.com/883486/44588560-bcebe080-a7be-11e8-8eea-42f1ab021c31.gif)


### Logic

The extension is executed at page load and performs the following steps:

1. Looks for `h1,h2,h3,h4` headings with the class `.tabs`
2. It starts walking the DOM siblings until it encounters a heading with level
   exactly one deeper than the original one.
  1. If this was the first encounter, it injects two container elements:
    1. A `<ul class="tabs__buttons"></ul>` for the tab buttons
    2. A `<div class="tabs__body"></div>` for the tab bodies
  2. On the first encounter, and for every encounter after, it creates a tab
     button with the name equal to the heading text, and a blank `<div>` inside
     the tabs body container.
  3. Every other element encountered is automatically moved into the last body
     div that was created on the previous step.

## Urgency
- [ ] Blocker
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
