### PR TITLE
Fix broken autoscale repo link ck/DCOS-25870

### DIFF
--- a/pages/1.10/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.10/tutorials/autoscaling/cpu-memory/index.md
@@ -40,7 +40,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
     
     **Tip:** Run `dcos node` to get the available node IDs.
     
-1.  Clone the [autoscale][13] GitHub repository to your node.
+1.  Clone the [autoscale Github repository](https://github.com/mesosphere/marathon-autoscale) to your node.
 
     ```bash
     git clone https://github.com/mesosphere/marathon-autoscale.git

--- a/pages/1.11/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.11/tutorials/autoscaling/cpu-memory/index.md
@@ -36,7 +36,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 
     **Note:** Run `dcos node` to get the available node IDs.
 
-1.  Clone the [autoscale][13] GitHub repository to your node.
+1.  Clone the [autoscale Github repository](https://github.com/mesosphere/marathon-autoscale) to your node.
 
     ```bash
     git clone https://github.com/mesosphere/marathon-autoscale.git

--- a/pages/1.12/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.12/tutorials/autoscaling/cpu-memory/index.md
@@ -36,7 +36,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 
     **Tip:** Run `dcos node` to get the available node IDs.
 
-1.  Clone the [autoscale][13] GitHub repository to your node.
+1.  Clone the [autoscale Github repository](https://github.com/mesosphere/marathon-autoscale) to your node.
 
     ```bash
     git clone https://github.com/mesosphere/marathon-autoscale.git

--- a/pages/1.9/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.9/tutorials/autoscaling/cpu-memory/index.md
@@ -40,7 +40,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
     
     **Tip:** Run `dcos node` to get the available node IDs.
     
-1.  Clone the [autoscale][13] GitHub repository to your node.
+1.  Clone the [autoscale Github repository](https://github.com/mesosphere/marathon-autoscale) to your node.
 
     ```bash
     git clone https://github.com/mesosphere/marathon-autoscale.git


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25870
Broken link format fixed across 1.9-1.12

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
