### PR TITLE
kubernetes: remove extra version string in the title

### DIFF
--- a/pages/services/kubernetes/1.3.0-1.10.8/index.md
+++ b/pages/services/kubernetes/1.3.0-1.10.8/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle: Kubernetes Version 1.3.0-1.10.8
-title: Kubernetes Version 1.3.0-1.10.8
+navigationTitle: Kubernetes 1.3.0-1.10.8
+title: Kubernetes 1.3.0-1.10.8
 menuWeight: 10
 excerpt:
 ---


### PR DESCRIPTION
## Description
This PR is to remove the extra `Version` string in the `1.3.0-1.10.8` documentation 

https://jira.mesosphere.com/browse/DCOS-42027

## Urgency
- [x] Blocker
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
