### PR TITLE
1.12>>Installing docs - Replaced 1.11 with 1.12.

### DIFF
--- a/pages/1.12/installing/evaluation/cloud-installation/aws/advanced/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/aws/advanced/index.md
@@ -39,7 +39,7 @@ You must have an AWS EC2 <a href="https://aws.amazon.com/ec2/pricing/" target="_
 - An AWS EC2 Key Pair for the same region as your cluster. Key pairs cannot be shared across regions. The AWS key pair uses public-key cryptography to provide secure login to your AWS cluster. For more information about creating an AWS EC2 Key Pair, see the <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair" target="_blank">documentation</a>.
 - AWS [Command Line Interface](https://aws.amazon.com/cli/).
 - The CLI JSON processor [jq](https://github.com/stedolan/jq/wiki/Installation).
-- A node that meets the bootstrap node [system requirements](/1.11/installing/ent/custom/system-requirements/).
+- A node that meets the bootstrap node [system requirements](/1.12/installing/ent/custom/system-requirements/).
 - An AWS S3 bucket with read-write access.
     - The S3 bucket must have a bucket policy that allows the launched AWS instances to download the files from the s3 bucket. Here is a sample policy that allows anyone to download:
 
@@ -96,7 +96,7 @@ The required parameters for Enterprise and Open Source users are:
     aws_template_storage_secret_access_key: <your-secret-access_key>
 
 
-For parameters descriptions and configuration examples, see the [documentation](/1.11/installing/ent/custom/configuration/configuration-parameters/).
+For parameters descriptions and configuration examples, see the [documentation](/1.12/installing/ent/custom/configuration/configuration-parameters/).
 
 3.  Run the DC/OS installer script with the AWS argument specified. This command creates and uploads a custom build of the DC/OS artifacts and templates to the specified S3 bucket.
 
@@ -196,7 +196,7 @@ Use the `zen.sh` script to create the template dependencies. These dependencies 
 
 1.  Go to [CloudFormation](https://console.aws.amazon.com/cloudformation/home) and click **Create Stack**.
 
-- On the **Select Template** page, upload the [Zen](/1.11/installing/evaluation/cloud-installation/aws/advanced/template-reference/#zen) template from your workstation and click **Next**.
+- On the **Select Template** page, upload the [Zen](/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/#zen) template from your workstation and click **Next**.
 
 Template examples:
 
@@ -206,12 +206,12 @@ Template examples:
 
 2.  On the **Specify Details** page, specify these values and and click **Next**.
 
-    ![AWS UI](/1.11/img/aws-advanced-1.png)
+    ![AWS UI](/1.12/img/aws-advanced-1.png)
 
      Figure 1. AWS Advanced web interface
 
     *  **Stack name** Specify the cluster name.
-    *  **CustomAMI** Optional: Specify the AMI ID. For more information, see [Installing Using a Custom AMI](/1.11/installing/ent/cloud/aws/advanced/aws-ami).
+    *  **CustomAMI** Optional: Specify the AMI ID. For more information, see [Installing Using a Custom AMI](/1.12/installing/ent/cloud/aws/advanced/aws-ami).
     *  **InternetGateway** Specify the `InternetGatewayID` output value from the `zen.sh` script. The Internet Gateway ID must be attached to the VPC. This Internet Gateway will be used by all nodes for outgoing internet access.
     *  **KeyName** Specify your AWS EC2 Key Pair.
     *  **MasterInstanceType** Specify the AWS EC2 instance type. The <a href="https://aws.amazon.com/ec2/pricing/" target="_blank">m3.xlarge</a> instance type is recommended.
@@ -237,7 +237,7 @@ In CloudFormation you should see that:
 
 *  The cluster stack spins up over a period of 15 to 20 minutes. You will have a stack created for each of these, where `<stack-name>` is the value you specified for **Stack name** and `<stack-id>` is an auto-generated ID.
 
-   ![AWS UI](/1.11/img/aws-advanced-2.png)
+   ![AWS UI](/1.12/img/aws-advanced-2.png)
 
    Figure 2. AWS Stack details
 
@@ -265,7 +265,7 @@ You can launch the DC/OS web interface by entering the master hostname. Follow t
 
     **Note:** You might need to resize your window to see this tab. You can find your DC/OS hostname any time from the <a href="https://console.aws.amazon.com/cloudformation/home" target="_blank">AWS CloudFormation Management</a> page.
 
-    ![Monitor stack creation](/1.11/img/dcos-aws-step3a.png)
+    ![Monitor stack creation](/1.12/img/dcos-aws-step3a.png)
 
     Figure 3. Mesos master hostname
 
@@ -277,7 +277,7 @@ You can launch the DC/OS web interface by entering the master hostname. Follow t
     </tr> 
     </table>
 
-    ![UI installer success](/1.11/img/gui-installer-success-ee.gif)
+    ![UI installer success](/1.12/img/gui-installer-success-ee.gif)
 
     Figure 4. Success screen
 
@@ -285,13 +285,13 @@ You can launch the DC/OS web interface by entering the master hostname. Follow t
 
     **Note:** The default username is `bootstrapuser` and default password is `deleteme`.
 
-    ![alt text](/1.11/img/ui-installer-auth2.png)
+    ![alt text](/1.12/img/ui-installer-auth2.png)
 
     Figure 5. Sign-in screen
 
     You are done!
 
-    ![UI dashboard](/1.11/img/dashboard-ee.png)
+    ![UI dashboard](/1.12/img/dashboard-ee.png)
 
     Figure 6. DC/OS dashboard
 
@@ -301,7 +301,7 @@ Now that your advanced template DC/OS installation is up and running, you can ad
 
 ### Add more agent nodes
 
-You can add more agent nodes by creating a new stack. Use the [advanced-priv-agent.json](/1.11/installing/evaluation/cloud-installation/aws/advanced/template-reference/#private-agent) or [advanced-pub-agent.json](/1.11/installing/evaluation/cloud-installation/aws/advanced/template-reference/#public-agent) templates. These templates create agents which are then attached to the `PrivateAgentStack` or `PublicAgentStack` as a part of an AutoScalingGroup.
+You can add more agent nodes by creating a new stack. Use the [advanced-priv-agent.json](/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/#private-agent) or [advanced-pub-agent.json](/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/#public-agent) templates. These templates create agents which are then attached to the `PrivateAgentStack` or `PublicAgentStack` as a part of an AutoScalingGroup.
 
 Use the output values from the `zen.sh` script and your Master and Infra stacks. These new agent nodes will automatically be added to your DC/OS cluster.
 
@@ -323,7 +323,7 @@ Public agents:
 *  **PublicAgentSecurityGroup** Specify the security group ID for public agents. This group should have limited external access. You can find this value in the **Outputs** tab of the Infrastructure stack (`<stack-name>-Infrastructure-<stack-id>`).
 *  **PublicSubnet** Specify the `Public SubnetId` output value from the `zen.sh` script. This subnet ID will be used by all public agents.
 
-For all of the advanced configuration options, see the template reference [documentation](/1.11/installing/evaluation/cloud-installation/aws/advanced/template-reference/).
+For all of the advanced configuration options, see the template reference [documentation](/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/).
 
 
 # Limitations
@@ -335,4 +335,4 @@ For all of the advanced configuration options, see the template reference [docum
 
 
 # Template reference
-For the complete advanced configuration options, see the template reference [documentation](/1.11/installing/evaluation/cloud-installation/aws/advanced/template-reference/).
+For the complete advanced configuration options, see the template reference [documentation](/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/).

--- a/pages/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/aws/advanced/template-reference/index.md
@@ -12,7 +12,7 @@ These advanced template parameters are specified in the individual JSON files. D
 The [Zen](#zen) templates orchestrate the individual component templates to create a DC/OS cluster.
 
 #### Agent templates
-The [agent](#private-agent) templates create [public](/1.11/overview/concepts/#public-agent-node) or [private](/1.11/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup.
+The [agent](#private-agent) templates create [public](/1.12/overview/concepts/#public-agent-node) or [private](/1.12/overview/concepts/#private-agent-node) agent nodes that are then attached to a DC/OS cluster as a part of an AutoScalingGroup.
 
 #### Master templates
 The [master](#master) templates create master nodes, on top of the infrastructure stack already created.

--- a/pages/1.12/installing/evaluation/cloud-installation/aws/basic/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/aws/basic/index.md
@@ -15,7 +15,7 @@ The basic templates provide:
 
 These instructions provide a basic AWS CloudFormation template that creates a DC/OS cluster that is suitable for demonstrations and POCs. This is the fastest way to get started with the DC/OS templates for AWS CloudFormation.
 
-For a complete set of DC/OS configuration options, see the [Advanced AWS Install Guide](/1.11/installing/ent/cloud/aws/advanced/).
+For a complete set of DC/OS configuration options, see the [Advanced AWS Install Guide](/1.12/installing/ent/cloud/aws/advanced/).
 
 <table class=“table” bgcolor=#858585>
 <tr> 
@@ -30,8 +30,8 @@ For a complete set of DC/OS configuration options, see the [Advanced AWS Install
 An AWS EC2 <a href="https://aws.amazon.com/ec2/pricing/" target="_blank">m3.xlarge</a> instance.  Selecting smaller-sized VMs is not recommended, and selecting fewer VMs will likely cause certain resource-intensive services, such as distributed datastores, to not work properly.
 
 *   You have the option of one or three Mesos master nodes.
-*   The default is five [private](/1.11/overview/concepts/#private-agent-node) Mesos agent nodes.
-*   The default is one [public](/1.11/overview/concepts/#public-agent-node) Mesos agent node. By default, ports are closed and health checks are configured for Marathon-LB. Ports 80 and 443 are configured for the AWS Elastic Load Balancer.
+*   The default is five [private](/1.12/overview/concepts/#private-agent-node) Mesos agent nodes.
+*   The default is one [public](/1.12/overview/concepts/#public-agent-node) Mesos agent node. By default, ports are closed and health checks are configured for Marathon-LB. Ports 80 and 443 are configured for the AWS Elastic Load Balancer.
 
 ## Software
 
@@ -62,7 +62,7 @@ An AWS EC2 <a href="https://aws.amazon.com/ec2/pricing/" target="_blank">m3.xlar
 </tr> 
 </table>
 
-   ![Launch stack](/1.11/img/dcos-aws-step2b.png)
+   ![Launch stack](/1.12/img/dcos-aws-step2b.png)
 
    Figure 1. Launch stack
 
@@ -72,7 +72,7 @@ An AWS EC2 <a href="https://aws.amazon.com/ec2/pricing/" target="_blank">m3.xlar
 
 6. Skip the Open Source users section and go to Step 6. 
 
-![Create stack](/1.11/img/dcos-aws-step2c-ee.png)
+![Create stack](/1.12/img/dcos-aws-step2c-ee.png)
 
 Figure 2. Create stack
 
@@ -84,7 +84,7 @@ Figure 2. Create stack
 
 2.  On the **Select Template** page, accept the defaults and click **Next**.
 
-   ![Launch stack](/1.11/img/dcos-aws-step2b.png)
+   ![Launch stack](/1.12/img/dcos-aws-step2b.png)
 
    Figure 3. Launch stack
 
@@ -99,7 +99,7 @@ Figure 2. Create stack
 
 4. Go to Step 6 in the "All users" section.
 
-![Create stack](/1.11/img/dcos-aws-step2c.png)
+![Create stack](/1.12/img/dcos-aws-step2c.png)
 
 Figure 4. Create stack
 
@@ -128,13 +128,13 @@ In <a href="https://console.aws.amazon.com/cloudformation/home" target="_blank">
 
 2.  Click the **Outputs** tab and copy the Mesos Master hostname.
 
-   ![Monitor stack creation](/1.11/img/dcos-stack.png)
+   ![Monitor stack creation](/1.12/img/dcos-stack.png)
 
    Figure 5. Monitor stack creation
 
 3.  Paste the hostname into your browser to open the DC/OS web interface. The interface runs on the standard HTTP port 80, so you do not need to specify a port number after the hostname.  Your browser may show a warning that your connection is not secure. This is because DC/OS uses self-signed certificates. You can ignore this error and click to proceed to the login screen.
 
-   ![DC/OS GUI auth](/1.11/img/dc-os-gui-login-ee.png)
+   ![DC/OS GUI auth](/1.12/img/dc-os-gui-login-ee.png)
 
    Figure 6. DC/OS web interface login screen
 
@@ -155,7 +155,7 @@ You must install the [DC/OS Command-Line Interface (CLI)][2] to administer your 
 - [Add users to your cluster][3]
 - [Scaling considerations][4]
 
- [1]: /1.11/administering-clusters/managing-aws/
- [2]: /1.11/cli/install/
- [3]: /1.11/security/ent/users-groups/
+ [1]: /1.12/administering-clusters/managing-aws/
+ [2]: /1.12/cli/install/
+ [3]: /1.12/security/ent/users-groups/
  [4]: https://aws.amazon.com/autoscaling/

--- a/pages/1.12/installing/evaluation/cloud-installation/aws/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/aws/index.md
@@ -16,5 +16,5 @@ You can create a DC/OS cluster for Amazon Web Services (AWS) by using the DC/OS 
 - Updates of DC/OS on AWS CloudFormation have not been automated, validated, or documented.
 - Modified CloudFormation templates are not supported by Mesosphere, Inc.
 
-The recommended way to install production-ready DC/OS that can be upgraded in-place is to use the [Installation method](1.11/installing/production/deploying-dcos/installation/).
+The recommended way to install production-ready DC/OS that can be upgraded in-place is to use the [Installation method](1.12/installing/production/deploying-dcos/installation/).
 [/message]

--- a/pages/1.12/installing/evaluation/cloud-installation/azure/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/azure/index.md
@@ -7,7 +7,7 @@ menuWeight: 10
 oss: true
 ---
 
-This page explains how to install DC/OS 1.11 using the Azure Resource Manager templates.
+This page explains how to install DC/OS 1.12 using the Azure Resource Manager templates.
 
 **Note:** To get support on Azure Marketplace-related questions, join the Azure Marketplace [Slack community](http://join.marketplace.azure.com).
 
@@ -117,7 +117,7 @@ Also, to access nodes in the DC/OS cluster you will need `ssh` installed and con
 
 ## Deploying the template
 
-To install DC/OS 1.11 on Azure, use the [Azure Resource Manager templates](https://downloads.dcos.io/dcos/stable/azure.html) provided.
+To install DC/OS 1.12 on Azure, use the [Azure Resource Manager templates](https://downloads.dcos.io/dcos/stable/azure.html) provided.
 
 Some notes on the template configuration:
 
@@ -130,13 +130,13 @@ Some notes on the template configuration:
 
 1. Look up `MASTERFQDN` in the outputs of the deployment. To find that, click on the link under `Last deployment` (which is `4/15/2016 (Succeeded)` here) and you should see this:
 
-![Deployment history](/1.11/img/dcos-azure-marketplace-step2a.png)
+![Deployment history](/1.12/img/dcos-azure-marketplace-step2a.png)
 
 Figure 1. Deployment history
 
 2. Click on the latest deployment and copy the value of `MASTERFQDN` in the `Outputs` section.
 
-![Deployment output](/1.11/img/dcos-azure-marketplace-step2b.png)
+![Deployment output](/1.12/img/dcos-azure-marketplace-step2b.png)
 
 Figure 2. Outputs section
 
@@ -150,37 +150,37 @@ In order to visit the the DC/OS Dashboard, you will need to access TCP port 80 o
 
 1. Find the network security group resource of the master node,
 
-![Resource - Master Node Network Security Group](/1.11/img/dcos-azure-step2case1a.png)
+![Resource - Master Node Network Security Group](/1.12/img/dcos-azure-step2case1a.png)
 
 Figure 1. Master node network security group
 
 2. Click on the **Inbound security rules** tab on the left side.
 
-![Inbound Security Rules](/1.11/img/dcos-azure-step2case1b.png)
+![Inbound Security Rules](/1.12/img/dcos-azure-step2case1b.png)
 
 Figure 2. Inbound security rules
 
 3. Add an inbound security rule.
 
-![Add Inbound Security Rules](/1.11/img/dcos-azure-step2case1c.png)
+![Add Inbound Security Rules](/1.12/img/dcos-azure-step2case1c.png)
 
 Figure 3. Adding an inbound security rule 
 
 4. Find the load balancer resource of the master node.
 
-![Resource - Master Node Load balancer](/1.11/img/dcos-azure-step2case1d.png)
+![Resource - Master Node Load balancer](/1.12/img/dcos-azure-step2case1d.png)
 
 Figure 4. Master node load balancer
 
 5. Click on the **Inbound NAT rules** tab on the left side,
 
-![Inbound NAT Rules](/1.11/img/dcos-azure-step2case1e.png)
+![Inbound NAT Rules](/1.12/img/dcos-azure-step2case1e.png)
 
 Figure 5. Inbound NAT rules
 
 6. Add an inbound NAT rule.
 
-![Add Inbound NAT Rules](/1.11/img/dcos-azure-step2case1f.png)
+![Add Inbound NAT Rules](/1.12/img/dcos-azure-step2case1f.png)
 
 Figure 6. Adding an inbound NAT rule
 
@@ -204,7 +204,7 @@ ssh azureuser@dcosmaster.westus.cloudapp.azure.com -L 8000:localhost:80
 
 Now you can visit `http://localhost:8000` on your local machine and view the DC/OS Dashboard.
 
-![DC/OS dashboard](/1.11/img/dcos-gui.png)
+![DC/OS dashboard](/1.12/img/dcos-gui.png)
 
 Figure 1. DC/OS dashboard
 
@@ -228,7 +228,7 @@ The following commands can be used to run the DC/OS CLI directly on the master n
 ssh azureuser@$MASTERFQDN
 
 # Install CLI on the master node and configure with http://localhost
-curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.11/dcos -o dcos &&
+curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos -o dcos &&
 sudo mv dcos /usr/local/bin &&
 sudo chmod +x /usr/local/bin/dcos &&
 dcos cluster setup http://localhost &&
@@ -248,6 +248,6 @@ If you have created a new resource group in the deployment step, it is easy to t
 - [Install the DC/OS Command-Line Interface (CLI)][2]
 - [Scaling considerations][4]
 
-[1]: /1.11/security/ent/users-groups/
-[2]: /1.11/cli/install/
+[1]: /1.12/security/ent/users-groups/
+[2]: /1.12/cli/install/
 [4]: https://azure.microsoft.com/en-us/documentation/articles/best-practices-auto-scaling/

--- a/pages/1.12/installing/evaluation/cloud-installation/digitalocean/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/digitalocean/index.md
@@ -102,11 +102,11 @@ The following have default values and may be changed depending on your requireme
 
 8.  Also from that same directory, run `terraform init` and then `terraform apply` which will deploy the servers into your project at DigitalOcean, and run the DC/OS installation routine. When it completes, you will see output similar to the following, but with the IP addresses assigned to your servers:
 
-  ![terraform apply output](/1.11/img/digitalocean_terraform_output.png)
+  ![terraform apply output](/1.12/img/digitalocean_terraform_output.png)
 
   Figure 1. Terraform apply output
 
-You may need to wait a few minutes from this point for all the DC/OS services to become active and the control panel to become available on the master node. After 15 or 20 minutes, check out the [troubleshooting](1.11/installing/troubleshooting/) documentation.
+You may need to wait a few minutes from this point for all the DC/OS services to become active and the control panel to become available on the master node. After 15 or 20 minutes, check out the [troubleshooting](1.12/installing/troubleshooting/) documentation.
 
 # Launch DC/OS
 Launch the DC/OS web interface by entering the Mesos master IP address:
@@ -115,7 +115,7 @@ Launch the DC/OS web interface by entering the Mesos master IP address:
 
 2.  Install the DC/OS Command-Line Interface (CLI). You can install the CLI to administer your DC/OS cluster. You can access the documentation at any time by clicking the cluster name in the upper-left side.
 
-  ![install CLI](/1.11/img/install-cli-terminal.png)
+  ![install CLI](/1.12/img/install-cli-terminal.png)
 
   Figure 2. Installing the CLI
 

--- a/pages/1.12/installing/evaluation/cloud-installation/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/index.md
@@ -14,6 +14,6 @@ DC/OS CloudFormation templates are intended for reference only and are not recom
 - Updates of DC/OS on AWS CloudFormation have not been automated, validated, or documented.
 - Modified CloudFormation templates are not supported by Mesosphere, Inc.
 
-You can use the [Production Installation](/1.11/installing/production/) methods to install a fully functional cluster.
+You can use the [Production Installation](/1.12/installing/production/) methods to install a fully functional cluster.
 
 

--- a/pages/1.12/installing/evaluation/cloud-installation/packet/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/packet/index.md
@@ -83,11 +83,11 @@ You can create a DC/OS cluster on Packet bare metal using Terraform. The include
 
 5.  Also from that same directory, run `terraform apply` which will deploy the servers into your project at Packet, and run the DC/OS installation routine. When it completes, you will see output similar to the following, but with the IP addresses assigned to your servers:
 
-    ![terraform apply output](/1.11/img/packet_terraform_output.png)
+    ![terraform apply output](/1.12/img/packet_terraform_output.png)
 
     Figure 1. "Terraform apply" output
 
-You may need to wait a few minutes from this point for all the DC/OS services to become active and the control panel available on the master node. After 15 or 20 minutes, see the [troubleshooting](/1.11/installing/troubleshooting/) documentation.
+You may need to wait a few minutes from this point for all the DC/OS services to become active and the control panel available on the master node. After 15 or 20 minutes, see the [troubleshooting](/1.12/installing/troubleshooting/) documentation.
 
 # Launch DC/OS
 Launch the DC/OS web interface by entering the Mesos master IP address:
@@ -96,7 +96,7 @@ Launch the DC/OS web interface by entering the Mesos master IP address:
 
 2.  Install the DC/OS Command-Line Interface (CLI). You can install the CLI to administer your DC/OS cluster. You can access the documentation at any time by clicking the cluster name in the upper-left side.
 
-    ![install CLI](/1.11/img/install-cli-terminal.png)
+    ![install CLI](/1.12/img/install-cli-terminal.png)
 
     Figure 2. Install DC/OS CLI screen
 

--- a/pages/1.12/installing/evaluation/index.md
+++ b/pages/1.12/installing/evaluation/index.md
@@ -23,9 +23,9 @@ DC/OS CloudFormation templates are intended for reference only and are not recom
 - Modified CloudFormation templates are not supported by Mesosphere, Inc.
 
 The following methods are used to install DC/OS:
-- [Provision DC/OS on Amazon Web Services](/1.11/installing/evaluation/cloud-installation/aws/) (AWS): Install your DC/OS cluster on Amazon Web Services (AWS) by using the DC/OS templates on AWS CloudFormation. 
-- [Provision DC/OS on Azure](/1.11/installing/evaluation/cloud-installation/azure/): Install your DC/OS cluster on Azure by using the Azure Resource Manager templates.
-- [Provision DC/OS on Google Cloud Platform (GCE)](/1.11/installing/evaluation/cloud-installation/gce/): Install your DC/OS cluster on Google Compute Engine (GCE) by using installation scripts. Upgrades are not supported with this installation method.
+- [Provision DC/OS on Amazon Web Services](/1.12/installing/evaluation/cloud-installation/aws/) (AWS): Install your DC/OS cluster on Amazon Web Services (AWS) by using the DC/OS templates on AWS CloudFormation. 
+- [Provision DC/OS on Azure](/1.12/installing/evaluation/cloud-installation/azure/): Install your DC/OS cluster on Azure by using the Azure Resource Manager templates.
+- [Provision DC/OS on Google Cloud Platform (GCE)](/1.12/installing/evaluation/cloud-installation/gce/): Install your DC/OS cluster on Google Compute Engine (GCE) by using installation scripts. Upgrades are not supported with this installation method.
 
 **Note:** The recommended way to install production ready DC/OS that can be upgraded in-place is to use the production installation method.
 

--- a/pages/1.12/installing/evaluation/on-premise-installation/index.md
+++ b/pages/1.12/installing/evaluation/on-premise-installation/index.md
@@ -18,5 +18,5 @@ You can install a DC/OS cluster on your own premises using the following methods
 **Note:** 
 - These installation methods are not officially supported by Mesosphere, but are supported by the DC/OS community. Contact the [mailing list](https://groups.google.com/a/dcos.io/forum/#!forum/users) or [Slack channel](http://chat.dcos.io/?_ga=2.226911897.58407594.1533244861-1110201164.1520633201) for community support.
 
-- The recommended way to install production-ready DC/OS that can be upgraded in place is to use the [production installation](/1.11/installing/production/deploying-dcos/installation/) method.
+- The recommended way to install production-ready DC/OS that can be upgraded in place is to use the [production installation](/1.12/installing/production/deploying-dcos/installation/) method.
 

--- a/pages/1.12/installing/index.md
+++ b/pages/1.12/installing/index.md
@@ -21,30 +21,30 @@ The DC/OS installation methods are as follows:
 This section describes an overview of the installation methods. Use the following installation methods based on your requirements.
 
 ## Development 
-You can run a cluster using the [local installation method](/1.11/installing/development/). This method is for first-time users or developers intending to build services or modify DC/OS. The Vagrant installer provides a quick, free way to deploy a virtual cluster on a single machine.
+You can run a cluster using the [local installation method](/1.12/installing/development/). This method is for first-time users or developers intending to build services or modify DC/OS. The Vagrant installer provides a quick, free way to deploy a virtual cluster on a single machine.
  
 
 ## Evaluation 
-You can [evaluate](/1.11/installing/evaluation/) the installation process using the following installation methods:
+You can [evaluate](/1.12/installing/evaluation/) the installation process using the following installation methods:
 
 ### <a name="cloud-install"></a>Cloud Installation 
 This installation method is used for fast demos and proofs of concept. DC/OS CloudFormation templates are intended for reference only and are not recommended for production use.
 
 Any of the following methods can be used to install DC/OS:
-- [Provision DC/OS on Amazon Web Services](/1.11/installing/evaluation/cloud-installation/aws/) (AWS): Install your DC/OS cluster on Amazon Web Services (AWS) by using the DC/OS templates on AWS CloudFormation. 
-- [Provision DC/OS on Azure](/1.11/installing/evaluation/cloud-installation/azure/): Install your DC/OS cluster on Azure by using the Azure Resource Manager templates.
-- [Provision DC/OS on DigitalOcean](/1.11/installing/evaluation/cloud-installation/digitalocean/): Install your DC/OS cluster on DigitalOcean by using Terraform templates that are configured to run Mesosphere DC/OS on DigitalOcean.
-- [Provision DC/OS on Google Cloud Platform (GCE)](/1.11/installing/evaluation/cloud-installation/gce/): Install your DC/OS cluster on Google Compute Engine (GCE) by using installation scripts. Upgrades are not supported with this installation method.
-- [Provision DC/OS on Packet bare metal](/1.11/installing/evaluation/cloud-installation/packet/): A bare metal environment is a computer system or network in which a virtual machine is installed directly on hardware rather than within the host operating system (OS). Install your DC/OS cluster on Packet bare metal using Terraform templates that are configured to run Mesosphere DC/OS on Packet.
+- [Provision DC/OS on Amazon Web Services](/1.12/installing/evaluation/cloud-installation/aws/) (AWS): Install your DC/OS cluster on Amazon Web Services (AWS) by using the DC/OS templates on AWS CloudFormation. 
+- [Provision DC/OS on Azure](/1.12/installing/evaluation/cloud-installation/azure/): Install your DC/OS cluster on Azure by using the Azure Resource Manager templates.
+- [Provision DC/OS on DigitalOcean](/1.12/installing/evaluation/cloud-installation/digitalocean/): Install your DC/OS cluster on DigitalOcean by using Terraform templates that are configured to run Mesosphere DC/OS on DigitalOcean.
+- [Provision DC/OS on Google Cloud Platform (GCE)](/1.12/installing/evaluation/cloud-installation/gce/): Install your DC/OS cluster on Google Compute Engine (GCE) by using installation scripts. Upgrades are not supported with this installation method.
+- [Provision DC/OS on Packet bare metal](/1.12/installing/evaluation/cloud-installation/packet/): A bare metal environment is a computer system or network in which a virtual machine is installed directly on hardware rather than within the host operating system (OS). Install your DC/OS cluster on Packet bare metal using Terraform templates that are configured to run Mesosphere DC/OS on Packet.
  
- **Note:** The recommended way to install production-ready DC/OS that can be upgraded in-place is to use the [production installation](/1.11/installing/production/) method.
+ **Note:** The recommended way to install production-ready DC/OS that can be upgraded in-place is to use the [production installation](/1.12/installing/production/) method.
 
 ### On-Premise Installation
-The [on-premise installation](/1.11/installing/evaluation/on-premise-installation/) methods are described in the [DC/OS labs repo](https://github.com/dcos-labs). The different types of on-premise installation methods are:
+The [on-premise installation](/1.12/installing/evaluation/on-premise-installation/) methods are described in the [DC/OS labs repo](https://github.com/dcos-labs). The different types of on-premise installation methods are:
 - [Using Ansible](https://github.com/dcos-labs/ansible-dcos/blob/master/docs/INSTALL_ONPREM.md)
 - [Using Chef](https://github.com/dcos-labs/dcos-chef)
 - [Using Puppet](https://github.com/dcos-labs/dcos-puppet)
 
 
 ## <a name="production-install"></a>Production
-The [production installation](/1.11/installing/production/) method is used to install production-ready DC/OS that can be upgraded. This method was previously called custom installation. It involves packaging the DC/OS distribution and connecting to every node manually to run the DC/OS installation commands. This method is recommended if you want to integrate with an existing system or if you do not have SSH access to your cluster.
+The [production installation](/1.12/installing/production/) method is used to install production-ready DC/OS that can be upgraded. This method was previously called custom installation. It involves packaging the DC/OS distribution and connecting to every node manually to run the DC/OS installation commands. This method is recommended if you want to integrate with an existing system or if you do not have SSH access to your cluster.

--- a/pages/1.12/installing/installation-faq/index.md
+++ b/pages/1.12/installing/installation-faq/index.md
@@ -11,13 +11,13 @@ excerpt: Frequently asked questions about installing DC/OS
 We recommend starting with a fresh cluster to ensure all defaults are set to expected values. This prevents unexpected conditions related to mismatched versions and configurations.
 
 ## Q. What are the OS requirements of DC/OS?
-See the [system requirements](/1.11/installing/production/system-requirements/) documentation.
+See the [system requirements](/1.12/installing/production/system-requirements/) documentation.
 
 ## Q. Does DC/OS install ZooKeeper?
 DC/OS runs its own ZooKeeper supervised by Exhibitor and `systemd`.
 
 ## Q. Is it necessary to maintain a bootstrap node after the cluster is created?
-If you specify an Exhibitor storage backend type other than `exhibitor_storage_backend: static` in your cluster configuration [file](/1.11/installing/production/advanced-configuration/configuration-reference/), you must maintain the external storage for the lifetime of your cluster to facilitate leader elections. If your cluster is mission critical, you should harden your external storage by using S3 or running the bootstrap ZooKeeper as a quorum. Interruptions of service from the external storage can be tolerated, but permanent loss of state can lead to unexpected conditions.
+If you specify an Exhibitor storage backend type other than `exhibitor_storage_backend: static` in your cluster configuration [file](/1.12/installing/production/advanced-configuration/configuration-reference/), you must maintain the external storage for the lifetime of your cluster to facilitate leader elections. If your cluster is mission critical, you should harden your external storage by using S3 or running the bootstrap ZooKeeper as a quorum. Interruptions of service from the external storage can be tolerated, but permanent loss of state can lead to unexpected conditions.
 
 ## Q. How can I add Mesos attributes to nodes to use Marathon constraints?
 

--- a/pages/1.12/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.12/installing/production/advanced-configuration/configuration-reference/index.md
@@ -15,9 +15,9 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 
 | Parameter                              | Description                                                                                                                                               |
 |----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [agent_list](#agent-list)                                              | A YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.11/overview/concepts/#private-agent-node) host names. |
+| [agent_list](#agent-list)                                              | A YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.12/overview/concepts/#private-agent-node) host names. |
 | aws_template_storage_access_key_id         | The [access key ID](http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) of the account owning the AWS S3 bucket. |
-| aws_template_storage_bucket                | The name of an S3 bucket to contain [customized advanced AWS templates](/1.11/installing/ent/cloud/aws/advanced/#create-your-templates). |
+| aws_template_storage_bucket                | The name of an S3 bucket to contain [customized advanced AWS templates](/1.12/installing/ent/cloud/aws/advanced/#create-your-templates). |
 | aws_template_storage_bucket_path           | The path to a location within the S3 bucket to store template artifacts.
 | aws_template_storage_region_name           | The region containing the S3 bucket.  |
 | aws_template_storage_secret_access_key     | The [secret access key](http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) of the account owning the AWS S3 bucket. |
@@ -38,7 +38,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [mesos_container_log_sink](#mesos-container-log-sink)                 | The log manager for containers (tasks). |
 | [log_offers](#log-offers)                                             | Indicates whether the leading Mesos master should log the offers sent to schedulers. |
 | [platform](#platform)                                                 | The infrastructure platform. |
-| [public_agent_list](#public-agent-list)                               | A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.11/overview/concepts/#public-agent-node) host names.  |
+| [public_agent_list](#public-agent-list)                               | A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.12/overview/concepts/#public-agent-node) host names.  |
 | [rexray_config](#rexray-config)                                       | The [REX-Ray](https://rexray.readthedocs.io/en/v0.9.0/user-guide/config/) configuration method for enabling external persistent volumes in Marathon. You cannot specify both `rexray_config` and `rexray_config_preset`.|
 | [rexray_config_preset](#rexray-config-preset) | If you run DC/OS on AWS setting this parameter to `aws`, sets the `rexray_config` parameter to a sensible default REX-Ray configuration that is bundled with DC/OS itself. You cannot specify both `rexray_config` and `rexray_config_preset`. |
 
@@ -91,9 +91,9 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [auth_cookie_secure_flag](#auth-cookie-secure-flag-enterprise)    | Indicates whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. [enterprise type="inline" size="small" /] |
 | [bouncer_expiration_auth_token_days](#bouncer-expiration-auth-token-days-enterprise) | Sets the auth token time-to-live (TTL) for Identity and Access Management. [enterprise type="inline" size="small" /]|
 | [customer_key](#customer-key-enterprise)                       | Required - The DC/OS Enterprise customer key. [enterprise type="inline" size="small" /] |
-| ca_certificate_path                   | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
-| ca_certificate_key_path           | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
-| ca_certificate_chain_path       | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/1.11/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
+| ca_certificate_path                   | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/1.12/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
+| ca_certificate_key_path           | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/1.12/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
+| ca_certificate_chain_path       | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/1.12/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
 | [permissions_cache_ttl_seconds](#permissions-cache-ttl-seconds)   | [enterprise type="inline" size="small" /] The maximum number of seconds for permission changes to propagate through the entire system. |
 | [security](#security-enterprise)                               | The security mode: `permissive` or `strict`. [enterprise type="inline" size="small" /] |
 | [ssh_key_path](#ssh-key-path)                            | The path the installer uses to log into the target nodes. |
@@ -119,7 +119,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 # Parameter Descriptions
 
 ## adminrouter_auth_cache_enabled [enterprise type="inline" size="small" /]
-_This option was added in DC/OS 1.11.1._
+_This option was added in DC/OS 1.12.1._
 
 Controls whether the Admin Router authorization cache is enabled.
 
@@ -135,7 +135,7 @@ Indicates whether to enable TLS 1.0 in Admin Router. Changing this setting has n
 
 You are advised not to enable TLS 1.0 as the protocol is considered insecure.
 
-If you have already installed your cluster and would like to change this in place, you can go through an [upgrade](/1.11/installing/production/upgrading/) with the `adminrouter_tls_1_0_enabled` parameter set to the desired value.
+If you have already installed your cluster and would like to change this in place, you can go through an [upgrade](/1.12/installing/production/upgrading/) with the `adminrouter_tls_1_0_enabled` parameter set to the desired value.
 
 
 ## adminrouter_tls_1_1_enabled [enterprise type="inline" size="small" /]
@@ -144,7 +144,7 @@ Indicates whether to enable TLS 1.1 in Admin Router. Changing this setting has n
 - `adminrouter_tls_1_1_enabled: 'true'` Enable the TLS 1.1 protocol in Admin Router. This is the default value.
 - `adminrouter_tls_1_1_enabled: 'false'` Disable the TLS 1.1 protocol in Admin Router.
 
-If you have already installed your cluster and would like to change this in-place, you can go through an [upgrade](/1.11/installing/production/upgrading/) with the `adminrouter_tls_1_1_enabled` parameter set to the desired value.
+If you have already installed your cluster and would like to change this in-place, you can go through an [upgrade](/1.12/installing/production/upgrading/) with the `adminrouter_tls_1_1_enabled` parameter set to the desired value.
 
 
 ## adminrouter_tls_1_2_enabled [enterprise type="inline" size="small" /]
@@ -155,7 +155,7 @@ Indicates whether to enable TLS 1.2 in Admin Router. Changing this setting has n
 
 It is advised to keep this protocol version enabled as its most secure widely supported TLS version.
 
-If you have already installed your cluster and would like to change this in place, you can go through an [upgrade](/1.11/installing/production/upgrading/) with the `adminrouter_tls_1_2_enabled` parameter set to the desired value.
+If you have already installed your cluster and would like to change this in place, you can go through an [upgrade](/1.12/installing/production/upgrading/) with the `adminrouter_tls_1_2_enabled` parameter set to the desired value.
 
 ## adminrouter_tls_cipher_suite [enterprise type="inline" size="small" /]
 Provide a custom list of TLS cipher suites. The value will be passed directly into Admin Router's [`ssl_ciphers`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers) configuration directive. There is no validation of this string. Setting it incorrectly will cause DC/OS installation to fail. This configuration settings affects only Admin Routers running on DC/OS master nodes.
@@ -167,7 +167,7 @@ To validate the accuracy of the provided value, use the `openssl ciphers` utilit
 **Note:** Due to Java jurisdiction limitations, it is not possible to install DC/OS with only AES256 cipher suites.
 
 ## agent_list
-A YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.11/overview/concepts/#private-agent-node) host names.
+A YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.12/overview/concepts/#private-agent-node) host names.
 
 ## auth_cookie_secure_flag [enterprise type="inline" size="small" /]
 Indicates whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. Because the DC/OS authentication cookie allows access to the DC/OS cluster, it should be sent over an encrypted connection.
@@ -192,7 +192,7 @@ Small expiration periods may be harmful to DC/OS components.
 We recommend that the this value is set to no less than 0.25.
 If you wish to use a lower value, contact a Mesosphere support representative for guidance.
 
-For more information, see the [security](/1.11/security/ent/) documentation.
+For more information, see the [security](/1.12/security/ent/) documentation.
 
 ## cluster_docker_credentials
 The dictionary of Docker credentials to pass.
@@ -213,7 +213,7 @@ You can use the following options to further configure the Docker credentials:
             *  `cluster_docker_credentials_write_to_etc: 'false'` Do not write a credentials file.
     *  `cluster_docker_credentials_dcos_owned: 'false'` The credentials file is stored in `/etc/mesosphere/docker_credentials`.
 
-For more information, see the [examples](/1.11/installing/ent/custom/configuration/examples/#docker-credentials).
+For more information, see the [examples](/1.12/installing/ent/custom/configuration/examples/#docker-credentials).
 
 ## cluster_docker_credentials_enabled
 Whether to pass the Mesos `--docker_config` option containing [`cluster_docker_credentials`](#cluster-docker-credentials) to Mesos.
@@ -247,10 +247,10 @@ Customer keys look like this:
 ab1c23de-45f6-7g8h-9012-i345j6k7lm8n
 ```
 
-For more information, see the [security documentation](/1.11/security/ent/).
+For more information, see the [security documentation](/1.12/security/ent/).
 
 ## custom_checks
-Custom installation checks that are added to the default check configuration process. The configuration is used by the [DC/OS Diagnostics component](/1.11/overview/architecture/components/#dcos-diagnostics) to perform installation and upgrade checks. These custom checks are run alongside the default pre- and post-flight checks during installation and upgrade.
+Custom installation checks that are added to the default check configuration process. The configuration is used by the [DC/OS Diagnostics component](/1.12/overview/architecture/components/#dcos-diagnostics) to perform installation and upgrade checks. These custom checks are run alongside the default pre- and post-flight checks during installation and upgrade.
 
 - `cluster_checks` - This group of parameters specifies the health checks across the DC/OS cluster.
 
@@ -266,7 +266,7 @@ Custom installation checks that are added to the default check configuration pro
     - `cmd` - Specify an array of health check command strings
     - `timeout` - Specify how long to wait, in seconds, before assuming the check failed. A check that times out is assumed to have a status of `3 (UNKNOWN)`
 
-For more information on how these custom checks are used, see the [examples](/1.11/installing/ent/custom/configuration/examples/#custom-checks) and [Node and Cluster Health Check](/1.11/installing/ent/custom/node-cluster-health-check/) documentation.
+For more information on how these custom checks are used, see the [examples](/1.12/installing/ent/custom/configuration/examples/#custom-checks) and [Node and Cluster Health Check](/1.12/installing/ent/custom/node-cluster-health-check/) documentation.
 
 
 ## dcos_audit_logging [enterprise type="inline" size="small" /]
@@ -275,12 +275,12 @@ Indicates whether security decisions (authentication, authorization) are logged 
 * `'dcos_audit_logging': 'true'` Mesos, Marathon, and Jobs are logged. This is the default value.
 * `'dcos_audit_logging': 'false'` Mesos, Marathon, and Jobs are not logged.
 
-For more information, see the [security documentation](/1.11/security/ent/).
+For more information, see the [security documentation](/1.12/security/ent/).
 
 ## dcos_overlay_enable
 Indicates whether to enable DC/OS virtual networks.
 
-**Note:** Virtual networks require Docker version 1.11 or later but, if you are using Docker 1.11 or earlier then you must specify `dcos_overlay_enable: 'false'`. For more information, see the [system requirements](/1.11/installing/ent/custom/system-requirements/).
+**Note:** Virtual networks require Docker version 1.12 or later but, if you are using Docker 1.12 or earlier then you must specify `dcos_overlay_enable: 'false'`. For more information, see the [system requirements](/1.12/installing/ent/custom/system-requirements/).
 
 *  `dcos_overlay_enable: 'false'` Do not enable the DC/OS virtual network.
 *  `dcos_overlay_enable: 'true'` Enable the DC/OS virtual network. This is the default value. After the virtual network is enabled, you can also specify the following parameters:
@@ -308,11 +308,11 @@ Indicates whether to enable DC/OS virtual networks.
         **Note:** The last three bytes must be `00`.
 
         *  `overlays`
-            *  `name` The canonical name (see [limitations](/1.11/networking/virtual-networks/) for constraints on naming virtual networks).
+            *  `name` The canonical name (see [limitations](/1.12/networking/virtual-networks/) for constraints on naming virtual networks).
             *  `subnet` The subnet that is allocated to the virtual network.
             *  `prefix` The size of the subnet that is allocated to each agent and thus defines the number of agents on which the overlay can run. The size of the subnet is carved from the overlay subnet.
 
- For more information, see the [example](/1.11/installing/ent/custom/configuration/examples/#overlay) and [documentation](/1.11/networking/virtual-networks/).
+ For more information, see the [example](/1.12/installing/ent/custom/configuration/examples/#overlay) and [documentation](/1.12/networking/virtual-networks/).
 
 
 ## dns_bind_ip_blacklist
@@ -352,8 +352,8 @@ The amount of time to wait before removing stale Docker images stored on the age
 ## enable_docker_gc
 Indicates whether to run the [docker-gc](https://github.com/spotify/docker-gc#excluding-images-from-garbage-collection) script, a simple Docker container and image garbage collection script, once every hour to clean up stray Docker containers. You can configure the runtime behavior by using the `/etc/` config. For more information, see the [documentation](https://github.com/spotify/docker-gc#excluding-images-from-garbage-collection)
 
-*  `enable_docker_gc: 'true'` Run the docker-gc scripts once every hour. This is the default value for [cloud](/1.11/installing/ent/cloud/) template installations.
-*  `enable_docker_gc: 'false'` Do not run the docker-gc scripts once every hour. This is the default value for [custom](/1.11/installing/ent/custom/) installations.
+*  `enable_docker_gc: 'true'` Run the docker-gc scripts once every hour. This is the default value for [cloud](/1.12/installing/ent/cloud/) template installations.
+*  `enable_docker_gc: 'false'` Do not run the docker-gc scripts once every hour. This is the default value for [custom](/1.12/installing/ent/custom/) installations.
 
 ## exhibitor_storage_backend
 The type of storage backend to use for Exhibitor. You can use internal DC/OS storage (`static`) or specify an external storage system (`ZooKeeper`, `aws_s3`, and `Azure`) for configuring and orchestrating ZooKeeper with Exhibitor on the master nodes. Exhibitor automatically configures your ZooKeeper installation on the master nodes during your DC/OS installation.
@@ -404,13 +404,13 @@ Indicates whether to enable GPU support in DC/OS.
 *  `enable_gpu_isolation: 'true'` Any GPUs that are installed in DC/OS will be automatically discovered and available as consumable resources for DC/OS tasks. This is the default value.
 *  `enable_gpu_isolation: 'false'` GPUs are not available for use in the cluster.
 
-For more information, see the [GPU documentation](/1.11/deploying-services/gpu/).
+For more information, see the [GPU documentation](/1.12/deploying-services/gpu/).
 
 ## gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.
 
 ## gpus_are_scarce
-Indicates whether to treat [GPUs](/1.11/deploying-services/gpu/) as a scarce resource in the cluster.
+Indicates whether to treat [GPUs](/1.12/deploying-services/gpu/) as a scarce resource in the cluster.
 
 *  `gpus_are_scarce: 'true'` Treat GPUs as a scarce resource. This reserves the GPUs exclusively for services that opt-in to consume GPUs via the [Mesos `GPU_RESOURCES` framework capability](http://mesos.apache.org/documentation/latest/gpu-support/). This is the default value.
 *  `gpus_are_scarce: 'false'` Treat GPUs like any other resource. GPUs will be offered indiscriminately to all frameworks, regardless of whether they use the [Mesos `GPU_RESOURCES` framework capability](http://mesos.apache.org/documentation/latest/gpu-support/) or not.
@@ -446,7 +446,7 @@ The Mesos master discovery method. The available options are `static` or `master
 *   `master_discovery: master_http_loadbalancer` The set of masters has an HTTP load balancer in front of them. The agent nodes will know the address of the load balancer. They use the load balancer to access Exhibitor on the masters to get the full list of master IPs. If you specify `master_http_load_balancer`, you must also specify these parameters:
 
     *  `exhibitor_address` (Required)
-       The address (preferably an IP address) of the load balancer in front of the masters. If you need to replace your masters, this address becomes the static address that agents can use to find the new master. For DC/OS Enterprise, this address is included in [DC/OS certificates](/1.11/security/ent/tls-ssl/).
+       The address (preferably an IP address) of the load balancer in front of the masters. If you need to replace your masters, this address becomes the static address that agents can use to find the new master. For DC/OS Enterprise, this address is included in [DC/OS certificates](/1.12/security/ent/tls-ssl/).
 
        The load balancer must accept traffic on ports 80, 443, 2181, 5050, 8080, 8181. The traffic must also be forwarded to the same ports on the master. For example, Mesos port 5050 on the load balancer should forward to port 5050 on the master. The master should forward any new connections via round robin, and should avoid machines that do not respond to requests on Mesos port 5050 to ensure the master is up.
 
@@ -468,7 +468,7 @@ Indicates whether the master DNS port is open. An open master DNS port listens p
 
 
 ## master_external_loadbalancer [enterprise type="inline" size="small" /]
-The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.11/security/ent/tls-ssl/) of the Admin Router on the master nodes.
+The DNS name or IP address for the load balancer. If specified, this is included as subject alternative name in the [DC/OS certificate](/1.12/security/ent/tls-ssl/) of the Admin Router on the master nodes.
 
 
 ## mesos_agent_work_dir [oss type="inline" size="small" /]
@@ -481,7 +481,7 @@ The log manager for containers (tasks). The options are:
 * `'logrotate'` - send task logs only to the file system (i.e. a stdout/err file)
 * `'journald+logrotate'` - send logs to both journald and the file system
 
-The default is `logrotate`. Due to performance issues, `journald` is not recommended. For details, see [Logging API](/1.11/monitoring/logging/logging-api/#compatibility).
+The default is `logrotate`. Due to performance issues, `journald` is not recommended. For details, see [Logging API](/1.12/monitoring/logging/logging-api/#compatibility).
 
 ## mesos_dns_set_truncate_bit
 Indicates whether Mesos-DNS sets the truncate bit if the response is too large to fit in a single packet.
@@ -518,7 +518,7 @@ The allowable amount of time, in seconds, for an action to begin after the proce
 **Note:** For a slower network, consider changing to `process_timeout: 600`.
 
 ## public_agent_list
-A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.11/overview/concepts/#public-agent-node) host names.
+A YAML nested list (`-`) of IPv4 addresses to your [public agent](/1.12/overview/concepts/#public-agent-node) host names.
 
 ## resolvers
 A YAML nested list (`-`) of DNS resolvers for your DC/OS cluster nodes. You can specify a maximum of 3 resolvers. Set this parameter to the most authoritative nameservers that you have.
@@ -531,7 +531,7 @@ A YAML nested list (`-`) of DNS resolvers for your DC/OS cluster nodes. You can 
     - 8.8.4.4
     - 8.8.8.8
     ```
--  If you do not have a DNS infrastructure and do not have access to internet DNS servers, you can specify `resolvers: []`. By specifying this setting, all requests to non-`.mesos` will return an error. For more information, see the Mesos-DNS [documentation](/1.11/networking/mesos-dns/).
+-  If you do not have a DNS infrastructure and do not have access to internet DNS servers, you can specify `resolvers: []`. By specifying this setting, all requests to non-`.mesos` will return an error. For more information, see the Mesos-DNS [documentation](/1.12/networking/mesos-dns/).
 
 **Caution:** If you set the `resolvers` parameter incorrectly, you will permanently damage your configuration and have to reinstall DC/OS.
 
@@ -552,7 +552,7 @@ The <a href="https://rexray.readthedocs.io/en/v0.9.0/user-guide/config/" target=
             tasks:
               logTimeout: 5m
 
-See the external persistent volumes [documentation](/1.11/storage/external-storage/) for information on how to create your configuration.
+See the external persistent volumes [documentation](/1.12/storage/external-storage/) for information on how to create your configuration.
 
 If the `rexray_config` parameter is provided, its contents are used verbatim for REX-Ray's configuration. This lets you define completely custom REX-Ray configurations which integrate with various [external storage providers]( https://rexray.readthedocs.io/en/v0.9.0/user-guide/storage-providers/). However, if you upgrade your cluster to a version that includes an updated version of REX-Ray, you must ensure that your `rexray_config` parameter is compatible with the newer version of REX-Ray.
 
@@ -566,7 +566,7 @@ Specify a security mode other than `security: permissive` (the default). The pos
 - `security: permissive`
 - `security: strict`
 
-Refer to the [security modes](/1.11/security/ent/#security-modes) section for a detailed discussion of each parameter.
+Refer to the [security modes](/1.12/security/ent/#security-modes) section for a detailed discussion of each parameter.
 
 ## ssh_key_path
 The path that the installer uses to log into the target nodes. By default this is set to `/genconf/ssh_key`. This parameter should not be changed because `/genconf` is local to the container that is running the installer, and is a mounted volume.
@@ -578,10 +578,10 @@ The port to SSH to, for example `22`.
 The SSH username, for example `centos`.
 
 ## superuser_password_hash (Required) [enterprise type="inline" size="small" /]
-The hashed superuser password. The `superuser_password_hash` is generated by using the installer `--hash-password` flag. This first super user account is used to provide a method of logging into DC/OS, at which point additional administrative accounts can be added. For more information, see the [security documentation](/1.11/security/ent/).
+The hashed superuser password. The `superuser_password_hash` is generated by using the installer `--hash-password` flag. This first super user account is used to provide a method of logging into DC/OS, at which point additional administrative accounts can be added. For more information, see the [security documentation](/1.12/security/ent/).
 
 ## superuser_username (Required) [enterprise type="inline" size="small" /]
-The user name of the superuser. This account uses the `superuser_password_hash`. For more information, see the [security documentation](/1.11/security/ent/).
+The user name of the superuser. This account uses the `superuser_password_hash`. For more information, see the [security documentation](/1.12/security/ent/).
 
 ## telemetry_enabled
 Indicates whether to enable sharing of anonymous data for your cluster. <!-- DC/OS auth -->
@@ -589,13 +589,13 @@ Indicates whether to enable sharing of anonymous data for your cluster. <!-- DC/
 - `telemetry_enabled: 'true'` Enable anonymous data sharing. This is the default value.
 - `telemetry_enabled: 'false'` Disable anonymous data sharing.
 
-If you have already installed your cluster and would like to disable this in place, you can go through an [upgrade](/1.11/installing/production/upgrading/) with the same parameter set.
+If you have already installed your cluster and would like to disable this in place, you can go through an [upgrade](/1.12/installing/production/upgrading/) with the same parameter set.
 
 ## use_proxy
 Indicates whether to enable the DC/OS proxy.
 
-*  `use_proxy: 'false'` Do not configure DC/OS [components](/1.11/overview/architecture/components/) to use a custom proxy. This is the default value.
-*  `use_proxy: 'true'` Configure DC/OS [components](/1.11/overview/architecture/components/) to use a custom proxy. If you specify `use_proxy: 'true'`, you can also specify these parameters:
+*  `use_proxy: 'false'` Do not configure DC/OS [components](/1.12/overview/architecture/components/) to use a custom proxy. This is the default value.
+*  `use_proxy: 'true'` Configure DC/OS [components](/1.12/overview/architecture/components/) to use a custom proxy. If you specify `use_proxy: 'true'`, you can also specify these parameters:
 
     **Note:** The specified proxies must be resolvable from the provided list of [resolvers](#resolvers).
 
@@ -605,7 +605,7 @@ Indicates whether to enable the DC/OS proxy.
 
         **Note:** Wildcard characters (`*`) are not supported.
 
-For more information, see the [examples](/1.11/installing/ent/custom/configuration/examples/#http-proxy).
+For more information, see the [examples](/1.12/installing/ent/custom/configuration/examples/#http-proxy).
 
 **Note:** You should also configure an HTTP proxy for [Docker](https://docs.docker.com/engine/admin/systemd/#/http-proxy).
 
@@ -620,7 +620,7 @@ Currently, IPv6 networks are supported only for Docker containers. Setting this 
 
 ## dcos_l4lb_enable_ipv6
 Indicates whether layer-4 load-balancing is available for IPv6 containers.
-*  `dcos_l4lb_enable_ipv6: 'false'` Disables [layer-4 load balancing](/1.11/networking/load-balancing-vips) for IPv6 containers. This is the default value.
+*  `dcos_l4lb_enable_ipv6: 'false'` Disables [layer-4 load balancing](/1.12/networking/load-balancing-vips) for IPv6 containers. This is the default value.
 *  `dcos_l4lb_enable_ipv6: 'true'` Enables layer-4 load balancing for IPv6 containers. **Note:** Layer-4 load balancing for IPv6 containers should be turned on with caution. `[DCOS_OSS-2010](https://jira.mesosphere.com/browse/DCOS_OSS-2010)
 
 ## dcos_ucr_default_bridge_subnet

--- a/pages/1.12/installing/production/advanced-configuration/configuring-gpu-nodes/index.md
+++ b/pages/1.12/installing/production/advanced-configuration/configuring-gpu-nodes/index.md
@@ -19,18 +19,18 @@ GPUs must be enabled during DC/OS installation. Follow the instructions below to
 ## Custom DC/OS Installation with GPUs
 
 1.  Install the [NVIDIA Management Library (NVML)](https://developer.nvidia.com/nvidia-management-library-nvml) on each node of your cluster that has GPUs. The minimum required NVIDIA driver version is 340.29. For detailed installation instructions, see the [Mesos GPU support documentation](http://mesos.apache.org/documentation/latest/gpu-support/#external-dependencies).
-1.  Install DC/OS using the [custom advanced installation instructions](/1.11/installing/production/deploying-dcos/installation/). Here are the GPU-specific configuration parameters:
+1.  Install DC/OS using the [custom advanced installation instructions](/1.12/installing/production/deploying-dcos/installation/). Here are the GPU-specific configuration parameters:
 
     -  **`enable_gpu_isolation`**: Indicates whether to enable GPU support in DC/OS. By default, this is set to `enable_gpu_isolation: 'true'`.
     -  **`gpus_are_scarce`**: Indicates whether to treat GPUs as a scarce resource in the cluster. By default, this is set to `gpus_are_scarce: 'true'`, which means DC/OS reserves GPU nodes exclusively for services that are configured to consume GPU resources. It's important to note that this setting will influence which agent nodes a GPU-aware framework will be deployed on DC/OS. This setting does not influence the individual tasks which the frameworks might launch while the framework is running. It is possible for a framework to schedule a non-GPU task on an agent node where GPU's are present.
 
-    For more information, see the [configuration parameter documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#enable-gpu-isolation) and Mesos [Nvidia GPU Support documentation](http://mesos.apache.org/documentation/latest/gpu-support/#external-dependencies).
+    For more information, see the [configuration parameter documentation](/1.12/installing/production/advanced-configuration/configuration-reference/#enable-gpu-isolation) and Mesos [Nvidia GPU Support documentation](http://mesos.apache.org/documentation/latest/gpu-support/#external-dependencies).
 
 ## AWS EC2 DC/OS Installation with GPUs
 
 ###  Prerequisites
-- The AWS DC/OS advanced template [system requirements](/1.11/installing/evaluation/cloud-installation/aws/advanced/).
-- The `zen.sh` script copied to your local machine. The script and instructions are [here](/1.11/installing/evaluation/cloud-installation/aws/advanced/).
+- The AWS DC/OS advanced template [system requirements](/1.12/installing/evaluation/cloud-installation/aws/advanced/).
+- The `zen.sh` script copied to your local machine. The script and instructions are [here](/1.12/installing/evaluation/cloud-installation/aws/advanced/).
 
 ### Create Dependencies
 
@@ -42,7 +42,7 @@ bash ./zen.sh <stack-name>
 
    **Note:** You must run the `zen.sh` script before performing the next steps.
 
-2. Follow the instructions [here](/1.11/installing/evaluation/cloud-installation/aws/advanced/) to create a cluster with advanced AWS templates, using the following GPU-specific configuration.
+2. Follow the instructions [here](/1.12/installing/evaluation/cloud-installation/aws/advanced/) to create a cluster with advanced AWS templates, using the following GPU-specific configuration.
 
 3. On the **Create Stack** > **Specify Details** page, specify your stack information and click **Next**. Here are the GPU-specific settings.
 

--- a/pages/1.12/installing/production/advanced-configuration/configuring-zones-regions/index.md
+++ b/pages/1.12/installing/production/advanced-configuration/configuring-zones-regions/index.md
@@ -53,7 +53,7 @@ Fault domain isolation is an important part of building HA systems. To correctly
  * Physical domains: this includes machine, rack, datacenter, region, and availability zone.
  * Network domains: machines within the same network may be subject to network partitions. For example, a shared network switch may fail or have invalid configuration.
 
-For more information, see the [multi-zone](/1.11/installing/high-availability/multi-zone/) and [multi-region](/1.11/installing/high-availability/multi-region/) documentation.
+For more information, see the [multi-zone](/1.12/installing/high-availability/multi-zone/) and [multi-region](/1.12/installing/high-availability/multi-region/) documentation.
 
 Applications which require HA should also be distributed across fault domains. With Marathon, this can be accomplished by using the [`UNIQUE`  and `GROUP_BY` constraints operator](https://mesosphere.github.io/marathon/docs/constraints.html).
 
@@ -83,7 +83,7 @@ When failures do occur, failover [should be as fast as possible](https://en.wiki
 
 A fast failover can be achieved by:
 
- * Using an HA load balancer like [Marathon-LB](/1.11/networking/marathon-lb/), or the internal [Layer 4 load balancer](/1.11/networking/load-balancing-vips/).
+ * Using an HA load balancer like [Marathon-LB](/1.12/networking/marathon-lb/), or the internal [Layer 4 load balancer](/1.12/networking/load-balancing-vips/).
  * Building apps in accordance with the [12-factor app](http://12factor.net/) manifesto.
  * Following REST best practices when building services: in particular, avoiding storing client state on the server between requests.
 

--- a/pages/1.12/installing/production/advanced-configuration/index.md
+++ b/pages/1.12/installing/production/advanced-configuration/index.md
@@ -8,7 +8,7 @@ excerpt: Configuring your DC/OS using advanced configuration methods
 
 This page displays the topics for advanced configuration methods.
 
-The DC/OS configuration parameters are specified in YAML format in a `config.yaml` file. This file is stored on your [bootstrap node](/1.11/installing/production/system-requirements/#bootstrap-node) and is used during DC/OS installation to generate a customized DC/OS build.
+The DC/OS configuration parameters are specified in YAML format in a `config.yaml` file. This file is stored on your [bootstrap node](/1.12/installing/production/system-requirements/#bootstrap-node) and is used during DC/OS installation to generate a customized DC/OS build.
 
-**Caution:** If you want to modify the configuration file after installation, you must follow the [DC/OS upgrade process](/1.11/installing/production/upgrading/).
+**Caution:** If you want to modify the configuration file after installation, you must follow the [DC/OS upgrade process](/1.12/installing/production/upgrading/).
 

--- a/pages/1.12/installing/production/deploying-dcos/configuration/index.md
+++ b/pages/1.12/installing/production/deploying-dcos/configuration/index.md
@@ -7,9 +7,9 @@ excerpt: Configuring your DC/OS parameters using a YAML file
 ---
 
 
-The DC/OS configuration parameters are specified in YAML format in a `config.yaml` file. This file is stored on your [bootstrap node](/1.11/installing/ent/custom/system-requirements/#bootstrap-node) and is used during DC/OS installation to generate a customized DC/OS build.
+The DC/OS configuration parameters are specified in YAML format in a `config.yaml` file. This file is stored on your [bootstrap node](/1.12/installing/ent/custom/system-requirements/#bootstrap-node) and is used during DC/OS installation to generate a customized DC/OS build.
 
-**Note:** If you want to modify the configuration file after installation, you must follow the [DC/OS upgrade process](/1.11/installing/ent/upgrading/).
+**Note:** If you want to modify the configuration file after installation, you must follow the [DC/OS upgrade process](/1.12/installing/ent/upgrading/).
 
 # Format
 
@@ -60,21 +60,21 @@ Some parameters are dependent on others. These dependent parameters are ignored 
 
 | Parameter                              | Description                                                                                                                                               |
 |----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [agent_list](/1/1.11/installing/production/advanced-configuration/configuration-reference/#agent-list)      | This parameter specifies a YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.11/overview/concepts/#private-agent-node) host names.                  |
-| [bootstrap_url](/1.11/installing/production/advanced-configuration/configuration-reference/#bootstrap-url)                          | This required parameter specifies the URL path for the DC/OS installer to store the customized DC/OS build files.                                         |
-| [cluster_name](/1.11/installing/production/advanced-configuration/configuration-reference/#cluster-name)                           | This parameter specifies the name of your cluster.    |
-| [exhibitor_storage_backend](/1.11/installing/production/advanced-configuration/configuration-reference/#exhibitor-storage-backend)         | This parameter specifies the type of storage backend to use for Exhibitor.          |
-| [master_discovery](/1.11/installing/production/advanced-configuration/configuration-reference/#master-discovery-required)                          | This required parameter specifies the Mesos master discovery method.         |
-| [public_agent_list](/1.11/installing/production/advanced-configuration/configuration-reference/#public-agent-list)       | This parameter specifies a YAML nested list (-) of IPv4 addresses to your [public agent](/1.11/overview/concepts/#public-agent-node) host names.    |
-| [resolvers](/1.11/installing/production/advanced-configuration/configuration-reference/#resolvers)       | This required parameter specifies a block of YAML nested list (`-`) of DNS resolvers for your DC/OS cluster nodes.   |
-| [security](/1.11/installing/production/advanced-configuration/configuration-reference/#security-enterprise)                           | [enterprise type="inline" size="small" /] This parameter specifies the security mode: `permissive` or `strict`.  |
-| [ssh_port](/1.11/installing/production/advanced-configuration/configuration-reference/#ssh-port)                           | This parameter specifies the port to SSH to, for example 22.          |
-| [ssh_user](/1.11/installing/production/advanced-configuration/configuration-reference/#ssh-user)                           | This parameter specifies the SSH username, for example `centos`.     |
-| [superuser_password_hash](/1.11/installing/production/advanced-configuration/configuration-reference/#superuser-password-hash-required-enterprise)            | [enterprise type="inline" size="small" /] This required parameter specifies the hashed superuser password.      |
-| [superuser_username](/1.11/installing/production/advanced-configuration/configuration-reference/#superuser-username-required-enterprise)               | [enterprise type="inline" size="small" /] This required parameter specifies the user name of the superuser.    |
-| [use_proxy](/1.11/installing/production/advanced-configuration/configuration-reference/#use-proxy)        | This parameter specifies whether to enable the DC/OS proxy.     |
+| [agent_list](/1/1.12/installing/production/advanced-configuration/configuration-reference/#agent-list)      | This parameter specifies a YAML nested list (`-`) of IPv4 addresses to your [private agent](/1.12/overview/concepts/#private-agent-node) host names.                  |
+| [bootstrap_url](/1.12/installing/production/advanced-configuration/configuration-reference/#bootstrap-url)                          | This required parameter specifies the URL path for the DC/OS installer to store the customized DC/OS build files.                                         |
+| [cluster_name](/1.12/installing/production/advanced-configuration/configuration-reference/#cluster-name)                           | This parameter specifies the name of your cluster.    |
+| [exhibitor_storage_backend](/1.12/installing/production/advanced-configuration/configuration-reference/#exhibitor-storage-backend)         | This parameter specifies the type of storage backend to use for Exhibitor.          |
+| [master_discovery](/1.12/installing/production/advanced-configuration/configuration-reference/#master-discovery-required)                          | This required parameter specifies the Mesos master discovery method.         |
+| [public_agent_list](/1.12/installing/production/advanced-configuration/configuration-reference/#public-agent-list)       | This parameter specifies a YAML nested list (-) of IPv4 addresses to your [public agent](/1.12/overview/concepts/#public-agent-node) host names.    |
+| [resolvers](/1.12/installing/production/advanced-configuration/configuration-reference/#resolvers)       | This required parameter specifies a block of YAML nested list (`-`) of DNS resolvers for your DC/OS cluster nodes.   |
+| [security](/1.12/installing/production/advanced-configuration/configuration-reference/#security-enterprise)                           | [enterprise type="inline" size="small" /] This parameter specifies the security mode: `permissive` or `strict`.  |
+| [ssh_port](/1.12/installing/production/advanced-configuration/configuration-reference/#ssh-port)                           | This parameter specifies the port to SSH to, for example 22.          |
+| [ssh_user](/1.12/installing/production/advanced-configuration/configuration-reference/#ssh-user)                           | This parameter specifies the SSH username, for example `centos`.     |
+| [superuser_password_hash](/1.12/installing/production/advanced-configuration/configuration-reference/#superuser-password-hash-required-enterprise)            | [enterprise type="inline" size="small" /] This required parameter specifies the hashed superuser password.      |
+| [superuser_username](/1.12/installing/production/advanced-configuration/configuration-reference/#superuser-username-required-enterprise)               | [enterprise type="inline" size="small" /] This required parameter specifies the user name of the superuser.    |
+| [use_proxy](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)        | This parameter specifies whether to enable the DC/OS proxy.     |
 
 
 # Advanced settings
 
-See the [configuration reference](/1.11/installing/production/advanced-configuration/configuration-reference/#configuration-parameters) and [examples](/1.11/installing/production/deploying-dcos/configuration/examples/).
+See the [configuration reference](/1.12/installing/production/advanced-configuration/configuration-reference/#configuration-parameters) and [examples](/1.12/installing/production/deploying-dcos/configuration/examples/).

--- a/pages/1.12/installing/production/deploying-dcos/configure-proxy/index.md
+++ b/pages/1.12/installing/production/deploying-dcos/configure-proxy/index.md
@@ -6,6 +6,6 @@ excerpt: Using a corporate proxy to configure DC/OS
 ---
 
 
-By default, the DC/OS [Universe](https://github.com/mesosphere/universe) repository is hosted on the internet. If your DC/OS cluster is behind a corporate proxy, you must specify your proxy configuration in the [configuration file](/1.11/installing/production/advanced-configuration/configuration-reference/#use-proxy) file before installation. This will enable your cluster to connect to the Universe packages.
+By default, the DC/OS [Universe](https://github.com/mesosphere/universe) repository is hosted on the internet. If your DC/OS cluster is behind a corporate proxy, you must specify your proxy configuration in the [configuration file](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy) file before installation. This will enable your cluster to connect to the Universe packages.
 
 **Note:** You should also configure an HTTP proxy for [Docker](https://docs.docker.com/engine/admin/systemd/#/http-proxy).

--- a/pages/1.12/installing/production/deploying-dcos/index.md
+++ b/pages/1.12/installing/production/deploying-dcos/index.md
@@ -10,7 +10,7 @@ excerpt: Deploying DC/OS in a production-ready environment
 
 The production installation method is used to install production-ready DC/OS that can be upgraded. Using this method, you can package the DC/OS distribution and connect to every node manually to run the DC/OS installation commands. This installation method is recommended if you want to integrate with an existing system or if you do not have SSH access to your cluster. 
 
-The DC/OS installation process requires a bootstrap node, master node, public agent node, and a private agent node. You can view the [nodes](/1.11/overview/concepts/#node) documentation for more information.
+The DC/OS installation process requires a bootstrap node, master node, public agent node, and a private agent node. You can view the [nodes](/1.12/overview/concepts/#node) documentation for more information.
 
 The following steps are required to install DC/OS clusters:
 
@@ -18,7 +18,7 @@ The following steps are required to install DC/OS clusters:
 *   Install DC/OS on master node
 *   Install DC/OS on agent node
 
-![Production Installation Process](/1.11/img/advanced-installer.png)
+![Production Installation Process](/1.12/img/advanced-installer.png)
 
 Figure 1. The production installation process
 

--- a/pages/1.12/installing/production/deploying-dcos/installation/index.md
+++ b/pages/1.12/installing/production/deploying-dcos/installation/index.md
@@ -9,7 +9,7 @@ excerpt: Installing production-ready DC/OS
 
 This section describes how to install a production-ready deployment of DC/OS that can be upgraded. Using this method, you can package the DC/OS distribution and connect to every node manually to run the DC/OS installation commands. This installation method is recommended if you want to integrate with an existing system or if you do not have SSH access to your cluster.
 
-The DC/OS installation process requires a bootstrap node, master node, public agent node, and a private agent node. You can view the [nodes](/1.11/overview/concepts/#node) documentation for more information.
+The DC/OS installation process requires a bootstrap node, master node, public agent node, and a private agent node. You can view the [nodes](/1.12/overview/concepts/#node) documentation for more information.
 
 # Production Installation Process
 
@@ -19,7 +19,7 @@ The DC/OS installation process requires a bootstrap node, master node, public ag
 1. Install DC/OS on master node
 1. Install DC/OS on agent node
 
-![Production Installation Process](/1.11/img/advanced-installer.png)
+![Production Installation Process](/1.12/img/advanced-installer.png)
 Figure 1. The production installation process
 
 
@@ -35,7 +35,7 @@ The DC/OS installation creates the following folders:
 | `/opt/mesosphere`                       | Contains the DC/OS binaries, libraries, and cluster configuration. Do not modify.                                                              |
 | `/etc/systemd/system/dcos.target.wants` | Contains the systemd services that start the systemd components. They must be located outside of `/opt/mesosphere` because of systemd constraints.   |
 | `/etc/systemd/system/dcos.<units>`      | Contains copies of the units in `/etc/systemd/system/dcos.target.wants`. They must be at the top folder as well as inside `dcos.target.wants`. |
-| `/var/lib/dcos/exhibitor/zookeeper`     | Contains the [ZooKeeper](/1.11/overview/concepts/#exhibitor-zookeeper) data.                                                                   |
+| `/var/lib/dcos/exhibitor/zookeeper`     | Contains the [ZooKeeper](/1.12/overview/concepts/#exhibitor-zookeeper) data.                                                                   |
 | `/var/lib/docker`                       | Contains the Docker data.                                                                                                                      |
 | `/var/lib/dcos`                         | Contains the DC/OS data.                                                                                                                       |
 | `/var/lib/mesos`                        | Contains the Mesos data.                                                                                                                       |
@@ -43,7 +43,7 @@ The DC/OS installation creates the following folders:
 **Note:** Changes to `/opt/mesosphere` are unsupported. They can lead to unpredictable behavior in DC/OS and prevent upgrades.
 
 ## Prerequisites
-Before installing DC/OS, your cluster must meet the software and hardware [requirements](/1.11/installing/production/system-requirements/).
+Before installing DC/OS, your cluster must meet the software and hardware [requirements](/1.12/installing/production/system-requirements/).
 
 
 # <a name="configure-cluster"></a>Configure your cluster
@@ -56,7 +56,7 @@ Before installing DC/OS, your cluster must meet the software and hardware [requi
 [enterprise]
 # <a name="license"></a>Store license file
 [/enterprise]
-1.  Create a [license file](/1.11/administering-clusters/licenses) containing the license text received in email sent by your Authorized Support Contact and save as `genconf/license.txt`.
+1.  Create a [license file](/1.12/administering-clusters/licenses) containing the license text received in email sent by your Authorized Support Contact and save as `genconf/license.txt`.
 
 # <a name="ip-detect-script"></a>Create an IP detection script
 
@@ -64,7 +64,7 @@ In this step, an IP detection script is created. This script reports the IP addr
 
 **Note:**
 
-- The IP address of a node must not change after DC/OS is installed on the node. For example, the IP address should not change when a node is rebooted or if the DHCP lease is renewed. If the IP address of a node does change, the node must be [uninstalled](/1.11/installing/production/uninstalling/).
+- The IP address of a node must not change after DC/OS is installed on the node. For example, the IP address should not change when a node is rebooted or if the DHCP lease is renewed. If the IP address of a node does change, the node must be [uninstalled](/1.12/installing/production/uninstalling/).
 - The script must return the same IP address as specified in the `config.yaml`. For example, if the private master IP is specified as `10.2.30.4` in the `config.yaml`, your script should return this same value when run on the master.
 
 1.  Create an IP detection script for your environment and save as `genconf/ip-detect`. This script needs to be `UTF-8` encoded and have a valid [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line. You can use the examples below.
@@ -152,7 +152,7 @@ BEGIN { ec = 1 }
 # Create a fault domain detection script
 [/enterprise]
 
-By default, DC/OS clusters have [fault domain awareness](/1.11/deploying-services/fault-domain-awareness/) enabled, so no changes to your `config.yaml` are required to use this feature. However, you must include a fault domain detection script named `fault-domain-detect` in your `./genconf` directory. To opt out of fault domain awareness, set the `fault_domain_enabled` parameter of your `config.yaml` file to `false`.
+By default, DC/OS clusters have [fault domain awareness](/1.12/deploying-services/fault-domain-awareness/) enabled, so no changes to your `config.yaml` are required to use this feature. However, you must include a fault domain detection script named `fault-domain-detect` in your `./genconf` directory. To opt out of fault domain awareness, set the `fault_domain_enabled` parameter of your `config.yaml` file to `false`.
 
 
 1. Create a fault domain detect script named `fault-domain-detect` to run on each node to detect the node's fault domain. During installation, the output of this script is passed to Mesos.
@@ -201,7 +201,7 @@ The Enterprise template specifies three Mesos masters, static master discovery l
 
 This Open Source template specifies three Mesos masters, three ZooKeeper instances for Exhibitor storage, static master discovery list, internal storage backend for Exhibitor, a custom proxy, and cloud specific DNS resolvers. [oss type="inline" size="small" /]
 
-If your servers are installed with a domain name in your `/etc/resolv.conf`, add the `dns_search` parameter. For parameter descriptions and configuration examples, see the [documentation](/1.11/installing/ent/custom/configuration/configuration-parameters/).
+If your servers are installed with a domain name in your `/etc/resolv.conf`, add the `dns_search` parameter. For parameter descriptions and configuration examples, see the [documentation](/1.12/installing/ent/custom/configuration/configuration-parameters/).
 
 **Note:**
 
@@ -218,7 +218,7 @@ bootstrap_url: http://<bootstrap_ip>:80
 cluster_name: <cluster-name>
 superuser_username:
 superuser_password_hash:
-#customer_key in yaml file has been replaced by genconf/license.txt in DC/OS 1.11
+#customer_key in yaml file has been replaced by genconf/license.txt in DC/OS 1.12
 #customer_key: <customer-key>
 exhibitor_storage_backend: static
 master_discovery: static
@@ -238,7 +238,7 @@ https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>
 no_proxy:
 - 'foo.bar.com'
 - '.baz.com'
-# Fault domain entry required for DC/OS Enterprise 1.11+
+# Fault domain entry required for DC/OS Enterprise 1.12+
 fault_domain_enabled: false
 #If IPv6 is disabled in your kernel, you must disable it in the config.yaml
 enable_ipv6: 'false'
@@ -276,8 +276,8 @@ In this step, you will create a custom DC/OS build file on your bootstrap node a
 
 **Note:**
 
-- Due to a cluster configuration issue with overlay networks, we recommend setting `enable_ipv6` to `false` in `config.yaml` when upgrading or configuring a new cluster. If you have already upgraded to DC/OS 1.11.x without configuring `enable_ipv6` or if `config.yaml` file is set to `true` then do not add new nodes. You can find additional information and a more detailed remediation procedure in our latest critical [product advisory](https://support.mesosphere.com/s/login/?startURL=%2Fs%2Farticle%2FCritical-Issue-with-Overlay-Networking&ec=302). [enterprise type="inline" size="small" /]
-- Do not install DC/OS until you have these items working: ip-detect script, DNS, and NTP on all DC/OS nodes with time synchronized. See [troubleshooting](/1.11/installing/ent/troubleshooting/) for more information.
+- Due to a cluster configuration issue with overlay networks, we recommend setting `enable_ipv6` to `false` in `config.yaml` when upgrading or configuring a new cluster. If you have already upgraded to DC/OS 1.12.x without configuring `enable_ipv6` or if `config.yaml` file is set to `true` then do not add new nodes. You can find additional information and a more detailed remediation procedure in our latest critical [product advisory](https://support.mesosphere.com/s/login/?startURL=%2Fs%2Farticle%2FCritical-Issue-with-Overlay-Networking&ec=302). [enterprise type="inline" size="small" /]
+- Do not install DC/OS until you have these items working: ip-detect script, DNS, and NTP on all DC/OS nodes with time synchronized. See [troubleshooting](/1.12/installing/ent/troubleshooting/) for more information.
 - If something goes wrong and you want to rerun your setup, use the cluster [uninstall][11] instructions.
 
 **Prerequisites**
@@ -403,13 +403,13 @@ At this point your directory structure should resemble:
             sudo bash dcos_install.sh slave_public
             ```
 
-    __Note:__ If you encounter errors such as `Time is marked as bad`, `adjtimex`, or `Time not in sync` in journald, verify that Network Time Protocol (NTP) is enabled on all nodes. For more information, see the [system requirements](/1.11/installing/ent/custom/system-requirements/#port-and-protocol) documentation.
+    __Note:__ If you encounter errors such as `Time is marked as bad`, `adjtimex`, or `Time not in sync` in journald, verify that Network Time Protocol (NTP) is enabled on all nodes. For more information, see the [system requirements](/1.12/installing/ent/custom/system-requirements/#port-and-protocol) documentation.
 
 5.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`.
 
     **Note:** This process can take about 10 minutes. During this time, you will see the Master nodes become visible on the Exhibitor consoles and come online, eventually showing a green light.
 
-![Exhibitor for ZooKeeper](/1.11/img/chef-zk-status.png)
+![Exhibitor for ZooKeeper](/1.12/img/chef-zk-status.png)
 
 Figure 2. Exhibitor for ZooKeeper
 
@@ -421,14 +421,14 @@ Figure 2. Exhibitor for ZooKeeper
 
 7.  Enter your administrator username and password.
 
-![Login screen](/1.11/img/ui-installer-auth2.png)
+![Login screen](/1.12/img/ui-installer-auth2.png)
 
 Figure 3. Sign in dialogue
 
 
 You are done! The UI dashboard will now be displayed.
 
-![UI dashboard](/1.11/img/dashboard-ee.png)
+![UI dashboard](/1.12/img/dashboard-ee.png)
 
 Figure 4. DC/OS UI dashboard
 
@@ -437,7 +437,7 @@ Figure 4. DC/OS UI dashboard
 
 You can find information on the next steps listed below:
 - [Assign user roles][7].
-- [System Requirements](/1.11/installing/production/system-requirements/)
+- [System Requirements](/1.12/installing/production/system-requirements/)
 - [Public agent nodes][2]
 - [Private agent nodes][3]
 - [Install the DC/OS Command-Line Interface (CLI)][9]
@@ -446,16 +446,16 @@ You can find information on the next steps listed below:
 - [Uninstalling DC/OS][11]
 
 
-[1]: /1.11/installing/production/system-requirements/
-[2]: /1.11/overview/concepts/#public
-[3]: /1.11/overview/concepts/#private
-[5]: /1.11/img/ui-installer-auth2.png
-[6]: /1.11/img/dashboard-ee.png
-[7]: /1.11/security/ent/users-groups/
-[8]: /1.11/security/ent/users-groups/
-[9]: /1.11/cli/install/
-[12]: /1.11/installing/production/deploying-dcos/node-cluster-health-check/
-[10]: /1.11/installing/oss/troubleshooting/
-[11]: /1.11/installing/oss/custom/uninstall/
+[1]: /1.12/installing/production/system-requirements/
+[2]: /1.12/overview/concepts/#public
+[3]: /1.12/overview/concepts/#private
+[5]: /1.12/img/ui-installer-auth2.png
+[6]: /1.12/img/dashboard-ee.png
+[7]: /1.12/security/ent/users-groups/
+[8]: /1.12/security/ent/users-groups/
+[9]: /1.12/cli/install/
+[12]: /1.12/installing/production/deploying-dcos/node-cluster-health-check/
+[10]: /1.12/installing/oss/troubleshooting/
+[11]: /1.12/installing/oss/custom/uninstall/
 
 

--- a/pages/1.12/installing/production/deploying-dcos/node-cluster-health-check/index.md
+++ b/pages/1.12/installing/production/deploying-dcos/node-cluster-health-check/index.md
@@ -37,11 +37,11 @@ Custom health checks are user-defined commands that are added to the set of chec
 Optionally, you can configure the checks to output a human-readable message to `stderr` or `stdout`.
 
 ## Specifying Custom Health Checks
-Before installing DC/OS, you must specify custom health checks in the `custom_checks` installation configuration parameter. If you want to modify the configuration file after installation, you must follow the [DC/OS upgrade process](/1.11/installing/production/upgrading/).
+Before installing DC/OS, you must specify custom health checks in the `custom_checks` installation configuration parameter. If you want to modify the configuration file after installation, you must follow the [DC/OS upgrade process](/1.12/installing/production/upgrading/).
 
 If it is an absolute path (for example, if you have an executable in `/usr/bin/`), you can specify it directly in the `cmd`. If you reference an executable by name without an absolute path (for example, `echo` instead of `/usr/bin/echo`), the system will look for it by using this search path, and use the first executable that it finds: `/opt/mesosphere/bin:/usr/bin:/bin:/sbin`.
 
-For a description of this parameter and examples, see the [configuration parameter documentation](/1.11/installing/production/advanced-configuration/configuration-reference/#custom-checks).
+For a description of this parameter and examples, see the [configuration parameter documentation](/1.12/installing/production/advanced-configuration/configuration-reference/#custom-checks).
 
 ## Custom Health Check Executables
 Before installing DC/OS, you may optionally provide a directory of executables at `genconf/check_bins/` that will be distributed to all cluster nodes for use in custom checks. If provided, these executables will be added to the end of the search path for check executables. In order to use custom check executables, reference them in the `custom_checks` parameter by name without an absolute path (for example, to use `genconf/check_bins/custom_script.sh` in a custom check, refer to it as `custom_script.sh`).
@@ -62,7 +62,7 @@ You can run the following commands from your cluster node to invoke custom or pr
 - DC/OS is installed and you are logged in with superuser permission.
 
 
-1.  [SSH to a cluster node](/1.11/administering-clusters/sshcluster/).
+1.  [SSH to a cluster node](/1.12/administering-clusters/sshcluster/).
 
     ```bash
     dcos node --master-proxy --mesos-id=<agent-node-id>

--- a/pages/1.12/installing/production/deploying-dcos/opt-out/index.md
+++ b/pages/1.12/installing/production/deploying-dcos/opt-out/index.md
@@ -8,24 +8,24 @@ menuWeight: 20
 
 ## Authentication
 
-You can opt out of the provided authentication by disabling it for your cluster. To disable authentication, add this parameter to your [`config.yaml`](/1.11/installing/production/advanced-configuration/configuration-reference/) file during installation (this requires using the [installation](/1.11/installing/production/deploying-dcos/installation/) method):
+You can opt out of the provided authentication by disabling it for your cluster. To disable authentication, add this parameter to your [`config.yaml`](/1.12/installing/production/advanced-configuration/configuration-reference/) file during installation (this requires using the [installation](/1.12/installing/production/deploying-dcos/installation/) method):
 
 ```yaml
 oauth_enabled: 'false'
 ```
 
-**Note:** If you have already installed your cluster and would like to disable this in place, you can go through an upgrade with the same [configuration parameter](/1.11/installing/production/advanced-configuration/configuration-reference/) set.
+**Note:** If you have already installed your cluster and would like to disable this in place, you can go through an upgrade with the same [configuration parameter](/1.12/installing/production/advanced-configuration/configuration-reference/) set.
 
 ## Telemetry
 
 You can opt out of providing anonymous data by disabling telemetry for your cluster. To disable telemetry, you can either:
 
-- Add this parameter to your [`config.yaml`](/1.11/installing/production/advanced-configuration/configuration-reference/) file during installation (this requires using the [installation][1] method):
+- Add this parameter to your [`config.yaml`](/1.12/installing/production/advanced-configuration/configuration-reference/) file during installation (this requires using the [installation][1] method):
 
     ```yaml
     telemetry_enabled: 'false'
     ```
 
 
-**Note:** If you have already installed your cluster and would like to disable this in place, you can go through an upgrade with the same [configuration parameter](/1.11/installing/production/advanced-configuration/configuration-reference/) set.
+**Note:** If you have already installed your cluster and would like to disable this in place, you can go through an upgrade with the same [configuration parameter](/1.12/installing/production/advanced-configuration/configuration-reference/) set.
 

--- a/pages/1.12/installing/production/patching/index.md
+++ b/pages/1.12/installing/production/patching/index.md
@@ -15,15 +15,15 @@ A patching process includes the following:
 - Does not impact workloads which is an essential piece of patching live clusters with no downtime
 - Helps users to understand the minor changes impacting the functionality of DC/OS
 
-Example: DC/OS 1.X.A to 1.X.B (1.11.1 --> 1.11.2)
+Example: DC/OS 1.X.A to 1.X.B (1.12.1 --> 1.12.2)
 
 **Note:** A patching process occurs only between minor releases.
 
 ## Important guidelines
 
-- Review the [release notes](/1.11/release-notes/) before patching DC/OS.
-- Due to a cluster configuration issue with overlay networks, it is recommended to set `enable_ipv6` to false in `config.yaml` when patching or configuring a new cluster. If you have already patched to DC/OS 1.11.x without configuring `enable_ipv6` or if `config.yaml` file is set to `true` then do not add new nodes until DC/OS 1.11.3 has been released. You can find additional information and a more robust remediation procedure in our latest critical [product advisory](https://support.mesosphere.com/s/login/?startURL=%2Fs%2Farticle%2FCritical-Issue-with-Overlay-Networking&ec=302).
-- There are new options in the `config.yaml` file which must be declared prior to patching. Even if you have previously installed DC/OS successfully with your `config.yaml` file, the file will require new additions to function with DC/OS 1.11. Check if `fault_domain_enabled` and `enable_ipv6` are added in the `config.yaml` file. You can review the sample file [here](1.11/installing/production/deploying-dcos/installation/#create-a-configuration-file).
+- Review the [release notes](/1.12/release-notes/) before patching DC/OS.
+- Due to a cluster configuration issue with overlay networks, it is recommended to set `enable_ipv6` to false in `config.yaml` when patching or configuring a new cluster. If you have already patched to DC/OS 1.12.x without configuring `enable_ipv6` or if `config.yaml` file is set to `true` then do not add new nodes until DC/OS 1.12.3 has been released. You can find additional information and a more robust remediation procedure in our latest critical [product advisory](https://support.mesosphere.com/s/login/?startURL=%2Fs%2Farticle%2FCritical-Issue-with-Overlay-Networking&ec=302).
+- There are new options in the `config.yaml` file which must be declared prior to patching. Even if you have previously installed DC/OS successfully with your `config.yaml` file, the file will require new additions to function with DC/OS 1.12. Check if `fault_domain_enabled` and `enable_ipv6` are added in the `config.yaml` file. You can review the sample file [here](1.12/installing/production/deploying-dcos/installation/#create-a-configuration-file).
 - If IPv6 is disabled in the kernel, then IPv6 must be disabled in the `config.yaml` file for the patch to succeed.
 - DC/OS Enterprise now enforces license keys. The license key must reside in a genconf/license.txt file or the patch will fail. [enterprise type="inline" size="small" /]
 - The DC/OS GUI and other higher-level system APIs may be inconsistent or unavailable until all master nodes have been patched. For example, a patched DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been patched. When this occurs:
@@ -35,9 +35,9 @@ Example: DC/OS 1.X.A to 1.X.B (1.11.1 --> 1.11.2)
 - DC/OS Enterprise downloads can be found [here](https://support.mesosphere.com/hc/en-us/articles/213198586-Mesosphere-Enterprise-DC-OS-Downloads). [enterprise type="inline" size="small" /]
 
 ## Supported patch paths
-- From the latest GA version of previous to the latest GA version of current. For example, if 1.10.2 is the latest and 1.11.0 is the latest, this patch would be supported.
-- From any current release to the next. For example, a patch from 1.11.1 to 1.11.2 would be supported.
-- From any current release to an identical release. For example, a patch from 1.11.0 to 1.11.0 would be supported. This is useful for making configuration changes.
+- From the latest GA version of previous to the latest GA version of current. For example, if 1.10.2 is the latest and 1.12.0 is the latest, this patch would be supported.
+- From any current release to the next. For example, a patch from 1.12.1 to 1.12.2 would be supported.
+- From any current release to an identical release. For example, a patch from 1.12.0 to 1.12.0 would be supported. This is useful for making configuration changes.
 
 
 ## Modifying DC/OS configuration
@@ -50,19 +50,19 @@ Only a subset of DC/OS configuration parameters can be modified. The adverse eff
 
 Here is a list of the parameters that you can modify:
 
-- [`dns_search`](/1.11/installing/production/advanced-configuration/configuration-reference/#dns-search)
-- [`docker_remove_delay`](/1.11/installing/production/advanced-configuration/configuration-reference/#docker-remove-delay)
-- [`gc_delay`](/1.11/installing/production/advanced-configuration/configuration-reference/#gc-delay)
-- [`resolvers`](/1.11/installing/production/advanced-configuration/configuration-reference/#resolvers)
-- [`telemetry_enabled`](/1.11/installing/production/advanced-configuration/configuration-reference/#telemetry-enabled)
-- [`use_proxy`](/1.11/installing/production/advanced-configuration/configuration-reference/#use-proxy)
-    - [`http_proxy`](/1.11/installing/production/advanced-configuration/configuration-reference/#use-proxy)
-    - [`https_proxy`](/1.11/installing/production/advanced-configuration/configuration-reference/#use-proxy)
-    - [`no_proxy`](/1.11/installing/production/advanced-configuration/configuration-reference/#use-proxy)
+- [`dns_search`](/1.12/installing/production/advanced-configuration/configuration-reference/#dns-search)
+- [`docker_remove_delay`](/1.12/installing/production/advanced-configuration/configuration-reference/#docker-remove-delay)
+- [`gc_delay`](/1.12/installing/production/advanced-configuration/configuration-reference/#gc-delay)
+- [`resolvers`](/1.12/installing/production/advanced-configuration/configuration-reference/#resolvers)
+- [`telemetry_enabled`](/1.12/installing/production/advanced-configuration/configuration-reference/#telemetry-enabled)
+- [`use_proxy`](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)
+    - [`http_proxy`](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)
+    - [`https_proxy`](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)
+    - [`no_proxy`](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)
 
 The security mode (`security`) can be changed but only to a stricter security mode. Security downgrades are not supported. For example, if your cluster is in `strict` mode and you want to downgrade to `permissive` mode, you must reinstall the cluster and terminate all running workloads.
 
-See the security [mode](/1.11/installing/production/advanced-configuration/configuration-reference/#security-enterprise) for information on different security modes.
+See the security [mode](/1.12/installing/production/advanced-configuration/configuration-reference/#security-enterprise) for information on different security modes.
 
 # Instructions
 These steps must be performed for version patches and cluster configuration changes.
@@ -76,31 +76,31 @@ These steps must be performed for version patches and cluster configuration chan
 - All hosts (masters and agents) must be able to communicate with all other hosts on all ports, for both TCP and UDP.
 - In CentOS or RedHat, install IP sets with this command (used in some IP detect scripts): `sudo yum install -y ipset`
 - You must be familiar with using `systemctl` and `journalctl` command line tools to review and monitor service status. Troubleshooting notes can be found at the end of this [document](#troubleshooting).
-- You must be familiar with the [DC/OS Installation Guide](/1.11/installing/production/deploying-dcos/installation/).
+- You must be familiar with the [DC/OS Installation Guide](/1.12/installing/production/deploying-dcos/installation/).
 - Take a snapshot of ZooKeeper prior to patching. Marathon supports rollbacks, but does not support downgrades.
-- [Take a snapshot of the IAM database](/1.11/installing/installation-faq/#q-how-do-i-backup-the-iam-database-enterprise) prior to patching.
+- [Take a snapshot of the IAM database](/1.12/installing/installation-faq/#q-how-do-i-backup-the-iam-database-enterprise) prior to patching.
 - Ensure that Marathon event subscribers are disabled before beginning the patch. Leave them disabled after completing the patch, as this feature is now deprecated.
 - **Note:** Marathon event subscribers are disabled by default. Check to see if the line `--event_subscriber "http_callback"` has been added to `sudo vi /opt/mesosphere/bin/marathon.sh` on your master node(s). If this is the case you will need to remove that line in order to disable event subscribers.
 - Verify that all Marathon application constraints are valid before beginning the patch. Use [this script](https://github.com/mesosphere/public-support-tools/blob/master/check-constraints.py) to check if your constraints are valid.
-- [Back up your cluster](/1.11/administering-clusters/backup-and-restore/).
-- **Optional** You can add custom [node and cluster health checks](/1.11/installing/production/deploying-dcos/node-cluster-health-check/#custom-health-checks) to your `config.yaml`.
+- [Back up your cluster](/1.12/administering-clusters/backup-and-restore/).
+- **Optional** You can add custom [node and cluster health checks](/1.12/installing/production/deploying-dcos/node-cluster-health-check/#custom-health-checks) to your `config.yaml`.
 
 ## Bootstrap Node
 
 Choose your desired security mode and then follow the applicable patch instructions.
 
-- [Patching DC/OS 1.11 without changing security mode](#current-security)
-- [Patching DC/OS 1.11 to strict mode](#strict)
+- [Patching DC/OS 1.12 without changing security mode](#current-security)
+- [Patching DC/OS 1.12 to strict mode](#strict)
 
-# <a name="current-security"></a>Patching DC/OS 1.11 without changing security mode
-This procedure patches a DC/OS 1.10 cluster to DC/OS 1.11 without changing the cluster's [security mode](//1.11/installing/production/advanced-configuration/configuration-reference/#security-enterprise).
+# <a name="current-security"></a>Patching DC/OS 1.12 without changing security mode
+This procedure patches a DC/OS 1.10 cluster to DC/OS 1.12 without changing the cluster's [security mode](//1.12/installing/production/advanced-configuration/configuration-reference/#security-enterprise).
 1.  Copy your existing `config.yaml` and `ip-detect` files to an empty `genconf` folder on your bootstrap node. The folder should be in the same directory as the installer.
 1.  Merge the old `config.yaml` into the new `config.yaml` format. In most cases the differences will be minimal.
 
     **Note:**
 
     *  You cannot change the `exhibitor_zk_backend` setting during a patch.
-    *  The syntax of the `config.yaml` may be different from the earlier version. For a detailed description of the current `config.yaml` syntax and parameters, see the [documentation](/1.11/installing/production/advanced-configuration/configuration-reference/).
+    *  The syntax of the `config.yaml` may be different from the earlier version. For a detailed description of the current `config.yaml` syntax and parameters, see the [documentation](/1.12/installing/production/advanced-configuration/configuration-reference/).
 1. After updating the format of the config.yaml, compare the old `config.yaml` and new `config.yaml`. Verify that there are no differences in pathways or configurations. Changing these while patching can lead to catastrophic cluster failures.
 1.  Modify the `ip-detect` file as desired.
 1.  Build your installer package.
@@ -111,19 +111,19 @@ This procedure patches a DC/OS 1.10 cluster to DC/OS 1.11 without changing the c
         dcos_generate_config.ee.sh --generate-node-patch-script <installed_cluster_version>
         ```
     1.  The command in the previous step will produce a URL in the last line of its output, prefixed with `Node patch script URL:`. Record this URL for use in later steps. It will be referred to in this document as the "Node patch script URL".
-    1.  Run the [nginx](/1.11/installing/production/deploying-dcos/installation/) container to serve the installation files.
+    1.  Run the [nginx](/1.12/installing/production/deploying-dcos/installation/) container to serve the installation files.
 
-1.  Go to the DC/OS Master [procedure](/1.11/installing/production/patching/#masters) to complete your installation.
+1.  Go to the DC/OS Master [procedure](/1.12/installing/production/patching/#masters) to complete your installation.
 
-# <a name="strict"></a>Patching DC/OS 1.11 in strict mode
-This procedure patches DC/OS 1.11 in security strict [mode](/1.11/installing/production/advanced-configuration/configuration-reference/#security-enterprise).
+# <a name="strict"></a>Patching DC/OS 1.12 in strict mode
+This procedure patches DC/OS 1.12 in security strict [mode](/1.12/installing/production/advanced-configuration/configuration-reference/#security-enterprise).
 
 If you are updating a running DC/OS cluster to run in `security: strict` mode, be aware that security vulnerabilities may persist even after migration to strict mode. When moving to strict mode, your services will now require authentication and authorization to register with Mesos or access its HTTP API. You should test these configurations in permissive mode before patching to strict, to maintain scheduler and script uptimes across the patch.
 
 **Prerequisites:**
 
-- Your cluster must be a [recently patched version of DC/OS 1.11](#current-security) and running in [permissive security mode](#permissive) before it can be updated to strict mode. If your cluster was running in strict mode before it was patched to DC/OS 1.11, you can skip this procedure.
-- If you have running pods or if the Mesos "HTTP command executors" feature has been enabled in a custom configuration, you must restart these tasks in DC/OS 1.11 permissive security mode before patching to strict mode. Otherwise, these tasks will be restarted when the masters are patched.
+- Your cluster must be a [recently patched version of DC/OS 1.12](#current-security) and running in [permissive security mode](#permissive) before it can be updated to strict mode. If your cluster was running in strict mode before it was patched to DC/OS 1.12, you can skip this procedure.
+- If you have running pods or if the Mesos "HTTP command executors" feature has been enabled in a custom configuration, you must restart these tasks in DC/OS 1.12 permissive security mode before patching to strict mode. Otherwise, these tasks will be restarted when the masters are patched.
 
 To update a cluster from permissive security to strict security, complete the following procedure:
 
@@ -221,7 +221,7 @@ sudo journalctl -u dcos-spartan
 sudo systemctl | grep dcos
 ```
 
-If your patch fails because of a [custom node or cluster check](/1.11/installing/production/deploying-dcos/node-cluster-health-check/#custom-health-checks), run these commands for more details:
+If your patch fails because of a [custom node or cluster check](/1.12/installing/production/deploying-dcos/node-cluster-health-check/#custom-health-checks), run these commands for more details:
 ```bash
 dcos-diagnostics check node-poststart
 dcos-diagnostics check cluster
@@ -243,5 +243,5 @@ sudo journalctl -u dcos-mesos-slave
 
 ## Notes:
 
-- Packages available in the DC/OS 1.11 Universe are newer than those in the older versions of Universe. Services are not automatically patched when DC/OS is installed because not all DC/OS services have patch paths that will preserve an existing state.
+- Packages available in the DC/OS 1.12 Universe are newer than those in the older versions of Universe. Services are not automatically patched when DC/OS is installed because not all DC/OS services have patch paths that will preserve an existing state.
 

--- a/pages/1.12/installing/production/system-requirements/custom-ami/index.md
+++ b/pages/1.12/installing/production/system-requirements/custom-ami/index.md
@@ -23,7 +23,7 @@ This is the recommended method for building your own AMI.
 
     Verify that you can build and deploy an AMI using these scripts as-is, without modification. An AMI must be deployed to every region where a cluster will be launched. The DC/OS Packer build script [create_dcos_ami.sh](https://github.com/dcos/dcos/blob/master/cloud_images/centos7/create_dcos_ami.sh) can deploy the AMI to multiple regions by setting the environment variable `DEPLOY_REGIONS` before running the script.
 
-1.  Launch the DC/OS advanced template using the AWS CloudFormation web console and specify the DC/OS cloud_images AMI. Verify that the cluster launched successfully. For more information, see the [documentation](/1.11/installing/evaluation/cloud-installation/aws/advanced/#launch).
+1.  Launch the DC/OS advanced template using the AWS CloudFormation web console and specify the DC/OS cloud_images AMI. Verify that the cluster launched successfully. For more information, see the [documentation](/1.12/installing/evaluation/cloud-installation/aws/advanced/#launch).
 
 ## Modify the DC/OS cloud_images AMI 
 
@@ -35,10 +35,10 @@ After you have successfully built and deployed the unmodified DC/OS cloud_images
 
 1.  Launch the DC/OS advanced templates using the AWS CloudFormation web console and specify your customized AMI. Verify that DC/OS starts as expected and that services can be launched on the DC/OS cluster.
 
-1.  Complete your installation by following [these instructions](/1.11/installing/evaluation/cloud-installation/aws/advanced/#launch).
+1.  Complete your installation by following [these instructions](/1.12/installing/evaluation/cloud-installation/aws/advanced/#launch).
 
 ## Troubleshooting
 
-- Familiarize yourself with the DC/OS service startup [process](/1.11/overview/architecture/boot-sequence/).
-- See the installation troubleshooting [documentation](/1.11/installing/troubleshooting/). To troubleshoot you must have [SSH access](/1.11/administering-clusters/sshcluster/) to all of the cluster nodes.
+- Familiarize yourself with the DC/OS service startup [process](/1.12/overview/architecture/boot-sequence/).
+- See the installation troubleshooting [documentation](/1.12/installing/troubleshooting/). To troubleshoot you must have [SSH access](/1.12/administering-clusters/sshcluster/) to all of the cluster nodes.
 - The [DC/OS Slack](/support/) community is another a good place to get help.

--- a/pages/1.12/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.12/installing/production/system-requirements/docker-centos/index.md
@@ -16,7 +16,7 @@ These directions cover the installation of Docker CE on CentOS/RHEL. Before inst
 
 * Format node storage as XFS with the `ftype=1` option. As of CentOS/RHEL 7.2, [only XFS is currently supported for use as a lower layer file system][2].
 
-* For more generic Docker requirements, see [System Requirements: Docker](/1.11/installing/production/system-requirements/#docker).
+* For more generic Docker requirements, see [System Requirements: Docker](/1.12/installing/production/system-requirements/#docker).
 
 **Note:** In modern versions of Centos and RHEL, `ftype=1` is the default. The `xfs_info` utility can be used to verify that `ftype=1`.
 

--- a/pages/1.12/installing/production/system-requirements/ports/index.md
+++ b/pages/1.12/installing/production/system-requirements/ports/index.md
@@ -7,7 +7,7 @@ excerpt: Understanding configured ports for DC/OS deployment
 ---
 This section describes each pre-configured port in your DC/OS deployment. 
 
-[DC/OS components](/1.11/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed. DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
+[DC/OS components](/1.12/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed. DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 
 - These ports must not be used in a firewall configuration between nodes or cluster zones.
 - For DC/OS to install and function as intended, these ports must be open and accessible upon initial installation. 

--- a/pages/1.12/installing/production/upgrading/index.md
+++ b/pages/1.12/installing/production/upgrading/index.md
@@ -14,12 +14,12 @@ Example: 1.X to 1.Y (1.11 --> 1.12)
 
 If an upgrade is performed on a supported OS with all prerequisites fulfilled, then upgrade _should_ preserve the state of running tasks on the cluster.  This document reuses portions of the [DC/OS Installation Guide][install].
 
-- Review the [release notes](/1.11/release-notes/) before upgrading DC/OS.
-- Due to a cluster configuration issue with overlay networks, it is recommended to set `enable_ipv6` to false in `config.yaml` when upgrading or configuring a new cluster. If you have already upgraded to DC/OS 1.11.x without configuring `enable_ipv6` or if `config.yaml` file is set to `true` then do not add new nodes until DC/OS 1.11.3 has been released. You can find additional information and a more detailed remediation procedure in our latest critical [product advisory](https://support.mesosphere.com/s/login/?startURL=%2Fs%2Farticle%2FCritical-Issue-with-Overlay-Networking&ec=302). [enterprise type="inline" size="small" /]
-- There are new options in the `config.yaml` file which must be declared prior to upgrading. Even if you have previously installed DC/OS successfully with your `config.yaml` file, the file will require new additions to function with DC/OS 1.11. Check if `fault_domain_enabled` and `enable_ipv6` are added in the `config.yaml` file. You can review the sample file [here](/latest/installing/ent/custom/advanced/#create-a-configuration-file). [enterprise type="inline" size="small" /]
-- The `disabled` security mode has been removed from DC/OS Enterprise 1.12. To upgrade a `disabled` mode 1.11 cluster to 1.12, [upgrade from `disabled` to `permissive` mode](/1.11/installing/production/patching/#patching-dcos-111-in-permissive-mode) as a separate step before upgrading from 1.11 to 1.12. [enterprise type="inline" size="small" /]
+- Review the [release notes](/1.12/release-notes/) before upgrading DC/OS.
+- Due to a cluster configuration issue with overlay networks, it is recommended to set `enable_ipv6` to false in `config.yaml` when upgrading or configuring a new cluster.  You can find additional information and a more detailed remediation procedure in our latest critical [product advisory](https://support.mesosphere.com/s/login/?startURL=%2Fs%2Farticle%2FCritical-Issue-with-Overlay-Networking&ec=302). [enterprise type="inline" size="small" /]
+- There are new options in the `config.yaml` file which must be declared prior to upgrading. Even if you have previously installed DC/OS successfully with your `config.yaml` file, the file will require new additions to function with DC/OS 1.12. Check if `fault_domain_enabled` and `enable_ipv6` are added in the `config.yaml` file. You can review the sample file [here](/latest/installing/ent/custom/advanced/#create-a-configuration-file). [enterprise type="inline" size="small" /]
+- The `disabled` security mode has been removed from DC/OS Enterprise 1.12. To upgrade a `disabled` mode 1.12 cluster to 1.12, [upgrade from `disabled` to `permissive` mode](/1.12/installing/production/patching/#patching-dcos-111-in-permissive-mode) as a separate step before upgrading from 1.12 to 1.12. [enterprise type="inline" size="small" /]
 - If IPv6 is disabled in the kernel, then IPv6 must be disabled in the `config.yaml` file for the upgrade to succeed.
-- The Advanced installation method is the _only_ recommended upgrade path for DC/OS. It is recommended that you familiarize yourself with the [Advanced DC/OS Installation Guide](/1.11/installing/oss/custom/advanced) before proceeding. 
+- The Advanced installation method is the _only_ recommended upgrade path for DC/OS. It is recommended that you familiarize yourself with the [Advanced DC/OS Installation Guide](/1.12/installing/oss/custom/advanced) before proceeding. 
 - DC/OS Enterprise now enforces license keys. The license key must reside in a genconf/license.txt file or the upgrade will fail. [enterprise type="inline" size="small" /]
 - The DC/OS GUI and other higher-level system APIs may be inconsistent or unavailable until all master nodes have been upgraded. 
   When this occurs: 
@@ -46,22 +46,22 @@ Only a subset of DC/OS configuration parameters can be modified. The adverse eff
 
 Here is a list of the parameters that you can modify:
 
-- [`dns_search`](/1.11/installing/ent/custom/configuration/configuration-parameters/#dns-search)
-- [`docker_remove_delay`](/1.11/installing/ent/custom/configuration/configuration-parameters/#docker-remove-delay)
-- [`gc_delay`](/1.11/installing/ent/custom/configuration/configuration-parameters/#gc-delay)
-- [`resolvers`](/1.11/installing/ent/custom/configuration/configuration-parameters/#resolvers)
-- [`telemetry_enabled`](/1.11/installing/ent/custom/configuration/configuration-parameters/#telemetry-enabled)
-- [`use_proxy`](/1.11/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
-    - [`http_proxy`](/1.11/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
-    - [`https_proxy`](/1.11/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
-    - [`no_proxy`](/1.11/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
+- [`dns_search`](/1.12/installing/ent/custom/configuration/configuration-parameters/#dns-search)
+- [`docker_remove_delay`](/1.12/installing/ent/custom/configuration/configuration-parameters/#docker-remove-delay)
+- [`gc_delay`](/1.12/installing/ent/custom/configuration/configuration-parameters/#gc-delay)
+- [`resolvers`](/1.12/installing/ent/custom/configuration/configuration-parameters/#resolvers)
+- [`telemetry_enabled`](/1.12/installing/ent/custom/configuration/configuration-parameters/#telemetry-enabled)
+- [`use_proxy`](/1.12/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
+    - [`http_proxy`](/1.12/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
+    - [`https_proxy`](/1.12/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
+    - [`no_proxy`](/1.12/installing/ent/custom/configuration/configuration-parameters/#use-proxy)
 
 The security mode (`security`) can be changed but has special caveats. [enterprise type="inline" size="small" /]
 
 - You can only update to a stricter security mode. Security downgrades are not supported. For example, if your cluster is in `strict` mode and you want to downgrade to `permissive` mode, you must reinstall the cluster and terminate all running workloads. [enterprise type="inline" size="small" /]
 - During each update, you can only increase your security by a single level. For example, you cannot update directly from `disabled` to `strict` mode. To increase from `disabled` to `strict` mode you must first update to `permissive` mode, and then update from `permissive` to `strict` mode. [enterprise type="inline" size="small" /]
 
-See the security [mode](/1.11/installing/ent/custom/configuration/configuration-parameters/#security-enterprise) for information on different security modes. [enterprise type="inline" size="small" /]
+See the security [mode](/1.12/installing/ent/custom/configuration/configuration-parameters/#security-enterprise) for information on different security modes. [enterprise type="inline" size="small" /]
 
 # Instructions
 These steps must be performed for version upgrades and cluster configuration changes.
@@ -78,14 +78,14 @@ These steps must be performed for version upgrades and cluster configuration cha
 - You must be familiar with using `systemctl` and `journalctl` command line tools to review and monitor service status. Troubleshooting notes can be found at the end of this [document](#troubleshooting).
 - You must be familiar with the [DC/OS Installation Guide][install].
 - Take a snapshot of ZooKeeper prior to upgrading. Marathon supports rollbacks, but does not support downgrades.
-- [Take a snapshot of the IAM database](/1.11/installing/ent/faq/#q-how-do-i-backup-the-iam-database-enterprise) prior to upgrading. [enterprise type="inline" size="small" /]
+- [Take a snapshot of the IAM database](/1.12/installing/ent/faq/#q-how-do-i-backup-the-iam-database-enterprise) prior to upgrading. [enterprise type="inline" size="small" /]
 - Ensure that Marathon event subscribers are disabled before beginning the upgrade. Leave them disabled after completing the upgrade, as this feature is now deprecated.
 
 **Note:** Marathon event subscribers are disabled by default, check if the line `--event_subscriber "http_callback"` has been added to `sudo vi /opt/mesosphere/bin/marathon.sh` on your master node(s). In this case, you will need to remove that line in order to disable event subscribers. [enterprise type="inline" size="small" /]
 
 - Verify that all Marathon application constraints are valid before beginning the upgrade. Use [this script](https://github.com/mesosphere/public-support-tools/blob/master/check-constraints.py) to check if your constraints are valid.
-- [Back up your cluster](/1.11/administering-clusters/backup-and-restore/). [enterprise type="inline" size="small" /]
-- Optional: You can add custom [node and cluster health checks](/1.11/installing/ent/custom/node-cluster-health-check/#custom-health-checks) to your `config.yaml`.
+- [Back up your cluster](/1.12/administering-clusters/backup-and-restore/). [enterprise type="inline" size="small" /]
+- Optional: You can add custom [node and cluster health checks](/1.12/installing/ent/custom/node-cluster-health-check/#custom-health-checks) to your `config.yaml`.
 - Verify that all your masters are in a healthy state: 
    - Check the Exhibitor UI to confirm that all masters have joined the quorum successfully (the status indicator will show green). The Exhibitor UI is available at `http://<dcos_master>:8181/`.
    - Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1` for each master.
@@ -99,18 +99,18 @@ These steps must be performed for version upgrades and cluster configuration cha
 
 Choose your desired security mode and then follow the applicable upgrade instructions.
 
-- [Upgrading DC/OS 1.11 without changing security mode](#current-security)
-- [Upgrading DC/OS 1.11 in permissive mode](#permissive)
-- [Upgrading DC/OS 1.11 in strict mode](#strict)
+- [Upgrading DC/OS 1.12 without changing security mode](#current-security)
+- [Upgrading DC/OS 1.12 in permissive mode](#permissive)
+- [Upgrading DC/OS 1.12 in strict mode](#strict)
 
-#### <a name="current-security"></a>Upgrading DC/OS 1.11 without changing security mode 
-This procedure upgrades a DC/OS 1.10 cluster to DC/OS 1.11 without changing the cluster's [security mode](/1.11/installing/ent/custom/configuration/configuration-parameters/#security-enterprise).
+#### <a name="current-security"></a>Upgrading DC/OS 1.12 without changing security mode 
+This procedure upgrades a DC/OS 1.10 cluster to DC/OS 1.12 without changing the cluster's [security mode](/1.12/installing/ent/custom/configuration/configuration-parameters/#security-enterprise).
 
 1.  Copy your existing `config.yaml` and `ip-detect` files to an empty `genconf` folder on your bootstrap node. The folder should be in the same directory as the installer.
 2.  Merge the old `config.yaml` into the new `config.yaml` format. In most cases the differences will be minimal.
 
     *  You cannot change the `exhibitor_zk_backend` setting during an upgrade.
-    *  The syntax of the `config.yaml` may be different from the earlier version. For a detailed description of the current `config.yaml` syntax and parameters, see the [documentation](/1.11/installing/ent/custom/configuration/configuration-parameters/).
+    *  The syntax of the `config.yaml` may be different from the earlier version. For a detailed description of the current `config.yaml` syntax and parameters, see the [documentation](/1.12/installing/ent/custom/configuration/configuration-parameters/).
 3. After updating the format of the config.yaml, compare the old config.yaml and new config.yaml. Verify that there are no differences in pathways or configurations. Changing these while upgrading can lead to catastrophic cluster failures.
 4.  Modify the `ip-detect` file as desired.
 5.  Build your installer package.
@@ -125,14 +125,14 @@ This procedure upgrades a DC/OS 1.10 cluster to DC/OS 1.11 without changing the 
 
 6.  Go to the DC/OS Master [procedure](#masters) to complete your installation.
 
-#### <a name="permissive"></a>Upgrading DC/OS 1.11 in permissive mode 
-This procedure upgrades to DC/OS 1.11 in [permissive security mode](/1.11/installing/ent/custom/configuration/configuration-parameters/#security-enterprise).
+#### <a name="permissive"></a>Upgrading DC/OS 1.12 in permissive mode 
+This procedure upgrades to DC/OS 1.12 in [permissive security mode](/1.12/installing/ent/custom/configuration/configuration-parameters/#security-enterprise).
 
 **Prerequisite:**
 
-- Your cluster must be [upgraded to DC/OS 1.11](#current-security) and running in [disabled security mode](/1.11/installing/ent/custom/configuration/configuration-parameters/#security-enterprise) before it can be upgraded to permissive mode. If your cluster was running in permissive mode before it was upgraded to DC/OS 1.10, you can skip this procedure.
+- Your cluster must be [upgraded to DC/OS 1.12](#current-security) and running in [disabled security mode](/1.12/installing/ent/custom/configuration/configuration-parameters/#security-enterprise) before it can be upgraded to permissive mode. If your cluster was running in permissive mode before it was upgraded to DC/OS 1.10, you can skip this procedure.
 
-**Note:** Any [custom node or cluster health checks](/1.11/installing/ent/custom/node-cluster-health-check/#custom-health-checks) you have configured will fail for an upgrade from disabled to permissive security mode. A future release will allow you to bypass the health checks.
+**Note:** Any [custom node or cluster health checks](/1.12/installing/ent/custom/node-cluster-health-check/#custom-health-checks) you have configured will fail for an upgrade from disabled to permissive security mode. A future release will allow you to bypass the health checks.
 
 To update a cluster from disabled security to permissive security, complete the following procedure:
 
@@ -150,15 +150,15 @@ To update a cluster from disabled security to permissive security, complete the 
 
 4.  Go to the DC/OS Master [procedure](#masters) to complete your installation.
 
-#### <a name="strict"></a>Upgrading DC/OS 1.11 in strict mode 
-This procedure upgrades to DC/OS 1.11 in security strict [mode](/1.11/installing/ent/custom/configuration/configuration-parameters/#security-enterprise).
+#### <a name="strict"></a>Upgrading DC/OS 1.12 in strict mode 
+This procedure upgrades to DC/OS 1.12 in security strict [mode](/1.12/installing/ent/custom/configuration/configuration-parameters/#security-enterprise).
 
 If you are updating a running DC/OS cluster to run in `security: strict` mode, beware that security vulnerabilities may persist even after migration to strict mode. When moving to strict mode, your services will now require authentication and authorization to register with Mesos or access its HTTP API. You should test these configurations in permissive mode before upgrading to strict, to maintain scheduler and script uptimes across the upgrade.
 
 **Prerequisites:**
 
-- Your cluster must be [upgraded to DC/OS 1.11](#current-security) and running in [permissive security mode](#permissive) before it can be updated to strict mode. If your cluster was running in strict mode before it was upgraded to DC/OS 1.11, you can skip this procedure.
-- If you have running pods or if the Mesos "HTTP command executors" feature has been enabled in a custom configuration, you must restart these tasks in DC/OS 1.11 permissive security mode before upgrading to strict mode. Otherwise, these tasks will be restarted when the masters are upgraded.
+- Your cluster must be [upgraded to DC/OS 1.12](#current-security) and running in [permissive security mode](#permissive) before it can be updated to strict mode. If your cluster was running in strict mode before it was upgraded to DC/OS 1.12, you can skip this procedure.
+- If you have running pods or if the Mesos "HTTP command executors" feature has been enabled in a custom configuration, you must restart these tasks in DC/OS 1.12 permissive security mode before upgrading to strict mode. Otherwise, these tasks will be restarted when the masters are upgraded.
 
 To update a cluster from permissive security to strict security, complete the following procedure:
 
@@ -183,11 +183,11 @@ To update a cluster from permissive security to strict security, complete the fo
 1.  Copy and update the DC/OS 1.10 `config.yaml` and `ip-detect` files to a new, clean folder on your bootstrap node.
 
     *  You cannot change the `exhibitor_zk_backend` setting during an upgrade.
-    *  The syntax of the DC/OS 1.11 `config.yaml` differs from that of previous versions. See the [documentation](/1.11/installing/oss/custom/configuration/configuration-parameters/) for the latest information.
+    *  The syntax of the DC/OS 1.12 `config.yaml` differs from that of previous versions. See the [documentation](/1.12/installing/oss/custom/configuration/configuration-parameters/) for the latest information.
 
 1.  After updating the format of the `config.yaml`, compare the old `config.yaml` and new `config.yaml`.  Verify that there are no differences in pathways or configurations. Changing these while upgrading can lead to catastrophic cluster failures.
 
-1.  After you have converted your 1.10 `config.yaml` into the 1.11 `config.yaml` format, you can build your installer package:
+1.  After you have converted your 1.10 `config.yaml` into the 1.12 `config.yaml` format, you can build your installer package:
 
     1.  Download the file `dcos_generate_config.sh`.
     1.  Generate the installation files. Replace `<installed_cluster_version>` in the below command with the DC/OS version currently running on the cluster you intend to upgrade, for example `1.9.2`.
@@ -281,7 +281,7 @@ sudo journalctl -u dcos-spartan
 sudo systemctl | grep dcos
 ```
 
-If your upgrade fails because of a [custom node or cluster check](/1.11/installing/ent/custom/node-cluster-health-check/#custom-health-checks), run these commands for more details:
+If your upgrade fails because of a [custom node or cluster check](/1.12/installing/ent/custom/node-cluster-health-check/#custom-health-checks), run these commands for more details:
 ```bash
 dcos-diagnostics check node-poststart
 dcos-diagnostics check cluster
@@ -313,6 +313,6 @@ sudo journalctl -u dcos-mesos-slave
 
 ### Notes:
 
-- Packages available in the DC/OS 1.11 Universe are newer than those in the older versions of Universe. Services are not automatically upgraded when DC/OS is installed because not all DC/OS services have upgrade paths that will preserve existing state.
+- Packages available in the DC/OS 1.12 Universe are newer than those in the older versions of Universe. Services are not automatically upgraded when DC/OS is installed because not all DC/OS services have upgrade paths that will preserve existing state.
 
-[install]: /1.11/installing/ent/custom/advanced/
+[install]: /1.12/installing/ent/custom/advanced/

--- a/pages/1.12/installing/troubleshooting/index.md
+++ b/pages/1.12/installing/troubleshooting/index.md
@@ -13,17 +13,17 @@ excerpt: Troubleshooting DC/OS installation issues
 
 ## IP detect script
 
-You must have a valid [ip-detect](/1.11/installing/production/advanced/#create-an-ip-detection-script) script. You can manually run `ip-detect` on all the nodes in your cluster or check `/opt/mesosphere/bin/detect_ip` on an existing installation to ensure that it returns a valid IP address. A valid IP address does not have:
+You must have a valid [ip-detect](/1.12/installing/production/advanced/#create-an-ip-detection-script) script. You can manually run `ip-detect` on all the nodes in your cluster or check `/opt/mesosphere/bin/detect_ip` on an existing installation to ensure that it returns a valid IP address. A valid IP address does not have:
 
   - extra lines
   - white space
   - special or hidden characters
 
-We recommended that you use the `ip-detect` [examples](/1.11/installing/production/deploying-dcos/installation/).
+We recommended that you use the `ip-detect` [examples](/1.12/installing/production/deploying-dcos/installation/).
 
 ## DNS resolvers
 
-You must have working DNS resolvers, specified in your [config.yaml](1.11/installing/production/advanced-configuration/configuration-reference/#resolvers) file. We recommended that you have forward and reverse lookups for FQDNs, short hostnames, and IP addresses. It is possible for DC/OS to function in environments without valid DNS support, but the following _must_ work to support DC/OS services, including Spark:
+You must have working DNS resolvers, specified in your [config.yaml](1.12/installing/production/advanced-configuration/configuration-reference/#resolvers) file. We recommended that you have forward and reverse lookups for FQDNs, short hostnames, and IP addresses. It is possible for DC/OS to function in environments without valid DNS support, but the following _must_ work to support DC/OS services, including Spark:
 
   - `hostname -f` returns the FQDN
   - `hostname -s` returns the short hostname
@@ -64,7 +64,7 @@ When troubleshooting problems with a DC/OS installation, you should explore the 
 
 * Verify that Exhibitor is up and running at`http://<MASTER_IP>:8181/exhibitor`. If Exhibitor is not up and running:
 
-    - [SSH](/1.11/administering-clusters/sshcluster/) to your master node and enter this command to check the Exhibitor service logs:
+    - [SSH](/1.12/administering-clusters/sshcluster/) to your master node and enter this command to check the Exhibitor service logs:
 
     ```bash
     journalctl -flu dcos-exhibitor
@@ -80,7 +80,7 @@ When troubleshooting problems with a DC/OS installation, you should explore the 
 	    
 * Check the output of `/exhibitor/v1/cluster/status` and verify that it shows the correct number of masters and that all of them are `"serving"` but only one of them is designated as `"isLeader": true`
 
-  For example, [SSH](/1.11/administering-clusters/sshcluster/) to your master node and enter this command:
+  For example, [SSH](/1.12/administering-clusters/sshcluster/) to your master node and enter this command:
 
 
     curl -fsSL http://localhost:8181/exhibitor/v1/cluster/status | python -m json.tool
@@ -298,9 +298,9 @@ For example, here is a snippet of the Mesos-DNS log as it converges to a success
 
 ## <a name="zookeeper-and-exhibitor"></a>ZooKeeper and Exhibitor
 
-ZooKeeper and Exhibitor start on the master nodes. The Exhibitor storage location must be configured properly for this to work. For more information, see the [exhibitor_storage_backend](/1.11/installing/production/advanced-configuration/configuration-reference/#exhibitor-storage-backend) parameter.
+ZooKeeper and Exhibitor start on the master nodes. The Exhibitor storage location must be configured properly for this to work. For more information, see the [exhibitor_storage_backend](/1.12/installing/production/advanced-configuration/configuration-reference/#exhibitor-storage-backend) parameter.
 
-DC/OS uses ZooKeeper, a high-performance coordination service to manage the installed DC/OS services. Exhibitor automatically configures ZooKeeper on the master nodes during your DC/OS installation. For more information, see [Configuration Parameters](/1.11/installing/production/advanced-configuration/configuration-reference/).
+DC/OS uses ZooKeeper, a high-performance coordination service to manage the installed DC/OS services. Exhibitor automatically configures ZooKeeper on the master nodes during your DC/OS installation. For more information, see [Configuration Parameters](/1.12/installing/production/advanced-configuration/configuration-reference/).
 
 * Go to the Exhibitor web interface and view status at `<master-hostname>/exhibitor`.
 
@@ -328,10 +328,10 @@ For example, here is a snippet of the Exhibitor log as it converges to a success
 
 
 
- [1]: /1.11/installing/ent/custom/configuration/configuration-parameters/#exhibitor-storage-backend
+ [1]: /1.12/installing/ent/custom/configuration/configuration-parameters/#exhibitor-storage-backend
  [2]: https://open.mesosphere.com/reference/mesos-master/
- [3]: /1.11/installing/production/advanced-configuration/configuration-reference/#master-discovery
- [4]: /1.11/overview/architecture/boot-sequence/
- [5]: /1.11/installing/ent/custom/configuration/configuration-parameters/
- [6]: /1.11/administering-clusters/sshcluster/
+ [3]: /1.12/installing/production/advanced-configuration/configuration-reference/#master-discovery
+ [4]: /1.12/overview/architecture/boot-sequence/
+ [5]: /1.12/installing/ent/custom/configuration/configuration-parameters/
+ [6]: /1.12/administering-clusters/sshcluster/
 


### PR DESCRIPTION
Replaced 1.11 with 1.12 on https://docs.mesosphere.com/1.12/installing/

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
