### PR TITLE
ss/fix-pxc Correcting /include/ command in security page.

### DIFF
--- a/pages/services/pxc/0.1.0-5.7.21/security/index.md
+++ b/pages/services/pxc/0.1.0-5.7.21/security/index.md
@@ -26,7 +26,7 @@ The service uses the [DC/OS CA](/latest/security/ent/tls-ssl/) to generate the S
 
 ## Configure Transport Encryption
 
-#include /include/service-account.tmpl
+#include /services/include/service-account.tmpl
 
 ### Assign Permissions
 


### PR DESCRIPTION
## Description
Fix incorrect /services/include/ command in PXC security page.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

