### PR TITLE
ss/DCOS-44598 Correct wording on DC/OS installation page.

### DIFF
--- a/pages/1.10/installing/index.md
+++ b/pages/1.10/installing/index.md
@@ -11,7 +11,7 @@ The installation of DC/OS involves configuring your infrastructure, and installi
 
 The DC/OS installation methods are as follows:
 
-- **Mesosphere-supported installation:** Use the [Mesosphere-supported installation methods](#mesosphere-supported) to test or demo DC/OS on AWS, Azure, or GCP using an Universal Installer.
+- **Mesosphere-supported installation:** Use the [Mesosphere-supported installation methods](#mesosphere-supported)  to deploy DC/OS on AWS, Azure, or GCP using the Universal Installer.
 
 - **Community-supported installation:** Use the [Community-supported installation methods](#community-supported) to test or demo DC/OS on AWS, Azure, Digital Ocean or Packet.
 

--- a/pages/1.11/installing/index.md
+++ b/pages/1.11/installing/index.md
@@ -11,7 +11,7 @@ The installation of DC/OS involves configuring your infrastructure, and installi
 
 The DC/OS installation methods are as follows:
 
-- **Mesosphere-supported installation:** Use the [Mesosphere-supported installation methods](#mesosphere-supported) to test or demo DC/OS on AWS, Azure, or GCP using an Universal Installer.
+- **Mesosphere-supported installation:** Use the [Mesosphere-supported installation methods](#mesosphere-supported)  to deploy DC/OS on AWS, Azure, or GCP using the Universal Installer.
 
 - **Community-supported installation:** Use the [Community-supported installation methods](#community-supported) to test or demo DC/OS on AWS, Azure, Digital Ocean or Packet.
 

--- a/pages/1.12/installing/index.md
+++ b/pages/1.12/installing/index.md
@@ -11,7 +11,7 @@ The installation of DC/OS involves configuring your infrastructure, and installi
 
 The DC/OS installation methods are as follows:
 
-- **Mesosphere-supported installation:** Use the [Mesosphere-supported installation methods](#mesosphere-supported) to test or demo DC/OS on AWS, Azure, or GCP using an Universal Installer.
+- **Mesosphere-supported installation:** Use the [Mesosphere-supported installation methods](#mesosphere-supported)  to deploy DC/OS on AWS, Azure, or GCP using the Universal Installer.
 
 - **Community-supported installation:** Use the [Community-supported installation methods](#community-supported) to test or demo DC/OS on AWS, Azure, Digital Ocean or Packet.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-44598
https://docs.mesosphere.com/1.12/installing/#mesosphere-supported

Although this issue is valid for all supported versions, meaning 1.12, 1.11, 1.10.

After the heading on installation, it says:

The DC/OS installation methods are as follows:

Mesosphere-supported installation: Use the Mesosphere-supported installation methods to test or demo DC/OS on AWS, Azure, or GCP using an Universal Installer.

Community-supported installation: Use the Community-supported installation methods to test or demo DC/OS on AWS, Azure, Digital Ocean or Packet.

It should not say *to test or demo DC/OS on AWS, Azure, or GCP using an Univeral Installer."

It should say Use the Mesosphere-supported installation methods to deploy DC/OS on AWS, Azure, or GCP using the Universal Installer.

Small tweaks, but makes a huge difference. Our installation method is not for testing & demoing only - it's for deploying DC/OS. And there's no such thing as an Universal Installer - it's the naming we came up for our tool.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected as requested. Versions affected:

- [x] 1.10
- [x] 1.11
- [x] 1.12