### PR TITLE
ck/COPS-4196 ReRestore backup/restore information for 1.10 and 1.11

### DIFF
--- a/pages/1.10/installing/installation-faq/index.md
+++ b/pages/1.10/installing/installation-faq/index.md
@@ -55,7 +55,7 @@ If Auto Scaling groups are in use, the node will be replaced automatically.
 ## Q. How do I backup the IAM database?
 [/enterprise]
 
-To backup the IAM database to a file run the following command on one of the master nodes:
+To backup the IAM database to a file, run the following command on one of the master nodes:
 
     ```bash
     sudo /opt/mesosphere/bin/cockroach dump --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) iam > ~/iam-backup.sql
@@ -65,7 +65,7 @@ To backup the IAM database to a file run the following command on one of the mas
 ## Q. How do I restore the IAM database?
 [/enterprise]
 
-To restore the IAM database from a file `~/iam-backup.sql` run the following commands on one of the master nodes:
+To restore the IAM database from a file `~/iam-backup.sql`, run the following commands on one of the master nodes:
 
 1. First, we create a new database called `iam_new` into which to load the backup.
 

--- a/pages/1.10/installing/installation-faq/index.md
+++ b/pages/1.10/installing/installation-faq/index.md
@@ -50,20 +50,48 @@ If Auto Scaling groups are in use, the node will be replaced automatically.
     ```bash
     sudo systemctl kill -s SIGUSR1 dcos-mesos-slave-public && sudo systemctl stop dcos-mesos-slave-public
     ```
+
+[enterprise]
 ## Q. How do I backup the IAM database?
+[/enterprise]
 
-- To backup the IAM database to a file run the following command on one of the master nodes:
+To backup the IAM database to a file run the following command on one of the master nodes:
 
-```bash
-dcos-shell iam-database-backup > ~/iam-backup.sql
-```
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach dump --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) iam > ~/iam-backup.sql
+    ```
 
+[enterprise]
 ## Q. How do I restore the IAM database?
+[/enterprise]
 
-- To restore the IAM database from a file `~/iam-backup.sql` run the following command on one of the master nodes:
+To restore the IAM database from a file `~/iam-backup.sql` run the following commands on one of the master nodes:
 
-```bash
-dcos-shell iam-database-restore ~/iam-backup.sql
-```
+1. First, we create a new database called `iam_new` into which to load the backup.
 
-The IAM database is restored from the backup file and the cluster is operational.
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) -e "CREATE DATABASE iam_new"
+    ```
+
+1. Next, we load the data into the new database.
+
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) --database=iam_new < ~/iam-backup.sql
+    ```
+
+1. With the backup data loaded into the `iam_new` database, we now need to rename the `iam` database to `iam_old`.
+
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) -e "ALTER DATABASE iam RENAME TO iam_old"
+    ```
+
+    <p class="message--note"><strong>NOTE: </strong>After this command is issued, the IAM is completely unavailable. Any requests to the IAM will fail.</p>
+
+1. Finally, we rename the `iam_new` database to `iam`.
+
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) -e "ALTER DATABASE iam_new RENAME TO iam"
+    ```
+    <p class="message--note"><strong>NOTE: </strong>After this command is issued, the IAM is available again. Requests to the IAM will once again succeed.</p>
+
+    The IAM database is restored from the backup file and the cluster is operational.

--- a/pages/1.11/installing/installation-faq/index.md
+++ b/pages/1.11/installing/installation-faq/index.md
@@ -50,20 +50,48 @@ If Auto Scaling groups are in use, the node will be replaced automatically.
     ```bash
     sudo systemctl kill -s SIGUSR1 dcos-mesos-slave-public && sudo systemctl stop dcos-mesos-slave-public
     ```
+
+[enterprise]
 ## Q. How do I backup the IAM database?
+[/enterprise]
 
-- To backup the IAM database to a file run the following command on one of the master nodes:
+To backup the IAM database to a file run the following command on one of the master nodes:
 
-```bash
-dcos-shell iam-database-backup > ~/iam-backup.sql
-```
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach dump --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) iam > ~/iam-backup.sql
+    ```
 
+[enterprise]
 ## Q. How do I restore the IAM database?
+[/enterprise]
 
-- To restore the IAM database from a file `~/iam-backup.sql` run the following command on one of the master nodes:
+To restore the IAM database from a file `~/iam-backup.sql` run the following commands on one of the master nodes:
 
-```bash
-dcos-shell iam-database-restore ~/iam-backup.sql
-```
+1. First, we create a new database called `iam_new` into which to load the backup.
 
-The IAM database is restored from the backup file and the cluster is operational.
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) -e "CREATE DATABASE iam_new"
+    ```
+
+1. Next, we load the data into the new database.
+
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) --database=iam_new < ~/iam-backup.sql
+    ```
+
+1. With the backup data loaded into the `iam_new` database, we now need to rename the `iam` database to `iam_old`.
+
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) -e "ALTER DATABASE iam RENAME TO iam_old"
+    ```
+
+    <p class="message--note"><strong>NOTE: </strong>After this command is issued, the IAM is completely unavailable. Any requests to the IAM will fail.</p>
+
+1. Finally, we rename the `iam_new` database to `iam`.
+
+    ```bash
+    sudo /opt/mesosphere/bin/cockroach sql --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) -e "ALTER DATABASE iam_new RENAME TO iam"
+    ```
+    <p class="message--note"><strong>NOTE: </strong>After this command is issued, the IAM is available again. Requests to the IAM will once again succeed.</p>
+
+    The IAM database is restored from the backup file and the cluster is operational.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-4196
Restored the older information for 1.10 and 1.11 regarding backup and restoring the IAM database

## Urgency
- [ X] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
