### PR TITLE
CK/DCOS-44149 Remove docker instructions

### DIFF
--- a/pages/1.10/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.10/installing/production/system-requirements/docker-centos/index.md
@@ -6,57 +6,26 @@ menuWeight: 5
 excerpt: Requirements, recommendations and procedures for installing Docker CE on CentOS/RHEL
 ---
 
-# Requirements and Recommendations
+## Customer Advisory
+A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory controller (kmem) causes instability for the entire system when the `kmem` accounting feature is activated. Customers may notice tasks or commands getting stuck indefinitely and kernel-related error messages in the system logs. Mesosphere DC/OS customers and community members who utilize RedHat or CentOS as their base operating systems are strongly advised to install and use RedHat’s fork of Docker 1.13. This fork of Docker does not require an RHN subscription.
 
-These directions cover the installation of Docker CE on CentOS/RHEL. Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
+<p class="message--note"><strong>NOTE: </strong>More specific details on the Docker bug and mitigation instructions are located <a href="https://mesosphere-community.force.com/s/article/Critical-Issue-KMEM-MSPH-2018-0006">here</a>.</p>
+
+## Requirements and Recommendations
+
+Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
 
 * OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.
 
-* These instructions are specific to CentOS/RHEL 7.4. Other versions of CentOS/RHEL 7 should work but might require minor modifications to the commands.
-
 * Format node storage as XFS with the `ftype=1` option. As of CentOS/RHEL 7.2, [only XFS is currently supported for use as a lower layer file system][2].
 
