### PR TITLE
Updated Mount Disk Resources instructions to use cache system.

### DIFF
--- a/pages/1.10/storage/mount-disk-resources/index.md
+++ b/pages/1.10/storage/mount-disk-resources/index.md
@@ -46,10 +46,10 @@ In this example, a disk resource is added to a DC/OS agent post-install on a run
       ```
 
 4.  Clear agent state.
-    1. Remove volume mount discovery resource state with this command:
+    1. Cache volume mount discovery resource state with this command:
 
         ```bash
-        sudo rm -f /var/lib/dcos/mesos-resources
+        sudo mv -f /var/lib/dcos/mesos-resources /var/lib/dcos/mesos-resources.cache
         ```
 
     1. Remove agent checkpoint state with this command:

--- a/pages/1.11/storage/mount-disk-resources/index.md
+++ b/pages/1.11/storage/mount-disk-resources/index.md
@@ -49,10 +49,10 @@ Please note that this example handles **adding** resources exclusively and can n
       ```
 
 4.  Clear agent state.
-    1. Remove volume mount discovery resource state with this command:
+    1. Cache volume mount discovery resource state with this command:
 
         ```bash
-        sudo rm -f /var/lib/dcos/mesos-resources
+        sudo mv -f /var/lib/dcos/mesos-resources /var/lib/dcos/mesos-resources.cache
         ```
 
     1. Remove agent checkpoint state with this command:

--- a/pages/1.12/storage/mount-disk-resources/index.md
+++ b/pages/1.12/storage/mount-disk-resources/index.md
@@ -48,11 +48,12 @@ Please note that this example handles **adding** resources exclusively and can n
       ```
 
 4.  Clear agent state.
-    1. Remove volume mount discovery resource state with this command:
+    1. Cache volume mount discovery resource state with this command:
 
         ```bash
-        sudo rm -f /var/lib/dcos/mesos-resources
+        sudo mv -f /var/lib/dcos/mesos-resources /var/lib/dcos/mesos-resources.cache
         ```
+       DC/OS will check this file later on to generate a new resource state for the agent.
 
     1. Remove agent checkpoint state with this command:
 


### PR DESCRIPTION
We now recommend to move the previous Mesos resources file to a cache
instead of removing it. Following the DC/OS update for 1.10/1.11/1.12,
this cache will automatically be used when creating the new resources
file and thus fix the issue described in DCOS_OSS-3921.

## Description
https://jira.mesosphere.com/browse/DCOS_OSS-3921

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
