### PR TITLE
beta-storage: hide versions that require DCOS 1.12

### DIFF
--- a/pages/services/beta-storage/0.3.0-beta/index.md
+++ b/pages/services/beta-storage/0.3.0-beta/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DC/OS Storage Service 0.3.0
 title: DC/OS Storage Service 0.3.0
-menuWeight: 0
+menuWeight: -1
 excerpt:
 ---
 

--- a/pages/services/beta-storage/0.3.2-beta/index.md
+++ b/pages/services/beta-storage/0.3.2-beta/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DC/OS Storage Service 0.3.2
 title: DC/OS Storage Service 0.3.2
-menuWeight: 0
+menuWeight: -1
 excerpt:
 ---
 

--- a/pages/services/beta-storage/0.4.0-beta/index.md
+++ b/pages/services/beta-storage/0.4.0-beta/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DC/OS Storage Service 0.4.0
 title: DC/OS Storage Service 0.4.0
-menuWeight: 0
+menuWeight: -1
 excerpt:
 ---
 


### PR DESCRIPTION
DSS versions 0.3.x+ all require DC/OS 1.12 and since we have not yet
released that, we do not want to show those versions of DSS in our docs.

## Description
https://jira.mesosphere.com/browse/DCOS-42911

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
