### PR TITLE
ss/DCOS-40388 Corrected menuweights for Edge-LB nav menu.

### DIFF
--- a/pages/services/edge-lb/0.1/index.md
+++ b/pages/services/edge-lb/0.1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Edge-LB 0.1
 title: Edge-LB 0.1
-menuWeight: 30
+menuWeight: 100
 excerpt: Edge-LB proxies and load balances traffic to all services that run on DC/OS.
 
 enterprise: false

--- a/pages/services/edge-lb/1.0/index.md
+++ b/pages/services/edge-lb/1.0/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Edge-LB 1.0
 title: Edge-LB 1.0
-menuWeight: 20
+menuWeight: 90
 excerpt: Edge-LB proxies and load balances traffic to all services that run on DC/OS.
 
 enterprise: false

--- a/pages/services/edge-lb/1.1/index.md
+++ b/pages/services/edge-lb/1.1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Edge-LB 1.1
 title: Edge-LB 1.1
-menuWeight: 10
+menuWeight: 80
 excerpt: Edge-LB proxies and load balances traffic to all services that run on DC/OS.
 
 enterprise: false

--- a/pages/services/edge-lb/1.2/index.md
+++ b/pages/services/edge-lb/1.2/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Edge-LB 1.2
 title: Edge-LB 1.2
-menuWeight: 10
+menuWeight: 20
 excerpt: Edge-LB proxies and load balances traffic to all services that run on DC/OS.
 
 enterprise: false


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-40388

The nav menu for Edge-LB is out of order. Also, reporter requested a change to the ordering of release notes for different versions of the software.
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

![screen shot 2018-11-01 at 2 21 29 pm](https://user-images.githubusercontent.com/37596413/47881190-b000f400-dde2-11e8-9e9c-553cb632cb71.png)
