### PR TITLE
Update index.md

### DIFF
--- a/pages/1.12/deploying-services/creating-services/index.md
+++ b/pages/1.12/deploying-services/creating-services/index.md
@@ -47,7 +47,7 @@ Example:
 ```json
 {
     "id": "basic-1",
-    "cmd": "`chmod u+x cool-script.sh && ./cool-script.sh`",
+    "cmd": "`chmod u+x /mnt/mesos/sandbox/cool-script.sh && /mnt/mesos/sandbox/cool-script.sh`",
     "cpus": 0.1,
     "mem": 10.0,
     "instances": 1,
@@ -55,7 +55,7 @@ Example:
 }
 ```
 
-The example above executes the contents of `cmd`, downloads the resource `https://example.com/app/cool-script.sh` (via Mesos), and makes it available in the service instance's Mesos sandbox. You can verify that it has been downloaded by visiting the DC/OS web interface and clicking on an instance of `basic-1`, then on the **Files** tab. You should find `cool-script.sh` there.
+The example above executes the contents of `cmd`, downloads the resource `https://example.com/app/cool-script.sh` (via Mesos), and makes it available in the service instance's Mesos sandbox. You can verify that it has been downloaded by visiting the DC/OS web interface and clicking on an instance of `basic-1`, then on the **Files** tab. You should find `cool-script.sh` there. Generally, the file will be downloaded into `/mnt/mesos/sandbox/`.
 
 <p class="message--note"><strong>NOTE: </strong>The fetcher does not make dowloaded files executable by default. In the example above, <code>cmd</code> first makes the file executable.</p>
 


### PR DESCRIPTION
Fetcher will actually download files into `/mnt/mesos/sandbox/`, instead of current working directory. The old document leaves the impression that users can find downloaded files in the working directory of their image, which is not true?

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
