### PR TITLE
ss/DCOS-44599 Adding link from /install/production/ to /install/evalu…

### DIFF
--- a/pages/1.10/installing/production/index.md
+++ b/pages/1.10/installing/production/index.md
@@ -10,6 +10,8 @@ DC/OS is installed in your environment by using a dynamically generated configur
 
 The DC/OS installation process requires a cluster of nodes to install DC/OS onto and a single node to run the DC/OS installation from. For fully functional clusters on any infrastructure including on-premise, public or private clouds, follow the Production installation instructions. The Production installation method was previously called Custom installation. 
 
+The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed discussion of the Universal Installer may be found [here](/1.10/installing/evaluation/#overview-of-universal-installer).
+
 # Access DC/OS Configuration File
 
 - For installing DC/OS Enterprise Edition contact your sales representative or <sales@mesosphere.io>. You can access the DC/OS Enterprise configuration file from the [support website](https://support.mesosphere.com/s/downloads) using a [login credential](https://support.mesosphere.com/s/login/). [enterprise type="inline" size="small" /]

--- a/pages/1.10/installing/production/index.md
+++ b/pages/1.10/installing/production/index.md
@@ -10,7 +10,7 @@ DC/OS is installed in your environment by using a dynamically generated configur
 
 The DC/OS installation process requires a cluster of nodes to install DC/OS onto and a single node to run the DC/OS installation from. For fully functional clusters on any infrastructure including on-premise, public or private clouds, follow the Production installation instructions. The Production installation method was previously called Custom installation. 
 
-The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed discussion of the Universal Installer may be found [here](/1.10/installing/evaluation/#overview-of-universal-installer).
+The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed overview and instructions for the Universal Installer may be found [here](/1.10/installing/evaluation/#overview-of-universal-installer).
 
 # Access DC/OS Configuration File
 

--- a/pages/1.11/installing/production/index.md
+++ b/pages/1.11/installing/production/index.md
@@ -10,7 +10,7 @@ DC/OS is installed in your environment by using a dynamically generated configur
 
 The DC/OS installation process requires a cluster of nodes to install DC/OS onto and a single node to run the DC/OS installation from. For fully functional clusters on any infrastructure including on-premise, public or private clouds, follow the Production installation instructions. The Production installation method was previously called Custom installation. 
 
-The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed discussion of the Universal Installer may be found [here](/1.11/installing/evaluation/#overview-of-universal-installer).
+The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed overview and instructions for the Universal Installer may be found [here](/1.11/installing/evaluation/#overview-of-universal-installer).
 
 # Access DC/OS Configuration File
 

--- a/pages/1.11/installing/production/index.md
+++ b/pages/1.11/installing/production/index.md
@@ -10,6 +10,8 @@ DC/OS is installed in your environment by using a dynamically generated configur
 
 The DC/OS installation process requires a cluster of nodes to install DC/OS onto and a single node to run the DC/OS installation from. For fully functional clusters on any infrastructure including on-premise, public or private clouds, follow the Production installation instructions. The Production installation method was previously called Custom installation. 
 
+The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed discussion of the Universal Installer may be found [here](/1.11/installing/evaluation/#overview-of-universal-installer).
+
 # Access DC/OS Configuration File
 
 - For installing DC/OS Enterprise Edition contact your sales representative or <sales@mesosphere.io>. You can access the DC/OS Enterprise configuration file from the [support website](https://support.mesosphere.com/s/downloads) using a [login credential](https://support.mesosphere.com/s/login/). [enterprise type="inline" size="small" /]

--- a/pages/1.12/installing/production/index.md
+++ b/pages/1.12/installing/production/index.md
@@ -10,7 +10,7 @@ DC/OS is installed in your environment by using a dynamically generated configur
 
 The DC/OS installation process requires a cluster of nodes to install DC/OS onto and a single node to run the DC/OS installation from. For fully functional clusters on any infrastructure including on-premise, public or private clouds, follow the Production installation instructions. The Production installation method was previously called Custom installation. 
 
-The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed discussion of the Universal Installer may be found [here](/1.12/installing/evaluation/#overview-of-universal-installer).
+The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed overview and instructions for the Universal Installer may be found [here](/1.12/installing/evaluation/#overview-of-universal-installer).
 
 # Access DC/OS Configuration File
 

--- a/pages/1.12/installing/production/index.md
+++ b/pages/1.12/installing/production/index.md
@@ -10,6 +10,8 @@ DC/OS is installed in your environment by using a dynamically generated configur
 
 The DC/OS installation process requires a cluster of nodes to install DC/OS onto and a single node to run the DC/OS installation from. For fully functional clusters on any infrastructure including on-premise, public or private clouds, follow the Production installation instructions. The Production installation method was previously called Custom installation. 
 
+The Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on a subset of our supported platforms. A more detailed discussion of the Universal Installer may be found [here](/1.12/installing/evaluation/#overview-of-universal-installer).
+
 # Access DC/OS Configuration File
 
 - For installing DC/OS Enterprise Edition contact your sales representative or <sales@mesosphere.io>. You can access the DC/OS Enterprise configuration file from the [support website](https://support.mesosphere.com/s/downloads) using a [login credential](https://support.mesosphere.com/s/login/). [enterprise type="inline" size="small" /]


### PR DESCRIPTION
…ation/ for Universal Installer.

## Description
https://jira.mesosphere.com/browse/DCOS-44599
We need the Universal Installer and those instructions mentioned in the Production Installation, not just in the Evaluation.

Otherwise, it looks like the Universal Installer is purely an evaluation tool when we already have customers using it in production + the tool is meant to be in production.

Can be as simple as just a note at the top or an additional paragraph on the key Production Installation pages. Please reach out via Slack fror details.


## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

Added link from Production page to Evaluation page re: Overview of Universal Installer. Versions affected:

- [x] 1.10
- [x] 1.11
- [x] 1.12