### PR TITLE
ss/DCOS-42475 Adding disclaimer re: DC/OS OSS and Enterprise security…

### DIFF
--- a/pages/1.10/tutorials/autoscaling/index.md
+++ b/pages/1.10/tutorials/autoscaling/index.md
@@ -6,10 +6,8 @@ menuWeight: 4
 excerpt:
 ---
 
+#include /include/tutorial-disclaimer.tmpl
 
+You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
 
-
-
-You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some examples to show you how to implement autoscaling for your services.
-
-<table class="table" bgcolor="#FAFAFA"> <tr> <td style="border-left: thin solid; border-top: thin solid; border-bottom: thin solid;border-right: thin solid;"><b>Important:</b> Mesosphere does not support this tutorial, associated scripts, or commands, which are provided without warranty of any kind. The purpose of this tutorial is to demonstrate capabilities, and may not be suited for use in a production environment. Before using a similar solution in your environment, you must adapt, validate, and test.</td> </tr> </table>
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security mode "disabled".</p>

--- a/pages/1.11/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.11/tutorials/autoscaling/cpu-memory/index.md
@@ -8,8 +8,7 @@ excerpt: Autoscaling Marathon services using CPU and memory
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
-<table class="table" bgcolor="#FAFAFA"> <tr> <td style="border-left: thin solid; border-top: thin solid; border-bottom: thin solid;border-right: thin solid;"><b>Important:</b> Mesosphere does not support this tutorial, associated scripts, or commands, which are provided without warranty of any kind. The purpose of this tutorial is to demonstrate capabilities, and may not be suited for use in a production environment. Before using a similar solution in your environment, you must adapt, validate, and test.</td> </tr> </table>
+#include /include/tutorial-disclaimer.tmpl
 
 You can use a Python service, `marathon-autoscale.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 

--- a/pages/1.11/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.11/tutorials/autoscaling/cpu-memory/index.md
@@ -10,6 +10,9 @@ enterprise: false
 
 #include /include/tutorial-disclaimer.tmpl
 
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security modes other than "disabled".</p>
+
+
 You can use a Python service, `marathon-autoscale.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
 Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.

--- a/pages/1.11/tutorials/autoscaling/index.md
+++ b/pages/1.11/tutorials/autoscaling/index.md
@@ -9,6 +9,6 @@ excerpt: Autoscaling resources based on usage
 #include /include/tutorial-disclaimer.tmpl
 
 
-You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
+You can use autoscaling to automatically increase or decrease computing resources based on usage so that you are using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
 
-<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security mode "disabled".</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security modes other than "disabled".</p>

--- a/pages/1.11/tutorials/autoscaling/index.md
+++ b/pages/1.11/tutorials/autoscaling/index.md
@@ -11,4 +11,4 @@ excerpt: Autoscaling resources based on usage
 
 You can use autoscaling to automatically increase or decrease computing resources based on usage so that you are using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
 
-<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security modes other than "disabled".</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works for DC/OS Open Source or for DC/OS Enterprise security modes differently, depending on the usage. Pay special attention to notes at the top of each tutorial section.</p>

--- a/pages/1.11/tutorials/autoscaling/index.md
+++ b/pages/1.11/tutorials/autoscaling/index.md
@@ -6,8 +6,9 @@ menuWeight: 3
 excerpt: Autoscaling resources based on usage
 ---
 
-<table class="table" bgcolor="#FAFAFA"> <tr> <td style="border-left: thin solid; border-top: thin solid; border-bottom: thin solid;border-right: thin solid;"><b>Important:</b> Mesosphere does not support this tutorial, associated scripts, or commands, which are provided without warranty of any kind. The purpose of this tutorial is to demonstrate capabilities, and may not be suited for use in a production environment. Before using a similar solution in your environment, you must adapt, validate, and test.</td> </tr> </table>
+#include /include/tutorial-disclaimer.tmpl
 
 
 You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
 
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security mode "disabled".</p>

--- a/pages/1.11/tutorials/autoscaling/requests-second/index.md
+++ b/pages/1.11/tutorials/autoscaling/requests-second/index.md
@@ -8,7 +8,11 @@ enterprise: false
 ---
 
 
-<table class="table" bgcolor="#FAFAFA"> <tr> <td style="border-left: thin solid; border-top: thin solid; border-bottom: thin solid;border-right: thin solid;"><b>Important:</b> Mesosphere does not support this tutorial, associated scripts, or commands, which are provided without warranty of any kind. The purpose of this tutorial is to demonstrate capabilities, and may not be suited for use in a production environment. Before using a similar solution in your environment, you must adapt, validate, and test.</td> </tr> </table>
+#include /include/tutorial-disclaimer.tmpl
+
+
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security mode "disabled".</p>
+
 
 You can use the [marathon-lb-autoscale](https://github.com/mesosphere/marathon-lb-autoscale) application to implement request rate-based autoscaling with Marathon. The marathon-lb-autoscale application works with any application that uses TCP traffic and can be routed through HAProxy.
 

--- a/pages/1.12/tutorials/autoscaling/index.md
+++ b/pages/1.12/tutorials/autoscaling/index.md
@@ -11,6 +11,4 @@ excerpt: Understanding autoscaling
 
 You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
 
-
-You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
-
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security mode "disabled".</p>

--- a/pages/1.9/tutorials/autoscaling/index.md
+++ b/pages/1.9/tutorials/autoscaling/index.md
@@ -7,6 +7,9 @@ excerpt:
 
 enterprise: false
 ---
-You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some examples to show you how to implement autoscaling for your services.
+#include /include/tutorial-disclaimer.tmpl
 
-<table class="table" bgcolor="#FAFAFA"> <tr> <td style="border-left: thin solid; border-top: thin solid; border-bottom: thin solid;border-right: thin solid;"><b>Important:</b> Mesosphere does not support this tutorial, associated scripts, or commands, which are provided without warranty of any kind. The purpose of this tutorial is to demonstrate capabilities, and may not be suited for use in a production environment. Before using a similar solution in your environment, you must adapt, validate, and test.</td> </tr> </table>
+
+You can use autoscaling to automatically increase or decrease computing resources based on usage so that you're using only the resources you need. Here are some tutorials to show you how to implement autoscaling for your services.
+
+<p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security mode "disabled".</p>


### PR DESCRIPTION
… disabled to front page of Autoscaling tutorial.

## Description
https://jira.mesosphere.com/browse/DCOS-42475
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

@surdy "I do see the value of it being their in terms of giving a technically able user to take the pointers there and build a solution on their own . Also this does work of OSS DC/OS.
Perhaps making it very clear that this only works for OSS and Enterprise disabled security mode being highlighted."

I added the following disclaimer to the landing page for the autoscaling tutorial:
Autoscaling works **only** for DC/OS Open Source or for DC/OS Enterprise in security mode "disabled".

Versions changed:

- [x] 1.9
- [x] 1.10
- [x] 1.11
- [x] 1.12