### PR TITLE
Expose hidden DSS docs for 1.12

### DIFF
--- a/pages/services/beta-storage/0.3.0-beta/index.md
+++ b/pages/services/beta-storage/0.3.0-beta/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DC/OS Storage Service 0.3.0
 title: DC/OS Storage Service 0.3.0
-menuWeight: -1
+menuWeight: 0
 excerpt:
 ---
 

--- a/pages/services/beta-storage/0.3.1-beta/index.md
+++ b/pages/services/beta-storage/0.3.1-beta/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DC/OS Storage Service 0.3.1
 title: DC/OS Storage Service 0.3.1
-menuWeight: -1
+menuWeight: 0
 excerpt:
 ---
 

--- a/pages/services/beta-storage/0.3.2-beta/index.md
+++ b/pages/services/beta-storage/0.3.2-beta/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DC/OS Storage Service 0.3.2
 title: DC/OS Storage Service 0.3.2
-menuWeight: -1
+menuWeight: 0
 excerpt:
 ---
 

--- a/pages/services/beta-storage/0.4.0-beta/index.md
+++ b/pages/services/beta-storage/0.4.0-beta/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DC/OS Storage Service 0.4.0
 title: DC/OS Storage Service 0.4.0
-menuWeight: -1
+menuWeight: 0
 excerpt:
 ---
 


### PR DESCRIPTION
No need to be hidden given 1.12 is GA now.

## Description

Expose hidden DSS docs for 1.12

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
