### PR TITLE
DCOS-40865 Allow grid to take up entire width

### DIFF
--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -4,6 +4,7 @@
   flex-wrap: wrap;
   justify-content: space-between;
   margin-top: 3rem;
+  width: 100%;
   * {
     text-decoration: none;
   }


### PR DESCRIPTION
When it doesn't, this causes a problem with the width of
the subtopic cards when there is only one because the
card width is ~50% of grid

## Description
https://jira.mesosphere.com/browse/DCOS-40865

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
