### PR TITLE
LG/DCOS-33779-a Added uninstall from ZK to 2.0.0, 2.0.1, 2.1.0, 2.1.0…

### DIFF
--- a/pages/services/spark/2.1.0-2.2.0-1/upgrade/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/upgrade/index.md
@@ -10,12 +10,20 @@ enterprise: false
 
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
+Because the Spark service dispatcher persists its state in ZooKeeper, upgrading the DC/OS Spark package requires you to complete the following steps:
+- Remove the DC/OS Spark package from ZooKeeper.
+- Uninstall your current DC/OS Spark service package.
+- Install the DC/OS Spark service upgrade. 
 
-1.  Go to the **Universe** > **Installed** page of the DC/OS GUI. Hover over your Spark Service to see the **Uninstall** button, then select it. Alternatively, enter the following from the DC/OS CLI:
+To upgrade DC/OS Spark, do the following:
+1. Navigate to `http://<dcos-url>/exhibitor`. 
+1. Click `Explorer`. 
+1. Delete the znode corresponding to your instance of the Spark service. By default, the znode instance is `spark_mesos_Dispatcher`.
+1. Delete the Spark service using the DC/OS web interface or by running the following command using the DC/OS CLI:
 
         dcos package uninstall spark
 
-1.  Verify that you no longer see your Spark service on the **Services** page.
-1.  Reinstall Spark.
+1. Verify that you no longer see the Spark service on the **Services** page.
+1. Install the new DC/OS Spark package by running the following command:
 
         dcos package install spark

--- a/pages/services/spark/2.1.0-2.2.1-1/upgrade/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/upgrade/index.md
@@ -9,13 +9,20 @@ featureMaturity:
 ---
 
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+Because the Spark service dispatcher persists its state in ZooKeeper, upgrading the DC/OS Spark package requires you to complete the following steps:
+- Remove the DC/OS Spark package from ZooKeeper.
+- Uninstall your current DC/OS Spark service package.
+- Install the DC/OS Spark service upgrade. 
 
-
-1.  Go to the **Universe** > **Installed** page of the DC/OS GUI. Hover over your Spark Service to see the **Uninstall** button, then select it. Alternatively, enter the following from the DC/OS CLI:
+To upgrade DC/OS Spark, do the following:
+1. Navigate to `http://<dcos-url>/exhibitor`. 
+1. Click `Explorer`. 
+1. Delete the znode corresponding to your instance of the Spark service. By default, the znode instance is `spark_mesos_Dispatcher`.
+1. Delete the Spark service using the DC/OS web interface or by running the following command using the DC/OS CLI:
 
         dcos package uninstall spark
 
-1.  Verify that you no longer see your Spark service on the **Services** page.
-1.  Reinstall Spark.
+1. Verify that you no longer see the Spark service on the **Services** page.
+1. Install the new DC/OS Spark package by running the following command:
 
         dcos package install spark

--- a/pages/services/spark/2.3.0-2.2.1-2/upgrade/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/upgrade/index.md
@@ -10,12 +10,20 @@ featureMaturity:
 
 <!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
 
+Because the Spark service dispatcher persists its state in ZooKeeper, upgrading the DC/OS Spark package requires you to complete the following steps:
+- Remove the DC/OS Spark package from ZooKeeper.
+- Uninstall your current DC/OS Spark service package.
+- Install the DC/OS Spark service upgrade. 
 
-1.  Go to the **Universe** > **Installed** page of the DC/OS GUI. Hover over your Spark Service to see the **Uninstall** button, then select it. Alternatively, enter the following from the DC/OS CLI:
+To upgrade DC/OS Spark, do the following:
+1. Navigate to `http://<dcos-url>/exhibitor`. 
+1. Click `Explorer`. 
+1. Delete the znode corresponding to your instance of the Spark service. By default, the znode instance is `spark_mesos_Dispatcher`.
+1. Select the Spark service from the list of Services in DC/OS web interface and click **Delete** or run the following command from the DC/OS CLI:
 
         dcos package uninstall spark
 
-1.  Verify that you no longer see your Spark service on the **Services** page.
-1.  Reinstall Spark.
+1. Verify that you no longer see the Spark service on the **Services** page.
+1. Install the new DC/OS Spark package by running the following command:
 
         dcos package install spark

--- a/pages/services/spark/v2.0.0-2.2.0-1/upgrade/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/upgrade/index.md
@@ -10,12 +10,20 @@ enterprise: false
 
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
+Because the Spark service dispatcher persists its state in ZooKeeper, upgrading the DC/OS Spark package requires you to complete the following steps:
+- Remove the DC/OS Spark package from ZooKeeper.
+- Uninstall your current DC/OS Spark service package.
+- Install the DC/OS Spark service upgrade. 
 
-1.  Go to the **Universe** > **Installed** page of the DC/OS GUI. Hover over your Spark Service to see the **Uninstall** button, then select it. Alternatively, enter the following from the DC/OS CLI:
+To upgrade DC/OS Spark, do the following:
+1. Navigate to `http://<dcos-url>/exhibitor`. 
+1. Click `Explorer`. 
+1. Delete the znode corresponding to your instance of the Spark service. By default, the znode instance is `spark_mesos_Dispatcher`.
+1. Delete the Spark service using the DC/OS web interface or by running the following command using the DC/OS CLI:
 
         dcos package uninstall spark
 
-1.  Verify that you no longer see your Spark service on the **Services** page.
-1.  Reinstall Spark.
+1. Verify that you no longer see the Spark service on the **Services** page.
+1. Install the new DC/OS Spark package by running the following command:
 
         dcos package install spark

--- a/pages/services/spark/v2.0.1-2.2.0-1/upgrade/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/upgrade/index.md
@@ -9,13 +9,20 @@ enterprise: false
 ---
 
 <!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
+Because the Spark service dispatcher persists its state in ZooKeeper, upgrading the DC/OS Spark package requires you to complete the following steps:
+- Remove the DC/OS Spark package from ZooKeeper.
+- Uninstall your current DC/OS Spark service package.
+- Install the DC/OS Spark service upgrade. 
 
-
-1.  Go to the **Universe** > **Installed** page of the DC/OS GUI. Hover over your Spark Service to see the **Uninstall** button, then select it. Alternatively, enter the following from the DC/OS CLI:
+To upgrade DC/OS Spark, do the following:
+1. Navigate to `http://<dcos-url>/exhibitor`. 
+1. Click `Explorer`. 
+1. Delete the znode corresponding to your instance of the Spark service. By default, the znode instance is `spark_mesos_Dispatcher`.
+1. Delete the Spark service using the DC/OS web interface or by running the following command using the DC/OS CLI:
 
         dcos package uninstall spark
 
-1.  Verify that you no longer see your Spark service on the **Services** page.
-1.  Reinstall Spark.
+1. Verify that you no longer see the Spark service on the **Services** page.
+1. Install the new DC/OS Spark package by running the following command:
 
         dcos package install spark


### PR DESCRIPTION
…, 2.3.0 service releases, changed the step for uninstalling Spark to focus on CLI command

## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS-33779

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
