### PR TITLE
1.12 edits in developing dcos, fix table on tunnel page

### DIFF
--- a/pages/1.11/developing-services/tunnel/index.md
+++ b/pages/1.11/developing-services/tunnel/index.md
@@ -34,7 +34,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
 
 # DC/OS Tunnel Options at a Glance
 
-
 <table class="table">
    <tr>
       <th>&nbsp;</th>
@@ -56,8 +55,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
       </td>
    </tr>
    <tr>
-  </tr>
-  <tr>
       <th>HTTP (transparent)</th>
       <td>
          <ul>
@@ -65,6 +62,7 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
             <li>No application configuration</li>
          </ul>
       </td>
+      <td>
          <ul>
             <li>Cannot specify ports (except through SRV)</li>
             <li>Only supports HTTP</li>
@@ -91,32 +89,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
       <th>VPN</th>
       <td>
          <ul>
-          <ul>
-              <li>Cannot specify ports (except through SRV)</li>
-              <li>Only supports HTTP</li>
-              <li>Runs as superuser</li>
-          </ul>
-          </td>
-    </tr>
-    <tr>
-        <th>HTTP (standard)</th>
-        <td>
-        <ul>
-            <li>SRV as URL</li>
-            <li>Specify ports</li>
-        </ul>
-        </td>
-        <td>
-        <ul>
-            <li>Requires application configuration</li>
-            <li>Only supports HTTP/HTTPS</li>
-        </ul>
-        </td>
-     </tr>
-     <tr>
-        <th>VPN</th>
-        <td>
-        <ul>
             <li>No application configuration</li>
             <li>Full and direct access to cluster</li>
             <li>Specify ports</li>
@@ -125,10 +97,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
       </td>
       <td>
          <ul>
-        </ul>
-        </td>
-        <td>
-        <ul>
             <li>More prerequisites</li>
             <li>Runs as superuser</li>
             <li><i>May</i> need to manually reconfigure DNS</li>
@@ -136,9 +104,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
          </ul>
       </td>
    </tr>
-        </ul>
-        </td>
-      </tr>
 </table>
 
 # Using DC/OS Tunnel

--- a/pages/1.12/developing-services/cli-spec/index.md
+++ b/pages/1.12/developing-services/cli-spec/index.md
@@ -9,7 +9,7 @@ enterprise: false
 ---
 This document is intended for a developer creating new DC/OS CLI subcommands. See also [Universe Getting Started][1]. 
 
-The [DC/OS command-line interface (CLI)](/1.11/cli) is a utility to manage cluster nodes, install and manage packages, inspect the cluster state, and manage services and tasks. The DC/OS CLI is open and extensible: anyone can create a new subcommand and make it available for installation by end users. For example, the [Spark DC/OS service][2] provides CLI extensions for working with Spark. When installed, you can type the following command to submit Spark jobs and query their status:
+The [DC/OS command-line interface (CLI)](/1.12/cli) is a utility to manage cluster nodes, install and manage packages, inspect the cluster state, and manage services and tasks. The DC/OS CLI is open and extensible: anyone can create a new subcommand and make it available for installation by end users. For example, the [Spark DC/OS service][2] provides CLI extensions for working with Spark. When installed, you can type the following command to submit Spark jobs and query their status:
 
     dcos spark [<flags>] <command>
 
@@ -30,7 +30,7 @@ or
 
 The same [packaging format and repository][11] is used for both DC/OS services and CLI subcommands.
 
-**Note:** CLI modules are [cluster-specific](/1.11/administering-clusters/multiple-clusters/) and stored in `~/.dcos/clusters/<cluster_id>/subcommands`. You must install a CLI module for each cluster. For example, if you connect to cluster 1, and install the Spark module, then connect to cluster 2 which is also running Spark, Spark CLI commands are not available until you install the module for that cluster.
+**Note:** CLI modules are [cluster-specific](/1.12/administering-clusters/multiple-clusters/) and stored in `~/.dcos/clusters/<cluster_id>/subcommands`. You must install a CLI module for each cluster. For example, if you connect to cluster 1, and install the Spark module, then connect to cluster 2 which is also running Spark, Spark CLI commands are not available until you install the module for that cluster.
 
 ## Creating a DC/OS CLI subcommand
 

--- a/pages/1.12/developing-services/index.md
+++ b/pages/1.12/developing-services/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 This section describes the developer-specific DC/OS components, explaining what is necessary to package and provide your own service on DC/OS. 
 
