### PR TITLE
ss/DCOS_OSS-4062 Corrected reference to package name.

### DIFF
--- a/pages/services/edge-lb/1.1/upgrading/index.md
+++ b/pages/services/edge-lb/1.1/upgrading/index.md
@@ -19,8 +19,8 @@ Perform an Edge-LB upgrade by following this procedure.
 1. Remove the old package repositories.
 
     ```bash
-    dcos package repo remove edgelb-aws
-    dcos package repo remove edgelb-pool-aws
+    dcos package repo remove edgelb
+    dcos package repo remove edgelb-pool
     ```
 
 1. Add the new package repositories.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-4062?filter=29702

Source: https://docs.mesosphere.com/services/edge-lb/1.1/upgrading

This page has references to a different package name:

```
dcos package repo remove edgelb-aws
dcos package repo remove edgelb-pool-aws

```
It is noted in other sections of the same document.

These should refer to:

```
dcos package repo remove edgelb
dcos package repo remove edgelb-pool
```

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected command in v. 1.2. Does not apply to previous versions.
