### PR TITLE
ss/COPS-2966 Editing requirement to not mount /tmp/ with noexec.

### DIFF
--- a/pages/1.10/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.10/installing/oss/custom/system-requirements/index.md
@@ -76,7 +76,7 @@ The agent nodes must also have:
 
     **Important:** Do not remotely mount `/var/lib/mesos` or the Docker storage directory (by default `/var/lib/docker`).
 
-*   Do not mount `/tmp` with `noexec`. This will prevent Exhibitor and ZooKeeper from running.    
+*   Mounting `noexec` on a system where you intend to use the DC/OS CLI could break CLI functionality unless a TMPDIR environment variable is set to something other than `/tmp/`.   
 
 ### Port and Protocol Configuration
 

--- a/pages/1.11/installing/production/system-requirements/index.md
+++ b/pages/1.11/installing/production/system-requirements/index.md
@@ -94,8 +94,7 @@ The agent nodes must also have:
 
     **Note:** Do not remotely mount `/var/lib/mesos` or the Docker storage directory (by default `/var/lib/docker`).
 
-- Do not mount `/tmp` with `noexec`. This will prevent Exhibitor and ZooKeeper from running.
-
+*   Mounting `noexec` on a system where you intend to use the DC/OS CLI could break CLI functionality unless a TMPDIR environment variable is set to something other than `/tmp/`.  
 -   If you are planning a cluster with hundreds of agent nodes or intend to have a high rate of deploying and deleting services, isolating this directory to dedicated SSD storage is recommended.
 
     | Directory Path | Description |

--- a/pages/1.12/installing/production/system-requirements/index.md
+++ b/pages/1.12/installing/production/system-requirements/index.md
@@ -95,7 +95,7 @@ The agent nodes must also have:
 
     **Note:** Do not remotely mount `/var/lib/mesos` or the Docker storage directory (by default `/var/lib/docker`).
 
-*   Do not mount `/tmp` with `noexec`. This will prevent Exhibitor and ZooKeeper from running.
+*   Mounting `noexec` on a system where you intend to use the DC/OS CLI could break CLI functionality unless a TMPDIR environment variable is set to something other than `/tmp/`.  
 
 *   If you are planning a cluster with hundreds of agent nodes or intend to have a high rate of deploying and deleting services, isolating this directory to dedicated SSD storage is recommended.
 

--- a/pages/1.8/administration/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.8/administration/installing/oss/custom/system-requirements/index.md
@@ -98,8 +98,7 @@ Here are the agent node hardware requirements.
 
     **Important:** Do not remotely mount `/var/lib/mesos` or the Docker storage directory (by default `/var/lib/docker`).
 
-*   Do not mount `/tmp` with `noexec`. This will prevent Exhibitor and ZooKeeper from running.
-
+*   Mounting `noexec` on a system where you intend to use the DC/OS CLI could break CLI functionality unless a TMPDIR environment variable is set to something other than `/tmp/`.  
 ### <a name="port-and-protocol"></a>Port and Protocol Configuration
 
 *   Secure Shell (SSH) must be enabled on all nodes.

--- a/pages/1.9/installing/oss/custom/system-requirements/index.md
+++ b/pages/1.9/installing/oss/custom/system-requirements/index.md
@@ -74,7 +74,7 @@ The agent nodes must also have:
 
     **Important:** Do not remotely mount `/var/lib/mesos` or the Docker storage directory (by default `/var/lib/docker`).
 
-*   Do not mount `/tmp` with `noexec`. This will prevent Exhibitor and ZooKeeper from running.
+*   Mounting `noexec` on a system where you intend to use the DC/OS CLI could break CLI functionality unless a TMPDIR environment variable is set to something other than `/tmp/`.  
 
 ### <a name="port-and-protocol"></a>Port and Protocol Configuration
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-2966

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

For all versions, docs currently say that mounting /tmp/ with noexec is not supported.
https://docs.mesosphere.com/1.10/installing/oss/custom/system-requirements/#agent-nodes

Based on COPS-1663 and DCOS_OSS-634, it appears that this is no longer a requirement. 

However, a caveat might be necessary to indicate that noexec on a system where you intend to use the DC/OS CLI could break CLI functionality unless a TMPDIR environment variable is set to something other than /tmp/.

Versions edited:
1.8
1.9
1.10
1.11
1.12