### PR TITLE
removes incorrect 'Note:' to use https on strict mode exhibitor

### DIFF
--- a/pages/1.10/installing/ent/upgrading/index.md
+++ b/pages/1.10/installing/ent/upgrading/index.md
@@ -185,8 +185,6 @@ Proceed with upgrading every master node one-at-a-time in any order using the fo
 1.  Validate the upgrade:
 
     1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green).
-
-        **Tip:** If you are upgrading from permissive to strict mode, this URL will be `https://...`.
     1.  Wait until the `dcos-mesos-master` unit is up and running.
     1.  Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
         **Tip:** If you are upgrading from permissive to strict mode, this URL will be `curl https://...` and you will need a JWT for access.

--- a/pages/1.11/installing/production/upgrading/index.md
+++ b/pages/1.11/installing/production/upgrading/index.md
@@ -221,8 +221,6 @@ Proceed with upgrading every master node one at a time in any order using the fo
 1.  Validate the upgrade:
 
     1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green).
-
-        **Note:** If you are upgrading from permissive to strict mode, this URL will be `https://...`.
     1.  Wait until the `dcos-mesos-master` unit is up and running.
     1.  Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`. [enterprise type="inline" size="small" /]
 

--- a/pages/1.12/installing/production/upgrading/index.md
+++ b/pages/1.12/installing/production/upgrading/index.md
@@ -223,8 +223,6 @@ Proceed with upgrading every master node one at a time in any order using the fo
 1.  Validate the upgrade:
 
     1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green).
-
-        **Note:** If you are upgrading from permissive to strict mode, this URL will be `https://...`.
     1.  Wait until the `dcos-mesos-master` unit is up and running.
     1.  Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`. [enterprise type="inline" size="small" /]
 

--- a/pages/1.9/installing/ent/upgrading/index.md
+++ b/pages/1.9/installing/ent/upgrading/index.md
@@ -188,9 +188,7 @@ Proceed with upgrading every master node one-at-a-time in any order using the fo
 
 1.  Validate the upgrade:
 
-    1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green). 
-    
-        **Tip:** If you are upgrading from permissive to strict mode, this URL will be `https://...`.
+    1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green).
     1.  Wait until the `dcos-mesos-master` unit is up and running.
     1.  Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
         **Tip:** If you are upgrading from permissive to strict mode, this URL will be `curl https://...` and you will need a JWT for access.


### PR DESCRIPTION
## Description
Exhibitors http endpoint does not support https, even
in strict mode. We should recommend accessing exhibitor via
adminrouter anyway, but for this low-level post-upgrade
check its a valid appraoch *for now*.

Also see this thread in slack: https://mesosphere.slack.com/archives/C07D97YFL/p1535160038000100
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