-The Mesosphere Datacenter Operating System (DC/OS) provides the optimal user experience possible for orchestrating and managing a datacenter. If you are an Apache Mesos developer, you are already familiar with developing a framework. DC/OS extends Apache Mesos by including a web interface for health checks and monitoring, a command-line, a service packaging description, and a [repository](/1.11/administering-clusters/repo/) that catalogs those packages.
+The Mesosphere Datacenter Operating System (DC/OS) provides the optimal user experience possible for orchestrating and managing a datacenter. If you are an Apache Mesos developer, you are already familiar with developing a framework. DC/OS extends Apache Mesos by including a web interface for health checks and monitoring, a command-line, a service packaging description, and a [repository](/1.12/administering-clusters/repo/) that catalogs those packages.
 
 # <a name="universe"></a>Package Repositories
 

--- a/pages/1.12/developing-services/tunnel/index.md
+++ b/pages/1.12/developing-services/tunnel/index.md
@@ -38,7 +38,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
 
 # DC/OS Tunnel Options at a Glance
 
-
 <table class="table">
    <tr>
       <th>&nbsp;</th>
@@ -60,10 +59,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
       </td>
    </tr>
    <tr>
-        </ul>
-        </td>
-  </tr>
-  <tr>
       <th>HTTP (transparent)</th>
       <td>
          <ul>
@@ -98,32 +93,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
       <th>VPN</th>
       <td>
          <ul>
-          <ul>
-              <li>Cannot specify ports (except through SRV)</li>
-              <li>Only supports HTTP</li>
-              <li>Runs as superuser</li>
-          </ul>
-          </td>
-    </tr>
-    <tr>
-        <th>HTTP (standard)</th>
-        <td>
-        <ul>
-            <li>SRV as URL</li>
-            <li>Specify ports</li>
-        </ul>
-        </td>
-        <td>
-        <ul>
-            <li>Requires application configuration</li>
-            <li>Only supports HTTP/HTTPS</li>
-        </ul>
-        </td>
-     </tr>
-     <tr>
-        <th>VPN</th>
-        <td>
-        <ul>
             <li>No application configuration</li>
             <li>Full and direct access to cluster</li>
             <li>Specify ports</li>
@@ -132,10 +101,6 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
       </td>
       <td>
          <ul>
-        </ul>
-        </td>
-        <td>
-        <ul>
             <li>More prerequisites</li>
             <li>Runs as superuser</li>
             <li><i>May</i> need to manually reconfigure DNS</li>
@@ -143,18 +108,15 @@ DC/OS Tunnel provides you with full access to the DNS, masters, and agents from 
          </ul>
       </td>
    </tr>
-        </ul>
-        </td>
-      </tr>
 </table>
 
 # Using DC/OS Tunnel
 
 ## Prerequisites
 * Only Linux and macOS are currently supported.
-* The [DC/OS CLI](/1.11/cli/install/).
+* The [DC/OS CLI](/1.12/cli/install/).
 * The DC/OS Tunnel package. Run `dcos package install tunnel-cli --cli`.
-* [SSH access](/1.11/administering-clusters/sshcluster/) (key authentication only).
+* [SSH access](/1.12/administering-clusters/sshcluster/) (key authentication only).
 * [The OpenVPN client](https://openvpn.net/index.php/open-source/downloads.html) for VPN functionality.
 
 ## Example Application
@@ -224,7 +186,7 @@ The `<service-name>` is the entry in the **ID** field of a service you create fr
 To name a port from the DC/OS web interface, go to the **Services > Services** tab, click the name of your service, and then click **Edit**. Enter a name for your port on the **Networking** tab.
 
 #### Add a Named Port in a Marathon Application Definition
-Alternatively, you can add `name` to the `portMappings` or `portDefinitions` field of a Marathon application definition. Whether you use `portMappings` or `portDefinitions` depends on whether you are using `BRIDGE` or `HOST` networking. [Learn more about networking and ports in Marathon](/1.11/deploying-services/service-ports/).
+Alternatively, you can add `name` to the `portMappings` or `portDefinitions` field of a Marathon application definition. Whether you use `portMappings` or `portDefinitions` depends on whether you are using `BRIDGE` or `HOST` networking. [Learn more about networking and ports in Marathon](/1.12/deploying-services/service-ports/).
 
 ```json
 "portMappings": [


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-42316

1.12 edits in the developing dcos services page
also updated a table on the tunnel subpage, and went to 1.11 to fix that one too

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
