### PR TITLE
ss/DCOS-43037 Updating Breaking change section with Marathon version …

### DIFF
--- a/pages/1.10/release-notes/1.10.0-beta2/index.md
+++ b/pages/1.10/release-notes/1.10.0-beta2/index.md
@@ -121,7 +121,8 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-## Latest version of Marathon-LB is required for 1.10
+## Latest version of Marathon-LB 
+
 Before upgrading to 1.10, uninstall your existing Marathon-LB package and reinstall the updated version.
 
 - REX-Ray configuration change

--- a/pages/1.10/release-notes/1.10.0-rc1/index.md
+++ b/pages/1.10/release-notes/1.10.0-rc1/index.md
@@ -137,8 +137,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for 1.10.0.
-  Before upgrading to 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0. Before upgrading to 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 
 - REX-Ray configuration change.
   DC/OS 1.10.0 upgrades REX-Ray from v03.3 to v0.9.0 and the REX-Ray configuration format has changed. If you have specified custom REX-Ray configuration in the [`rexray_config`](/1.10/installing/oss/custom/configuration/configuration-parameters/#rexray-config) parameter of your `config.yaml` file, either update the configuration to the new format or remove `rexray_config` and set the parameter to `rexray_config_preset: aws`, which configures the `rexray_config` parameter to the default REX-Ray configuration bundled with DC/OS. This option has the benefit of automatically upgrading your cluster's REX-Ray configuration when you upgrade to a newer version of DC/OS. **Note:** The `rexray_config_preset: aws` option is only relevant to DC/OS clusters running on AWS.

--- a/pages/1.10/release-notes/1.10.0/index.md
+++ b/pages/1.10/release-notes/1.10.0/index.md
@@ -130,7 +130,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`. [enterprise type="inline" size="small" /]
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.1/index.md
+++ b/pages/1.10/release-notes/1.10.1/index.md
@@ -163,7 +163,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.2/index.md
+++ b/pages/1.10/release-notes/1.10.2/index.md
@@ -185,7 +185,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.3/index.md
+++ b/pages/1.10/release-notes/1.10.3/index.md
@@ -199,7 +199,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.4/index.md
+++ b/pages/1.10/release-notes/1.10.4/index.md
@@ -206,7 +206,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.5/index.md
+++ b/pages/1.10/release-notes/1.10.5/index.md
@@ -229,7 +229,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.6/index.md
+++ b/pages/1.10/release-notes/1.10.6/index.md
@@ -158,7 +158,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.7/index.md
+++ b/pages/1.10/release-notes/1.10.7/index.md
@@ -145,7 +145,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 

--- a/pages/1.10/release-notes/1.10.8/index.md
+++ b/pages/1.10/release-notes/1.10.8/index.md
@@ -147,7 +147,7 @@ The GUI sidebar tabs have been updated to offer a more intuitive experience.
 
   TLS 1.0 no longer meets common minimum security requirements. To use TLS 1.0, set `adminrouter_tls_1_0_enabled` to `true` in your `config.yaml` at install time. The default is `false`.
 
-- Latest version of Marathon-LB is required for DC/OS 1.10.0.
+- Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.
 
   Before upgrading to DC/OS 1.10.0, uninstall your existing Marathon-LB package and reinstall the updated version.
 


### PR DESCRIPTION
…requirement.

## Description
https://jira.mesosphere.com/browse/DCOS-43037

Issue:  In all of the 1.10.x Release Notes, there's a Breaking Change listed:

Latest version of Marathon-LB is required for DC/OS 1.10.0.

However, Marathon-LB has had a few releases come out since that was written and it's creating a bit of confusion for customers. Can we change this to (or something like this):

Marathon-LB 1.11.0 or greater is required for DC/OS 1.10.0.

Thanks!

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Updated all versions of the 10.0 release notes that had this line in them. 