### PR TITLE
ss/DCOS-42747 Correcting menuweight for beta-kubernetes docs in Servi…

### DIFF
--- a/pages/services/beta-kubernetes/index.md
+++ b/pages/services/beta-kubernetes/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Beta Kubernetes
 title: Beta Kubernetes
-menuWeight: 75
+menuWeight: 175
 excerpt:
 featureMaturity:
 enterprise: false


### PR DESCRIPTION
…ce Docs landing page.

## Description
https://jira.mesosphere.com/browse/DCOS-42747

The menuweight assigned to the latest Beta-Kubernetes docs is too low, and results in the service being listed out of order. 

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium


