### PR TITLE
ss/DCOS-44490 Removing most beta packages from service docs landing p…

### DIFF
--- a/pages/services/beta-cassandra/index.md
+++ b/pages/services/beta-cassandra/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Beta Cassandra
 title: Beta Cassandra
-menuWeight: 110
+menuWeight: -1
 excerpt: DC/OS Apache Cassandra is an automated service that makes it easy to deploy and manage Apache Cassandra on DC/OS
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-confluent-kafka-zookeeper/index.md
+++ b/pages/services/beta-confluent-kafka-zookeeper/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Beta Confluent Kafka Zookeeper
 title: Beta Confluent Kafka Zookeeper
-menuWeight: 125
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-confluent-kafka/index.md
+++ b/pages/services/beta-confluent-kafka/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: 
 title: Beta Confluent Kafka
-menuWeight: 120
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-dse/index.md
+++ b/pages/services/beta-dse/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Beta DataStax Enterprise
 title: Beta DataStax Enterprise
-menuWeight: 130
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-elastic/index.md
+++ b/pages/services/beta-elastic/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Beta Elastic
 title: Beta Elastic
-menuWeight: 140
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-hdfs/index.md
+++ b/pages/services/beta-hdfs/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Beta HDFS
 title: Beta HDFS
-menuWeight: 150
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-kafka-zookeeper/index.md
+++ b/pages/services/beta-kafka-zookeeper/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Beta Kafka ZooKeeper
 title: Beta Kafka ZooKeeper
-menuWeight: 163
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-kafka/index.md
+++ b/pages/services/beta-kafka/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Beta Kafka
 title: Beta Kafka
-menuWeight: 160
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-kubernetes/index.md
+++ b/pages/services/beta-kubernetes/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Beta Kubernetes
 title: Beta Kubernetes
-menuWeight: 175
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false

--- a/pages/services/beta-spark/index.md
+++ b/pages/services/beta-spark/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Beta Spark
 title: Beta Spark
-menuWeight: 200
+menuWeight: -1
 excerpt:
 featureMaturity:
 enterprise: false


### PR DESCRIPTION
…age.

## Description
https://jira.mesosphere.com/browse/DCOS-44490

Remove all references on the Service Docs Landing Page to Beta documents, except for those packages which have ONLY Beta docs (DSS and Jupyter, currently). Although Beta Confluent Kafka Zookeeper has no Beta version, that was removed as well.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

All Beta packages were given a menuweight of -1, which removes them from the display. Exceptions were those packages for which there is no non-Beta version:

- [x] Beta DSS
- [x] Beta Jupyter


Changes confirmed by testing in local build. See attached.
