### PR TITLE
kubernetes: add nodeport/hostport limitation

### DIFF
--- a/pages/services/kubernetes/1.0.0-1.9.3/limitations/index.md
+++ b/pages/services/kubernetes/1.0.0-1.9.3/limitations/index.md
@@ -24,3 +24,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Disabling the `high_availability` option after install is not supported.
 * Losing `etcd` pod when `high_availability` is disabled may result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.0.1-1.9.4/limitations/index.md
+++ b/pages/services/kubernetes/1.0.1-1.9.4/limitations/index.md
@@ -25,3 +25,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Disabling the `high_availability` option after install is not supported.
 * Losing `etcd` pod when `high_availability` is disabled may result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.0.2-1.9.6/limitations/index.md
+++ b/pages/services/kubernetes/1.0.2-1.9.6/limitations/index.md
@@ -27,3 +27,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * The Kubernetes Dashboard cannot be accessed at the usual
   `https://<apiserver-url>/ui/` URL.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.0.3-1.9.7/limitations/index.md
+++ b/pages/services/kubernetes/1.0.3-1.9.7/limitations/index.md
@@ -27,3 +27,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * The Kubernetes Dashboard cannot be accessed at the usual
   `https://<apiserver-url>/ui/` URL.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.1.0-1.10.3/limitations/index.md
+++ b/pages/services/kubernetes/1.1.0-1.10.3/limitations/index.md
@@ -25,3 +25,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Losing `etcd` pod when `high_availability` is disabled may result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * Changing the authorization mode after installing the package is not supported.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.1.1-1.10.4/limitations/index.md
+++ b/pages/services/kubernetes/1.1.1-1.10.4/limitations/index.md
@@ -24,3 +24,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Losing `etcd` pod when `high_availability` is disabled may result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * Changing the authorization mode after installing the package is not supported.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.2.0-1.10.5/limitations/index.md
+++ b/pages/services/kubernetes/1.2.0-1.10.5/limitations/index.md
@@ -25,3 +25,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Replacing or permanently losing the `etcd` pod when `kubernetes.high_availability` is disabled will result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * Changing the value of the `kubernetes.authorization_mode` option after installing the package is not supported.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.2.1-1.10.6/limitations/index.md
+++ b/pages/services/kubernetes/1.2.1-1.10.6/limitations/index.md
@@ -25,3 +25,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Replacing or permanently losing the `etcd` pod when `kubernetes.high_availability` is disabled will result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * Changing the value of the `kubernetes.authorization_mode` option after installing the package is not supported.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.2.2-1.10.7/limitations/index.md
+++ b/pages/services/kubernetes/1.2.2-1.10.7/limitations/index.md
@@ -25,3 +25,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Replacing or permanently losing the `etcd` pod when `kubernetes.high_availability` is disabled will result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * Changing the value of the `kubernetes.authorization_mode` option after installing the package is not supported.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.3.0-1.10.8/limitations/index.md
+++ b/pages/services/kubernetes/1.3.0-1.10.8/limitations/index.md
@@ -22,3 +22,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Replacing or permanently losing the `etcd` pod when `kubernetes.high_availability` is disabled will result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * Changing the value of the `kubernetes.authorization_mode` option after installing the package is not supported.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.

--- a/pages/services/kubernetes/1.3.1-1.10.8/limitations/index.md
+++ b/pages/services/kubernetes/1.3.1-1.10.8/limitations/index.md
@@ -22,3 +22,4 @@ Currently, the DC/OS Kubernetes package has the following limitations:
 * Replacing or permanently losing the `etcd` pod when `kubernetes.high_availability` is disabled will result in permanent data loss.
 * Nodes are restricted to running 10 pods per available CPU core, up to a maximum of 100 pods per node.
 * Changing the value of the `kubernetes.authorization_mode` option after installing the package is not supported.
+* Kubernetes `Service NodePort` and `Pod hostPort` are not supported. Using them can have unpredictable results if any other DC/OS service binds also to the very same port.


### PR DESCRIPTION
## Description
Update the kubernetes documentation to add limitation warning about `Service NodePort` and `Pod hostPort`


## Urgency
- [ ] Blocker 
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
