### PR TITLE
Update and correct path for log capture

### DIFF
--- a/pages/1.11/monitoring/logging/aggregating/splunk/index.md
+++ b/pages/1.11/monitoring/logging/aggregating/splunk/index.md
@@ -131,7 +131,7 @@ For each agent node in your DC/OS cluster:
 
 4.  Add the task logs as inputs to the forwarder:
 
-        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave' \
+        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave/slaves' \
             -whitelist '/stdout$|/stderr$'
 
 


### PR DESCRIPTION
This issue was discovered while working on [MESOS-9196](https://issues.apache.org/jira/browse/MESOS-9196). Discussed with @jieyu that this may be causing a serious issue for splunk users.

## Description
[MESOS-9196](https://issues.apache.org/jira/browse/MESOS-9196)

Scraping the /mesos/slave directory in environments that frequently launch and destroy jobs causes forwarder to lock files and prevent containers from being destroyed. This cascades into situations where containers become stuck in a restart cycle.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ x ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
