### PR TITLE
1.11.6 relnotes: Remove Enterprise label from ZooKeeper bump

### DIFF
--- a/pages/1.11/release-notes/1.11.6/index.md
+++ b/pages/1.11/release-notes/1.11.6/index.md
@@ -20,7 +20,7 @@ DC/OS 1.11.6 includes the following components:
 
 # Notable Changes in DC/OS 1.11.6
 - DCOS-22310/DCOS-40495/DCOS-41282 - Update DC/OS UI for [1.11+v1.23.0](https://github.com/dcos/dcos-ui/blob/1.11+v1.23.0/CHANGELOG.md). [oss type="inline" size="small" /]
-- DCOS_OSS-4106/DCOS_OSS-4109 - Bump ZooKeeper to [3.4.13](https://zookeeper.apache.org/doc/r3.4.13/releasenotes.html). [enterprise type="inline" size="small" /]
+- DCOS_OSS-4106/DCOS_OSS-4109 - Bump ZooKeeper to [3.4.13](https://zookeeper.apache.org/doc/r3.4.13/releasenotes.html). 
 - Update DC/OS UI for [1.11+v1.23.0+f17c3335](https://github.com/mesosphere/dcos-ui-plugins-private/compare/1.11+v1.20.0+1c67f4b5...1.11+v1.23.0+f17c3335). [enterprise type="inline" size="small" /]
 
 # Issues Fixed in DC/OS 1.11.6


### PR DESCRIPTION
See discussion in https://groups.google.com/a/dcos.io/d/msgid/users/CAPrjPrDqAMw0rHodzppiaa0QkYX37prvMZdSDcggn%3DsQ5mC-ow%40mail.gmail.com?utm_medium=email&utm_source=footer
