### PR TITLE
DCOS-39286 Allow data loading and templates in dcos versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,8 +128,7 @@ CB.use(timer('CB: Ignore'));
 //     data2: path/to/my.yml (access content in my.yml as model.data2.foo.bar)
 CB.use(dataLoader({
   dataProperty: 'model',
-  // Only enable in service pages for now.
-  match: 'services/**/*.md',
+  match: '**/*.md',
 }));
 CB.use(timer('CB: Dataloader'));
 
@@ -139,8 +138,7 @@ CB.use(timer('CB: Dataloader'));
 CB.use(includeContent({
   // Style as a C-like include statement. Must be on its own line.
   pattern: '^#include ([^ \n]+)$',
-  // Only enable in service pages for now.
-  match: 'services/**/*.md*',
+  match: '**/*.md*',
 }));
 CB.use(timer('CB: IncludeContent'));
 
@@ -149,8 +147,7 @@ CB.use(timer('CB: IncludeContent'));
 //   render: mustache
 CB.use(inPlace({
   renderProperty: 'render',
-  // Only enable in service pages for now.
-  match: 'services/**/*.md',
+  match: '**/*.md',
 }));
 CB.use(timer('CB: Mustache'));
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-39286

I did testing to make sure data loading and templates work. Feel free to do some testing of your own. I just copied existing template and data files from the service docs.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
