### PR TITLE
ck/DCOS_OSS-4394 Add Spark limitation

### DIFF
--- a/pages/services/spark/2.1.0-2.2.0-1/limitations/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/limitations/index.md
@@ -16,3 +16,5 @@ enterprise: false
 *   Spark jobs run in Docker containers. The first time you run a Spark job on a node, it might take longer than you expect because of the `docker pull`.
 
 *   DC/OS Apache Spark only supports running the Spark shell from within a DC/OS cluster. See the Spark Shell section for more information. For interactive analytics, we recommend Zeppelin, which supports visualizations and dynamic dependency management.
+
+*   {{ model.techShortName }} does not support CNI at this time. If {{ model.techShortName }} Drivers and       Executors are deployed on CNI Networks, Shuffle Operations will fail.

--- a/pages/services/spark/2.1.0-2.2.1-1/limitations/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/limitations/index.md
@@ -16,3 +16,5 @@ featureMaturity:
 *   Spark jobs run in Docker containers. The first time you run a Spark job on a node, it might take longer than you expect because of the `docker pull`.
 
 *   DC/OS Apache Spark only supports running the Spark shell from within a DC/OS cluster. See the Spark Shell section for more information. For interactive analytics, we recommend Zeppelin, which supports visualizations and dynamic dependency management.
+
+*   {{ model.techShortName }} does not support CNI at this time. If {{ model.techShortName }} Drivers and       Executors are deployed on CNI Networks, Shuffle Operations will fail.

--- a/pages/services/spark/2.3.0-2.2.1-2/limitations/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/limitations/index.md
@@ -43,3 +43,5 @@ featureMaturity:
     resource owned by a user with a different UID, preventing the service from launching. If the hosts in your cluster
     have a UID for `nobody` other than 65534, you will need to maintain the default user (`root`) to run DC/OS Spark
     successfully.
+
+*   {{ model.techShortName }} does not support CNI at this time. If {{ model.techShortName }} Drivers and       Executors are deployed on CNI Networks, Shuffle Operations will fail.

--- a/pages/services/spark/2.3.1-2.2.1-2/limitations/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/limitations/index.md
@@ -39,6 +39,8 @@ featureMaturity:
     have a UID for `nobody` other than 65534, you will need to maintain the default user (`root`) to run DC/OS Spark
     successfully.
 
+*   {{ model.techShortName }} does not support CNI at this time. If {{ model.techShortName }} Drivers and       Executors are deployed on CNI Networks, Shuffle Operations will fail.
+
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
 # DC/OS Spark limits test results

--- a/pages/services/spark/2.4.0-2.2.1-3/limitations/index.md
+++ b/pages/services/spark/2.4.0-2.2.1-3/limitations/index.md
@@ -41,3 +41,5 @@ model: /services/spark/data.yml
     resource owned by a user with a different UID, preventing the service from launching. If the hosts in your cluster
     have a UID for `nobody` other than 65534, you will need to maintain the default user (`root`) to run DC/OS {{ model.techShortName }}
     successfully.
+
+*   {{ model.techShortName }} does not support CNI at this time. If {{ model.techShortName }} Drivers and       Executors are deployed on CNI Networks, Shuffle Operations will fail.

--- a/pages/services/spark/v2.0.0-2.2.0-1/limitations/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/limitations/index.md
@@ -16,3 +16,5 @@ enterprise: false
 *   Spark jobs run in Docker containers. The first time you run a Spark job on a node, it might take longer than you expect because of the `docker pull`.
 
 *   DC/OS Apache Spark only supports running the Spark shell from within a DC/OS cluster. See the Spark Shell section for more information. For interactive analytics, we recommend Zeppelin, which supports visualizations and dynamic dependency management.
+
+*   {{ model.techShortName }} does not support CNI at this time. If {{ model.techShortName }} Drivers and       Executors are deployed on CNI Networks, Shuffle Operations will fail.

--- a/pages/services/spark/v2.0.1-2.2.0-1/limitations/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/limitations/index.md
@@ -16,3 +16,5 @@ enterprise: false
 *   Spark jobs run in Docker containers. The first time you run a Spark job on a node, it might take longer than you expect because of the `docker pull`.
 
 *   DC/OS Apache Spark only supports running the Spark shell from within a DC/OS cluster. See the Spark Shell section for more information. For interactive analytics, we recommend Zeppelin, which supports visualizations and dynamic dependency management.
+
+*   {{ model.techShortName }} does not support CNI at this time. If {{ model.techShortName }} Drivers and       Executors are deployed on CNI Networks, Shuffle Operations will fail.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-4394

Added line indicating Spark does not currentlly work with CNI and shuffle operations will fail. 

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
