### PR TITLE
Fixing enterprise tag error in Administering-Clusters.

### DIFF
--- a/pages/1.11/administering-clusters/index.md
+++ b/pages/1.11/administering-clusters/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle:  Administering Clusters
 title: Administering Clusters
 menuWeight: 60
-enterprise: true
 excerpt: Administering your DC/OS clusters
 enterprise: false
 


### PR DESCRIPTION
## Description

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

Administering-clusters index page had duplicate enterprise tags. Deleted "enterprise: true" tag.