### PR TITLE
dcos-monitoring: Update docs for 0.1.1

### DIFF
--- a/pages/services/dcos-monitoring/0.1.1/index.md
+++ b/pages/services/dcos-monitoring/0.1.1/index.md
@@ -1,0 +1,9 @@
+---
+layout: layout.pug
+navigationTitle: Beta DC/OS Monitoring Service 0.1.1
+title: Beta DC/OS Monitoring Service 0.1.1
+menuWeight: 0
+excerpt:
+---
+
+DC/OS Beta Monitoring Service is a service that allows you to monitor DC/OS.

--- a/pages/services/dcos-monitoring/0.1.1/install/index.md
+++ b/pages/services/dcos-monitoring/0.1.1/install/index.md
@@ -1,0 +1,96 @@
+---
+layout: layout.pug
+navigationTitle: Install
+title: Install
+menuWeight: 10
+excerpt: Instructions for installing the DC/OS Monitoring service.
+---
+
+# Prerequisites
+
+- DC/OS Enterprise 1.12 or above.
+- [DC/OS CLI](/latest/cli/install/) is installed and has been logged in as a superuser.
+
+## Install package registry
+
+Please follow these [instructions](https://docs.mesosphere.com/1.12/administering-clusters/repo/package-registry/quickstart/) to install the package registry.
+
+# Install DC/OS Monitoring service
+
+## Download the package
+
+The `.dcos` package of the DC/OS Monitoring Service can be downloaded from Mesosphere support site.
+
+## Install the service
+
+Assume that the downloaded package is called `dcos-monitoring.dcos` in the current working directory.
+
+```bash
+dcos registry add --dcos-file dcos-monitoring.dcos
+dcos package install dcos-monitoring --package-version=<VERSION>
+```
+
+## Verify service deployment
+
+To monitor the deployment of your service, install the package cli (see command above) and run the command:
+
+```bash
+dcos dcos-monitoring plan show deploy
+```
+
+# Integration with DC/OS access controls
+
+The DC/OS Monitoring service may be run on DC/OS clusters in either permissive or strict mode.
+DC/OS access controls has to be used to restrict access to the DC/OS Monitoring service when running on [strict mode](https://docs.mesosphere.com/latest/security/ent/#security-modes) clusters.
+This is done by configuring the DC/OS Monitoring service to authenticate itself using a certificate and only granting permissions needed by the service.
+
+## Create a service account
+
+The following CLI commands create a service account named `dcos-monitoring-principal` and store its private certificate in a secret named `dcos-monitoring/service-private-key`:
+
+```bash
+dcos security org service-accounts keypair dcos-monitoring-private-key.pem dcos-monitoring-public-key.pem
+dcos security org service-accounts create -p dcos-monitoring-public-key.pem -d "DC/OS Monitoring service account" dcos-monitoring-principal
+dcos security secrets create-sa-secret --strict dcos-monitoring-private-key.pem dcos-monitoring-principal dcos-monitoring/service-private-key
+```
+
+## Add service permissions
+
+Grant the `dcos-monitoring-principal` the permissions required to run the DC/OS Monitoring service:
+
+```bash
+dcos security org users grant dcos-monitoring-principal dcos:adminrouter:service:marathon full
+dcos security org users grant dcos-monitoring-principal dcos:adminrouter:package full
+dcos security org users grant dcos-monitoring-principal dcos:adminrouter:service:dcos-monitoring full
+dcos security org users grant dcos-monitoring-principal dcos:service:marathon:marathon:services:/ full
+dcos security org users grant dcos-monitoring-principal dcos:secrets:default:/dcos-monitoring/\* full
+dcos security org users grant dcos-monitoring-principal dcos:secrets:list:default:/dcos-monitoring read
+dcos security org users grant dcos-monitoring-principal dcos:adminrouter:ops:ca:rw full
+dcos security org users grant dcos-monitoring-principal dcos:adminrouter:ops:ca:ro full
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:framework:principal:dcos-monitoring-principal full
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:framework:role full
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:reservation delete
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:reservation:role full
+```
+
+## Install with custom options
+
+The DC/OS Monitoring service has to know which service account and certificate it should use for authentication.
+This is done by installing the service with a custom configuration that sets the `service_account` field to the principal name and the `service_account_secret` field to the secret where the service certificate is stored.
+
+Create a custom options file (`options.json`):
+
+```json
+{
+  "service": {
+    "service_account": "dcos-monitoring-principal",
+    "service_account_secret": "dcos-monitoring/service-private-key"
+  }
+}
+```
+
+Then, install the service with custom options:
+
+```bash
+dcos package install dcos-monitoring --options=options.json
+```

--- a/pages/services/dcos-monitoring/0.1.1/release-notes/index.md
+++ b/pages/services/dcos-monitoring/0.1.1/release-notes/index.md
@@ -1,0 +1,38 @@
+---
+layout: layout.pug
+navigationTitle: Release Notes
+title: Release Notes
+menuWeight: 90
+excerpt: Discover the new features, updates, and known limitations in this release of the Beta DC/OS Monitoring Service.
+---
+
+# Version v0.1.1
+
+Bug fix release.
+
+## Updates
+
+* Add missing release notes.
+* Fix documentation.
+
+# Version v0.1.0
+
+Initial release.
+
+## New features
+
+* Prometheus v2.2.1.
+* Grafana v5.0.1.
+* Alert Manager v0.15.2.
+* Push Gateway v0.5.2.
+* Automatically scrape dcos-metrics service endpoints in Prometheus.
+* Automatically load Grafana dashboard configurations from a git repository.
+* Automatically load Alert Manager configurations from a git repository.
+* Support strict mode DC/OS cluster.
+* Support launching Grafana server on public agents.
+
+## Limitations
+
+* No persistent storage for Grafana dashboard configurations.
+* No external storage for Prometheus data.
+* No backup for Prometheus data.

--- a/pages/services/dcos-monitoring/0.1.1/tutorial/alertmanager-configs/index.md
+++ b/pages/services/dcos-monitoring/0.1.1/tutorial/alertmanager-configs/index.md
@@ -1,0 +1,87 @@
+---
+layout: layout.pug
+navigationTitle: Alert Manager Configurations
+title: Alert Manager Configurations
+menuWeight: 10
+excerpt: Automatically loading Alert Manager configurations.
+---
+
+# Automatically loading Alert Manager configurations
+
+The DC/OS Monitoring service can be configured to automatically load Alert Manager configurations from a git repository.
+
+## Save Alert Manager configurations
+
+You should save your Alert Manager configuration file (YAML format), as well as all template files in a git repository.
+Assume that the repository is `https://github.com/company/alertmanager-configs`.
+
+You may put the configuration file and template files in a subfolder in the repository.
+For instance, `https://github.com/company/alertmanager-configs/production`.
+
+The git repository can be either public or private.
+If the git repository is private, you will need to configure the credentials to access the git repository (see below).
+
+## Create secrets for git repository credentials
+
+If the git repository containing the Alert Manager configurations is private, you will need to configure the secrets first:
+
+```bash
+dcos security secrets create --value=<GITHUB_USERNAME> githubusername
+dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
+```
+
+For github, the password can be the API token.
+
+## Secrets in Alert Manager configuration file
+
+Instead of putting plain text secrets in the configuration file, you can save the secrets in the secret store, and the service will automatically configure the global default value in the Alert Manager configuration file.
+
+Currently, the following secrets in the configuration file are supported:
+
+### Slack API URL
+
+The service will automatically add the following global default value for `slack_api_url` in the configuration file.
+
+```yaml
+global:
+- slack_api_url: '<SLACK_API_URL>'
+```
+
+Then, you need to save the secret in the secret store.
+
+```bash
+dcos security secrets create --value=<SLACK_API_URL> slackapiurl
+```
+
+When installing the service, you need to configure the `secrets` section to point to the secret created (see below).
+
+## Install DC/OS Monitoring service
+
+Now, create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the git repository is public.
+
+```json
+{
+  "alertmanager": {
+    "secrets": {
+      "slack_api_url": "slackapiurl"
+    },
+    "config_repository": {
+      "url": "https://github.com/company/alertmanager-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+Then, install the service:
+
+```bash
+dcos package install dcos-monitoring --options=options.json
+```
+
+The Alert Manager configurations defined in the repository will be automatically loaded when the service finishes deploying.

--- a/pages/services/dcos-monitoring/0.1.1/tutorial/grafana-dashboard-configs/index.md
+++ b/pages/services/dcos-monitoring/0.1.1/tutorial/grafana-dashboard-configs/index.md
@@ -1,0 +1,70 @@
+---
+layout: layout.pug
+navigationTitle: Grafana Dashboard Configurations
+title: Grafana Dashboard Configurations
+menuWeight: 10
+excerpt: Automatically loading Grafana dashboard configurations.
+---
+
+# Automatically loading Grafana dashboard configurations
+
+The DC/OS Monitoring service can be configured to automatically load Grafana dashboard configurations from a git repository.
+
+## Save Grafana dashboard configurations
+
+You should save your Grafana dashboard configurations (JSON format) in a git repository.
+Assume that the repository is `https://github.com/company/dashboard-configs`.
+
+You may put the Grafana dashboard configurations in a subfolder in the repository.
+For instance, `https://github.com/company/dashboard-configs/production`.
+
+The git repository can be either public or private.
+If the git repository is private, you will need to configure the credentials to access the git repository (see below).
+
+## Create secrets for git repository credentials
+
+If the git repository containing the Grafana dashboard configurations is private, you will need to configure the secrets first:
+
+```bash
+dcos security secrets create --value=<GITHUB_USERNAME> githubusername
+dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
+```
+
+For github, the password can be the API token.
+
+## Install DC/OS Monitoring service
+
+Now, create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the git repository is public.
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "https://github.com/company/dashboard-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+Then, install the service:
+
+```bash
+dcos package install dcos-monitoring --options=options.json
+```
+
+The Grafana dashboards defined in the repository will be automatically loaded when the service finishes deploying.
+You can go to the Grafana UI to verify.
+
+## Triggering a reload of Grafana dashboard configurations
+
+It is possible to trigger a reload of the Grafana dashboard configurations after the service is installed.
+
+```bash
+dcos dcos-monitoring plan start reload-grafana-dashboard-configs
+```

--- a/pages/services/dcos-monitoring/0.1.1/tutorial/index.md
+++ b/pages/services/dcos-monitoring/0.1.1/tutorial/index.md
@@ -1,0 +1,9 @@
+---
+layout: layout.pug
+navigationTitle: Tutorials
+title: Tutorials
+menuWeight: 30
+excerpt: Step by step walkthrough of using DC/OS Monitoring service.
+---
+
+This section provides step by step walkthrough of using DC/OS Monitoring service.

--- a/pages/services/dcos-monitoring/0.1.1/uninstall/index.md
+++ b/pages/services/dcos-monitoring/0.1.1/uninstall/index.md
@@ -1,0 +1,15 @@
+---
+layout: layout.pug
+navigationTitle: Uninstall
+title: Uninstall
+menuWeight: 20
+excerpt: Instructions for removing the DC/OS Monitoring Service from a DC/OS cluster.
+---
+
+# Uninstall the DC/OS Monitoring service
+
+You can simply uninstall the service using the following command:
+
+```bash
+dcos package uninstall dcos-monitoring
+```


### PR DESCRIPTION
## Description

DC/OS Monitoring service v0.1.1 release.

Comparing v0.1.0, this release adds the missing release note. Nothing else has been changed.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
