### PR TITLE
ss/DCOS-44475 Correcting hyperlink to Certified Universe Packages.

### DIFF
--- a/pages/1.12/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.12/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -270,5 +270,5 @@ interface.
     sudo make DCOS_VERSION=1.10 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-4.  Perform all of the steps as described in [Certified Universe packages][#certified].
+4.  Perform all of the steps as described in [Certified Universe packages](#certified).
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-44475

https://docs.mesosphere.com/1.12/administering-clusters/deploying-a-local-dcos-universe/ is leaking Markdown formatting at the very end (there's raw Markdown where there should be a link).

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Fixed and tested formatting for hyperlink/anchor so that it takes user to correct link. Fixed only in 1.12; issue not found in earlier versions of this page.