### PR TITLE
Add network security section

### DIFF
--- a/pages/1.10/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.10/administering-clusters/securing-your-cluster/index.md
@@ -18,6 +18,24 @@ network interfaces with iptables or other firewalls, and regularly applying
 updates from the Linux distribution used with DC/OS to ensure that system
 libraries, utilities and core services like systemd and OpenSSH are secure.
 
+# Network security
+
+You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes.
+
+Depending on your cluster environment, this may include:
+- using physical or virtual subnets to isolate [DC/OS Security Zones](#security-zones);
+- using router firewalls to restrict access to ports;
+- using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
+
+Use these mechanisms to:
+- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+- block connection requests on all ports from external machines to private agent nodes.
+- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.10/installing/production/system-requirements/ports/#agent).
+
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
 ## Security Zones
 
 At the highest level we can distinguish three security zones in a DC/OS

--- a/pages/1.10/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.10/administering-clusters/securing-your-cluster/index.md
@@ -32,6 +32,8 @@ Use these mechanisms to:
 - block connection requests on all ports from external machines to private agent nodes.
 - block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.10/installing/production/system-requirements/ports/#agent).
 
+For connections between cluster nodes, refer to [DC/OS Ports](/1.10/installing/ports/).
+
 You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
 Although DC/OS components do not currently support private network selection, you can configure
 `ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.

--- a/pages/1.10/installing/ent/ports/index.md
+++ b/pages/1.10/installing/ent/ports/index.md
@@ -9,9 +9,18 @@ enterprise: false
 
 [DC/OS components](/docs/1.10/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed.
 
-DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
+- For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
+- The ports must be open between the indicated source and destination nodes, including over cluster zones.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+	- block connection requests on all ports from external machines to private agent nodes.
+	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
 
-**Important:** These ports must not be used in a firewall configuration between nodes or cluster zones.
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
+DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 
 ## All nodes
 

--- a/pages/1.10/installing/ent/ports/index.md
+++ b/pages/1.10/installing/ent/ports/index.md
@@ -11,7 +11,7 @@ enterprise: false
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/). Use these mechanisms to:
 	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
 	- block connection requests on all ports from external machines to private agent nodes.
 	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).

--- a/pages/1.10/installing/oss/ports/index.md
+++ b/pages/1.10/installing/oss/ports/index.md
@@ -9,9 +9,18 @@ enterprise: false
 
 [DC/OS components](/docs/1.10/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed.
 
-DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
+- For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
+- The ports must be open between the indicated source and destination nodes, including over cluster zones.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+	- block connection requests on all ports from external machines to private agent nodes.
+	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
 
-**Important:** These ports must not be used in a firewall configuration between nodes or cluster zones.
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
+DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 
 ## All nodes
 

--- a/pages/1.10/installing/oss/ports/index.md
+++ b/pages/1.10/installing/oss/ports/index.md
@@ -11,7 +11,7 @@ enterprise: false
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/). Use these mechanisms to:
 	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
 	- block connection requests on all ports from external machines to private agent nodes.
 	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).

--- a/pages/1.10/installing/ports/index.md
+++ b/pages/1.10/installing/ports/index.md
@@ -9,9 +9,18 @@ enterprise: false
 
 [DC/OS components](/docs/1.10/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed.
 
-DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
+- For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
+- The ports must be open between the indicated source and destination nodes, including over cluster zones.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+	- block connection requests on all ports from external machines to private agent nodes.
+	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
 
-**Important:** These ports must not be used in a firewall configuration between nodes or cluster zones.
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
+DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 
 ## All nodes
 

--- a/pages/1.10/installing/ports/index.md
+++ b/pages/1.10/installing/ports/index.md
@@ -11,7 +11,7 @@ enterprise: false
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/). Use these mechanisms to:
 	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
 	- block connection requests on all ports from external machines to private agent nodes.
 	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).

--- a/pages/1.10/security/ent/hardening/index.md
+++ b/pages/1.10/security/ent/hardening/index.md
@@ -20,6 +20,8 @@ Your cluster will become more secure as you move from `disabled` to `permissive`
 
 However, there are a number of settings that you can modify independent of your security mode to increase the security of your cluster.
 
+- Ensure the network is setup according to the information for [securing your cluster](/1.10/administering-clusters/securing-your-cluster/).
+
 - <a name="secure-flag"></a>In `permissive` and `strict` modes, set the [`auth_cookie_secure_flag`](/1.10/installing/ent/custom/configuration/configuration-parameters/#auth-cookie-secure-flag-enterprise) to `true`.
 
 - <a name="zk"></a>Do not use the default ZooKeeper credentials. Instead, specify long, random values for the following: [`zk_super_credentials`](/1.10/installing/ent/custom/configuration/configuration-parameters/#zk-superuser), [`zk_master_credentials`](/1.10/installing/ent/custom/configuration/configuration-parameters/#zk-master), and [`zk_agent_credentials`](/1.10/installing/ent/custom/configuration/configuration-parameters/#zk-agent).

--- a/pages/1.10/security/oss/index.md
+++ b/pages/1.10/security/oss/index.md
@@ -5,6 +5,9 @@ title: DC/OS Open Source Security
 menuWeight: 80
 oss: true
 ---
+
+Ensure the network is setup according to the information for [securing your cluster](/1.10/administering-clusters/securing-your-cluster/).
+
 You can enable authentication in your datacenter with DC/OS [oauth](https://github.com/dcos/dcos-oauth). Authentication is managed through the DC/OS web interface. The Admin Router enforces access control.
 
 Out of the box DC/OS has an OpenID Connect 1.0 endpoint at [dcos.auth0.com](https://dcos.auth0.com/.well-known/openid-configuration) (in cooperation with [Auth0](https://auth0.com/)) with connections to Google, GitHub, and Microsoft to provide basic authentication for DC/OS installations. DC/OS automatically adds the first user that logs in to the DC/OS cluster.

--- a/pages/1.11/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.11/administering-clusters/securing-your-cluster/index.md
@@ -15,6 +15,24 @@ network interfaces with iptables or other firewalls, and regularly applying
 updates from the Linux distribution used with DC/OS to ensure that system
 libraries, utilities and core services like systemd and OpenSSH are secure.
 
+# Network security
+
+You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes.
+
+Depending on your cluster environment, this may include:
+- using physical or virtual subnets to isolate [DC/OS Security Zones](#security-zones);
+- using router firewalls to restrict access to ports;
+- using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
+
+Use these mechanisms to:
+- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+- block connection requests on all ports from external machines to private agent nodes.
+- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.11/installing/production/system-requirements/ports/#agent).
+
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
 ## Security zones
 
 At the highest level we can distinguish three security zones in a DC/OS

--- a/pages/1.11/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.11/administering-clusters/securing-your-cluster/index.md
@@ -29,6 +29,8 @@ Use these mechanisms to:
 - block connection requests on all ports from external machines to private agent nodes.
 - block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.11/installing/production/system-requirements/ports/#agent).
 
+For connections between cluster nodes, refer to [DC/OS Ports](/1.11/installing/production/system-requirements/ports/).
+
 You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
 Although DC/OS components do not currently support private network selection, you can configure
 `ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.

--- a/pages/1.11/installing/production/system-requirements/ports/index.md
+++ b/pages/1.11/installing/production/system-requirements/ports/index.md
@@ -7,11 +7,20 @@ excerpt: Understanding configured ports for DC/OS deployment
 ---
 This section describes each pre-configured port in your DC/OS deployment. 
 
-[DC/OS components](/1.11/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed. DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
+[DC/OS components](/1.11/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed.
 
-- These ports must not be used in a firewall configuration between nodes or cluster zones.
-- For DC/OS to install and function as intended, these ports must be open and accessible upon initial installation. 
-- Therefore, network-specific security measures - from outside of the cluster as well as between internal cluster nodes and zones - for each of these ports should be evaluated and, if necessary, put in place by the network administrator before installing and implementing DC/OS. Moreover, DC/OS security modes ("disabled", "permissive", and "strict") do not affect access to these ports.
+- For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
+- The ports must be open between the indicated source and destination nodes, including over cluster zones.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.11/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+	- block connection requests on all ports from external machines to private agent nodes.
+	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
+
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
+DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 
 ## All nodes
 

--- a/pages/1.11/installing/production/system-requirements/ports/index.md
+++ b/pages/1.11/installing/production/system-requirements/ports/index.md
@@ -11,7 +11,7 @@ This section describes each pre-configured port in your DC/OS deployment.
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.11/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.11/administering-clusters/securing-your-cluster/). Use these mechanisms to:
 	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
 	- block connection requests on all ports from external machines to private agent nodes.
 	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).

--- a/pages/1.11/security/ent/hardening/index.md
+++ b/pages/1.11/security/ent/hardening/index.md
@@ -11,6 +11,8 @@ enterprise: true
 
 Your cluster will become more secure as you move from `disabled` to `permissive` to `strict` [security modes](/1.11/security/ent/#security-modes). However, there are a number of settings that you can modify independently of your security mode to increase the security of your cluster.
 
+- Ensure the network is setup according to the information for [securing your cluster](/1.11/administering-clusters/securing-your-cluster/).
+
 - <a name="secure-flag"></a>In `permissive` and `strict` modes, set the [`auth_cookie_secure_flag`](/1.11/installing/ent/custom/configuration/configuration-parameters/#auth-cookie-secure-flag-enterprise) to `true`.
 
 - <a name="zk"></a>Do not use the default ZooKeeper credentials. Instead, specify long, random values for the following: [`zk_super_credentials`](/1.11/installing/ent/custom/configuration/configuration-parameters/#zk-superuser), [`zk_master_credentials`](/1.11/installing/ent/custom/configuration/configuration-parameters/#zk-master), and [`zk_agent_credentials`](/1.11/installing/ent/custom/configuration/configuration-parameters/#zk-agent).

--- a/pages/1.11/security/oss/index.md
+++ b/pages/1.11/security/oss/index.md
@@ -6,6 +6,8 @@ menuWeight: 80
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
+Ensure the network is setup according to the information for [securing your cluster](/1.11/administering-clusters/securing-your-cluster/).
+
 You can enable authentication in your datacenter with DC/OS [oauth](https://github.com/dcos/dcos-oauth). Authentication is managed through the DC/OS web interface. The Admin Router enforces access control.
 
 Out-of-the-box DC/OS has an OpenID Connect endpoint at [dcos.auth0.com](https://dcos.auth0.com/.well-known/openid-configuration) (in cooperation with [Auth0](https://auth0.com/)) with connections to Google, GitHub, and Microsoft to provide basic authentication for DC/OS installations. DC/OS automatically adds the first user that logs in to the DC/OS cluster.

--- a/pages/1.12/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.12/administering-clusters/securing-your-cluster/index.md
@@ -15,6 +15,24 @@ network interfaces with `iptables` or other firewalls, and regularly applying
 updates from the Linux distribution used with DC/OS to ensure that system
 libraries, utilities and core services like systemd and OpenSSH are secure.
 
+# Network security
+
+You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes.
+
+Depending on your cluster environment, this may include:
+- using physical or virtual subnets to isolate [DC/OS Security Zones](#security-zones);
+- using router firewalls to restrict access to ports;
+- using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
+
+Use these mechanisms to:
+- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+- block connection requests on all ports from external machines to private agent nodes.
+- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.12/installing/production/system-requirements/ports/#agent).
+
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
 # Security zones
 
 At the highest level we can distinguish three security zones in a DC/OS

--- a/pages/1.12/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.12/administering-clusters/securing-your-cluster/index.md
@@ -29,6 +29,8 @@ Use these mechanisms to:
 - block connection requests on all ports from external machines to private agent nodes.
 - block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.12/installing/production/system-requirements/ports/#agent).
 
+For connections between cluster nodes, refer to [DC/OS Ports](/1.12/installing/production/system-requirements/ports/).
+
 You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
 Although DC/OS components do not currently support private network selection, you can configure
 `ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.

--- a/pages/1.12/installing/production/system-requirements/ports/index.md
+++ b/pages/1.12/installing/production/system-requirements/ports/index.md
@@ -7,11 +7,20 @@ excerpt: Understanding configured ports for DC/OS deployment
 ---
 This section describes each pre-configured port in your DC/OS deployment. 
 
-[DC/OS components](/1.12/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed. DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
+[DC/OS components](/1.12/overview/architecture/components/) listen on multiple ports on each node. These ports must be available for installation to succeed.
 
-- These ports must not be used in a firewall configuration between nodes or cluster zones.
-- For DC/OS to install and function as intended, these ports must be open and accessible upon initial installation. 
-- Therefore, network-specific security measures - from outside of the cluster as well as between internal cluster nodes and zones - for each of these ports should be evaluated and, if necessary, put in place by the network administrator before installing and implementing DC/OS. Moreover, DC/OS security modes ("permissive" or "strict") do not affect access to these ports.
+- For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
+- The ports must be open between the indicated source and destination nodes, including over cluster zones.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.12/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
+	- block connection requests on all ports from external machines to private agent nodes.
+	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
+
+You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
+Although DC/OS components do not currently support private network selection, you can configure
+`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+
+DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 
 ## All nodes
 

--- a/pages/1.12/installing/production/system-requirements/ports/index.md
+++ b/pages/1.12/installing/production/system-requirements/ports/index.md
@@ -11,7 +11,7 @@ This section describes each pre-configured port in your DC/OS deployment.
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.12/administering-clusters/securing-your-cluster/#security-zones). Use these mechanisms to:
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.12/administering-clusters/securing-your-cluster/). Use these mechanisms to:
 	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
 	- block connection requests on all ports from external machines to private agent nodes.
 	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).

--- a/pages/1.12/security/ent/hardening/index.md
+++ b/pages/1.12/security/ent/hardening/index.md
@@ -11,6 +11,8 @@ enterprise: true
 
 Your cluster will become more secure as you move from `permissive` to `strict` [security modes](/1.12/security/ent/#security-modes). However, there are a number of settings that you can modify independently of your security mode to increase the security of your cluster.
 
+- Ensure the network is setup according to the information for [securing your cluster](/1.12/administering-clusters/securing-your-cluster/).
+
 - <a name="secure-flag"></a>Set the [`auth_cookie_secure_flag`](/1.12/installing/ent/custom/configuration/configuration-parameters/#auth-cookie-secure-flag-enterprise) to `true`.
 
 - <a name="zk"></a>Do not use the default ZooKeeper credentials. Instead, specify long, random values for the following: [`zk_super_credentials`](/1.12/installing/ent/custom/configuration/configuration-parameters/#zk-superuser), [`zk_master_credentials`](/1.12/installing/ent/custom/configuration/configuration-parameters/#zk-master), and [`zk_agent_credentials`](/1.12/installing/ent/custom/configuration/configuration-parameters/#zk-agent).

--- a/pages/1.12/security/oss/index.md
+++ b/pages/1.12/security/oss/index.md
@@ -6,6 +6,8 @@ menuWeight: 80
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
+Ensure the network is setup according to the information for [securing your cluster](/1.12/administering-clusters/securing-your-cluster/).
+
 You can enable authentication in your datacenter with DC/OS [oauth](https://github.com/dcos/dcos-oauth). Authentication is managed through the DC/OS web interface. The Admin Router enforces access control.
 
 Out-of-the-box DC/OS has an OpenID Connect 1.0 endpoint at [dcos.auth0.com](https://dcos.auth0.com/.well-known/openid-configuration) (in cooperation with [Auth0](https://auth0.com/)) with connections to Google, GitHub, and Microsoft to provide basic authentication for DC/OS installations. DC/OS automatically adds the first user that logs in to the DC/OS cluster.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-42583

We need to ensure that our documentation emphasizes network security, especially from external access. This changes text in several relevant places to give a more definite action for cluster installers and administrators to take.

## Urgency
- [x] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
