### PR TITLE
Fix yaml links in cluster-links pages

### DIFF
--- a/pages/1.11/administering-clusters/multiple-clusters/cluster-link-api/index.md
+++ b/pages/1.11/administering-clusters/multiple-clusters/cluster-link-api/index.md
@@ -56,4 +56,4 @@ To assign permissions to your account, see the [permissions reference](/1.11/sec
 
 The Cluster Link API allows you to manage cluster link operations on your DC/OS cluster.
 
-[api-explorer api='/1.11/api/cluster-link.yaml']
+[swagger api='/1.11/api/cluster-link.yaml']

--- a/pages/1.12/administering-clusters/multiple-clusters/cluster-link-api/index.md
+++ b/pages/1.12/administering-clusters/multiple-clusters/cluster-link-api/index.md
@@ -56,4 +56,4 @@ To assign permissions to your account, see the [permissions reference](/1.11/sec
 
 The Cluster Link API allows you to manage cluster link operations on your DC/OS cluster.
 
-[api-explorer api='/1.11/api/cluster-link.yaml']
+[swagger api='/1.11/api/cluster-link.yaml']


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-42284

Found that there was an old reference to api-explorer in the links, changed that to swagger and yaml file works

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
