### PR TITLE
ss/COPS-2120 Added warning at top of disaster-recovery doc re service…

### DIFF
--- a/pages/services/cassandra/2.0.1-3.0.14/disaster-recovery/index.md
+++ b/pages/services/cassandra/2.0.1-3.0.14/disaster-recovery/index.md
@@ -3,13 +3,14 @@ layout: layout.pug
 navigationTitle:  Disaster Recovery
 title: Disaster Recovery
 menuWeight: 80
-excerpt:
+excerpt: Backing up and restoring your Cassandra service
 featureMaturity:
 enterprise: false
 ---
 
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
+<p class="message--warning"><strong>WARNING: </strong>The limitation described in the <a href="/services/cassandra/2.0.1-3.0.14/limitations/#service-user">Service user section</a> of the Limitations topic is crucial for the data backup procedure described below. Be sure to review that section before proceeding with any backup or restore operations.</p>
 
 # Backup
 

--- a/pages/services/cassandra/2.0.2-3.0.14/disaster-recovery/index.md
+++ b/pages/services/cassandra/2.0.2-3.0.14/disaster-recovery/index.md
@@ -3,13 +3,14 @@ layout: layout.pug
 navigationTitle:  Disaster Recovery
 title: Disaster Recovery
 menuWeight: 80
-excerpt:
+excerpt: Backing up and restoring your Cassandra service
 featureMaturity:
 enterprise: false
 ---
 
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
+<p class="message--warning"><strong>WARNING: </strong>The limitation described in the <a href="/services/cassandra/2.0.2-3.0.14/limitations/#service-user">Service user section</a> of the Limitations topic is crucial for the data backup procedure described below. Be sure to review that section before proceeding with any backup or restore operations.</p>
 
 # Backup
 

--- a/pages/services/cassandra/2.0.3-3.0.14/disaster-recovery/index.md
+++ b/pages/services/cassandra/2.0.3-3.0.14/disaster-recovery/index.md
@@ -3,10 +3,11 @@ layout: layout.pug
 navigationTitle:  Disaster Recovery
 title: Disaster Recovery
 menuWeight: 80
-excerpt:
+excerpt: Backing up and restoring your Cassandra service
 featureMaturity:
 enterprise: false
 ---
+<p class="message--warning"><strong>WARNING: </strong>The limitation described in the <a href="/services/cassandra/2.0.3-3.0.14/limitations/#service-user">Service user section</a> of the Limitations topic is crucial for the data backup procedure described below. Be sure to review that section before proceeding with any backup or restore operations.</p>
 
 # Backup
 

--- a/pages/services/cassandra/v2.0.0-3.0.14/disaster-recovery/index.md
+++ b/pages/services/cassandra/v2.0.0-3.0.14/disaster-recovery/index.md
@@ -3,13 +3,13 @@ layout: layout.pug
 navigationTitle:  Disaster Recovery
 title: Disaster Recovery
 menuWeight: 80
-excerpt:
+excerpt: Backing up and restoring your Cassandra service
 featureMaturity:
 enterprise: false
 ---
 
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
-
+<p class="message--warning"><strong>WARNING: </strong>The limitation described in the <a href="/services/cassandra/v2.0.0-3.0.14/limitations/#service-user">Service user section</a> of the Limitations topic is crucial for the data backup procedure described below. Be sure to review that section before proceeding with any backup or restore operations.</p>
 
 # Backup
 


### PR DESCRIPTION
… user limitation.
https://jira.mesosphere.com/browse/COPS-2120

The limitation described in the Service user section of the Cassandra guide is crucial for the data backup procedure described in the Disaster Recovery document.

Can we put a note to the "Disaster Recovery" document with the link to the "Service user section": to avoid situations described in the following customer tickets.

https://mesosphere.zendesk.com/agent/tickets/9146
https://mesosphere.zendesk.com/agent/tickets/8929

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Added Warning to beginning of /disaster-recovery/ sections in the following versions:

2.0.0-3.0.14
2.0.1-3.0.14
2.0.2-3.0.14
2.0.3-3.0.14

I did not find this issue in the -3.0.16 version or the v1.0.25 version.