### PR TITLE
Put Makefile dependencies in correct position

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ build-redirects:
 # Build
 #
 
-build-development: ## Rebuild nginx, swagger, and static content
-	build-api
+## Rebuild nginx, swagger, and static content
+build-development: build-api
 	npm run dev
 
 #
@@ -56,8 +56,7 @@ build-pdf-concat-development:
 # Build API
 #
 
-build-api:
-	build-swagger build-ngindox
+build-api: build-swagger build-ngindox
 
 build-swagger:
 	./scripts/swagger.sh ./pages ./build-swagger


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-41611

A `Makefile` contains dependencies (artifacts that must be built before the current artifact) and shell commands. The dependencies must be listed after the colon following the artifact to be built. Currently, they are listed in following lines, and hence are interpreted as shell commands.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
