### PR TITLE
Ss/dcos 44059

### DIFF
--- a/pages/services/edge-lb/1.1/installing/index.md
+++ b/pages/services/edge-lb/1.1/installing/index.md
@@ -170,7 +170,7 @@ dcos security org groups add_user superusers edge-lb-principal
 
 ### Grant limited actions to service account
 
-<p class="message--note"><strong>NOTE: </strong>These steps are not necessary if you added <code>edge-lb-principal</code> to the <code>superusers<code> group.</p>
+<p class="message--note"><strong>NOTE: </strong>These steps are not necessary if you added <code>edge-lb-principal</code> to the <code>superusers</code> group.</p>
 
 These more limited permissions include management of DC/OS packages, Marathon tasks, Edge-LB pools and tasks. They also enable Edge-LB pool framework schedulers to register with mesos master and launch load-balancer tasks.
 

--- a/pages/services/edge-lb/1.2/installing/index.md
+++ b/pages/services/edge-lb/1.2/installing/index.md
@@ -170,7 +170,7 @@ dcos security org groups add_user superusers edge-lb-principal
 
 ### Grant limited actions to service account
 
-<p class="message--note"><strong>NOTE: </strong>These steps are not necessary if you added <code>edge-lb-principal</code> to the <code>superusers<code> group.</p>
+<p class="message--note"><strong>NOTE: </strong>These steps are not necessary if you added <code>edge-lb-principal</code> to the <code>superusers</code> group.</p>
 
 These more limited permissions include management of DC/OS packages, Marathon tasks, Edge-LB pools and tasks. They also enable Edge-LB pool framework schedulers to register with mesos master and launch load-balancer tasks.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-44059
Hey team, this doc https://docs.mesosphere.com/services/edge-lb/1.2/installing/ is using only monospaced fonts after https://docs.mesosphere.com/services/edge-lb/1.2/installing/#grant-limited-actions-to-service-account this chapter :slightly_smiling_face: looks like a missing closing tag
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

Affects versions 1.1 and 1.2