### PR TITLE
1.12: Deploying Services using a Custom Marathon with Security Features

### DIFF
--- a/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
+++ b/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
@@ -10,7 +10,7 @@ enterprise: true
 
 This topic describes how to deploy a non-native instance of Marathon with isolated roles, reservations, quotas, and security features. The advanced non-native Marathon procedure should only be used if you require [secrets](/1.12/security/ent/secrets/) or fine-grain ACLs, otherwise use the [basic procedure](/1.12/deploying-services/marathon-on-marathon/basic/).
 
-For this procedure, we are assuming that you have obtained an enterprise version of Marathon from your sales representative (<sales@mesosphere.io>). This custom tarball contains Marathon plus secrets and auth plugins. These additional plugins allow you to use secrets and fine-grained access control in your non-native Marathon folder hierarchy.
+For this procedure, we are assuming that you have obtained an enterprise version of Marathon from your sales representative (<sales@mesosphere.io>). This custom tarball contains Marathon plus plugins to support enterprise features, such as secrets and authorization. These additional plugins allow you to use secrets and fine-grained access control in your non-native Marathon folder hierarchy.
 
 **Prerequisites:**
 
@@ -235,7 +235,7 @@ Depending on your [security mode](/1.12/security/ent/#security-modes), a Maratho
 | Permissive | Optional |
 | Strict | Required |
 
-1.  Create a 2048-bit RSA private-public key pair (`${PRIVATE_KEY}` and `${PUBLIC_KEY}`) and save each value into a separate file within the current directory.
+1.  Create a 2048-bit RSA private and public key pair (`${PRIVATE_KEY}` and `${PUBLIC_KEY}`) and save each value into a separate file within the current directory.
 
     With the following command, we create a pair of private and public keys. The public key will be used to create the Marathon service account. The private key we will store in the [secret store](/1.12/security/ent/secrets/) and later passed to Marathon so it can authorize itself using this account. 
 
@@ -302,7 +302,7 @@ Grant service account `${SERVICE_ACCOUNT_ID}` permission to launch Mesos tasks t
 
 To allow executing tasks as a different Linux user, replace `nobody` with that user's Linux user ID. For example, to launch tasks as Linux user `bob`, replace `nobody` with `bob` below.
 
-Note that the `nobody` and `root` users exist on all agents by default, but if a custom `bob` user is specified it has to be manually created (using the `adduser` or a similar utility) on every agent that tasks can be executed on.
+Note that the `nobody` and `root` users exist on all agents by default; if a custom user `bob` is specified, then the user `bob` will need to be manually created on every agent on which tasks can be executed (e.g. using the Linux `adduser` or a similar utility).
 
 ```bash
 dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:task:user:nobody create --description "Tasks can execute as Linux user nobody"
@@ -642,11 +642,11 @@ In this step, you log in as a authorized user to the non-native Marathon DC/OS s
 
 # Known pitfalls
 
-- When launching docker containers user _nobody_ does not have enough rights to execute the command e.g. stating _nginx_ as _nobody_ will fail because _nobody_ does not have the right  to write logs to /var/log (as nginx needs). 
+- When launching docker containers, the user `nobody` may not have enough rights to successfully run. For example, starting an `nginx` Docker container as the user `nobody` will fail because `nobody` does not have write permissions to `/var/log`, which `nginx` needs.
 
-- User `nobody` has different UIDs on different systems (99 on coreos, 65534 on ubuntu). Depending on the agent's distribution you might need to modify the container image so that UIDs match! (the same goes if you use the user _bob_)
+- User `nobody` has different UIDs on different systems (99 on coreos, 65534 on ubuntu). Depending on the agent's distribution, you may need to modify the container image so that UIDs match! The same goes if you use the user `bob`.
 
-- If using custom users e.g. _bob_, this user has to exist on the agent and within the container.
+- When using custom users (e.g. `bob`), the user must exist on the agent, or in the case of using containers, within the container.
 
-- When using a new user e.g. _bob_ don't forget to give Marathon service account permissions to run tasks with this user 
+- When using a new user (e.g. `bob`), remember to give the Marathon service account permissions to run tasks as this user.
 

--- a/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
+++ b/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
@@ -30,7 +30,7 @@ The following table contains all the variables used in this page:
 
 | Variable | Description |
 |--------------------------|--------------------------------------------|
-| `${MY_USER_ID}` | The username that you use to login to your cluster. That's the username that you were prompted during `dcos cluster setup`. |
+| `${MY_USER_ID}` | The username that you use to log in to your cluster. That is the username that you were prompted during `dcos cluster setup`. |
 | `${AGENT_ID}` | The ID of an agent in your DC/OS cluster. You can obtain an agent ID using the `dcos node` command. |
 | `${MESOS_ROLE}` | The name of the [Mesos Role](https://mesos.apache.org/documentation/latest/roles/) that the new Marathon instance will use. This should be a valid [Mesos role name](https://mesos.apache.org/documentation/latest/roles/#invalid-role-names), for example `"marathon_ee"`. |
 | `${SERVICE_ACCOUNT_ID}` | The name of the [Service Account](/1.12/security/ent/service-auth/) that Marathon will use to communicate with the other services in DC/OS. The name should include only lowercase alphabet, uppercase alphabet, numbers, `@`, `.`, `\`, `_`, and `-`. For example `"marathon_user_ee"` |
@@ -43,7 +43,7 @@ The following table contains all the variables used in this page:
 | `${MARATHON_IMAGE}` | The name of the Marathon image **in your private repository**, for example `private-repo/marathon-dcos-ee`. |
 | `${MARATHON_TAG}` | The Docker image tag of the Marathon version that you want to deploy. For example `v1.5.11_1.10.2` (version 0.11.0 or newer).  |
 
-**Note:** If you are working on a MacOS or Linux machine, you can pre-define all the above variables in your terminal session and just copy and paste the snippets in your terminal:
+**Note:** If you are working on a Mac OS or Linux machine, you can pre-define all the above variables in your terminal session and just copy and paste the snippets in your terminal:
 
 ```
 set -a
@@ -73,7 +73,7 @@ For the following steps, we are assuming that you have already:
     **Warning:** The name of the secret should either be in the root path (ex. `/some-secret-name`) or prefixed with the name of your app (ex. `/${MARATHON_INSTANCE_NAME}/some-secret-name`). Failing to do so, will make root Marathon unable to read the secret value and will fail to launch your custom Marathon-on-Marathon instance.
 
 # Step 2: Reserve Resources (Optional) {.tabs}
-In this step, we are going to define a [Mesos Role](https://mesos.apache.org/documentation/latest/roles/) for our new Marathon instance, and reserve some dedicated resources for it. This step is optional, but it's recommended if you want your new marathon instance to have a minimum resource guarantee for it's tasks.
+In this step, we are going to define a [Mesos Role](https://mesos.apache.org/documentation/latest/roles/) for our new Marathon instance, and reserve some dedicated resources for it. This step is optional, but it is recommended if you want your new Marathon instance to have a minimum resource guarantee for its tasks.
 
 **Important:** If you choose not to reserve resources, you should use `MESOS_ROLE="*"` in any further occurrence of this variable.
 
@@ -302,7 +302,7 @@ Grant service account `${SERVICE_ACCOUNT_ID}` permission to launch Mesos tasks t
 
 To allow executing tasks as a different Linux user, replace `nobody` with that user's Linux user ID. For example, to launch tasks as Linux user `bob`, replace `nobody` with `bob` below.
 
-Note that the `nobody` and `root` users exist on all agents by default; if a custom user `bob` is specified, then the user `bob` will need to be manually created on every agent on which tasks can be executed (e.g. using the Linux `adduser` or a similar utility).
+Note that the `nobody` and `root` users exist on all agents by default; if a custom user is specified (e.g. `bob`), then the user `bob` will need to be manually created on every agent on which tasks can be executed (e.g. using the Linux `adduser` or a similar utility).
 
 ```bash
 dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:task:user:nobody create --description "Tasks can execute as Linux user nobody"
@@ -332,7 +332,7 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
 
     ### Permissive
 
-    Use the following JSON template if you are running a cluster in `permissive` security mode. Don't forget to **replace** all the environment variables that follow the `${VARIABLES}` format:
+    Use the following JSON template if you are running a cluster in `permissive` security mode. Do not forget to **replace** all the environment variables that follow the `${VARIABLES}` format:
 
     ```json
     {
@@ -513,7 +513,7 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
     ```
 
 # Step 7: Grant User Access to Non-Native Marathon
-By now, your new Marathon instance is accessible only by the DC/OS Superusers. In order to give access to regular users, you need to explicitly give them access permissions, according to your cluster security mode: 
+By now, your new Marathon instance is accessible only by the DC/OS superusers. In order to give access to regular users, you need to explicitly give them access permissions, according to your cluster security mode:
 
   ## {.tabs}
 

--- a/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
+++ b/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
@@ -199,19 +199,12 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
             "pullConfig": {
                 "secret": "docker-registry-credential"
             }
-         },
-         "volumes":[
-            {
-               "containerPath":"/opt/mesosphere",
-               "hostPath":"/opt/mesosphere",
-               "mode":"RO"
-            }
-         ]
+         }
       },
       "env":{
          "JVM_OPTS":"-Xms256m -Xmx2g",
          "DCOS_STRICT_SECURITY_ENABLED":"false",
-         "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE":{
+         "DCOS_SERVICE_ACCOUNT_CREDENTIAL":{
             "secret":"service-credential"
          },
          "MESOS_AUTHENTICATEE":"com_mesosphere_dcos_ClassicRPCAuthenticatee",
@@ -287,24 +280,16 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
             "pullConfig": {
                 "secret": "docker-registry-credential"
             }
-         },
-         "volumes":[
-            {
-               "containerPath":"/opt/mesosphere",
-               "hostPath":"/opt/mesosphere",
-               "mode":"RO"
-            }
-         ]
+         }
       },
       "env":{
          "JVM_OPTS":"-Xms256m -Xmx2g",
          "DCOS_STRICT_SECURITY_ENABLED":"true",
-         "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE":{
+         "DCOS_SERVICE_ACCOUNT_CREDENTIAL":{
             "secret":"service-credential"
          },
          "MESOS_AUTHENTICATEE":"com_mesosphere_dcos_ClassicRPCAuthenticatee",
-         "MESOS_MODULES":"file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
-         "MESOS_NATIVE_JAVA_LIBRARY":"/opt/mesosphere/lib/libmesos.so",
+         "MESOS_MODULES":"{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
          "MESOS_VERBOSE":"true",
          "GLOG_v":"2",
          "PLUGIN_ACS_URL":"https://master.mesos",

--- a/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
+++ b/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
@@ -30,7 +30,6 @@ The following table contains all the variables used in this page:
 
 | Variable | Description |
 |--------------------------|--------------------------------------------|
-| `${MY_USERNAME}` | The username that you use to log in to your cluster. That is the username that you were prompted during `dcos cluster setup`. |
 | `${MESOS_ROLE}` | The name of the [Mesos Role](https://mesos.apache.org/documentation/latest/roles/) that the new Marathon instance will use. This should be all lowercase, and be a valid [Mesos role name](https://mesos.apache.org/documentation/latest/roles/#invalid-role-names), for example `"marathon_ee"`. |
 | `${SERVICE_ACCOUNT}` | The name of the [Service Account](/1.12/security/ent/service-auth/) that Marathon will use to communicate with the other services in DC/OS. The name should include only letters, numbers, `@`, `.`, `\`, `_`, and `-`. For example `"marathon_user_ee"` |
 | `${MARATHON_INSTANCE_NAME}` | The service name of your new Marathon instance, as launched by the root Marathon instance. This should be a valid [Marathon service name](https://mesosphere.github.io/marathon/docs/application-basics.html), for example `"mom_ee"`. |
@@ -45,7 +44,6 @@ The following table contains all the variables used in this page:
 
 ```
 set -a
-MY_USERNAME="..."
 MESOS_ROLE="..."
 SERVICE_ACCOUNT="..."
 BEGIN_PORT="..."

--- a/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
+++ b/pages/1.12/deploying-services/marathon-on-marathon/advanced/index.md
@@ -8,77 +8,102 @@ enterprise: true
 
 ---
 
-This topic describes how to deploy a non-native instance of Marathon with isolated roles, reservations, quotas, and security features. The advanced non-native Marathon procedure should only be used if you require [secrets](/1.11/security/ent/secrets/) or fine-grain ACLs, otherwise use the [basic procedure](/1.11/deploying-services/marathon-on-marathon/basic/).
+This topic describes how to deploy a non-native instance of Marathon with isolated roles, reservations, quotas, and security features. The advanced non-native Marathon procedure should only be used if you require [secrets](/1.12/security/ent/secrets/) or fine-grain ACLs, otherwise use the [basic procedure](/1.12/deploying-services/marathon-on-marathon/basic/).
 
-To use this procedure, you must obtain the custom non-native Marathon tarball from your sales representative (<sales@mesosphere.io>). This custom tarball contains Marathon plus a secrets and auth plugin. These additional plugins allow you to use secrets and fine-grained access control in your non-native Marathon folder hierarchy.
+For this procedure, we are assuming that you have obtained an enterprise version of Marathon from your sales representative (<sales@mesosphere.io>). This custom tarball contains Marathon plus secrets and auth plugins. These additional plugins allow you to use secrets and fine-grained access control in your non-native Marathon folder hierarchy.
 
 **Prerequisites:**
 
--  DC/OS and DC/OS CLI [installed](/1.11/installing/).
--  [DC/OS Enterprise CLI 0.4.14 or later](/1.11/cli/enterprise-cli/#ent-cli-install).
--  Custom non-native Marathon tarball. Contact your sales representative or <sales@mesosphere.io> for access to this file.
--  A private Docker registry that each private DC/OS agent can access over the network. You can follow [these](/1.11/deploying-services/private-docker-registry/) instructions for how to set up in Marathon, or use another option such as [DockerHub](https://hub.docker.com/), [Amazon EC2 Container Registry](https://aws.amazon.com/ecr/), and [Quay](https://quay.io/)).
+-  DC/OS and DC/OS CLI [installed](/1.12/installing/).
+-  [DC/OS Enterprise CLI 0.4.14 or later](/1.12/cli/enterprise-cli/#ent-cli-install).
+-  A private Docker registry that each private DC/OS agent can access over the network. You can follow [these](/1.12/deploying-services/private-docker-registry/) instructions for how to set up in Marathon, or use another option such as [DockerHub](https://hub.docker.com/), [Amazon EC2 Container Registry](https://aws.amazon.com/ecr/), and [Quay](https://quay.io/)).
+-  Custom non-native Marathon (version 0.11.0 or newer) image [deployed in your private Docker registry](/1.12/deploying-services/private-docker-registry#tarball-instructions). Contact your sales representative or <sales@mesosphere.io> for obtain the enterprise Marathon image file.
 -  You must be logged in as a superuser.
 -  SSH access to the cluster.
 
-# Step 1 - Load and Push the Custom Non-Native Marathon Image
-In this step, the custom non-native Marathon instance is pushed to the private Docker registry.
+<a name="variables-in-example"></a>
+**Variables in this example**
 
-1. Load the tarball into Docker with the custom non-native Marathon file (`marathon-dcos-ee.<version>.tar`) specified.
+Throughout this page, you will be instructed to invoke commands or take actions that differ according to your setup. For the parts that differ, we are using the `${VARIABLE}` notation, that should be replaced with the appropriate value that fits in your case.
 
-   ```bash
-   docker load -i marathon-dcos-ee.<version>.tar
-   ```
+The following table contains all the variables used in this page:
 
-    **Tip:** You can view the Marathon image with this command.
+| Variable | Description |
+|--------------------------|--------------------------------------------|
+| `${MY_USER_ID}` | The username that you use to login to your cluster. That's the username that you were prompted during `dcos cluster setup`. |
+| `${AGENT_ID}` | The ID of an agent in your DC/OS cluster. You can obtain an agent ID using the `dcos node` command. |
+| `${MESOS_ROLE}` | The name of the [Mesos Role](https://mesos.apache.org/documentation/latest/roles/) that the new Marathon instance will use. This should be a valid [Mesos role name](https://mesos.apache.org/documentation/latest/roles/#invalid-role-names), for example `"marathon_ee"`. |
+| `${SERVICE_ACCOUNT_ID}` | The name of the [Service Account](/1.12/security/ent/service-auth/) that Marathon will use to communicate with the other services in DC/OS. The name should include only lowercase alphabet, uppercase alphabet, numbers, `@`, `.`, `\`, `_`, and `-`. For example `"marathon_user_ee"` |
+| `${BEGIN_PORT}` - `${END_PORT}` | A port range that will be reserved on the agent, for the custom Marathon instance. Check the output of the `dcos node --json | jq '.[] | {id, ports: .resources.ports}'` command to find out what is a valid range for your agents. |
+| `${MARATHON_INSTANCE_NAME}` | The name of your non-native instance. This should be a valid [Marathon service name](https://mesosphere.github.io/marathon/docs/application-basics.html), for example `"mom_ee"`. |
+| `${SERVICE_ACCOUNT_SECRET}` | The path of the secret in the [Secret Store](/1.12/security/ent/secrets/) that holds the private key that Marathon will use along with the `${SERVICE_ACCOUNT_ID}` account to authenticate on DC/OS. This the name **must not** contain the character `/`. For example `"marathon_user_ee_secret"` |
+| `${DOCKER_REGISTRY_SECRET}` | The path of the secret in the [Secret Store](/1.12/security/ent/secrets/) that holds the credentials for fetching the Marathon Docker image from the private registry. This the name **must not** contain the character `/`. For example `"registry_secret"`. |
+| `${PRIVATE_KEY}` | The path to the private key file (in your local file system). Feel free to pick any file name ending with `.pem`. |
+| `${PUBLIC_KEY}` | The path to the public key file (in your local file system). Feel free to pick any file name ending with `.pem` |
+| `${MARATHON_IMAGE}` | The name of the Marathon image **in your private repository**, for example `private-repo/marathon-dcos-ee`. |
+| `${MARATHON_TAG}` | The Docker image tag of the Marathon version that you want to deploy. For example `v1.5.11_1.10.2` (version 0.11.0 or newer).  |
 
-    ```
-    docker images
-    ```
+**Note:** If you are working on a MacOS or Linux machine, you can pre-define all the above variables in your terminal session and just copy and paste the snippets in your terminal:
 
-    You should see output similar to this:
+```
+set -a
+MY_USER_ID="..."
+AGENT_ID="..."
+MESOS_ROLE="..."
+SERVICE_ACCOUNT_ID="..."
+BEGIN_PORT="..."
+END_PORT="..."
+MARATHON_INSTANCE_NAME="..."
+SERVICE_ACCOUNT_SECRET="..."
+DOCKER_REGISTRY_SECRET="..."
+PRIVATE_KEY="..."
+PUBLIC_KEY="..."
+MARATHON_IMAGE="..."
+MARATHON_TAG="..."
+```
 
-    ```bash
-    REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
-    mesosphere/marathon-dcos-ee   1.4.0-RC4_1.9.4     d1ffa68a50c0        3 months ago        926.4 MB
-    ```
 
-1. Rename the file to match the repository that you are using in your private Docker registry, where:
-   - `<mesosphere-tag>` is the tag of the image from Mesosphere. Typically, this will match the version number in the filename.
-   - `<your-repo>` is the name of the private repository that you want to store the image in.
-   - `<your-tag>` is the tag for the image. It is recommended that you use the same tag as the Mesosphere image.
+# Step 1: Preparation
 
-   ```bash
-   docker tag mesosphere/marathon-dcos-ee:<mesosphere-tag> <your-repo>/marathon-dcos-ee:<your-tag>
-   ```
+For the following steps, we are assuming that you have already:
 
-1. Push the Marathon image up to your private Docker registry.
+1. Pushed the enterprise image of Marathon to your private registry [(Instructions)](/1.12/deploying-services/private-docker-registry#tarball-instructions), under the name `${MARATHON_IMAGE}:${MARATHON_TAG}`.
+1. Stored your private Docker credentials in the secrets store [(Instructions)](/1.12/deploying-services/private-docker-registry/#referencing-private-docker-registry-credentials-in-the-secrets-store-enterprise), under the name `${DOCKER_REGISTRY_SECRET}`.
 
-   ```bash
-   docker push <your-repo>/marathon-dcos-ee:<your-tag>
-   ```
+    **Warning:** The name of the secret should either be in the root path (ex. `/some-secret-name`) or prefixed with the name of your app (ex. `/${MARATHON_INSTANCE_NAME}/some-secret-name`). Failing to do so, will make root Marathon unable to read the secret value and will fail to launch your custom Marathon-on-Marathon instance.
 
-# Step 2 - Reserve Resources
-In this step, Mesos resources are reserved. Choose the procedure for either [static](#static-reservations) or [dynamic](#dynamic-reservations) reservations.
+# Step 2: Reserve Resources (Optional) {.tabs}
+In this step, we are going to define a [Mesos Role](https://mesos.apache.org/documentation/latest/roles/) for our new Marathon instance, and reserve some dedicated resources for it. This step is optional, but it's recommended if you want your new marathon instance to have a minimum resource guarantee for it's tasks.
+
+**Important:** If you choose not to reserve resources, you should use `MESOS_ROLE="*"` in any further occurrence of this variable.
+
+You can choose between [static](#static-reservations) reservations, [dynamic](#dynamic-reservations) reservations or [quotas](#quotas).
+
+| Method | Description |
+|--------|-------------|
+| Static | Dedicates entire agent(s) to the new Marathon |
+| Dynamic | Dedicates a portion of agent(s) resources to the new Marathon |
+| Quotas | Ensures a minimum resource allocation to the new Marathon, regardless of where it's found. |
 
 ## Static Reservations
+A _static_ reservation is achieved by changing the default Mesos Role of a particular agent in order to dedicate all of its resources to the new Marathon instance.
 
 <table class=“table” bgcolor=#ffd000>
 <tr> 
   <td align=justify style=color:black><strong>Warning:</strong> This procedure kills all running tasks on your node.</td> 
 </tr> 
 </table>
+>>>>>>> variant B
 
-1.  [SSH](/1.11/administering-clusters/sshcluster/) to your private agent node.
+1.  [SSH](/1.12/administering-clusters/sshcluster/) to your private agent node.
 
    ```bash
-   dcos node ssh --master-proxy --mesos-id=<agent-id>
+   dcos node ssh --master-proxy --mesos-id=${AGENT_ID}
    ```
-
-1.  Navigate to `/var/lib/dcos` and create a file named `mesos-slave-common` with these contents, where `<myrole>` is the name of your role.
+1.  Navigate to `/var/lib/dcos` and create a file named `mesos-slave-common` with these contents, where `${MESOS_ROLE}` is the name of your role.
 
     ```bash
-    MESOS_DEFAULT_ROLE='<myrole>'
+    MESOS_DEFAULT_ROLE="${MESOS_ROLE}"
     ```
 1.  Stop the private agent node:
 
@@ -115,7 +140,7 @@ In this step, Mesos resources are reserved. Choose the procedure for either [sta
 1.  Repeat these steps for each additional node.
 
 ## Dynamic Reservations
-Reserve resources for your non-native Marathon instance with the Mesos ID (`<mesos-id>`), user ID (`<userid>`), role (`<myrole>`), and ports (`<begin-port>` and `<end-port>`) specified.
+A _dynamic_ [reservation](https://mesos.apache.org/documentation/latest/reservation/#dynamic-reservation) is reserving a portion of an agent's resources to a role. To achieve this we are going to use the Mesos API which will be a less intrusive method to your cluster.
 
 ```bash
 curl -i -k \
@@ -126,16 +151,16 @@ curl -i -k \
   "type": "RESERVE_RESOURCES",
   "reserve_resources": {
     "agent_id": {
-      "value": "<mesos-id>"
+      "value": "'${AGENT_ID}'"
     },
     "resources": [
       {
         "type": "SCALAR",
         "name": "cpus",
         "reservation": {
-          "principal": "<userid>"
+          "principal": "'${MY_USER_ID}'"
         },
-        "role": "<myrole>",
+        "role": "'${MESOS_ROLE}'",
         "scalar": {
           "value": 1.0
         }
@@ -144,9 +169,9 @@ curl -i -k \
         "type": "SCALAR",
         "name": "mem",
         "reservation": {
-          "principal": "<userid>"
+          "principal": "'${MY_USER_ID}'"
         },
-        "role": "<myrole>",
+        "role": "'${MESOS_ROLE}'",
         "scalar": {
           "value": 512.0
         }
@@ -155,12 +180,12 @@ curl -i -k \
         "type": "RANGES",
         "name": "ports",
         "reservation": {
-          "principal": "<userid>"
+          "principal": "'${MY_USER_ID}'"
         },
-        "role": "<myrole>",
+        "role": "'${MESOS_ROLE}'",
         "ranges": {
-          "begin": "[<begin-port>]",
-          "end": "[<end-port>]"
+          "begin": "['${BEGIN_PORT}]'",
+          "end": "['${END_PORT}']"
         }
       }
     ]
@@ -169,195 +194,150 @@ curl -i -k \
       -X POST "`dcos config show core.dcos_url`/mesos/api/v1"
 ```
 
-# Step 3 - Create a Marathon Service Account
-Depending on your [security mode](/1.11/security/ent/#security-modes), a Marathon Service Account is either optional or required.
+## Quotas
+Since both _static_ and _dynamic_ reservations are pinned to a particular agent, they are susceptible to the individual agents failing. This can either be mitigated by reserving enough resources on multiple agent nodes, or by using [Quotas](https://mesos.apache.org/documentation/latest/quota/) instead.
+
+A _Quota_ is simply a mechanism for guaranteeing that a role will receive a certain minimum amount of resources.
+
+**Warning:** You can only use `SCALAR` resources with _Quotas_. This means that if you want to reserve a port range you have to use _static_ or _dynamic Reservations_.
+
+```bash
+curl -i -k \
+      -H "Authorization: token=`dcos config show core.dcos_acs_token`" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      -d '{
+  "role": "'${MESOS_ROLE}'",
+  "guarantee": [
+    {
+      "type": "SCALAR",
+      "name": "cpus",
+      "scalar": { "value": 1.0 }
+    },
+    {
+      "type": "SCALAR",
+      "name": "mem",
+      "scalar": { "value": 512.0 }
+    }
+  ]
+}' \
+      -X POST "`dcos config show core.dcos_url`/mesos/quota"
+```
+
+
+# Step 3: Create a Marathon Service Account
+In this step, a Marathon [Service Account](/1.12/security/ent/service-auth/) is created. This account will be used by Marathon to authenticate on the rest of DC/OS components. The permissions later given to this account are going to define what Marathon is allowed to do.
+
+Depending on your [security mode](/1.12/security/ent/#security-modes), a Marathon Service Account is either optional or required.
 
 | Security Mode | Marathon Service Account |
-|---------------|----------------------|
+|---------------|--------------------------|
 | Permissive | Optional |
 | Strict | Required |
 
-1.  Create a 2048-bit RSA public-private key pair (`<private-key>.pem` and `<public-key>.pem`) and save each value into a separate file within the current directory.
+1.  Create a 2048-bit RSA private-public key pair (`${PRIVATE_KEY}` and `${PUBLIC_KEY}`) and save each value into a separate file within the current directory.
+
+    With the following command, we create a pair of private and public keys. The public key will be used to create the Marathon service account. The private key we will store in the [secret store](/1.12/security/ent/secrets/) and later passed to Marathon so it can authorize itself using this account. 
 
     ```bash
-    dcos security org service-accounts keypair <private-key>.pem <public-key>.pem
+    dcos security org service-accounts keypair ${PRIVATE_KEY} ${PUBLIC_KEY}
     ```
 
-1.  Create a new service account called `<service-account-id>`, with the public key specified (`<public-key>.pem`).
+1.  Create a new service account called `${SERVICE_ACCOUNT_ID}`, with the public key specified (`${PUBLIC_KEY}`).
 
     ```bash
-    dcos security org service-accounts create -p <public-key>.pem -d "Non-native Marathon service account" <service-account-id>
+    dcos security org service-accounts create -p ${PUBLIC_KEY} -d "Marathon-on-Marathon User" ${SERVICE_ACCOUNT_ID}
     ```
 
-# Step 4 - Create Private Docker Registry Credentials for Private Agents
-In this step, the credential tarball is transferred to the local file system of each private agent using [secure copy](https://linux.die.net/man/1/scp). The following instructions are optimized for CoreOS masters and agents. If you are running CentOS, replace `core` with `centos` throughout the following commands.
 
-1. From a terminal prompt, log into your private Docker registry.
-   -  If your private repository is on Docker Hub, use this command:
+# Step 4: Create a Service Account Secret
+In this step, a secret is created for the Marathon service account and stored in the Secret Store.
+
+  The secret created (`${SERVICE_ACCOUNT_SECRET}`) will contain the private key (`${PRIVATE_KEY}`) and the name of the service account (`${SERVICE_ACCOUNT_ID}`). This information will be used by Marathon to authenticate against DC/OS.
+
+  ## {.tabs}
+
+  ### Permissive
+
+  ```bash
+  dcos security secrets create-sa-secret ${PRIVATE_KEY} ${SERVICE_ACCOUNT_ID} ${SERVICE_ACCOUNT_SECRET}
+  ```
+
+  ### Strict
+
+  ```bash
+  dcos security secrets create-sa-secret --strict ${PRIVATE_KEY} ${SERVICE_ACCOUNT_ID} ${SERVICE_ACCOUNT_SECRET}
+  ```
+
+  #### Recommendations
+
+  * Make sure that your secret is in place, using the following command:
+
+     ```bash
+     dcos security secrets list /
+     ```
+
+  *  Review your secret to ensure that it contains the correct service account ID, private key, and `login_endpoint` URL. If you're in `strict` it should be HTTPS, in `permissive` mode it should be HTTP. If the URL is incorrect, try [upgrading the DC/OS Enterprise CLI](/1.12/cli/enterprise-cli/#ent-cli-upgrade), deleting the secret, and recreating it. 
+
+      You can use this commands to view the contents (requires [jq 1.5 or later](https://stedolan.github.io/jq/download) installed):
 
       ```bash
-      docker login
-      ```
-   -  If your private repository is not on Docker Hub, use this command, with the domain name (`<domain-name>`) of your private registry specified.
-
-      ```bash
-      docker login <domain-name>
+      dcos security secrets get ${SERVICE_ACCOUNT_SECRET} --json | jq -r .value | jq
       ```
 
-1. Navigate into your home directory and verify the contents of the `.docker` directory look similar to this.
+  *  Delete the private key file from your file system to prevent bad actors from using the private key to authenticate into DC/OS.
 
-   ```bash
-   ls -la .docker
-   drwxr-xr-x    4 user  group   136 Aug 15 17:29 .
-   drwxr-xr-x+ 118 user  group  4012 Jan 26 18:16 ..
-   -rw-------    1 user  group   217 Jan 25 13:52 config.json
-   ```
 
-1. Compress the Docker credentials.
-
-   ```bash
-   sudo tar cvzf docker.tar.gz .docker
-   ```
-
-    You can confirm that the operation succeeded with this command.
-
-   ```bash
-   tar -tvf docker.tar.gz
-   ```
-
-   You should see output similar to this.
-
-   ```bash
-   drwxr-xr-x  0 user group       0 Jan 23 15:47 .docker/
-   -rw-------  0 user group     217 Jan 23 15:48 .docker/config.json
-   ```
-
-1. Copy the Docker credentials file to one of your masters with the public master IP address (`<public-master-ip>`) specified.
-
-   You can find the public master IP address by clicking on the cluster name in the top-left corner of the DC/OS web interface.
-
-   ```bash
-   scp docker.tar.gz core@<public-master-ip>:~
-   ```
-
-1. [SSH](/1.11/administering-clusters/sshcluster/) to the master node that contains the Docker credentials file.
-
-   ```bash
-   dcos node ssh --master-proxy --mesos-id=<master-id>
-   ```
-
-1. Store the IP address of each private agent in an environment variable. <!-- What is this step for -->The steps required depend on your [security mode](/1.11/security/ent/#security-modes).
-
-   ### Permissive
-
-   ```bash
-   PRIVATE_AGENT_IPS=$(curl -sS leader.mesos:5050/slaves | jq '.slaves[] | select(.reserved_resources.slave_public == null) | .hostname' | tr -d '"');
-   ```
-
-   ### Strict
-
-   1.  Authenticate and save your authentication token to the `AUTH_TOKEN` environment variable, with your DC/OS username (`<username>`) and password (`<password>` specified.
-
-       ```bash
-       AUTH_TOKEN=$(curl -X POST localhost:8101/acs/api/v1/auth/login \
-       -d '{"uid":"<username>","password":"<password>"}' \
-       -H 'Content-Type: application/json' | jq -r '.token')
-       ```
-
-   1.  Download the certificate bundle, with your cluster URL (`<cluster-url>`) specified.
-
-       ```bash
-       sudo curl -k -v https://<cluster-url>/ca/dcos-ca.crt -o /etc/ssl/certs/dcos-ca.crt
-       ```
-
-   1.  Save the private IP address of each of your private agents to the `PRIVATE_AGENT_IPS` environment variable.
-
-       ```bash
-       PRIVATE_AGENT_IPS=$(curl -sS --cacert /etc/ssl/certs/dcos-ca.crt \
-       -H "Authorization: token=$AUTH_TOKEN" https://leader.mesos:5050/slaves | jq '.slaves[] | select(.reserved_resources.slave_public == null) | .hostname' | tr -d '"');
-       ```
-
-1. Copy the `docker.tar.gz` file to the `/home/core` directory of each of your private agents.
-
-   ```bash
-   for i in $PRIVATE_AGENT_IPS; do scp -o StrictHostKeyChecking=no docker.tar.gz core@$i:~/docker.tar.gz ; done
-   ```
-# Step 5 - Create a Service Account Secret
-In this step, a secret is created for the Marathon service account and stored in the Secret Store. Create a secret (`<path-to-secret-name>`) for your service account. The secret will contain the private key (`<private-key>.pem`) and the name of the service account (`<service-account-id>`).
-
-### Permissive
-
-```bash
-dcos security secrets create-sa-secret <private-key>.pem <service-account-id> <path-to-secret-name>
-```
-
-### Strict
-
-```bash
-dcos security secrets create-sa-secret --strict <private-key>.pem <service-account-id> <path-to-secret-name>
-```  
-
-#### Recommendations
-
--  Review your secret to ensure that it contains the correct service account ID, private key, and `login_endpoint` URL. If you're in `strict` it should be HTTPS, in `permissive` mode it may be HTTP or HTTPS. If the URL is incorrect, try [upgrading the DC/OS Enterprise CLI](/1.11/cli/enterprise-cli/#ent-cli-upgrade), deleting the secret, and recreating it. You can use this command to view the contents:
-
-   ```bash
-   dcos security secrets list /
-   ```
-
-   Alternatively, if you have [jq 1.5 or later](https://stedolan.github.io/jq/download) installed, you can use this command:
-
-   ```bash
-   dcos security secrets get /momee-serv-group/momee-serv-group-service/<secret-name> --json | jq -r .value | jq
-   ```
-
--  Delete the private key file from your file system to prevent bad actors from using the private key to authenticate to DC/OS.
-
-# Step 6 - Assign Permissions (Strict mode only)
-In this step, permissions are assigned to the Marathon-on-Marathon instance. Permissions are required in strict mode and are ignored in permissive security mode.
+# Step 5: Assign Permissions (Strict mode only)
+In this step, permissions are assigned to the Marathon-on-Marathon instance. Permissions are required in strict mode and are ignored in other security modes.
 
 | Security Mode | Permissions |
 |---------------|----------------------|
 | Permissive | Not available |
 | Strict | Required |
 
-All CLI commands can also be executed via the [IAM API](/1.11/security/ent/iam-api).
+All CLI commands can also be executed via the [IAM API](/1.12/security/ent/iam-api).
 
-Grant service account `<service-account-id>` permission to launch Mesos tasks that will execute as Linux user `nobody`.
+Grant service account `${SERVICE_ACCOUNT_ID}` permission to launch Mesos tasks that will execute as Linux user `nobody`.
+
 To allow executing tasks as a different Linux user, replace `nobody` with that user's Linux user ID. For example, to launch tasks as Linux user `bob`, replace `nobody` with `bob` below.
-Note that the `nobody` and `root` users exist on all agents by default, but if a custom `bob` user is specified it must have been manually created (using the `adduser` or similar utility) on every agent that tasks can be executed on.
+
+Note that the `nobody` and `root` users exist on all agents by default, but if a custom `bob` user is specified it has to be manually created (using the `adduser` or a similar utility) on every agent that tasks can be executed on.
 
 ```bash
-dcos security org users grant <service-account-id> dcos:mesos:master:task:user:nobody create --description "Tasks can execute as Linux user nobody"
-dcos security org users grant <service-account-id> dcos:mesos:master:framework:role:<myrole> create --description "Controls the ability of <myrole> to register as a framework with the Mesos master"
-dcos security org users grant <service-account-id> dcos:mesos:master:reservation:role:<myrole> create --description "Controls the ability of <myrole> to reserve resources"
-dcos security org users grant <service-account-id> dcos:mesos:master:volume:role:<myrole> create --description "Controls the ability of <myrole> to access volumes"
-dcos security org users grant <service-account-id> dcos:mesos:master:reservation:principal:<service-account-id> delete --description "Controls the ability of <service-account-id> to reserve resources"
-dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:/ create --description "Controls the ability to launch tasks"
-dcos security org users grant <service-account-id> dcos:mesos:master:volume:principal:<service-account-id> delete --description "Controls the ability of <service-account-id> to access volumes"
+dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:task:user:nobody create --description "Tasks can execute as Linux user nobody"
+dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:framework:role:${MESOS_ROLE} create --description "Controls the ability of ${MESOS_ROLE} to register as a framework with the Mesos master"
+dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:reservation:role:${MESOS_ROLE} create --description "Controls the ability of ${MESOS_ROLE} to reserve resources"
+dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:volume:role:${MESOS_ROLE} create --description "Controls the ability of ${MESOS_ROLE} to access volumes"
+dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:reservation:principal:${SERVICE_ACCOUNT_ID} delete --description "Controls the ability of ${SERVICE_ACCOUNT_ID} to reserve resources"
+dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:task:app_id:/ create --description "Controls the ability to launch tasks"
+dcos security org users grant ${SERVICE_ACCOUNT_ID} dcos:mesos:master:volume:principal:${SERVICE_ACCOUNT_ID} delete --description "Controls the ability of ${SERVICE_ACCOUNT_ID} to access volumes"
 ```
 
-# Step 7 - Install a Non-Native Marathon Instance with Assigned Role
+
+# Step 6: Install a Non-Native Marathon Instance with Assigned Role {.tabs}
 In this step, a non-native Marathon instance is installed on DC/OS with the Mesos role assigned.
 
-1.  Create a custom JSON config file and save as `config.json`. This file is used to install the custom non-native Marathon instance. The JSON file contents vary according to your [security mode](/1.11/security/ent/#security-modes). Replace these variables in the examples with your specific information:
+1.  Create a custom JSON config that will be used to install the custom non-native Marathon instance. The JSON file contents vary according to your [security mode](/1.12/security/ent/#security-modes).
 
-    | Variable | Description |
-    |--------------------------|--------------------------------------------|
-    | `<non-native-marathon>` | Non-native Marathon framework name |
-    | `<service-account-id>` | Non-native Marathon service account |
-    | `<secret-name>` | Secret  |
-    | `<myrole>` | Mesos role |
-    | `<your-repo>` | Private Docker registry repo |
-    | `<your-tag>` | Docker tag |
-    | `<linux-user>` | Linux user  `core` or `centos` |
+    Make sure you replace all the `${VARIABLES}` in the JSON file with the correct values for your case.
+
+    Alternatively, if you have exposed the values for all these variables in your terminal session (as explained in the [Variables Section](#variables-in-example)) you can use the following command to automatically replace all the variables with the correct values. It will save the result file in `marathon-filled.json`:
+
+    ```bash
+    perl -p -e 's/\$\{(\w+)\}/(exists $ENV{$1}?$ENV{$1}:"missing variable $1")/eg' < marathon.json > marathon-filled.json
+    ```
+
+    ## {.tabs}
 
     ### Permissive
 
+    Use the following JSON template if you are running a cluster in `permissive` security mode. Don't forget to **replace** all the environment variables that follow the `${VARIABLES}` format:
+
     ```json
-    {  
-      "id":"/<non-native-marathon>",
-      "cmd":"cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*,<myrole>\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name <non-native-marathon> --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role <myrole>  --zk zk://master.mesos:2181/universe/<non-native-marathon> --mesos_user nobody --mesos_authentication --mesos_authentication_principal <service-account-id>",
+    {
+      "id":"/${MARATHON_INSTANCE_NAME}",
+      "cmd":"cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*,${MESOS_ROLE}\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name ${MARATHON_INSTANCE_NAME} --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role ${MESOS_ROLE}  --zk zk://master.mesos:2181/universe/${MARATHON_INSTANCE_NAME} --mesos_user nobody --mesos_authentication --mesos_authentication_principal ${SERVICE_ACCOUNT_ID}",
       "user":"nobody",
       "cpus":2,
       "mem":4096,
@@ -370,15 +350,12 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
          ]
       ],
       "container":{  
-         "type":"DOCKER",
+         "type": "MESOS",
          "docker":{  
-            "image":"<your-repo>/marathon-dcos-ee:<your-tag>",
-            "network":"HOST",
-            "privileged":false,
-            "parameters":[  
-
-            ],
-            "forcePullImage":false
+            "image":"${MARATHON_IMAGE}:${MARATHON_TAG}",
+            "pullConfig": {
+                "secret": "docker-registry-credential"
+            }
          },
          "volumes":[  
             {  
@@ -417,11 +394,14 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
       ],
       "secrets":{  
          "service-credential":{  
-            "source":"<path-to-secret-name>"
+            "source":"${SERVICE_ACCOUNT_SECRET}"
+         },
+         "docker-registry-credential": {
+            "source":"${DOCKER_REGISTRY_SECRET}"
          }
       },
       "labels":{  
-         "DCOS_SERVICE_NAME":"<non-native-marathon>",
+         "DCOS_SERVICE_NAME":"${MARATHON_INSTANCE_NAME}",
          "DCOS_SERVICE_PORT_INDEX":"0",
          "DCOS_SERVICE_SCHEME":"http"
       },
@@ -434,21 +414,18 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
             "port":0,
             "name":"libprocess"
          }
-      ],
-      "fetch":[  
-         {  
-            "uri":"file:///home/<linux-user>/docker.tar.gz"
-         }
       ]
     }
     ```
 
     ### Strict
 
+    Use the following JSON template if you are running a cluster in `strict` security mode. Don't forget to **replace** all the environment variables that follow the `${VARIABLES}` format:
+
     ```json
     {  
-      "id":"/<non-native-marathon>",
-      "cmd":"cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*,<myrole>\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name <non-native-marathon> --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role <myrole>  --zk zk://master.mesos:2181/universe/<non-native-marathon> --mesos_user nobody --mesos_authentication --mesos_authentication_principal <service-account-id>",
+      "id":"/${MARATHON_INSTANCE_NAME}",
+      "cmd":"cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*,${MESOS_ROLE}\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name ${MARATHON_INSTANCE_NAME} --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role ${MESOS_ROLE}  --zk zk://master.mesos:2181/universe/${MARATHON_INSTANCE_NAME} --mesos_user nobody --mesos_authentication --mesos_authentication_principal ${SERVICE_ACCOUNT_ID}",
       "user":"nobody",
       "cpus":2,
       "mem":4096,
@@ -461,15 +438,12 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
          ]
       ],
       "container":{  
-         "type":"DOCKER",
+         "type": "MESOS",
          "docker":{  
-            "image":"<your-repo>/marathon-dcos-ee:<your-tag>",
-            "network":"HOST",
-            "privileged":false,
-            "parameters":[  
-
-            ],
-            "forcePullImage":false
+            "image":"${MARATHON_IMAGE}:${MARATHON_TAG}",
+            "pullConfig": {
+                "secret": "docker-registry-credential"
+            }
          },
          "volumes":[  
             {  
@@ -508,11 +482,14 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
       ],
       "secrets":{  
          "service-credential":{  
-            "source":"<path-to-secret-name>"
+            "source":"${SERVICE_ACCOUNT_SECRET}"
+         },
+         "docker-registry-credential": {
+            "source":"${DOCKER_REGISTRY_SECRET}"
          }
       },
       "labels":{  
-         "DCOS_SERVICE_NAME":"<non-native-marathon>",
+         "DCOS_SERVICE_NAME":"${MARATHON_INSTANCE_NAME}",
          "DCOS_SERVICE_PORT_INDEX":"0",
          "DCOS_SERVICE_SCHEME":"http"
       },
@@ -525,132 +502,151 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
             "port":0,
             "name":"libprocess"
          }
-      ],
-      "fetch":[  
-         {  
-            "uri":"file:///home/<linux-user>/docker.tar.gz"
-         }
       ]
     }
     ```
 
-1.  Deploy the Marathon instance.
+1.  Deploy the Marathon instance, passing the JSON file you created in the previous step.
 
     ```bash
-    dcos marathon app add config.json
+    dcos marathon app add marathon-filled.json
     ```
 
-# Step 8 - Grant User Access to Non-Native Marathon
-In this step, a user is granted access to the non-native Marathon instance.
+# Step 7: Grant User Access to Non-Native Marathon
+By now, your new Marathon instance is accessible only by the DC/OS Superusers. In order to give access to regular users, you need to explicitly give them access permissions, according to your cluster security mode: 
 
-1. Log into the DC/OS web interface as a user with the `superuser` permission.
+  ## {.tabs}
 
-   ![Login](/1.11/img/gui-installer-login-ee.gif)
+  ### Permissive
 
-   Figure 1. Login screen
+  For each `${USER_ACCOUNT}` that you want to give access, if you are running a cluster in `permissive` security mode, depending on what kind of permissions you want to give:
 
-1.  Select **Organization** and choose **Users** or **Groups**.
+  - To give **full** permissions to any service (or a group) that runs on the newly created Marathon:
 
-1.  Select the name of the user or group to grant the permission to.
+    ```bash
+    # Access to the new Marathon service under `/service/<name>` URL
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:${MARATHON_INSTANCE_NAME} full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:${MARATHON_INSTANCE_NAME}:services:/ full
 
-    ![Add permission cory](/1.11/img/services-tab-user.png)
+    # Access to the Mesos tasks and their sandbox
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:mesos full
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:slave full
 
-    Figure 2. Select user for permissions
+    # (Optionally) Access to the Marathon instance that runs on the root 
+    # Marathon and can be controlled via the DC/OS UI
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:marathon full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:marathon:services:/${MARATHON_INSTANCE_NAME} full
+    ```
 
-1.  From the **Permissions** tab click **ADD PERMISSION**.
+  - To give permissions to an **individual** service (or a group) that runs on the newly created Marathon and is named `${CHILD_SERVICE_NAME}`:
 
-1.  Click **INSERT PERMISSION STRING** to toggle the dialog.
+    ```bash
+    # Access to the new Marathon service under `/service/<name>` URL
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:${MARATHON_INSTANCE_NAME} full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:${MARATHON_INSTANCE_NAME}:services:/${CHILD_SERVICE_NAME} full
 
-    ![Add permission](/1.11/img/services-tab-user3.png)
+    # Access to the Mesos tasks and their sandbox
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:mesos full
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:slave full
 
-    Figure 3. Adding permission string
+    # (Optionally) Access to the Marathon instance that runs on the root 
+    # Marathon and can be controlled via the DC/OS UI
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:marathon full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:marathon:services:/${MARATHON_INSTANCE_NAME} full
+    ```
 
-1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.11/security/ent/#security-modes).
+  ### Strict
 
-    ### Permissive
+  For each `${USER_ACCOUNT}` that you want to give access, if you are running a cluster in `strict` security mode, depending on what kind of permissions you want to give:
 
-    -  **Full access**
+  - To give **full** permissions to any service (or a group) that runs on the newly created Marathon:
 
-        ```bash
-        dcos:adminrouter:service:<service-name> full
-        dcos:service:marathon:<service-name>:services:/ full
-        dcos:adminrouter:ops:mesos full
-        dcos:adminrouter:ops:slave full
-        ```
+    ```bash
+    # Access to the new Marathon service under `/service/<name>` URL
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:${MARATHON_INSTANCE_NAME} full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:${MARATHON_INSTANCE_NAME}:services:/ full
 
-    -  **Access to an individual service or group**
+    # Access to the Mesos tasks and their sandbox
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:mesos full
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:slave full
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:executor:app_id:/ read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:framework:role:${MESOS_ROLE} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:sandbox:app_id:/ read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:task:app_id:/ read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:master:executor:app_id:/ read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:master:framework:role:${MESOS_ROLE} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:master:task:app_id:/ read
 
-       Specify the service or group (`<service-or-group>`) and action (`<action>`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:marathon:<service-name>:services:/<service-or-group> read,update`.
+    # (Optionally) Access to the Marathon instance that runs on the root 
+    # Marathon and can be controlled via the DC/OS UI
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:marathon full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:marathon:services:/${MARATHON_INSTANCE_NAME} full
+    ```
 
-       ```bash
-       dcos:adminrouter:service:<service-name> full
-       dcos:service:marathon:<service-name>:services:/<service-or-group> <action>
-       dcos:adminrouter:ops:mesos full
-       dcos:adminrouter:ops:slave full
-       ```
+  - To give permissions to an **individual** service (or a group) that runs on the newly created Marathon and is named `${CHILD_SERVICE_NAME}`:
 
-    ### Strict
+    ```bash
+    # Access to the new Marathon service under `/service/<name>` URL
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:${MARATHON_INSTANCE_NAME} full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:${MARATHON_INSTANCE_NAME}:services:/${CHILD_SERVICE_NAME} full
 
-    -  **Full access**
+    # Access to the Mesos tasks and their sandbox
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:mesos full
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:ops:slave full
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:executor:app_id:/${CHILD_SERVICE_NAME} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:framework:role:${MESOS_ROLE} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:sandbox:app_id:/${CHILD_SERVICE_NAME} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:agent:task:app_id:/${CHILD_SERVICE_NAME} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:master:executor:app_id:/${CHILD_SERVICE_NAME} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:master:framework:role:${MESOS_ROLE} read
+    dcos security org users grant ${USER_ACCOUNT} dcos:mesos:master:task:app_id:/${CHILD_SERVICE_NAME} read
 
-        ```bash
-        dcos:adminrouter:service:<service-name> full
-        dcos:service:marathon:<service-name>:services:/ full
-        dcos:adminrouter:ops:mesos full
-        dcos:adminrouter:ops:slave full
-        dcos:mesos:agent:executor:app_id:/ read
-        dcos:mesos:agent:framework:role:<myrole> read
-        dcos:mesos:agent:sandbox:app_id:/ read
-        dcos:mesos:agent:task:app_id:/ read
-        dcos:mesos:master:executor:app_id:/ read
-        dcos:mesos:master:framework:role:<myrole> read
-        dcos:mesos:master:task:app_id:/ read
-        ```  
-
-    -  **Access to an individual service or group**
-
-       Specify the service or group (`<service-or-group>`), service name (`<service-name>`), role (`<myrole>`), and action (`<action>`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:marathon:<service-name>:services:/<service-or-group> read,update`.
-
-       ```bash
-       dcos:adminrouter:service:<service-name> full
-       dcos:service:marathon:<service-name>:services:/<service-or-group> <action>
-       dcos:adminrouter:ops:mesos full
-       dcos:adminrouter:ops:slave full
-       dcos:mesos:agent:executor:app_id:/<service-or-group> read
-       dcos:mesos:agent:framework:role:<myrole> read
-       dcos:mesos:agent:sandbox:app_id:/<service-or-group> read
-       dcos:mesos:agent:task:app_id:/<service-or-group> read
-       dcos:mesos:master:executor:app_id:/<service-or-group> read
-       dcos:mesos:master:framework:role:<myrole> read
-       dcos:mesos:master:task:app_id:/<service-or-group> read
-       ```
+    # (Optionally) Access to the Marathon instance that runs on the root 
+    # Marathon and can be controlled via the DC/OS UI
+    dcos security org users grant ${USER_ACCOUNT} dcos:adminrouter:service:marathon full
+    dcos security org users grant ${USER_ACCOUNT} dcos:service:marathon:marathon:services:/${MARATHON_INSTANCE_NAME} full
+    ```
 
 
-1.  Click **ADD PERMISSIONS** and then **Close**.
-
-# Step 9 - Access the Non-Native Marathon Instance
+# Step 8: Access the Non-Native Marathon Instance
 In this step, you log in as a authorized user to the non-native Marathon DC/OS service.
 
-1.  Launch the non-native Marathon interface at: `http://<master-public-ip>/service/<service-name>/`.
+1.  Launch the non-native Marathon interface at: `http://<master-public-ip>/service/${SERVICE_ACCOUNT_ID}/`.
 
 1.  Enter your username and password and click **LOG IN**.
 
-    ![Log in DC/OS](/1.11/img/gui-installer-login-ee.gif)
+    ![Log in DC/OS](/1.12/img/gui-installer-login-ee.gif)
 
     Figure 4. You are done!
 
-    ![Marathon on Marathon](/1.11/img/mom-marathon-gui.png)
+    ![Marathon on Marathon](/1.12/img/mom-marathon-gui.png)
 
-    Figure 5. Logged in on Marathon
 
 # Next Steps
 
-After deploying the non-native Marathon with a unique Mesos role, you may wish to use quotas, static reservations, or dynamic reservations to guarantee certain resources to the non-native Marathon instance.
+- You can configure the DC/OS CLI to interact with your non-native Marathon instance using the following command:
+    
+    ```sh
+    dcos config set marathon.url \
+      $(dcos config show core.dcos_url)/service/${MARATHON_INSTANCE_NAME}
+    ```
 
--  Dynamic reservations will take effect once some tasks complete and yield their resources. Alternatively, you can kill some tasks to free the resources.
--  Static reservations will require you to restart the agent and kill all of its tasks.
+    Now any future `dcos marathon ...` commands will target your new marathon instance.
 
-Please refer to the Apache Mesos documentation for more details.
+    To undo this change, use the following command:
 
--  [Reservations](http://mesos.apache.org/documentation/latest/reservation/)
--  [Quotas](https://mesos.apache.org/documentation/latest/quota/)
+    ```sh
+    dcos config unset marathon.url
+    ```
+
+
+# Known pitfalls
+
+- When launching docker containers user _nobody_ does not have enough rights to execute the command e.g. stating _nginx_ as _nobody_ will fail because _nobody_ does not have the right  to write logs to /var/log (as nginx needs). 
+
+- User `nobody` has different UIDs on different systems (99 on coreos, 65534 on ubuntu). Depending on the agent's distribution you might need to modify the container image so that UIDs match! (the same goes if you use the user _bob_)
+
+- If using custom users e.g. _bob_, this user has to exist on the agent and within the container.
+
+- When using a new user e.g. _bob_ don't forget to give Marathon service account permissions to run tasks with this user 
+

--- a/pages/1.12/deploying-services/private-docker-registry/index.md
+++ b/pages/1.12/deploying-services/private-docker-registry/index.md
@@ -235,7 +235,7 @@ Follow these steps to add your Docker registry credentials to the [DC/OS Enterpr
 <a name="tarball-instructions"></a>
 # Pushing a custom image to a private registry from a tarball
 
-In some cases, you might have obtained a Docker image in a form of a `.tar` archive (ex. if you asked your sales representative for an enterprise version of marathon). To deploy that image to your registry, follow these steps:
+If you asked your sales representative for an enterprise version of Marathon, you may have been given a Docker image in a `.tar` archive. Follow these steps to deploy it to your registry:
 
 ## Step 1: Import in the local machine
 

--- a/pages/1.12/deploying-services/private-docker-registry/index.md
+++ b/pages/1.12/deploying-services/private-docker-registry/index.md
@@ -230,3 +230,48 @@ Follow these steps to add your Docker registry credentials to the [DC/OS Enterpr
       ```
 
    The Docker image will now pull using the provided security credentials.
+
+
+<a name="tarball-instructions"></a>
+# Pushing a custom image to a private registry from a tarball
+
+In some cases, you might have obtained a Docker image in a form of a `.tar` archive (ex. if you asked your sales representative for an enterprise version of marathon). To deploy that image to your registry, follow these steps:
+
+## Step 1: Import in the local machine
+
+1. Load the tarball into your local Docker client, passing the path to your custom tarball. For example, `marathon-dcos-ee.<version>.tar`:
+   ```bash
+   docker load -i marathon-dcos-ee.<version>.tar
+   ```
+
+    **Tip:** You can view the Marathon image with this command.
+
+    ```
+    docker images
+    ```
+
+    You should see output similar to this:
+
+    ```bash
+    REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
+    mesosphere/marathon-dcos-ee   1.4.0-RC4_1.9.4     d1ffa68a50c0        3 months ago        926.4 MB
+    ```
+
+## Step 2: Push the image to the repository
+
+1. Re-tag the file to match the repository that you are using in your private Docker registry:
+   ```bash
+   docker tag \
+    mesosphere/marathon-dcos-ee:<mesosphere-tag> \
+    <your-repo>/marathon-dcos-ee:<your-tag>
+   ```
+
+   Where:
+
+   - `<mesosphere-tag>` is the tag of the image from Mesosphere. Typically, this will match the version number in the filename.
+   - `<your-repo>` is the name of the private repository that you want to store the image in.
+   - `<your-tag>` is the tag for the image. It is recommended that you use the same tag as the Mesosphere image.
+1. Push the new image to your private Docker registry:
+   ```bash
+   docker push <your-repo>/marathon-dcos-ee:<your-tag>
+   ```

--- a/pages/1.12/deploying-services/private-docker-registry/index.md
+++ b/pages/1.12/deploying-services/private-docker-registry/index.md
@@ -124,7 +124,11 @@ Follow these steps to add your Docker registry credentials to the [DC/OS Enterpr
     }
     ```
 
-    If you are using Mac OSX, you will need to manually encode your `username:password` string and modify your `config.json` to match the snippet above.
+    If you are using Mac OS, you will need to manually encode your `username:password` string and modify your `config.json` to match the snippet above. Be sure to omit a trailing new-line when base64 encoding the pair:
+
+    ```bash
+    echo -n myuser@domain.com:hard-to-guess-password | base64
+    ```
 
 1. Add the `config.json` file to the DC/OS secret store. [Learn more about creating secrets](/1.9/security/ent/secrets/create-secrets/).
 


### PR DESCRIPTION
## Description

* [DCOS-39293](https://jira.mesosphere.com/browse/DCOS-39293)

This commit does some major refactoring on the 1.12 documentation pages regarding deployment
of a custom marathon-on-marathon instance with security features. Once this PR is accepted, these changes will be applied to the 1.11, 1.10, and 1.9 documentation branches.

## Urgency
- [ ] Blocker
- [X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
