### PR TITLE
ss/DCOS-40326 Deleting service files marked for deletion.

### DIFF
--- a/pages/services/include/common-operations.tmpl
+++ b/pages/services/include/common-operations.tmpl
@@ -1,1 +1,0 @@
-TBDeleted

--- a/pages/services/include/diagnostic-tools.tmpl
+++ b/pages/services/include/diagnostic-tools.tmpl
@@ -1,1 +1,0 @@
-TBDeleted

--- a/pages/services/include/install1.tmpl
+++ b/pages/services/include/install1.tmpl
@@ -1,1 +1,0 @@
-TBDeleted

--- a/pages/services/include/install2.tmpl
+++ b/pages/services/include/install2.tmpl
@@ -1,1 +1,0 @@
-TBDeleted

--- a/pages/services/include/overview.tmpl
+++ b/pages/services/include/overview.tmpl
@@ -1,1 +1,0 @@
-TBDeleted


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-40326

Editing /services/include/ files. These five files were marked "TBDeleted" and were not called by any of the existing documents in the repo.