### PR TITLE
ss/COPS-677 Added recommendation to use CLI for package creation.

### DIFF
--- a/pages/1.10/developing-services/index.md
+++ b/pages/1.10/developing-services/index.md
@@ -14,7 +14,7 @@ DC/OS includes a service packaging specification and a [repository](/1.10/admini
 
 # <a name="universe"></a>Universe package repository
 
-The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe).
+The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe). Our general recommendation is to use the DC/OS CLI rather than the DC/OS web interface throughout the process of creating a package for the Universe.
 
 # DC/OS service structure
 

--- a/pages/1.11/developing-services/index.md
+++ b/pages/1.11/developing-services/index.md
@@ -14,7 +14,7 @@ The Mesosphere Datacenter Operating System (DC/OS) provides the optimal user exp
 
 # <a name="universe"></a>Package Repositories
 
-The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe).
+The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe). Our general recommendation is to use the DC/OS CLI rather than the DC/OS web interface throughout the process of creating a package for the Universe.
 
 All packaged services are required to meet a certain standard as defined by Mesosphere. For details on submitting a DC/OS service, see [Getting Started with Universe](https://github.com/mesosphere/universe/blob/version-3.x/docs/tutorial/GetStarted.md).
 

--- a/pages/1.12/developing-services/index.md
+++ b/pages/1.12/developing-services/index.md
@@ -14,7 +14,7 @@ The Mesosphere Datacenter Operating System (DC/OS) provides the optimal user exp
 
 # <a name="universe"></a>Package Repositories
 
-The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe).
+The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe). Our general recommendation is to use the DC/OS CLI rather than the DC/OS web interface throughout the process of creating a package for the Universe.
 
 All packaged services are required to meet a certain standard as defined by Mesosphere. For details on submitting a DC/OS service, see [Getting Started with Universe](https://github.com/mesosphere/universe/blob/version-3.x/docs/tutorial/GetStarted.md).
 

--- a/pages/1.9/developing-services/index.md
+++ b/pages/1.9/developing-services/index.md
@@ -10,13 +10,13 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
-This section describes the developer-specific DC/OS components, explaining what is necessary to package and provide your own service on DC/OS.
+This section describes the developer-specific DC/OS components, explaining what is necessary to package and provide your own service on DC/OS. 
 
 The Mesosphere Datacenter Operating System (DC/OS) provides the optimal user experience possible for orchestrating and managing a datacenter. If you are an Apache Mesos developer, you are already familiar with developing a framework. DC/OS extends Apache Mesos by including a web interface for health checks and monitoring, a command-line, a service packaging description, and a [repository](/1.9/administering-clusters/repo/) that catalogs those packages.
 
 # <a name="universe"></a>Package Repositories
 
-The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe).
+The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe). Our general recommendation is to use the DC/OS CLI rather than the DC/OS web interface throughout the process of creating a package for the Universe.
 
 All packaged services are required to meet a certain standard as defined by Mesosphere. For details on submitting a DC/OS service, see [Getting Started with Universe](https://github.com/mesosphere/universe/blob/version-3.x/docs/tutorial/GetStarted.md).
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-677

It would be helpful to add a note somewhere in this documentation that our general recommendation is to utilize the DC/OS CLI rather than the DC/OS GUI throughout the process of creating a package for the Universe.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Added the following to /developing-services/index.md:

"Our general recommendation is to use the DC/OS CLI rather than the DC/OS web interface throughout the process of creating a package for the Universe."

Versions changed:

- [x] 1.9
- [x] 1.10
- [x] 1.11
- [x] 1.12