### PR TITLE
ss/DCOS-41397 corrected splunk code for forwarder.

### DIFF
--- a/pages/1.10/monitoring/logging/aggregating/splunk/index.md
+++ b/pages/1.10/monitoring/logging/aggregating/splunk/index.md
@@ -130,7 +130,7 @@ For each agent node in your DC/OS cluster:
 
 4.  Add the task logs as inputs to the forwarder:
 
-        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave' \
+        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave/slaves' \
             -whitelist '/stdout$|/stderr$'
 
 # Known issue

--- a/pages/1.11/monitoring/logging/aggregating/splunk/index.md
+++ b/pages/1.11/monitoring/logging/aggregating/splunk/index.md
@@ -131,7 +131,7 @@ For each agent node in your DC/OS cluster:
 
 4.  Add the task logs as inputs to the forwarder:
 
-        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave' \
+        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave/slaves' \
             -whitelist '/stdout$|/stderr$'
 
 

--- a/pages/1.9/monitoring/logging/aggregating/splunk/index.md
+++ b/pages/1.9/monitoring/logging/aggregating/splunk/index.md
@@ -127,7 +127,7 @@ For each agent node in your DC/OS cluster:
 
 4.  Add the task logs as inputs to the forwarder:
 
-        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave' \
+        "$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave/slaves' \
             -whitelist '/stdout$|/stderr$'
 
 # Known issue


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-41397
https://jira.mesosphere.com/browse/DCOS-41398
iflowfor8hours:patch-1
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Problem:
We have documentation around splunk integration
https://docs.mesosphere.com/1.11/monitoring/logging/aggregating/splunk/

To collect sandbox logs, we recommand our customers to use this command:

"$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave' \
    -whitelist '/stdout$|/stderr$'
This will cause splunk to scan Mesos provisioner directories which contain Mesos container rootfses. Instead, we should ask Splunk to only scan `/var/lib/mesos/slave/slaves` where sandboxes are located.

Solution:
Changed 

'$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave' '

to 

'$SPLUNK_HOME/bin/splunk" add monitor '/var/lib/mesos/slave/slave'

in monitoring/logging/aggregating/splunk/ files

Versions affected:
1.9
1.10
1.11