### PR TITLE
ck/DCOS-25758 Correct Zen template header and normalize styling 

### DIFF
--- a/pages/1.10/installing/ent/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.10/installing/ent/cloud/aws/advanced/template-reference/index.md
@@ -19,16 +19,16 @@ enterprise: true
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-### Zen templates
+#### Zen templates
 The [Zen](#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
-### Agent templates
+#### Agent templates
 The [agent](#private-agent) templates create [public](/1.10/overview/concepts/#public-agent-node) or [private](/1.10/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup. 
 
-### Master templates
+#### Master templates
 The [master](#master) templates create master nodes, on top of the infrastructure stack already created.
 
-### Infrastructure template
+#### Infrastructure template
 The [infrastructure](#infrastructure) template defines and creates a DC/OS specific infrastructure that works well with an existing VPC. 
 
 

--- a/pages/1.10/installing/oss/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.10/installing/oss/cloud/aws/advanced/template-reference/index.md
@@ -11,7 +11,7 @@ menuWeight: 200
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-#### [Zen](#zen) template
+#### Zen template
 The [Zen](/1.10/installing/oss/cloud/aws/advanced/template-reference/#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
 #### Agent template

--- a/pages/1.11/installing/evaluation/cloud-installation/aws/advanced/template-reference/index.md
+++ b/pages/1.11/installing/evaluation/cloud-installation/aws/advanced/template-reference/index.md
@@ -8,16 +8,16 @@ excerpt: Advanced template parameters
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-### Zen templates
+#### Zen templates
 The [Zen](#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
-### Agent templates
+#### Agent templates
 The [agent](#private-agent) templates create [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup.
 
-### Master templates
+#### Master templates
 The [master](#master) templates create master nodes, on top of the infrastructure stack already created.
 
-### Infrastructure template
+#### Infrastructure template
 The [infrastructure](#infrastructure) template defines and creates a DC/OS specific infrastructure that works well with an existing VPC.
 
 

--- a/pages/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/index.md
@@ -8,16 +8,16 @@ excerpt: Advanced template parameters
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-### Zen templates
+#### Zen templates
 The [Zen](#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
-### Agent templates
+#### Agent templates
 The [agent](#private-agent) templates create [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup.
 
-### Master templates
+#### Master templates
 The [master](#master) templates create master nodes, on top of the infrastructure stack already created.
 
-### Infrastructure template
+#### Infrastructure template
 The [infrastructure](#infrastructure) template defines and creates a DC/OS specific infrastructure that works well with an existing VPC.
 
 

--- a/pages/1.7/administration/installing/ent/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.7/administration/installing/ent/cloud/aws/advanced/template-reference/index.md
@@ -16,16 +16,16 @@ enterprise: true
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-### Zen templates
+#### Zen templates
 The [Zen](#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
-### Agent templates
+#### Agent templates
 The [agent](#private-agent) templates create [public](/1.7/overview/concepts/#public-agent-node) or [private](/1.7/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup. 
 
-### Master templates
+#### Master templates
 The [master](#master) templates create master nodes, on top of the infrastructure stack already created.
 
-### Infrastructure template
+#### Infrastructure template
 The [infrastructure](#infrastructure) template defines and creates a DC/OS specific infrastructure that works well with an existing VPC. 
 
 

--- a/pages/1.7/administration/installing/oss/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.7/administration/installing/oss/cloud/aws/advanced/template-reference/index.md
@@ -11,7 +11,7 @@ menuWeight: 200
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-#### [Zen](#zen) template
+#### Zen template
 The [Zen](/1.7/administration/installing/oss/cloud/aws/advanced/template-reference/#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
 #### Agent template

--- a/pages/1.8/administration/installing/ent/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.8/administration/installing/ent/cloud/aws/advanced/template-reference/index.md
@@ -19,16 +19,16 @@ enterprise: true
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-### Zen templates
+#### Zen templates
 The [Zen](#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
-### Agent templates
+#### Agent templates
 The [agent](#private-agent) templates create [public](/1.8/overview/concepts/#public-agent-node) or [private](/1.8/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup. 
 
-### Master templates
+#### Master templates
 The [master](#master) templates create master nodes, on top of the infrastructure stack already created.
 
-### Infrastructure template
+#### Infrastructure template
 The [infrastructure](#infrastructure) template defines and creates a DC/OS specific infrastructure that works well with an existing VPC. 
 
 

--- a/pages/1.8/administration/installing/oss/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.8/administration/installing/oss/cloud/aws/advanced/template-reference/index.md
@@ -11,7 +11,7 @@ menuWeight: 200
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-#### [Zen](#zen) template
+#### Zen template
 The [Zen](/1.8/administration/installing/oss/cloud/aws/advanced/template-reference/#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
 #### Agent template

--- a/pages/1.9/installing/ent/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.9/installing/ent/cloud/aws/advanced/template-reference/index.md
@@ -19,16 +19,16 @@ enterprise: true
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-### Zen templates
+#### Zen templates
 The [Zen](#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
-### Agent templates
+#### Agent templates
 The [agent](#private-agent) templates create [public](/1.9/overview/concepts/#public-agent-node) or [private](/1.9/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup. 
 
-### Master templates
+#### Master templates
 The [master](#master) templates create master nodes, on top of the infrastructure stack already created.
 
-### Infrastructure template
+#### Infrastructure template
 The [infrastructure](#infrastructure) template defines and creates a DC/OS specific infrastructure that works well with an existing VPC. 
 
 

--- a/pages/1.9/installing/oss/cloud/aws/advanced/template-reference/index.md
+++ b/pages/1.9/installing/oss/cloud/aws/advanced/template-reference/index.md
@@ -11,7 +11,7 @@ menuWeight: 200
 
 These advanced template parameters are specified in the individual JSON files. During DC/OS installation these template files are used to generate a customized DC/OS build.
 
-#### [Zen](#zen) template
+#### Zen template
 The [Zen](/1.9/installing/oss/cloud/aws/advanced/template-reference/#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
 #### Agent template


### PR DESCRIPTION
Remove linking in header for Zen template info and normalize the styling across all the docs

## Description
https://jira.mesosphere.com/browse/DCOS-25758

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
