### PR TITLE
security cli update: change to --file ck/DCOS-40831

### DIFF
--- a/pages/1.10/cli/enterprise-cli/index.md
+++ b/pages/1.10/cli/enterprise-cli/index.md
@@ -579,7 +579,7 @@ Usage: dcos security secrets create [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME        Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.
@@ -648,7 +648,7 @@ Usage: dcos security secrets update [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME        Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.

--- a/pages/1.10/cli/enterprise-cli/index.md
+++ b/pages/1.10/cli/enterprise-cli/index.md
@@ -579,7 +579,7 @@ Usage: dcos security secrets create [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --value-file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME  Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.
@@ -648,7 +648,7 @@ Usage: dcos security secrets update [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --value-file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME  Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.

--- a/pages/1.10/deploying-services/private-docker-registry/index.md
+++ b/pages/1.10/deploying-services/private-docker-registry/index.md
@@ -131,13 +131,13 @@ Follow these steps to add your Docker registry credentials to the [DC/OS Enterpr
    **Note:** As of DC/OS version 1.10.0, you can add a file to the secret store only using the DC/OS CLI.
 
    ```bash
-   dcos security secrets create --value-file=config.json <path/to/secret>
+   dcos security secrets create --file=config.json <path/to/secret>
    ```
 
    If you plan to follow the example below, enter the following command to add the secret:
 
    ```bash
-   dcos security secrets create --value-file=config.json mesos-docker/pullConfig
+   dcos security secrets create --file=config.json mesos-docker/pullConfig
    ```
 
 ## Step 2: Add the secret to your service or pod definition

--- a/pages/1.11/cli/command-reference/dcos-security/index.md
+++ b/pages/1.11/cli/command-reference/dcos-security/index.md
@@ -544,7 +544,7 @@ Usage: dcos security secrets create [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME        Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.
@@ -613,7 +613,7 @@ Usage: dcos security secrets update [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME        Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.

--- a/pages/1.11/cli/command-reference/dcos-security/index.md
+++ b/pages/1.11/cli/command-reference/dcos-security/index.md
@@ -544,7 +544,7 @@ Usage: dcos security secrets create [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --value-file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME  Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.
@@ -613,7 +613,7 @@ Usage: dcos security secrets update [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --value-file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME  Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.

--- a/pages/1.11/deploying-services/private-docker-registry/index.md
+++ b/pages/1.11/deploying-services/private-docker-registry/index.md
@@ -134,13 +134,13 @@ Follow these steps to add your Docker registry credentials to the [DC/OS Enterpr
    <p class="message--note"><strong>NOTE: </strong>As of DC/OS version 1.10.0, you can add a file to the secret store only using the DC/OS CLI.</p>
 
    ```bash
-   dcos security secrets create --value-file=config.json <path/to/secret>
+   dcos security secrets create --file=config.json <path/to/secret>
    ```
 
    If you plan to follow the example below, enter the following command to add the secret:
 
    ```bash
-   dcos security secrets create --value-file=config.json mesos-docker/pullConfig
+   dcos security secrets create --file=config.json mesos-docker/pullConfig
    ```
 
 ## Step 2: Add the secret to your service or pod definition

--- a/pages/1.12/cli/command-reference/dcos-security/index.md
+++ b/pages/1.12/cli/command-reference/dcos-security/index.md
@@ -544,7 +544,7 @@ Usage: dcos security secrets create [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME        Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.
@@ -613,7 +613,7 @@ Usage: dcos security secrets update [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME        Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.

--- a/pages/1.12/cli/command-reference/dcos-security/index.md
+++ b/pages/1.12/cli/command-reference/dcos-security/index.md
@@ -544,7 +544,7 @@ Usage: dcos security secrets create [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --value-file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME  Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.
@@ -613,7 +613,7 @@ Usage: dcos security secrets update [OPTIONS] PATH
 Options:
   -s, --store-id TEXT        Secrets backend to use.
   -v, --value TEXT           Value of the secret.
-  -f, --value-file FILENAME  Treat contents of the file as value of the secret.
+  -f, --file FILENAME  Treat contents of the file as value of the secret.
                              The contents are assumed to be text encoded via
                              UTF-8.
   -h, --help                 Show this message and exit.

--- a/pages/1.12/deploying-services/private-docker-registry/index.md
+++ b/pages/1.12/deploying-services/private-docker-registry/index.md
@@ -135,13 +135,13 @@ Follow these steps to add your Docker registry credentials to the [DC/OS Enterpr
    <p class="message--note"><strong>NOTE: </strong>As of DC/OS version 1.10.0, you can add a file to the secret store only using the DC/OS CLI.</p>
 
    ```bash
-   dcos security secrets create --value-file=config.json <path/to/secret>
+   dcos security secrets create --file=config.json <path/to/secret>
    ```
 
    If you plan to follow the example below, enter the following command to add the secret:
 
    ```bash
-   dcos security secrets create --value-file=config.json mesos-docker/pullConfig
+   dcos security secrets create --file=config.json mesos-docker/pullConfig
    ```
 
 ## Step 2: Add the secret to your service or pod definition

--- a/pages/1.8/usage/cli/enterprise-cli/index.md
+++ b/pages/1.8/usage/cli/enterprise-cli/index.md
@@ -474,7 +474,7 @@ Options:
         Secrets backend to use.
     -v, --value <value>
         Value of the secret.
-    -f, --value-file <filename>  
+    -f, --file <filename>  
         Use file as value of the secret.
     -h, --help         
         Show this message and exit.
@@ -534,7 +534,7 @@ Options:
         Secrets backend to use
     -v, --value <value>           
         Value of the secret
-    -f, --value-file <filename>  
+    -f, --file <filename>  
         Use the file as value of the secret.
     -h, --help                 
         Show this message and exit.   

--- a/pages/1.9/cli/enterprise-cli/index.md
+++ b/pages/1.9/cli/enterprise-cli/index.md
@@ -472,7 +472,7 @@ Options:
         Secrets backend to use.
     -v, --value <value>
         Value of the secret.
-    -f, --value-file <filename>  
+    -f, --file <filename>  
         Use file as value of the secret.
     -h, --help         
         Show this message and exit.
@@ -532,7 +532,7 @@ Options:
         Secrets backend to use
     -v, --value <value>           
         Value of the secret
-    -f, --value-file <filename>  
+    -f, --file <filename>  
         Use the file as value of the secret.
     -h, --help                 
         Show this message and exit.   

--- a/pages/services/beta-confluent-kafka-zookeeper/2.1.1-4.0.0e-beta/kerberos/index.md
+++ b/pages/services/beta-confluent-kafka-zookeeper/2.1.1-4.0.0e-beta/kerberos/index.md
@@ -33,7 +33,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-confluent-kafka-zookeeper/2.1.1-4.0.0e-beta/kerberos/index.md
+++ b/pages/services/beta-confluent-kafka-zookeeper/2.1.1-4.0.0e-beta/kerberos/index.md
@@ -33,7 +33,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-confluent-kafka/2.1.1-4.0.0e-beta/kerberos/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.1-4.0.0e-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-confluent-kafka/2.1.1-4.0.0e-beta/kerberos/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.1-4.0.0e-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/kerberos/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/kerberos/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/kerberos/index.md
+++ b/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/kerberos/index.md
@@ -57,7 +57,7 @@ hdfs/name-0-node.hdfs-demo.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the HDFS principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/kerberos/index.md
+++ b/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/kerberos/index.md
@@ -57,7 +57,7 @@ hdfs/name-0-node.hdfs-demo.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the HDFS principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/kerberos/index.md
+++ b/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/kerberos/index.md
@@ -63,7 +63,7 @@ hdfs/name-0-node.myfolderhdfs.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the HDFS principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.
@@ -130,7 +130,7 @@ Here it is assumed that the domain `example.com` exists and that the domain user
 The generated file `hdfs.keytab` can now be base64-encoded and added to the DC/OS secret store as above:
 ```bash
 $ base64 -w0 hdfs.keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__ad_keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__ad_keytab --text-file keytab.base64
 ```
 
 Kerberized Apache HDFS can then be deployed using the following configuration options:

--- a/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/kerberos/index.md
+++ b/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/kerberos/index.md
@@ -63,7 +63,7 @@ hdfs/name-0-node.myfolderhdfs.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the HDFS principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.
@@ -130,7 +130,7 @@ Here it is assumed that the domain `example.com` exists and that the domain user
 The generated file `hdfs.keytab` can now be base64-encoded and added to the DC/OS secret store as above:
 ```bash
 $ base64 -w0 hdfs.keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__ad_keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__ad_keytab --file keytab.base64
 ```
 
 Kerberized Apache HDFS can then be deployed using the following configuration options:

--- a/pages/services/beta-kafka-zookeeper/2.1.0-3.4.11-beta/kerberos/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.0-3.4.11-beta/kerberos/index.md
@@ -34,7 +34,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka-zookeeper/2.1.0-3.4.11-beta/kerberos/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.0-3.4.11-beta/kerberos/index.md
@@ -34,7 +34,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka-zookeeper/2.1.1-3.4.11-beta/kerberos/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.1-3.4.11-beta/kerberos/index.md
@@ -33,7 +33,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka-zookeeper/2.1.1-3.4.11-beta/kerberos/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.1-3.4.11-beta/kerberos/index.md
@@ -33,7 +33,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka-zookeeper/2.1.2-3.4.11-beta/kerberos/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.2-3.4.11-beta/kerberos/index.md
@@ -36,7 +36,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka-zookeeper/2.1.2-3.4.11-beta/kerberos/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.2-3.4.11-beta/kerberos/index.md
@@ -36,7 +36,7 @@ Adding principals for additional hosts will make the service more resilient to r
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the ZooKeeper principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka/2.1.0-1.0.0-beta/kerberos/index.md
+++ b/pages/services/beta-kafka/2.1.0-1.0.0-beta/kerberos/index.md
@@ -28,7 +28,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka/2.1.0-1.0.0-beta/kerberos/index.md
+++ b/pages/services/beta-kafka/2.1.0-1.0.0-beta/kerberos/index.md
@@ -28,7 +28,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka/2.1.1-1.0.0-beta/kerberos/index.md
+++ b/pages/services/beta-kafka/2.1.1-1.0.0-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka/2.1.1-1.0.0-beta/kerberos/index.md
+++ b/pages/services/beta-kafka/2.1.1-1.0.0-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w 0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.

--- a/pages/services/beta-kafka/2.1.2-1.0.0-beta/kerberos/index.md
+++ b/pages/services/beta-kafka/2.1.2-1.0.0-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.
@@ -129,7 +129,7 @@ Here it is assumed that the domain `example.com` exists and that the domain user
 The generated file `kafka-brokers.keytab` can now be base64-encoded and added to the DC/OS secret store as above:
 ```bash
 $ base64 -w0 kafka-brokers.keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__ad_keytab --value-file keytab.base64
+$ dcos security secrets create  __dcos_base64__ad_keytab --file keytab.base64
 ```
 
 Kerberized Apache Kafka can then be deployed using the following configuration options:

--- a/pages/services/beta-kafka/2.1.2-1.0.0-beta/kerberos/index.md
+++ b/pages/services/beta-kafka/2.1.2-1.0.0-beta/kerberos/index.md
@@ -27,7 +27,7 @@ kafka/kafka-2-broker.kafka.autoip.dcos.thisdcos.directory@LOCAL
 Once the principals have been created, a keytab file must be generated and uploaded to the DC/OS secret store as a base-64-encoded value. Assuming the keytab for **all** the Kafka principals has been created as a file `keytab`, this can be added to the secret store as follows (note that the DC/OS Enterprise CLI needs to be installed to gain access to the `security` command):
 ```bash
 $ base64 -w0 keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__keytab --text-file keytab.base64
 ```
 
 The name of the secret created (`__dcos_base64__keytab`) can be changed, as long as the `__dcos__base64__` prefix is maintained.
@@ -129,7 +129,7 @@ Here it is assumed that the domain `example.com` exists and that the domain user
 The generated file `kafka-brokers.keytab` can now be base64-encoded and added to the DC/OS secret store as above:
 ```bash
 $ base64 -w0 kafka-brokers.keytab > keytab.base64
-$ dcos security secrets create  __dcos_base64__ad_keytab --file keytab.base64
+$ dcos security secrets create  __dcos_base64__ad_keytab --text-file keytab.base64
 ```
 
 Kerberized Apache Kafka can then be deployed using the following configuration options:

--- a/pages/services/beta-spark/2.2.0-2.2.0-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.2.0-2.2.0-2-beta/security/index.md
@@ -65,8 +65,8 @@ and truststores are server.jks.base64 and trust.jks.base64, respectively, then u
 commands to add them to the secret store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --value-file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --value-file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/beta-spark/2.2.0-2.2.0-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.2.0-2.2.0-2-beta/security/index.md
@@ -65,8 +65,8 @@ and truststores are server.jks.base64 and trust.jks.base64, respectively, then u
 commands to add them to the secret store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --text-file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --text-file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/beta-spark/2.2.1-2.2.0-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.2.1-2.2.0-2-beta/security/index.md
@@ -109,8 +109,8 @@ are server.jks.base64 and trust.jks.base64, respectively, then use the following
 store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --value-file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --value-file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/beta-spark/2.2.1-2.2.0-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.2.1-2.2.0-2-beta/security/index.md
@@ -109,8 +109,8 @@ are server.jks.base64 and trust.jks.base64, respectively, then use the following
 store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --text-file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --text-file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/beta-spark/2.3.0-2.2.0-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.3.0-2.2.0-2-beta/security/index.md
@@ -109,8 +109,8 @@ are server.jks.base64 and trust.jks.base64, respectively, then use the following
 store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --value-file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --value-file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/beta-spark/2.3.0-2.2.0-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.3.0-2.2.0-2-beta/security/index.md
@@ -109,8 +109,8 @@ are server.jks.base64 and trust.jks.base64, respectively, then use the following
 store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --text-file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --text-file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/beta-spark/2.3.1-2.2.1-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.3.1-2.2.1-2-beta/security/index.md
@@ -109,8 +109,8 @@ are server.jks.base64 and trust.jks.base64, respectively, then use the following
 store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --value-file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --value-file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/beta-spark/2.3.1-2.2.1-2-beta/security/index.md
+++ b/pages/services/beta-spark/2.3.1-2.2.1-2-beta/security/index.md
@@ -109,8 +109,8 @@ are server.jks.base64 and trust.jks.base64, respectively, then use the following
 store: 
 
 ```bash
-dcos security secrets create /__dcos_base64__keystore --file server.jks.base64
-dcos security secrets create /__dcos_base64__truststore --file trust.jks.base64
+dcos security secrets create /__dcos_base64__keystore --text-file server.jks.base64
+dcos security secrets create /__dcos_base64__truststore --text-file trust.jks.base64
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/include/advanced.tmpl
+++ b/pages/services/include/advanced.tmpl
@@ -247,7 +247,7 @@ You can store binary files, like a Kerberos keytab, in the DC/OS secrets store. 
 To create a secret called `mysecret` with the binary contents of `kerb5.keytab` run:
 
 ```bash
-$ dcos security secrets create --text-file kerb5.keytab mysecret
+$ dcos security secrets create --file kerb5.keytab mysecret
 ```
 
 #### DC/OS 1.10 or earlier

--- a/pages/services/include/advanced.tmpl
+++ b/pages/services/include/advanced.tmpl
@@ -267,7 +267,7 @@ $ base64 -w 0 krb5.keytab > kerb5.keytab.base64-encoded
 Now that the file is encoded it can be stored as a secret.
 
 ```bash
-$ dcos security secrets create --value-file kerb5.keytab.base64-encoded some/path/__dcos_base64__mysecret
+$ dcos security secrets create --file kerb5.keytab.base64-encoded some/path/__dcos_base64__mysecret
 ```
 
 <table class=“table” bgcolor=#858585>

--- a/pages/services/include/advanced.tmpl
+++ b/pages/services/include/advanced.tmpl
@@ -267,7 +267,7 @@ $ base64 -w 0 krb5.keytab > kerb5.keytab.base64-encoded
 Now that the file is encoded it can be stored as a secret.
 
 ```bash
-$ dcos security secrets create --file kerb5.keytab.base64-encoded some/path/__dcos_base64__mysecret
+$ dcos security secrets create --text-file kerb5.keytab.base64-encoded some/path/__dcos_base64__mysecret
 ```
 
 <table class=“table” bgcolor=#858585>

--- a/pages/services/include/advanced.tmpl
+++ b/pages/services/include/advanced.tmpl
@@ -247,7 +247,7 @@ You can store binary files, like a Kerberos keytab, in the DC/OS secrets store. 
 To create a secret called `mysecret` with the binary contents of `kerb5.keytab` run:
 
 ```bash
-$ dcos security secrets create --file kerb5.keytab mysecret
+$ dcos security secrets create --text-file kerb5.keytab mysecret
 ```
 
 #### DC/OS 1.10 or earlier

--- a/pages/services/spark/2.3.0-2.2.1-2/security/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/security/index.md
@@ -48,7 +48,7 @@ RFC 4648 prior to being stored as secrets.
 To create a secret called `mysecret` with the binary contents of `kerb5.keytab` run:
 
 ```bash
-$ dcos security secrets create --file kerb5.keytab mysecret
+$ dcos security secrets create --text-file kerb5.keytab mysecret
 ```
 
 #### DC/OS 1.10 or lower
@@ -168,8 +168,8 @@ are server.jks and trust.jks, respectively, then use the following commands to a
 store: 
 
 ```bash
-dcos security secrets create /spark/keystore --file server.jks
-dcos security secrets create /spark/truststore --file trust.jks
+dcos security secrets create /spark/keystore --text-file server.jks
+dcos security secrets create /spark/truststore --text-file trust.jks
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/spark/2.3.0-2.2.1-2/security/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/security/index.md
@@ -168,8 +168,8 @@ are server.jks and trust.jks, respectively, then use the following commands to a
 store: 
 
 ```bash
-dcos security secrets create /spark/keystore --text-file server.jks
-dcos security secrets create /spark/truststore --text-file trust.jks
+dcos security secrets create /spark/keystore --file server.jks
+dcos security secrets create /spark/truststore --file trust.jks
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/spark/2.3.0-2.2.1-2/security/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/security/index.md
@@ -168,8 +168,8 @@ are server.jks and trust.jks, respectively, then use the following commands to a
 store: 
 
 ```bash
-dcos security secrets create /spark/keystore --value-file server.jks
-dcos security secrets create /spark/truststore --value-file trust.jks
+dcos security secrets create /spark/keystore --file server.jks
+dcos security secrets create /spark/truststore --file trust.jks
 ```
 
 You must add the following configurations to your `dcos spark run ` command.

--- a/pages/services/spark/2.3.0-2.2.1-2/security/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/security/index.md
@@ -48,7 +48,7 @@ RFC 4648 prior to being stored as secrets.
 To create a secret called `mysecret` with the binary contents of `kerb5.keytab` run:
 
 ```bash
-$ dcos security secrets create --text-file kerb5.keytab mysecret
+$ dcos security secrets create --file kerb5.keytab mysecret
 ```
 
 #### DC/OS 1.10 or lower

--- a/pages/services/spark/2.3.1-2.2.1-2/security/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/security/index.md
@@ -83,7 +83,7 @@ RFC 4648 prior to being stored as secrets.
 To create a secret called `mysecret` with the binary contents of `kerb5.keytab` run:
 
 ```bash
-$ dcos security secrets create --text-file kerb5.keytab mysecret
+$ dcos security secrets create --file kerb5.keytab mysecret
 ```
 
 #### DC/OS 1.10 or earlier
@@ -202,8 +202,8 @@ are server.jks and trust.jks, respectively, then use the following commands to a
 store:
 
 ```bash
-dcos security secrets create /{{ model.serviceName }}/keystore --text-file server.jks
-dcos security secrets create /{{ model.serviceName }}/truststore --text-file trust.jks
+dcos security secrets create /{{ model.serviceName }}/keystore --file server.jks
+dcos security secrets create /{{ model.serviceName }}/truststore --file trust.jks
 ```
 
 You must add the following configurations to your `dcos {{ model.serviceName }} run ` command.

--- a/pages/services/spark/2.3.1-2.2.1-2/security/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/security/index.md
@@ -202,8 +202,8 @@ are server.jks and trust.jks, respectively, then use the following commands to a
 store:
 
 ```bash
-dcos security secrets create /{{ model.serviceName }}/keystore --value-file server.jks
-dcos security secrets create /{{ model.serviceName }}/truststore --value-file trust.jks
+dcos security secrets create /{{ model.serviceName }}/keystore --file server.jks
+dcos security secrets create /{{ model.serviceName }}/truststore --file trust.jks
 ```
 
 You must add the following configurations to your `dcos {{ model.serviceName }} run ` command.

--- a/pages/services/spark/2.3.1-2.2.1-2/security/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/security/index.md
@@ -83,7 +83,7 @@ RFC 4648 prior to being stored as secrets.
 To create a secret called `mysecret` with the binary contents of `kerb5.keytab` run:
 
 ```bash
-$ dcos security secrets create --file kerb5.keytab mysecret
+$ dcos security secrets create --text-file kerb5.keytab mysecret
 ```
 
 #### DC/OS 1.10 or earlier
@@ -202,8 +202,8 @@ are server.jks and trust.jks, respectively, then use the following commands to a
 store:
 
 ```bash
-dcos security secrets create /{{ model.serviceName }}/keystore --file server.jks
-dcos security secrets create /{{ model.serviceName }}/truststore --file trust.jks
+dcos security secrets create /{{ model.serviceName }}/keystore --text-file server.jks
+dcos security secrets create /{{ model.serviceName }}/truststore --text-file trust.jks
 ```
 
 You must add the following configurations to your `dcos {{ model.serviceName }} run ` command.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-40831

Updating the security cli for secrets creation to use --file instead of the old --value-file. 
- #### All code instances are currently changed to use --file
- #### Please indicate which ones should be --text-file (if any?)

Note, these changes will take effect for all docs 1.8-1.12

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
