### PR TITLE
Document intra-cluster network access explicitly

### DIFF
--- a/pages/1.10/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.10/administering-clusters/securing-your-cluster/index.md
@@ -27,12 +27,14 @@ Depending on your cluster environment, this may include:
 - using router firewalls to restrict access to ports;
 - using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
 
-Use these mechanisms to:
-- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-- block connection requests on all ports from external machines to private agent nodes.
-- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.10/installing/production/system-requirements/ports/#agent).
-
-For connections between cluster nodes, refer to [DC/OS Ports](/1.10/installing/ports/).
+Use these mechanisms to provide the following connectivity:
+- between master nodes: allow connections on all ports.
+- between agent nodes: allow connections on all ports.
+- from master nodes to agent nodes: allow connections on all ports.
+- from agent nodes to master nodes: allow connections on all ports except TCP ports 8201 and 26257.
+- from external machines to master nodes: block connection requests on all ports except TCP ports 80 and 443.
+- from external machines to private agent nodes: block connection requests on all ports.
+- from external machines to public agent nodes: block connection requests on all ports except [advertised port ranges](/1.10/installing/production/system-requirements/ports/#agent).
 
 You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
 Although DC/OS components do not currently support private network selection, you can configure

--- a/pages/1.10/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.10/administering-clusters/securing-your-cluster/index.md
@@ -24,7 +24,7 @@ You must use appropriate network mechanisms to prevent unauthorized access to cl
 
 Depending on your cluster environment, this may include:
 - using physical or virtual subnets to isolate [DC/OS Security Zones](#security-zones);
-- using router firewalls to restrict access to ports;
+- using router firewalls or security groups to restrict access to ports;
 - using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
 
 Use these mechanisms to provide the following connectivity:

--- a/pages/1.10/installing/ent/ports/index.md
+++ b/pages/1.10/installing/ent/ports/index.md
@@ -11,14 +11,7 @@ enterprise: false
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/). Use these mechanisms to:
-	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-	- block connection requests on all ports from external machines to private agent nodes.
-	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
-
-You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
-Although DC/OS components do not currently support private network selection, you can configure
-`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [network security](/1.10/administering-clusters/securing-your-cluster/#network-security).
 
 DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 

--- a/pages/1.10/installing/ent/ports/index.md
+++ b/pages/1.10/installing/ent/ports/index.md
@@ -58,6 +58,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` | agent/master | master |
 | 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
 | 8200  | Vault | `dcos-vault.service` [enterprise type="inline" size="small" /] | localhost| localhost(master) |
+| 8201  | Vault HA | `dcos-vault.service` | master| master |
 | 8443  | Marathon SSL | `dcos-marathon.service` | agent/master | master |
 | 8888  | DC/OS Certificate Authority | `dcos-ca.service` [enterprise type="inline" size="small" /] | localhost| localhost(master) |
 | 9090 | DC/OS Jobs (Metronome) | `dcos-metronome.service`| agent/master | master |
@@ -66,6 +67,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 15055 | DC/OS History | `dcos-history-service.service` | localhost| localhost(master) |
 | 15101 | Marathon libprocess | `dcos-marathon.service` | master | agent/master |
 | 15201 | DC/OS Jobs (Metronome) libprocess | `dcos-metronome.service`| master | agent/master |
+| 26257 | CockroachDB | `dcos-cockroach.service` | master | master |
 | 62500 | DC/OS Network Metrics | `dcos-networking_api.service` [enterprise type="inline" size="small" /] | master | master |
 | Ephemeral | DC/OS Component Package Manager (Pkgpanda) | `dcos-pkgpanda-api.service` | None | None |
 

--- a/pages/1.10/installing/oss/ports/index.md
+++ b/pages/1.10/installing/oss/ports/index.md
@@ -11,14 +11,7 @@ enterprise: false
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/). Use these mechanisms to:
-	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-	- block connection requests on all ports from external machines to private agent nodes.
-	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
-
-You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
-Although DC/OS components do not currently support private network selection, you can configure
-`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [network security](/1.10/administering-clusters/securing-your-cluster/#network-security).
 
 DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 

--- a/pages/1.10/installing/ports/index.md
+++ b/pages/1.10/installing/ports/index.md
@@ -11,14 +11,7 @@ enterprise: false
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.10/administering-clusters/securing-your-cluster/). Use these mechanisms to:
-	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-	- block connection requests on all ports from external machines to private agent nodes.
-	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
-
-You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
-Although DC/OS components do not currently support private network selection, you can configure
-`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [network security](/1.10/administering-clusters/securing-your-cluster/#network-security).
 
 DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 

--- a/pages/1.10/installing/ports/index.md
+++ b/pages/1.10/installing/ports/index.md
@@ -56,6 +56,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` | agent/master | master |
 | 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
 | 8200  | Vault | `dcos-vault.service` [enterprise type="inline" size="small" /] | localhost| localhost(master) |
+| 8201  | Vault HA | `dcos-vault.service` | master| master [enterprise type="inline" size="small" /] |
 | 8443  | Marathon SSL | `dcos-marathon.service` | agent/master | master |
 | 8888  | DC/OS Certificate Authority | `dcos-ca.service` [enterprise type="inline" size="small" /] | localhost| localhost(master) |
 | 9090 | DC/OS Jobs (Metronome) | `dcos-metronome.service`| agent/master | master |
@@ -64,6 +65,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 15055 | DC/OS History | `dcos-history-service.service` | localhost| localhost(master) |
 | 15101 | Marathon libprocess | `dcos-marathon.service` | master | agent/master |
 | 15201 | DC/OS Jobs (Metronome) libprocess | `dcos-metronome.service`| master | agent/master |
+| 26257 | CockroachDB | `dcos-cockroach.service` | master | master [enterprise type="inline" size="small" /] |
 | 62500 | DC/OS Network Metrics | `dcos-networking_api.service` [enterprise type="inline" size="small" /] | master | master |
 | Ephemeral | DC/OS Component Package Manager (Pkgpanda) | `dcos-pkgpanda-api.service` | None | None |
 

--- a/pages/1.11/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.11/administering-clusters/securing-your-cluster/index.md
@@ -21,7 +21,7 @@ You must use appropriate network mechanisms to prevent unauthorized access to cl
 
 Depending on your cluster environment, this may include:
 - using physical or virtual subnets to isolate [DC/OS Security Zones](#security-zones);
-- using router firewalls to restrict access to ports;
+- using router firewalls or security groups to restrict access to ports;
 - using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
 
 Use these mechanisms to provide the following connectivity:

--- a/pages/1.11/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.11/administering-clusters/securing-your-cluster/index.md
@@ -24,12 +24,14 @@ Depending on your cluster environment, this may include:
 - using router firewalls to restrict access to ports;
 - using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
 
-Use these mechanisms to:
-- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-- block connection requests on all ports from external machines to private agent nodes.
-- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.11/installing/production/system-requirements/ports/#agent).
-
-For connections between cluster nodes, refer to [DC/OS Ports](/1.11/installing/production/system-requirements/ports/).
+Use these mechanisms to provide the following connectivity:
+- between master nodes: allow connections on all ports.
+- between agent nodes: allow connections on all ports.
+- from master nodes to agent nodes: allow connections on all ports.
+- from agent nodes to master nodes: allow connections on all ports except TCP ports 8201 and 26257.
+- from external machines to master nodes: block connection requests on all ports except TCP ports 80 and 443.
+- from external machines to private agent nodes: block connection requests on all ports.
+- from external machines to public agent nodes: block connection requests on all ports except [advertised port ranges](/1.11/installing/production/system-requirements/ports/#agent).
 
 You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
 Although DC/OS components do not currently support private network selection, you can configure

--- a/pages/1.11/installing/evaluation/cloud-installation/digitalocean/index.md
+++ b/pages/1.11/installing/evaluation/cloud-installation/digitalocean/index.md
@@ -17,7 +17,7 @@ The included Terraform templates are configured to run Mesosphere DC/OS on Digit
 
 ## Security
 
-**Note:** All nodes are Internet-facing by default after deploying via Terraform and are not secured out-of-the-box. Additional configuration will be required to put master and agent nodes into a security group.
+<p class="message--important"><strong>IMPORTANT: </strong>With this method, the network is open by default. Because of this, <a href="/1.11/administering-clusters/securing-your-cluster/#network-security">network security</a> is a concern and should be addressed as soon as possible by the administrator.</p>
 
 ## Environment
 

--- a/pages/1.11/installing/evaluation/cloud-installation/packet/index.md
+++ b/pages/1.11/installing/evaluation/cloud-installation/packet/index.md
@@ -36,7 +36,7 @@ You can create a DC/OS cluster on Packet bare metal using Terraform. The include
 
 ## Installing DC/OS
 
-**Note:** With this method, the network is open by default. Because of this, network security is a concern and should be addressed as soon as possible by the administrator.
+<p class="message--important"><strong>IMPORTANT: </strong>With this method, the network is open by default. Because of this, <a href="/1.11/administering-clusters/securing-your-cluster/#network-security">network security</a> is a concern and should be addressed as soon as possible by the administrator.</p>
 
 1.  Download and install Terraform using the instructions on the link provided in the Prerequisites section.
 

--- a/pages/1.11/installing/evaluation/on-premise-installation/index.md
+++ b/pages/1.11/installing/evaluation/on-premise-installation/index.md
@@ -6,7 +6,7 @@ navigationTitle: On-Premise Installation
 menuWeight: 10
 ---
 
-
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure that your on-premises cluster is protected by appropriate <a href="/1.11/administering-clusters/securing-your-cluster/#network-security">network security</a> mechanisms.</p>
 
 You can install a DC/OS cluster on your own premises using the following methods:
 

--- a/pages/1.11/installing/production/system-requirements/ports/index.md
+++ b/pages/1.11/installing/production/system-requirements/ports/index.md
@@ -11,14 +11,7 @@ This section describes each pre-configured port in your DC/OS deployment.
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.11/administering-clusters/securing-your-cluster/). Use these mechanisms to:
-	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-	- block connection requests on all ports from external machines to private agent nodes.
-	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
-
-You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
-Although DC/OS components do not currently support private network selection, you can configure
-`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [network security](/1.11/administering-clusters/securing-your-cluster/#network-security).
 
 DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 

--- a/pages/1.11/installing/production/system-requirements/ports/index.md
+++ b/pages/1.11/installing/production/system-requirements/ports/index.md
@@ -56,6 +56,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` | localhost | localhost |
 | 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
 | 8200  | Vault | `dcos-vault.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
+| 8201  | Vault HA | `dcos-vault.service` | master| master [enterprise type="inline" size="small" /] |
 | 8443  | Marathon SSL | `dcos-marathon.service` | agent/master | master |
 | 8888  | DC/OS Certificate Authority | `dcos-ca.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 9090 | DC/OS Jobs (Metronome) | `dcos-metronome.service`| agent/master | master |
@@ -64,6 +65,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 15055 | DC/OS History | `dcos-history-service.service` | localhost| localhost(master) |
 | 15101 | Marathon libprocess | `dcos-marathon.service` | master | agent/master |
 | 15201 | DC/OS Jobs (Metronome) libprocess | `dcos-metronome.service`| master | agent/master |
+| 26257 | CockroachDB | `dcos-cockroach.service` | master | master [enterprise type="inline" size="small" /] |
 | 61053 | Mesos DNS | `dcos-mesos-net.service` | agent/master | master | 
 | 61430 | DC/OS Net | `dcos-net.service` | agent/master | master [enterprise type="inline" size="small" /]|
 | Ephemeral | DC/OS Component Package Manager (Pkgpanda) | `dcos-pkgpanda-api.service` | None | None |

--- a/pages/1.11/installing/production/system-requirements/ports/index.md
+++ b/pages/1.11/installing/production/system-requirements/ports/index.md
@@ -46,7 +46,6 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 |---|---|---|---|---|
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
-| 1337  | DC/OS Secrets |  `dcos-secrets.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
 | 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |

--- a/pages/1.12/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.12/administering-clusters/securing-your-cluster/index.md
@@ -21,7 +21,7 @@ You must use appropriate network mechanisms to prevent unauthorized access to cl
 
 Depending on your cluster environment, this may include:
 - using physical or virtual subnets to isolate [DC/OS Security Zones](#security-zones);
-- using router firewalls to restrict access to ports;
+- using router firewalls or security groups to restrict access to ports;
 - using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
 
 Use these mechanisms to provide the following connectivity:

--- a/pages/1.12/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.12/administering-clusters/securing-your-cluster/index.md
@@ -24,12 +24,14 @@ Depending on your cluster environment, this may include:
 - using router firewalls to restrict access to ports;
 - using firewall software (e.g. `iptables`) on the nodes to restrict access to ports.
 
-Use these mechanisms to:
-- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-- block connection requests on all ports from external machines to private agent nodes.
-- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](/1.12/installing/production/system-requirements/ports/#agent).
-
-For connections between cluster nodes, refer to [DC/OS Ports](/1.12/installing/production/system-requirements/ports/).
+Use these mechanisms to provide the following connectivity:
+- between master nodes: allow connections on all ports.
+- between agent nodes: allow connections on all ports.
+- from master nodes to agent nodes: allow connections on all ports.
+- from agent nodes to master nodes: allow connections on all ports except TCP ports 8201 and 26257.
+- from external machines to master nodes: block connection requests on all ports except TCP ports 80 and 443.
+- from external machines to private agent nodes: block connection requests on all ports.
+- from external machines to public agent nodes: block connection requests on all ports except [advertised port ranges](/1.12/installing/production/system-requirements/ports/#agent).
 
 You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
 Although DC/OS components do not currently support private network selection, you can configure

--- a/pages/1.12/installing/evaluation/cloud-installation/digitalocean/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/digitalocean/index.md
@@ -17,7 +17,7 @@ Upgrades are not supported with this installation method.
 
 ## Security
 
-<p class="message--note"><strong>NOTE: </strong>All nodes are Internet-facing by default after deploying via Terraform and are not secured out-of-the-box. Additional configuration will be required to put master and agent nodes into a security group.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>With this method, the network is open by default. Because of this, <a href="/1.12/administering-clusters/securing-your-cluster/#network-security">network security</a> is a concern and should be addressed as soon as possible by the administrator.</p>
 
 ## Environment
 

--- a/pages/1.12/installing/evaluation/cloud-installation/packet/index.md
+++ b/pages/1.12/installing/evaluation/cloud-installation/packet/index.md
@@ -31,7 +31,7 @@ You can create a DC/OS cluster on Packet bare metal using Terraform. The include
 
 ## Installing DC/OS
 
-<p class="message--important"><strong>IMPORTANT: </strong>With this method, the network is open by default. Because of this, network security is a concern and should be addressed as soon as possible by the administrator.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>With this method, the network is open by default. Because of this, <a href="/1.12/administering-clusters/securing-your-cluster/#network-security">network security</a> is a concern and should be addressed as soon as possible by the administrator.</p>
 
 1.  Download and install Terraform using the instructions on the link provided in the Prerequisites section.
 

--- a/pages/1.12/installing/evaluation/on-premise-installation/index.md
+++ b/pages/1.12/installing/evaluation/on-premise-installation/index.md
@@ -6,7 +6,7 @@ navigationTitle: On-Premise Installation
 menuWeight: 10
 ---
 
-
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure that your on-premises cluster is protected by appropriate <a href="/1.12/administering-clusters/securing-your-cluster/#network-security">network security</a> mechanisms.</p>
 
 You can install a DC/OS cluster on your own premises using the following methods:
 

--- a/pages/1.12/installing/production/system-requirements/ports/index.md
+++ b/pages/1.12/installing/production/system-requirements/ports/index.md
@@ -56,6 +56,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` | localhost | localhost |
 | 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
 | 8200  | Vault | `dcos-vault.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
+| 8201  | Vault HA | `dcos-vault.service` | master| master [enterprise type="inline" size="small" /] |
 | 8443  | Marathon SSL | `dcos-marathon.service` | agent/master | master |
 | 8888  | DC/OS Certificate Authority | `dcos-ca.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 9090 | DC/OS Jobs (Metronome) | `dcos-metronome.service`| agent/master | master |
@@ -64,6 +65,7 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 15055 | DC/OS History | `dcos-history-service.service` | localhost| localhost(master) |
 | 15101 | Marathon libprocess | `dcos-marathon.service` | master | agent/master |
 | 15201 | DC/OS Jobs (Metronome) libprocess | `dcos-metronome.service`| master | agent/master |
+| 26257 | CockroachDB | `dcos-cockroach.service` | master | master [enterprise type="inline" size="small" /] |
 | 61053 | Mesos DNS | `dcos-mesos-net.service` | agent/master | master | 
 | 61430 | DC/OS Net | `dcos-net.service` | agent/master | master [enterprise type="inline" size="small" /]|
 | Ephemeral | DC/OS Component Package Manager (Pkgpanda) | `dcos-pkgpanda-api.service` | None | None |

--- a/pages/1.12/installing/production/system-requirements/ports/index.md
+++ b/pages/1.12/installing/production/system-requirements/ports/index.md
@@ -46,7 +46,6 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 |---|---|---|---|---|
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
-| 1337  | DC/OS Secrets |  `dcos-secrets.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
 | 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |

--- a/pages/1.12/installing/production/system-requirements/ports/index.md
+++ b/pages/1.12/installing/production/system-requirements/ports/index.md
@@ -11,14 +11,7 @@ This section describes each pre-configured port in your DC/OS deployment.
 
 - For DC/OS to install and function as intended, these ports must be accessible upon initial installation.
 - The ports must be open between the indicated source and destination nodes, including over cluster zones.
-- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [securing your cluster](/1.12/administering-clusters/securing-your-cluster/). Use these mechanisms to:
-	- block connection requests on all ports from external machines to master nodes except TCP ports 80 and 443.
-	- block connection requests on all ports from external machines to private agent nodes.
-	- block connection requests on all ports from external machines to public agent ports except [advertised port ranges](#agent).
-
-You may want to open port 22 to external machines to allow administrative tasks using Secure Shell (`ssh`).
-Although DC/OS components do not currently support private network selection, you can configure
-`ssh` to be accessible to a private management network using the [`ListenAddress`](https://man.openbsd.org/sshd_config#ListenAddress) directive.
+- You must use appropriate network mechanisms to prevent unauthorized access to cluster nodes. Refer to the documentation on [network security](/1.12/administering-clusters/securing-your-cluster/#network-security).
 
 DC/OS allocates additional ports to services running on top of DC/OS. These ports are required to be available when services are installed.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-42708

Document the network rules required inside the cluster. Provides an explicit list of all the ports to be allowed or blocked between every type of node.

The list is removed from the ports page, to reduce duplication, but is linked from that page.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
