### PR TITLE
ss/DCOS_OSS-3724 Correcting protocol in pool config docs.

### DIFF
--- a/pages/services/edge-lb/0.1/pool-configuration/index.md
+++ b/pages/services/edge-lb/0.1/pool-configuration/index.md
@@ -317,14 +317,14 @@ Below is a simple example of a pool configuration for load-balancing a Marathon 
     "haproxy": {
       "frontends": [{
         "bindPort": 80,
-        "protocol": "HTTP",
+        "protocol": "TCP",
         "linkBackend": {
           "defaultBackend": "app-backend"
         }
       }],
       "backends": [{
         "name": "app-backend",
-        "protocol": "HTTP",
+        "protocol": "TCP",
         "servers": [{
           "framework": {
             "value": "marathon"

--- a/pages/services/edge-lb/1.0/pool-configuration/v2-examples/index.md
+++ b/pages/services/edge-lb/1.0/pool-configuration/v2-examples/index.md
@@ -228,14 +228,14 @@ For Mesos frameworks and DC/OS services that run tasks which are not managed by 
   "haproxy": {
     "frontends": [{
       "bindPort": 1025,
-      "protocol": "HTTP",
+      "protocol": "TCP",
       "linkBackend": {
         "defaultBackend": "kafka-backend"
       }
     }],
     "backends": [{
       "name": "kafka-backend",
-      "protocol": "HTTP",
+      "protocol": "TCP",
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",

--- a/pages/services/edge-lb/1.1/pool-configuration/v2-examples/index.md
+++ b/pages/services/edge-lb/1.1/pool-configuration/v2-examples/index.md
@@ -228,14 +228,14 @@ For Mesos frameworks and DC/OS services that run tasks which are not managed by 
   "haproxy": {
     "frontends": [{
       "bindPort": 1025,
-      "protocol": "HTTP",
+      "protocol": "TCP",
       "linkBackend": {
         "defaultBackend": "kafka-backend"
       }
     }],
     "backends": [{
       "name": "kafka-backend",
-      "protocol": "HTTP",
+      "protocol": "TCP",
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",

--- a/pages/services/edge-lb/1.2/pool-configuration/v2-examples/index.md
+++ b/pages/services/edge-lb/1.2/pool-configuration/v2-examples/index.md
@@ -228,14 +228,14 @@ For Mesos frameworks and DC/OS services that run tasks which are not managed by 
   "haproxy": {
     "frontends": [{
       "bindPort": 1025,
-      "protocol": "HTTP",
+      "protocol": "TCP",
       "linkBackend": {
         "defaultBackend": "kafka-backend"
       }
     }],
     "backends": [{
       "name": "kafka-backend",
-      "protocol": "HTTP",
+      "protocol": "TCP",
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-3724

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Source: https://docs.mesosphere.com/services/edge-lb/1.0/pool-configuration/v2-examples

https://docs.mesosphere.com/services/edge-lb/1.0/pool-configuration/v2-examples/#mesos-frameworks-and-dcos-services

 The protocol here should be TCP not HTTP.

Corrected all versions of Edge-LB to date.