-* For more generic Docker requirements, see [System Requirements: Docker](/1.12/installing/production/system-requirements/#docker).
+* For more a more detailed breakdown of installing docker, [see the Docker CE for CentOS installation page][4].
 
 <p class="message--note"><strong>NOTE: </strong> In modern versions of Centos and RHEL, <code>ftype=1</code> is the default. The <code>xfs_info</code> utility can be used to verify that <code>ftype=1</code>.</p>
 
 ```bash
 mkfs -t xfs -n ftype=1 /dev/sdc1
 ```
-
-## Customer Advisory
-A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory controller (kmem) causes instability for the entire system when the `kmem` accounting feature is activated. Customers may notice tasks or commands getting stuck indefinitely and kernel-related error messages in the system logs. Mesosphere DC/OS customers and community members who utilize RedHat or CentOS as their base operating systems are strongly advised to install and use RedHat’s fork of Docker 1.13. This fork of Docker does not require an RHN subscription.
-
-<p class="message--note"><strong>NOTE: </strong>More specific details on the Docker bug and mitigation instructions are located <a href="https://mesosphere-community.force.com/s/article/Critical-Issue-KMEM-MSPH-2018-0006">here</a>.</p>
-
-# Installation
-
-Refer to the the Docker [CentOS-specific installation instructions](https://docs.docker.com/install/linux/docker-ce/centos/) for a more thorough breakdown, keeping in mind the above customer advisory.
-
-## Example: Installing the Red Hat's fork of Docker 1.13 on RHEL
-
-1.  Install Docker CE:
-
-    ```bash
-    sudo yum install -y docker --enablerepo=rhui-REGION-rhel-server-extras
-    ```
-
-1.  Start Docker:
-
-    ```bash
-    sudo systemctl start docker
-    sudo systemctl enable docker
-    ```
-
-1.  Test Docker with `hello-world` app:
-
-    ```bash
-    sudo docker run hello-world
-    ```
-
-To continue setting up DC/OS, [please jump to the Advanced Installer][4]
-
-For more generic Docker requirements, see [System Requirements: Docker][1].
 
 [1]: /1.10/installing/production/system-requirements/#docker
 [2]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.2_Release_Notes/technology-preview-file_systems.html

--- a/pages/1.10/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.10/installing/production/system-requirements/docker-centos/index.md
@@ -20,10 +20,9 @@ These directions cover the installation of Docker CE on CentOS/RHEL. Before inst
 
 <p class="message--note"><strong>NOTE: </strong> In modern versions of Centos and RHEL, <code>ftype=1</code> is the default. The <code>xfs_info</code> utility can be used to verify that <code>ftype=1</code>.</p>
 
-
-    ```bash
-    mkfs -t xfs -n ftype=1 /dev/sdc1
-    ```
+```bash
+mkfs -t xfs -n ftype=1 /dev/sdc1
+```
 
 ## Customer Advisory
 A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory controller (kmem) causes instability for the entire system when the `kmem` accounting feature is activated. Customers may notice tasks or commands getting stuck indefinitely and kernel-related error messages in the system logs. Mesosphere DC/OS customers and community members who utilize RedHat or CentOS as their base operating systems are strongly advised to install and use RedHat’s fork of Docker 1.13. This fork of Docker does not require an RHN subscription.
@@ -32,72 +31,14 @@ A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory c
 
 # Installation
 
-Follow the Docker [CentOS-specific installation instructions](https://docs.docker.com/install/linux/docker-ce/centos/).
+Refer to the the Docker [CentOS-specific installation instructions](https://docs.docker.com/install/linux/docker-ce/centos/) for a more thorough breakdown, keeping in mind the above customer advisory.
 
-### RHEL-only requirements
+## Example: Installing the Red Hat's fork of Docker 1.13 on RHEL
 
-You must register with the subcription-manager to enable additional repos.
-
-Follow the Docker [CentOS-specific installation instructions][3]
-
-### RHEL Only: subcription-manager
-
-1.  Subscribe the RHEL system in subscription-manager and add the repos
+1.  Install Docker CE:
 
     ```bash
-    sudo subscription-manager register --username <RHEL-SUBSCRIPTION-USERNAME> --password ******** --auto-attach
-
-    sudo subscription-manager repos --enable=rhel-7-server-rpms
-    sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
-    sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
-    ```
-
-# Example: Installing Docker with OverlayFS on CentOS/RedHat
-
-The following instructions demonstrate how to use Docker with OverlayFS on CentOS 7.
-
-1.  Configure OS for overlay storage
-
-    ```bash
-    sudo echo 'overlay' >> /etc/modules-load.d/overlay.conf
-    sudo modprobe overlay
-    ```
-
-1.  Run yum update
-
-    ```bash
-    sudo yum update --exclude=docker-engine,docker-engine-selinux,centos-release* --assumeyes --tolerant
-    ```
-
-1.  Un-install old versions of Docker (if present):
-
-    ```bash
-    sudo yum remove docker \
-                  docker-common \
-                  docker-selinux \
-                  docker-engine
-    ```
-
-1.  Set up Docker CE repository:
-
-    ```bash
-    sudo yum-config-manager \
-        --add-repo \
-        https://download.docker.com/linux/centos/docker-ce.repo
-    ```
-
-1.  Show versions of Docker CE. 
-
-    ```bash
-    sudo yum list docker-ce --showduplicates | sort -r
-    ```
-
-The remainder of these instructions assume that you have installed the latest version.
-
-6.  Install Docker CE:
-
-    ```bash
-    sudo yum install docker-ce
+    sudo yum install -y docker --enablerepo=rhui-REGION-rhel-server-extras
     ```
 
 1.  Start Docker:
@@ -113,17 +54,11 @@ The remainder of these instructions assume that you have installed the latest ve
     sudo docker run hello-world
     ```
 
-1.  Verify that Docker is using the overlay driver:
-
-    ```bash
-    sudo docker info | grep Storage
-    ```
-
 To continue setting up DC/OS, [please jump to the Advanced Installer][4]
 
 For more generic Docker requirements, see [System Requirements: Docker][1].
 
-[1]: /1.12/installing/production/system-requirements/#docker
+[1]: /1.10/installing/production/system-requirements/#docker
 [2]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.2_Release_Notes/technology-preview-file_systems.html
 [3]: https://docs.docker.com/install/linux/docker-ce/centos/
-[4]: /1.12/installing/production/deploying-dcos/installation/
+[4]: /1.10/installing/production/deploying-dcos/installation/

--- a/pages/1.10/installing/production/system-requirements/index.md
+++ b/pages/1.10/installing/production/system-requirements/index.md
@@ -41,7 +41,7 @@ The table below shows the master node hardware requirements:
 
 There are many mixed workloads on the masters. Workloads that are expected to be continuously available or considered business critical should only be run on a DC/OS cluster with at least three masters. For more information about high availability requirements see the [High Availability documentation][0].
 
-[0]: /1.12/overview/high-availability/
+[0]: /1.10/overview/high-availability/
 
 
 Examples of mixed workloads on the masters are Mesos replicated logs and ZooKeeper. Some of these require fsync()ing every so often, and this can generate a lot of very expensive random I/O. We recommend the following:
@@ -77,7 +77,7 @@ The table below shows the agent node hardware requirements.
 
 The agent nodes must also have:
 
-- A `/var` directory with 20 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.12/deploying-services/containerizers/).
+- A `/var` directory with 20 GB or more of free space. This directory is used by the sandbox for both [Docker and DC/OS Universal container runtime](/1.10/deploying-services/containerizers/).
 - Network Access to a public Docker repository or to an internal Docker registry.
 - On RHEL 7 and CentOS 7, `firewalld` must be stopped and disabled. It is a known <a href="https://github.com/docker/docker/issues/16137" target="_blank">Docker issue</a> that `firewalld` interacts poorly with Docker. For more information, see the <a href="https://docs.docker.com/v1.6/installation/centos/#firewalld" target="_blank">Docker CentOS firewalld</a> documentation.
 
@@ -188,7 +188,7 @@ timedatectl
 
 Before installing DC/OS, you **must** ensure that your bootstrap node has the following prerequisites.
 
-<p class="message--important"><strong>IMPORTANT: </strong>If you specify `exhibitor_storage_backend: zookeeper`, the bootstrap node is a permanent part of your cluster. With `exhibitor_storage_backend: zookeeper`, the leader state and leader election of your Mesos masters is maintained in Exhibitor ZooKeeper on the bootstrap node. For more information, see the <a href="/1.12/installing/production/advanced-configuration/configuration-reference/">configuration parameter documentation</a>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>If you specify `exhibitor_storage_backend: zookeeper`, the bootstrap node is a permanent part of your cluster. With `exhibitor_storage_backend: zookeeper`, the leader state and leader election of your Mesos masters is maintained in Exhibitor ZooKeeper on the bootstrap node. For more information, see the <a href="/1.10/installing/production/advanced-configuration/configuration-reference/">configuration parameter documentation</a>.</p>
 
 
 - The bootstrap node must be separate from your cluster nodes.
@@ -286,6 +286,6 @@ localectl set-locale LANG=en_US.utf8
 - [Install Docker from Docker’s yum repository][1]
 - [DC/OS Installation Guide][2]
 
-[1]: /1.12/installing/production/system-requirements/docker-centos/
+[1]: /1.10/installing/production/system-requirements/docker-centos/
 
-[2]: /1.12/installing/production/deploying-dcos/installation/
+[2]: /1.10/installing/production/deploying-dcos/installation/

--- a/pages/1.11/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.11/installing/production/system-requirements/docker-centos/index.md
@@ -6,124 +6,28 @@ menuWeight: 5
 excerpt: Requirements, recommendations and procedures for installing Docker CE on CentOS/RHEL
 ---
 
-# Requirements and Recommendations
-
-These directions cover the installation of Docker CE on CentOS/RHEL. Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
-
-* OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.
-
-* These instructions are specific to CentOS/RHEL 7.4. Other versions of CentOS/RHEL 7 should work but might require minor modifications to the commands.
-
-* Format node storage as XFS with the `ftype=1` option. As of CentOS/RHEL 7.2, [only XFS is currently supported for use as a lower layer file system][2].
-
-* For more generic Docker requirements, see [System Requirements: Docker](/1.12/installing/production/system-requirements/#docker).
-
-<p class="message--note"><strong>NOTE: </strong> In modern versions of Centos and RHEL, <code>ftype=1</code> is the default. The <code>xfs_info</code> utility can be used to verify that <code>ftype=1</code>.</p>
-
-
-    ```bash
-    mkfs -t xfs -n ftype=1 /dev/sdc1
-    ```
-
 ## Customer Advisory
 A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory controller (kmem) causes instability for the entire system when the `kmem` accounting feature is activated. Customers may notice tasks or commands getting stuck indefinitely and kernel-related error messages in the system logs. Mesosphere DC/OS customers and community members who utilize RedHat or CentOS as their base operating systems are strongly advised to install and use RedHat’s fork of Docker 1.13. This fork of Docker does not require an RHN subscription.
 
 <p class="message--note"><strong>NOTE: </strong>More specific details on the Docker bug and mitigation instructions are located <a href="https://mesosphere-community.force.com/s/article/Critical-Issue-KMEM-MSPH-2018-0006">here</a>.</p>
 
-# Installation
+# Requirements and Recommendations
 
-Follow the Docker [CentOS-specific installation instructions](https://docs.docker.com/install/linux/docker-ce/centos/).
+Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
 
-### RHEL-only requirements
+* OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.
 
-You must register with the subcription-manager to enable additional repos.
+* Format node storage as XFS with the `ftype=1` option. As of CentOS/RHEL 7.2, [only XFS is currently supported for use as a lower layer file system][2].
 
-Follow the Docker [CentOS-specific installation instructions][3]
+* For more a more detailed breakdown of installing docker, [see the Docker CE for CentOS installation page][4].
 
-### RHEL Only: subcription-manager
+<p class="message--note"><strong>NOTE: </strong> In modern versions of Centos and RHEL, <code>ftype=1</code> is the default. The <code>xfs_info</code> utility can be used to verify that <code>ftype=1</code>.</p>
 
-1.  Subscribe the RHEL system in subscription-manager and add the repos
+```bash
+mkfs -t xfs -n ftype=1 /dev/sdc1
+```
 
-    ```bash
-    sudo subscription-manager register --username <RHEL-SUBSCRIPTION-USERNAME> --password ******** --auto-attach
-
-    sudo subscription-manager repos --enable=rhel-7-server-rpms
-    sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
-    sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
-    ```
-
-# Example: Installing Docker with OverlayFS on CentOS/RedHat
-
-The following instructions demonstrate how to use Docker with OverlayFS on CentOS 7.
-
-1.  Configure OS for overlay storage
-
-    ```bash
-    sudo echo 'overlay' >> /etc/modules-load.d/overlay.conf
-    sudo modprobe overlay
-    ```
-
-1.  Run yum update
-
-    ```bash
-    sudo yum update --exclude=docker-engine,docker-engine-selinux,centos-release* --assumeyes --tolerant
-    ```
-
-1.  Un-install old versions of Docker (if present):
-
-    ```bash
-    sudo yum remove docker \
-                  docker-common \
-                  docker-selinux \
-                  docker-engine
-    ```
-
-1.  Set up Docker CE repository:
-
-    ```bash
-    sudo yum-config-manager \
-        --add-repo \
-        https://download.docker.com/linux/centos/docker-ce.repo
-    ```
-
-1.  Show versions of Docker CE. 
-
-    ```bash
-    sudo yum list docker-ce --showduplicates | sort -r
-    ```
-
-The remainder of these instructions assume that you have installed the latest version.
-
-6.  Install Docker CE:
-
-    ```bash
-    sudo yum install docker-ce
-    ```
-
-1.  Start Docker:
-
-    ```bash
-    sudo systemctl start docker
-    sudo systemctl enable docker
-    ```
-
-1.  Test Docker with `hello-world` app:
-
-    ```bash
-    sudo docker run hello-world
-    ```
-
-1.  Verify that Docker is using the overlay driver:
-
-    ```bash
-    sudo docker info | grep Storage
-    ```
-
-To continue setting up DC/OS, [please jump to the Advanced Installer][4]
-
-For more generic Docker requirements, see [System Requirements: Docker][1].
-
-[1]: /1.12/installing/production/system-requirements/#docker
+[1]: /1.11/installing/production/system-requirements/#docker
 [2]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.2_Release_Notes/technology-preview-file_systems.html
 [3]: https://docs.docker.com/install/linux/docker-ce/centos/
-[4]: /1.12/installing/production/deploying-dcos/installation/
+[4]: /1.11/installing/production/deploying-dcos/installation/

--- a/pages/1.12/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.12/installing/production/system-requirements/docker-centos/index.md
@@ -6,122 +6,26 @@ menuWeight: 5
 excerpt: Requirements, recommendations and procedures for installing Docker CE on CentOS/RHEL
 ---
 
-# Requirements and Recommendations
-
-These directions cover the installation of Docker CE on CentOS/RHEL. Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
-
-* OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.
-
-* These instructions are specific to CentOS/RHEL 7.4. Other versions of CentOS/RHEL 7 should work but might require minor modifications to the commands.
-
-* Format node storage as XFS with the `ftype=1` option. As of CentOS/RHEL 7.2, [only XFS is currently supported for use as a lower layer file system][2].
-
-* For more generic Docker requirements, see [System Requirements: Docker](/1.12/installing/production/system-requirements/#docker).
-
-<p class="message--note"><strong>NOTE: </strong> In modern versions of Centos and RHEL, <code>ftype=1</code> is the default. The <code>xfs_info</code> utility can be used to verify that <code>ftype=1</code>.</p>
-
-
-    ```bash
-    mkfs -t xfs -n ftype=1 /dev/sdc1
-    ```
-
 ## Customer Advisory
 A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory controller (kmem) causes instability for the entire system when the `kmem` accounting feature is activated. Customers may notice tasks or commands getting stuck indefinitely and kernel-related error messages in the system logs. Mesosphere DC/OS customers and community members who utilize RedHat or CentOS as their base operating systems are strongly advised to install and use RedHat’s fork of Docker 1.13. This fork of Docker does not require an RHN subscription.
 
 <p class="message--note"><strong>NOTE: </strong>More specific details on the Docker bug and mitigation instructions are located <a href="https://mesosphere-community.force.com/s/article/Critical-Issue-KMEM-MSPH-2018-0006">here</a>.</p>
 
-# Installation
+## Requirements and Recommendations
 
-Follow the Docker [CentOS-specific installation instructions](https://docs.docker.com/install/linux/docker-ce/centos/).
+Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
 
-### RHEL-only requirements
+* OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.
 
-You must register with the subcription-manager to enable additional repos.
+* Format node storage as XFS with the `ftype=1` option. As of CentOS/RHEL 7.2, [only XFS is currently supported for use as a lower layer file system][2].
 
-Follow the Docker [CentOS-specific installation instructions][3]
+* For more a more detailed breakdown of installing docker, [see the Docker CE for CentOS installation page][4].
 
-### RHEL Only: subcription-manager
+<p class="message--note"><strong>NOTE: </strong> In modern versions of Centos and RHEL, <code>ftype=1</code> is the default. The <code>xfs_info</code> utility can be used to verify that <code>ftype=1</code>.</p>
 
-1.  Subscribe the RHEL system in subscription-manager and add the repos
-
-    ```bash
-    sudo subscription-manager register --username <RHEL-SUBSCRIPTION-USERNAME> --password ******** --auto-attach
-
-    sudo subscription-manager repos --enable=rhel-7-server-rpms
-    sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
-    sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
-    ```
-
-# Example: Installing Docker with OverlayFS on CentOS/RedHat
-
-The following instructions demonstrate how to use Docker with OverlayFS on CentOS 7.
-
-1.  Configure OS for overlay storage
-
-    ```bash
-    sudo echo 'overlay' >> /etc/modules-load.d/overlay.conf
-    sudo modprobe overlay
-    ```
-
-1.  Run yum update
-
-    ```bash
-    sudo yum update --exclude=docker-engine,docker-engine-selinux,centos-release* --assumeyes --tolerant
-    ```
-
-1.  Un-install old versions of Docker (if present):
-
-    ```bash
-    sudo yum remove docker \
-                  docker-common \
-                  docker-selinux \
-                  docker-engine
-    ```
-
-1.  Set up Docker CE repository:
-
-    ```bash
-    sudo yum-config-manager \
-        --add-repo \
-        https://download.docker.com/linux/centos/docker-ce.repo
-    ```
-
-1.  Show versions of Docker CE. 
-
-    ```bash
-    sudo yum list docker-ce --showduplicates | sort -r
-    ```
-
-The remainder of these instructions assume that you have installed the latest version.
-
-6.  Install Docker CE:
-
-    ```bash
-    sudo yum install docker-ce
-    ```
-
-1.  Start Docker:
-
-    ```bash
-    sudo systemctl start docker
-    sudo systemctl enable docker
-    ```
-
-1.  Test Docker with `hello-world` app:
-
-    ```bash
-    sudo docker run hello-world
-    ```
-
-1.  Verify that Docker is using the overlay driver:
-
-    ```bash
-    sudo docker info | grep Storage
-    ```
-
-To continue setting up DC/OS, [please jump to the Advanced Installer][4]
-
-For more generic Docker requirements, see [System Requirements: Docker][1].
+```bash
+mkfs -t xfs -n ftype=1 /dev/sdc1
+```
 
 [1]: /1.12/installing/production/system-requirements/#docker
 [2]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.2_Release_Notes/technology-preview-file_systems.html


### PR DESCRIPTION
## Description

https://jira.mesosphere.com/browse/DCOS-44149
Remove docker instructions due to bug that renders docker 17 unsupportable at the moment, these will be updated again once new set is written.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
