### PR TITLE
Add Python to Docker container

### DIFF
--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -15,7 +15,7 @@ ARG algolia_skip_sections
 ARG metalsmith_skip_sections
 
 RUN apt-get update -qq
-RUN apt-get install -y build-essential
+RUN apt-get install -y build-essential python
 
 RUN mkdir /src
 WORKDIR /src
@@ -39,7 +39,7 @@ npm run build
 
 # Add google site verifications
 # Google expects a very specific file format and metalsmith defaultly alters
-# it. This is temporary until a more permenant solution is made.
+# it. This is temporary until a more permanent solution is made.
 
 RUN echo "google-site-verification: google48ddb4a5390a503f.html" > /src/build/google48ddb4a5390a503f.html
 


### PR DESCRIPTION
## Description
When I run the instructions at https://github.com/mesosphere/dcos-docs-site/wiki/Local-Build#using-docker I get the error:
```
Building: /usr/local/bin/node /src/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [ '/usr/local/bin/node',
gyp verb cli   '/src/node_modules/node-gyp/bin/node-gyp.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library=' ]
gyp info using node-gyp@https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz
gyp info using node@8.1.2 | linux | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing "build" directory
gyp verb command configure []
gyp verb check python checking for Python executable "python2" in the PATH
gyp verb `which` failed Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/src/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/src/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/src/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /src/node_modules/which/which.js:89:16
gyp verb `which` failed     at /src/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /src/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed  python2 { Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/src/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/src/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/src/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /src/node_modules/which/which.js:89:16
gyp verb `which` failed     at /src/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /src/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed   stack: 'Error: not found: python2\n    at getNotFoundError (/src/node_modules/which/which.js:13:12)\n    at F (/src/node_modules/which/which.js:68:19)\n    at E (/src/node_modules/which/which.js:80:29)\n    at /src/node_modules/which/which.js:89:16\n    at /src/node_modules/isexe/index.js:42:5\n    at /src/node_modules/isexe/mode.js:8:5\n    at FSReqWrap.oncomplete (fs.js:152:21)',
gyp verb `which` failed   code: 'ENOENT' }
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` failed Error: not found: python
gyp verb `which` failed     at getNotFoundError (/src/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/src/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/src/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /src/node_modules/which/which.js:89:16
gyp verb `which` failed     at /src/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /src/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed  python { Error: not found: python
gyp verb `which` failed     at getNotFoundError (/src/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/src/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/src/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /src/node_modules/which/which.js:89:16
gyp verb `which` failed     at /src/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /src/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed   stack: 'Error: not found: python\n    at getNotFoundError (/src/node_modules/which/which.js:13:12)\n    at F (/src/node_modules/which/which.js:68:19)\n    at E (/src/node_modules/which/which.js:80:29)\n    at /src/node_modules/which/which.js:89:16\n    at /src/node_modules/isexe/index.js:42:5\n    at /src/node_modules/isexe/mode.js:8:5\n    at FSReqWrap.oncomplete (fs.js:152:21)',
gyp verb `which` failed   code: 'ENOENT' }
gyp ERR! configure error 
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/src/node_modules/node-gyp/lib/configure.js:483:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/src/node_modules/node-gyp/lib/configure.js:397:16)
gyp ERR! stack     at F (/src/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/src/node_modules/which/which.js:80:29)
gyp ERR! stack     at /src/node_modules/which/which.js:89:16
gyp ERR! stack     at /src/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /src/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:152:21)
gyp ERR! System Linux 4.15.0-34-generic
gyp ERR! command "/usr/local/bin/node" "/src/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /src/node_modules/node-sass
gyp ERR! node -v v8.1.2
gyp ERR! node-gyp -v vhttps://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz
gyp ERR! not ok 
Build failed with error code: 1
npm info lifecycle node-sass@4.7.2~postinstall: Failed to exec postinstall script
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-sass@4.7.2 postinstall: `node scripts/build.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-sass@4.7.2 postinstall script.
```

This PR adds Python to the Docker container, so it can be found.


## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
