### PR TITLE
ck/DCOS-4184 Add latest as a redirect for spark

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -1,1 +1,2 @@
 ~^/latest/(.*)$ /1.12/$1;
+~^/services/spark/latest/(.*) /services/spark/2.4.0-2.2.1-3/$1;


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-4184?filter=-1

By adding a redirect for spark/latest, we are covering a gap created by CLI instructions that point to services/spark/latest/uninstall, as there isn't actually a 'latest' redirect for any of the services docs.
The benefits of this are that it can handle latest for any subpage as long as that page exists in that version.
The drawbacks are making sure it stays up to date as the versions iterate through, and maintaining further redirects should there be a restructure of the services pages. However, they seem to be more static than the regular docs pages, and maintaining redirects would be a necessary check after that. 


- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
