### PR TITLE
ss/DCOS-45427 Correcting metadata in admin-cluster docs.

### DIFF
--- a/pages/cn/1.11/administering-clusters/index.md
+++ b/pages/cn/1.11/administering-clusters/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: 管理集群
 title: 管理集群
 menuWeight: 60
-enterprise: true
 excerpt: 管理您的 DC/OS 集群
 enterprise: false
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-45427
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

Metadata error in Administering Clusters Chinese edition caused the title to disappear from the landing page. Error fixed.