### PR TITLE
dcos-monitoring: Update docs for 0.2.1

### DIFF
--- a/pages/services/dcos-monitoring/0.2.1/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/index.md
@@ -1,0 +1,9 @@
+---
+layout: layout.pug
+navigationTitle: Beta DC/OS Monitoring Service 0.2.1
+title: Beta DC/OS Monitoring Service 0.2.1
+menuWeight: 0
+excerpt:
+---
+
+DC/OS Beta Monitoring Service is a service that allows you to monitor DC/OS.

--- a/pages/services/dcos-monitoring/0.2.1/install/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/install/index.md
@@ -9,7 +9,8 @@ excerpt: Instructions for installing the DC/OS Monitoring service.
 # Prerequisites
 
 - DC/OS Enterprise 1.12 or above.
-- [DC/OS CLI](/latest/cli/install/) is installed and has been logged in as a superuser.
+- [DC/OS CLI](/latest/cli/install/) is installed.
+- You are logged in as a superuser.
 
 ## Install package registry
 
@@ -19,11 +20,14 @@ Please follow these [instructions](https://docs.mesosphere.com/1.12/administerin
 
 ## Download the package
 
-The `.dcos` package of the DC/OS Monitoring Service can be downloaded from Mesosphere support site.
+<!-- Does this require that the user have a service account? Also, please add a link to the support site. -->
+Download the `.dcos` package of the DC/OS Monitoring Service from Mesosphere support site.
+
 
 ## Install the service
 
-Assume that the downloaded package is called `dcos-monitoring.dcos` in the current working directory.
+<!-- At what point is the "dcos registry add" command added? -->
+Install the service with the `dcos registry add` command. Assume that the downloaded package is called `dcos-monitoring.dcos` in the current working directory.
 
 ```bash
 dcos registry add --dcos-file dcos-monitoring.dcos
@@ -41,8 +45,8 @@ dcos dcos-monitoring plan show deploy
 # Integration with DC/OS access controls
 
 The DC/OS Monitoring service may be run on DC/OS clusters in either permissive or strict mode.
-DC/OS access controls has to be used to restrict access to the DC/OS Monitoring service when running on [strict mode](https://docs.mesosphere.com/latest/security/ent/#security-modes) clusters.
-This is done by configuring the DC/OS Monitoring service to authenticate itself using a certificate and only granting permissions needed by the service.
+DC/OS access controls must be used to restrict access to the DC/OS Monitoring service when running on [strict mode](https://docs.mesosphere.com/latest/security/ent/#security-modes) clusters.
+Configure the DC/OS Monitoring service to authenticate itself using a certificate and to  only grant permissions needed by the service.
 
 ## Create a service account
 
@@ -79,8 +83,7 @@ dcos security org users grant dcos-monitoring-principal dcos:secrets:list:defaul
 
 ## Install with custom options
 
-The DC/OS Monitoring service has to know which service account and certificate it should use for authentication.
-This is done by installing the service with a custom configuration that sets the `service_account` field to the principal name and the `service_account_secret` field to the secret where the service certificate is stored.
+You must identify for the DC/OS Monitoring service which service account and certificate it should use for authentication. Do so by installing the service with a custom configuration that sets the `service_account` field to the principal name and sets the `service_account_secret` field to the secret where the service certificate is stored.
 
 Create a custom options file (`options.json`):
 

--- a/pages/services/dcos-monitoring/0.2.1/install/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/install/index.md
@@ -20,13 +20,11 @@ Please follow these [instructions](https://docs.mesosphere.com/1.12/administerin
 
 ## Download the package
 
-<!-- Does this require that the user have a service account? Also, please add a link to the support site. -->
-Download the `.dcos` package of the DC/OS Monitoring Service from Mesosphere support site.
+Download the `.dcos` package of the DC/OS Monitoring Service from the [Mesosphere support site](https://support.mesosphere.com/s/downloads).
 
 
 ## Install the service
 
-<!-- At what point is the "dcos registry add" command added? -->
 Install the service with the `dcos registry add` command. Assume that the downloaded package is called `dcos-monitoring.dcos` in the current working directory.
 
 ```bash
@@ -46,7 +44,7 @@ dcos dcos-monitoring plan show deploy
 
 The DC/OS Monitoring service may be run on DC/OS clusters in either permissive or strict mode.
 DC/OS access controls must be used to restrict access to the DC/OS Monitoring service when running on [strict mode](https://docs.mesosphere.com/latest/security/ent/#security-modes) clusters.
-Configure the DC/OS Monitoring service to authenticate itself using a certificate and to  only grant permissions needed by the service.
+Configure the DC/OS Monitoring service to authenticate itself using a certificate and to only grant permissions needed by the service.
 
 ## Create a service account
 
@@ -60,7 +58,7 @@ dcos security secrets create-sa-secret --strict dcos-monitoring-private-key.pem 
 
 ## Add service permissions
 
-Grant the `dcos-monitoring-principal` the permissions required to run the DC/OS Monitoring service:
+Grant `dcos-monitoring-principal` the permissions required to run the DC/OS Monitoring service:
 
 ```bash
 dcos security org users grant dcos-monitoring-principal dcos:adminrouter:ops:ca:rw full

--- a/pages/services/dcos-monitoring/0.2.1/install/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/install/index.md
@@ -1,0 +1,100 @@
+---
+layout: layout.pug
+navigationTitle: Install
+title: Install
+menuWeight: 10
+excerpt: Instructions for installing the DC/OS Monitoring service.
+---
+
+# Prerequisites
+
+- DC/OS Enterprise 1.12 or above.
+- [DC/OS CLI](/latest/cli/install/) is installed and has been logged in as a superuser.
+
+## Install package registry
+
+Please follow these [instructions](https://docs.mesosphere.com/1.12/administering-clusters/repo/package-registry/quickstart/) to install the package registry.
+
+# Install DC/OS Monitoring service
+
+## Download the package
+
+The `.dcos` package of the DC/OS Monitoring Service can be downloaded from Mesosphere support site.
+
+## Install the service
+
+Assume that the downloaded package is called `dcos-monitoring.dcos` in the current working directory.
+
+```bash
+dcos registry add --dcos-file dcos-monitoring.dcos
+dcos package install dcos-monitoring --package-version=<VERSION>
+```
+
+## Verify service deployment
+
+To monitor the deployment of your service, install the package cli (see command above) and run the command:
+
+```bash
+dcos dcos-monitoring plan show deploy
+```
+
+# Integration with DC/OS access controls
+
+The DC/OS Monitoring service may be run on DC/OS clusters in either permissive or strict mode.
+DC/OS access controls has to be used to restrict access to the DC/OS Monitoring service when running on [strict mode](https://docs.mesosphere.com/latest/security/ent/#security-modes) clusters.
+This is done by configuring the DC/OS Monitoring service to authenticate itself using a certificate and only granting permissions needed by the service.
+
+## Create a service account
+
+The following CLI commands create a service account named `dcos-monitoring-principal` and store its private certificate in a secret named `dcos-monitoring/service-private-key`:
+
+```bash
+dcos security org service-accounts keypair dcos-monitoring-private-key.pem dcos-monitoring-public-key.pem
+dcos security org service-accounts create -p dcos-monitoring-public-key.pem -d "DC/OS Monitoring service account" dcos-monitoring-principal
+dcos security secrets create-sa-secret --strict dcos-monitoring-private-key.pem dcos-monitoring-principal dcos-monitoring/service-private-key
+```
+
+## Add service permissions
+
+Grant the `dcos-monitoring-principal` the permissions required to run the DC/OS Monitoring service:
+
+```bash
+dcos security org users grant dcos-monitoring-principal dcos:adminrouter:ops:ca:rw full
+dcos security org users grant dcos-monitoring-principal dcos:adminrouter:ops:ca:ro full
+dcos security org users grant dcos-monitoring-principal dcos:mesos:agent:framework:role:slave_public read
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:framework:role:dcos-monitoring-role create
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:framework:role:slave_public read
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:framework:role:slave_public/dcos-monitoring-role read
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:framework:role:slave_public/dcos-monitoring-role create
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:reservation:principal:dcos-monitoring-principal delete
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:reservation:role:dcos-monitoring-role create
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:reservation:role:slave_public/dcos-monitoring-role create
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:task:user:nobody create
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:volume:principal:dcos-monitoring-principal delete
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:volume:role:dcos-monitoring-role create
+dcos security org users grant dcos-monitoring-principal dcos:mesos:master:volume:role:slave_public/dcos-monitoring-role create
+dcos security org users grant dcos-monitoring-principal dcos:secrets:default:/dcos-monitoring/\* full
+dcos security org users grant dcos-monitoring-principal dcos:secrets:list:default:/dcos-monitoring read
+```
+
+## Install with custom options
+
+The DC/OS Monitoring service has to know which service account and certificate it should use for authentication.
+This is done by installing the service with a custom configuration that sets the `service_account` field to the principal name and the `service_account_secret` field to the secret where the service certificate is stored.
+
+Create a custom options file (`options.json`):
+
+```json
+{
+  "service": {
+    "service_account": "dcos-monitoring-principal",
+    "service_account_secret": "dcos-monitoring/service-private-key"
+  }
+}
+```
+
+Then, install the service with custom options:
+
+```bash
+dcos package install dcos-monitoring --options=options.json
+```

--- a/pages/services/dcos-monitoring/0.2.1/release-notes/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/release-notes/index.md
@@ -1,0 +1,60 @@
+---
+layout: layout.pug
+navigationTitle: Release Notes
+title: Release Notes
+menuWeight: 90
+excerpt: Discover the new features, updates, and known limitations in this release of the Beta DC/OS Monitoring Service.
+---
+
+# Version v0.2.1
+
+## Updates
+
+* Fix documentation.
+
+# Version v0.2.0
+
+## New features
+
+* Grafana v5.3.4.
+* Support SSH auth when fetching from git repository.
+* Add default Grafana dashboards which can be automatically loaded.
+* Support Grafana server placement constraints.
+* Support fetching from a branch in a git repository.
+
+## Updates
+
+* Use local persistent volume for Grafana server.
+* Used Docker image for Grafana server.
+* Recursively clone git sub-modules from a git repository.
+
+# Version v0.1.1
+
+Bug fix release.
+
+## Updates
+
+* Add missing release notes.
+* Fix documentation.
+
+# Version v0.1.0
+
+Initial release.
+
+## New features
+
+* Prometheus v2.2.1.
+* Grafana v5.0.1.
+* Alert Manager v0.15.2.
+* Push Gateway v0.5.2.
+* Automatically scrape dcos-metrics service endpoints in Prometheus.
+* Automatically load Grafana dashboard configurations from a git repository.
+* Automatically load Alert Manager configurations from a git repository.
+* Support strict mode DC/OS cluster.
+* Support launching Grafana server on public agents.
+
+## Limitations
+
+* No persistent storage for Grafana dashboard configurations.
+* No external storage for Prometheus data.
+* No backup for Prometheus data.

--- a/pages/services/dcos-monitoring/0.2.1/release-notes/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/release-notes/index.md
@@ -10,7 +10,7 @@ excerpt: Discover the new features, updates, and known limitations in this relea
 
 ## Updates
 
-* Fix documentation.
+* Correct permissions required to run the package.
 
 # Version v0.2.0
 
@@ -35,7 +35,6 @@ Bug fix release.
 ## Updates
 
 * Add missing release notes.
-* Fix documentation.
 
 # Version v0.1.0
 

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/alertmanager-configs/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/alertmanager-configs/index.md
@@ -1,0 +1,134 @@
+---
+layout: layout.pug
+navigationTitle: Alert Manager Configurations
+title: Alert Manager Configurations
+menuWeight: 10
+excerpt: Automatically loading Alert Manager configurations.
+---
+
+# Automatically loading Alert Manager configurations
+
+The DC/OS Monitoring service can be configured to automatically load Alert Manager configurations from a git repository.
+
+## Save Alert Manager configurations
+
+You should save your Alert Manager configuration file (YAML format), as well as all template files in a git repository.
+Assume that the repository is `https://github.com/company/alertmanager-configs`.
+
+You may put the configuration file and template files in a subfolder in the repository.
+For instance, `https://github.com/company/alertmanager-configs/production`.
+
+The git repository can be either public or private.
+If the git repository is private, you will need to configure the credentials to access the git repository (see below).
+
+## Create secrets for git repository credentials
+
+If the git repository containing the Alert Manager configurations is private, you will need to configure the secrets first.
+Currently, the following Auth types are supported.
+
+### HTTP Auth
+
+```bash
+dcos security secrets create --value=<GITHUB_USERNAME> githubusername
+dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
+```
+
+For github, the password can be the API token.
+
+Then, create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the git repository is public.
+
+```json
+{
+  "alertmanager": {
+    "config_repository": {
+      "url": "https://github.com/company/alertmanager-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+### SSH Auth
+
+```bash
+dcos security secrets create -f <PATH_TO_PRIVATE_KEY> gitsshkey
+```
+
+For github, please make sure to add [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (i.e., the public key) to the repository.
+
+Then, create a custom option file (`options.json`) like the following.
+
+```json
+{
+  "alertmanager": {
+    "config_repository": {
+      "url": "git@github.com:company/alertmanager-configs",
+      "path": "/production",
+      "credentials": {
+        "deploy_key": "gitsshkey"
+      }
+    }
+  }
+}
+```
+
+Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
+
+## Secrets in Alert Manager configuration file
+
+Instead of putting plain text secrets in the configuration file, you can save the secrets in the secret store, and the service will automatically configure the global default value in the Alert Manager configuration file.
+
+Currently, the following secrets in the configuration file are supported:
+
+### Slack API URL
+
+The service will automatically add the following global default value for `slack_api_url` in the configuration file.
+
+```yaml
+global:
+- slack_api_url: '<SLACK_API_URL>'
+```
+
+Then, you need to save the secret in the secret store.
+
+```bash
+dcos security secrets create --value=<SLACK_API_URL> slackapiurl
+```
+
+When installing the service, you need to configure the `secrets` section to point to the secret created (see below).
+
+## Install DC/OS Monitoring service
+
+Now, create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the git repository is public.
+
+```json
+{
+  "alertmanager": {
+    "secrets": {
+      "slack_api_url": "slackapiurl"
+    },
+    "config_repository": {
+      "url": "https://github.com/company/alertmanager-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+Then, install the service:
+
+```bash
+dcos package install dcos-monitoring --options=options.json
+```
+
+The Alert Manager configurations defined in the repository will be automatically loaded when the service finishes deploying.

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/alertmanager-configs/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/alertmanager-configs/index.md
@@ -8,22 +8,22 @@ excerpt: Automatically loading Alert Manager configurations.
 
 # Automatically loading Alert Manager configurations
 
-The DC/OS Monitoring service can be configured to automatically load Alert Manager configurations from a git repository.
+The DC/OS Monitoring service can be configured to automatically load Alert Manager configurations from a Git repository.
 
 ## Save Alert Manager configurations
 
-You should save your Alert Manager configuration file (YAML format), as well as all template files in a git repository.
+You should save your Alert Manager configuration file (YAML format), as well as all template files in a Git repository.
 Assume that the repository is `https://github.com/company/alertmanager-configs`.
 
 You may put the configuration file and template files in a subfolder in the repository.
 For instance, `https://github.com/company/alertmanager-configs/production`.
 
-The git repository can be either public or private.
-If the git repository is private, you will need to configure the credentials to access the git repository (see below).
+The Git repository can be either public or private.
+If the Git repository is private, you will need to configure the credentials to access the Git repository.
 
-## Create secrets for git repository credentials
+## Create secrets for Git repository credentials
 
-If the git repository containing the Alert Manager configurations is private, you will need to configure the secrets first.
+If the Git repository containing the Alert Manager configurations is private, you will need to configure the secrets first.
 Currently, the following Auth types are supported.
 
 ### HTTP Auth
@@ -33,10 +33,10 @@ dcos security secrets create --value=<GITHUB_USERNAME> githubusername
 dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
 ```
 
-For github, the password can be the API token.
+For Github, the password can be the API token.
 
-Then, create a custom option file (`options.json`) like the following.
-You may omit the `credentials` section if the git repository is public.
+Create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the Git repository is public.
 
 ```json
 {
@@ -59,15 +59,15 @@ You may omit the `credentials` section if the git repository is public.
 dcos security secrets create -f <PATH_TO_PRIVATE_KEY> gitsshkey
 ```
 
-For github, please make sure to add [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (i.e., the public key) to the repository.
+For Github, please make sure to add the [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (that is, the public key) to the repository.
 
-Then, create a custom option file (`options.json`) like the following.
+Create a custom option file (`options.json`) like the following.
 
 ```json
 {
   "alertmanager": {
     "config_repository": {
-      "url": "git@github.com:company/alertmanager-configs",
+      "url": "Git@github.com:company/alertmanager-configs",
       "path": "/production",
       "credentials": {
         "deploy_key": "gitsshkey"
@@ -77,13 +77,13 @@ Then, create a custom option file (`options.json`) like the following.
 }
 ```
 
-Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
+Note that you'll have to use `Git@github.com:<USER>/<REPO>.Git` instead of `https` as the scheme of the URL.
 
 ## Secrets in Alert Manager configuration file
 
 Instead of putting plain text secrets in the configuration file, you can save the secrets in the secret store, and the service will automatically configure the global default value in the Alert Manager configuration file.
 
-Currently, the following secrets in the configuration file are supported:
+The following secrets in the configuration file are supported:
 
 ### Slack API URL
 
@@ -100,12 +100,12 @@ Then, you need to save the secret in the secret store.
 dcos security secrets create --value=<SLACK_API_URL> slackapiurl
 ```
 
-When installing the service, you need to configure the `secrets` section to point to the secret created (see below).
+When installing the service, you must configure the `secrets` section to point to the secret created.
 
 ## Install DC/OS Monitoring service
 
-Now, create a custom option file (`options.json`) like the following.
-You may omit the `credentials` section if the git repository is public.
+Create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the Git repository is public.
 
 ```json
 {

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/alertmanager-configs/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/alertmanager-configs/index.md
@@ -67,7 +67,7 @@ Create a custom option file (`options.json`) like the following.
 {
   "alertmanager": {
     "config_repository": {
-      "url": "Git@github.com:company/alertmanager-configs",
+      "url": "git@github.com:company/alertmanager-configs",
       "path": "/production",
       "credentials": {
         "deploy_key": "gitsshkey"
@@ -77,7 +77,7 @@ Create a custom option file (`options.json`) like the following.
 }
 ```
 
-Note that you'll have to use `Git@github.com:<USER>/<REPO>.Git` instead of `https` as the scheme of the URL.
+Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
 
 ## Secrets in Alert Manager configuration file
 

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/default-grafana-dashboards/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/default-grafana-dashboards/index.md
@@ -1,0 +1,22 @@
+---
+layout: layout.pug
+navigationTitle: Default Grafana Dashboards for DC/OS
+title: Default Grafana Dashboards for DC/OS
+menuWeight: 30
+excerpt: Default Grafana dashboards for DC/OS.
+---
+
+# Load default Grafana dashboards for DC/OS
+
+DC/OS Monitoring service ships with a set of default Grafana dashboards for DC/OS.
+Those dashboards will be automatically loaded if `grafana.default_dashboards` is set to `true`.
+
+Users can choose to disable this feature by setting `grafana.default_dashboards` to `false.
+
+```json
+{
+  "grafana": {
+    "default_dashboards": true
+  }
+}
+```

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-dashboard-configs/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-dashboard-configs/index.md
@@ -1,0 +1,118 @@
+---
+layout: layout.pug
+navigationTitle: Grafana Dashboard Configurations
+title: Grafana Dashboard Configurations
+menuWeight: 10
+excerpt: Automatically loading Grafana dashboard configurations.
+---
+
+# Automatically loading Grafana dashboard configurations
+
+The DC/OS Monitoring service can be configured to automatically load Grafana dashboard configurations from a git repository.
+
+## Save Grafana dashboard configurations
+
+You should save your Grafana dashboard configurations (JSON format) in a git repository.
+Assume that the repository is `https://github.com/company/dashboard-configs`.
+
+You may put the Grafana dashboard configurations in a subfolder in the repository.
+For instance, `https://github.com/company/dashboard-configs/production`.
+
+The git repository can be either public or private.
+If the git repository is private, you will need to configure the credentials to access the git repository (see below).
+
+## Create secrets for git repository credentials
+
+If the git repository containing the Grafana dashboard configurations is private, you will need to configure the secrets first.
+Currently, the following Auth types are supported.
+
+### HTTP Auth
+
+```bash
+dcos security secrets create --value=<GITHUB_USERNAME> githubusername
+dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
+```
+
+For github, the password can be the API token.
+
+Then, create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the git repository is public.
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "https://github.com/company/dashboard-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+### SSH Auth
+
+```bash
+dcos security secrets create -f <PATH_TO_PRIVATE_KEY> gitsshkey
+```
+
+For github, please make sure to add [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (i.e., the public key) to the repository.
+
+Then, create a custom option file (`options.json`) like the following.
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "git@github.com:company/dashboard-configs.git",
+      "path": "/production",
+      "credentials": {
+        "deploy_key": "gitsshkey"
+      }
+    }
+  }
+}
+```
+
+Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
+
+## Fetching from a branch in a git repository
+
+By default, the service will fetch from the master branch (i.e., `refs/heads/master`) of the git repository.
+
+If you want to fetch the Grafana dashboard configurations from another branch in a git repository, you can set the `reference_name` field:
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "https://github.com/company/dashboard-configs",
+      "path": "/production",
+      "reference_name": "refs/heads/my_branch"
+    }
+  }
+}
+
+```
+
+## Install DC/OS Monitoring service
+
+Then, install the service:
+
+```bash
+dcos package install dcos-monitoring --options=options.json
+```
+
+The Grafana dashboards defined in the repository will be automatically loaded when the service finishes deploying.
+You can go to the Grafana UI to verify.
+
+## Triggering a reload of Grafana dashboard configurations
+
+It is possible to trigger a reload of the Grafana dashboard configurations after the service is installed.
+
+```bash
+dcos dcos-monitoring plan start reload-grafana-dashboard-configs
+```

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-dashboard-configs/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-dashboard-configs/index.md
@@ -8,22 +8,22 @@ excerpt: Automatically loading Grafana dashboard configurations.
 
 # Automatically loading Grafana dashboard configurations
 
-The DC/OS Monitoring service can be configured to automatically load Grafana dashboard configurations from a git repository.
+The DC/OS Monitoring service can be configured to automatically load Grafana dashboard configurations from a Git repository.
 
 ## Save Grafana dashboard configurations
 
-You should save your Grafana dashboard configurations (JSON format) in a git repository.
+You should save your Grafana dashboard configurations (JSON format) in a Git repository.
 Assume that the repository is `https://github.com/company/dashboard-configs`.
 
 You may put the Grafana dashboard configurations in a subfolder in the repository.
 For instance, `https://github.com/company/dashboard-configs/production`.
 
-The git repository can be either public or private.
-If the git repository is private, you will need to configure the credentials to access the git repository (see below).
+The Git repository can be either public or private.
+If the Git repository is private, you will need to configure the credentials to access the Git repository (see below).
 
-## Create secrets for git repository credentials
+## Create secrets for Git repository credentials
 
-If the git repository containing the Grafana dashboard configurations is private, you will need to configure the secrets first.
+If the Git repository containing the Grafana dashboard configurations is private, you will need to configure the secrets first.
 Currently, the following Auth types are supported.
 
 ### HTTP Auth
@@ -33,10 +33,10 @@ dcos security secrets create --value=<GITHUB_USERNAME> githubusername
 dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
 ```
 
-For github, the password can be the API token.
+For Github, the password can be the API token.
 
-Then, create a custom option file (`options.json`) like the following.
-You may omit the `credentials` section if the git repository is public.
+Create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the Git repository is public.
 
 ```json
 {
@@ -59,15 +59,15 @@ You may omit the `credentials` section if the git repository is public.
 dcos security secrets create -f <PATH_TO_PRIVATE_KEY> gitsshkey
 ```
 
-For github, please make sure to add [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (i.e., the public key) to the repository.
+For Github, please make sure to add [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (i.e., the public key) to the repository.
 
-Then, create a custom option file (`options.json`) like the following.
+Create a custom option file (`options.json`) like the following.
 
 ```json
 {
   "grafana": {
     "dashboard_config_repository": {
-      "url": "git@github.com:company/dashboard-configs.git",
+      "url": "Git@github.com:company/dashboard-configs.Git",
       "path": "/production",
       "credentials": {
         "deploy_key": "gitsshkey"
@@ -77,13 +77,13 @@ Then, create a custom option file (`options.json`) like the following.
 }
 ```
 
-Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
+Note that you'll have to use `Git@github.com:<USER>/<REPO>.Git` instead of `https` as the scheme of the URL.
 
-## Fetching from a branch in a git repository
+## Fetching from a branch in a Git repository
 
-By default, the service will fetch from the master branch (i.e., `refs/heads/master`) of the git repository.
+By default, the service will fetch from the master branch (that is, `refs/heads/master`) of the Git repository.
 
-If you want to fetch the Grafana dashboard configurations from another branch in a git repository, you can set the `reference_name` field:
+If you want to fetch the Grafana dashboard configurations from another branch in a Git repository, you can set the `reference_name` field:
 
 ```json
 {

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-dashboard-configs/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-dashboard-configs/index.md
@@ -67,7 +67,7 @@ Create a custom option file (`options.json`) like the following.
 {
   "grafana": {
     "dashboard_config_repository": {
-      "url": "Git@github.com:company/dashboard-configs.Git",
+      "url": "git@github.com:company/dashboard-configs.git",
       "path": "/production",
       "credentials": {
         "deploy_key": "gitsshkey"
@@ -77,7 +77,7 @@ Create a custom option file (`options.json`) like the following.
 }
 ```
 
-Note that you'll have to use `Git@github.com:<USER>/<REPO>.Git` instead of `https` as the scheme of the URL.
+Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
 
 ## Fetching from a branch in a Git repository
 

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-ui/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/grafana-ui/index.md
@@ -1,0 +1,25 @@
+---
+layout: layout.pug
+navigationTitle: Grafana UI
+title: Grafana UI
+menuWeight: 50
+excerpt: Access Grafana UI.
+---
+
+# Access Grafana UI
+
+Grafana will be installed on a public agent if `public` is set to `true` (default: `false`) in the package config.
+The port that Grafana uses can be configured by setting `ui_port` (default: `3000`).
+Go find that agent's public IP address.
+Grafana will be present at `<public_ip>:<ui_port>`.
+
+By default the username and password is `admin:admin`.
+
+```json
+{
+  "grafana": {
+    "public": true,
+    "ui_port": 3000
+  }
+}
+```

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/index.md
@@ -1,0 +1,9 @@
+---
+layout: layout.pug
+navigationTitle: Tutorials
+title: Tutorials
+menuWeight: 30
+excerpt: Step by step walkthrough of using DC/OS Monitoring service.
+---
+
+This section provides step by step walkthrough of using DC/OS Monitoring service.

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Tutorials
 title: Tutorials
 menuWeight: 30
-excerpt: Step by step walkthrough of using DC/OS Monitoring service.
+excerpt: Step by step introduction to using the DC/OS Monitoring service.
 ---
 
-This section provides step by step walkthrough of using DC/OS Monitoring service.
+This section provides step by step introduction to using the DC/OS Monitoring service.

--- a/pages/services/dcos-monitoring/0.2.1/tutorial/placement-constraint/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/tutorial/placement-constraint/index.md
@@ -1,0 +1,45 @@
+---
+layout: layout.pug
+navigationTitle: Placement Constraints
+title: Placement Constraints
+menuWeight: 40
+excerpt: Placement Constraints
+---
+
+# Placement constraints
+
+Placement constraints allow you to customize where a service is deployed in the DC/OS cluster.
+Placement constraints use the [Marathon operators](http://mesosphere.github.io/marathon/docs/constraints.html) syntax.
+For example, `[["hostname", "UNIQUE"]]` ensures that at most one pod instance is deployed per agent.
+
+A common task is to specify a list of whitelisted systems to deploy to.
+To achieve this, use the following syntax for the placement constraint:
+
+```json
+[["hostname", "LIKE", "10.0.0.159|10.0.1.202|10.0.3.3"]]
+```
+
+*IMPORTANT*: Be sure to include excess capacity in such a scenario so that if one of the whitelisted systems goes down, there is still enough capacity to repair your service.
+
+## Updating placement constraints
+
+Clusters change, and as such so will your placement constraints.
+However, already running service pods will **not** be affected by changes in placement constraints.
+This is because altering a placement constraint might invalidate the current placement of a running pod, and the pod will not be relocated automatically as doing so is a destructive action.
+We recommend using the following procedure to update the placement constraints of a pod:
+
+- Update the placement constraint definition in the service.
+- For each affected pod, one at a time, perform a `pod replace`.
+  This will (destructively) move the pod to be in accordance with the new placement constraints.
+
+# Grafana server placement constraints
+
+To control where to place Grafana server, please specify the placement constraints like the following:
+
+```json
+{
+  "grafana": {
+    "placement_constraints": "[[\"hostname\", \"IS\", \"10.0.0.73\"]]"
+  }
+}
+```

--- a/pages/services/dcos-monitoring/0.2.1/uninstall/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/uninstall/index.md
@@ -1,0 +1,15 @@
+---
+layout: layout.pug
+navigationTitle: Uninstall
+title: Uninstall
+menuWeight: 20
+excerpt: Instructions for removing the DC/OS Monitoring Service from a DC/OS cluster.
+---
+
+# Uninstall the DC/OS Monitoring service
+
+You can simply uninstall the service using the following command:
+
+```bash
+dcos package uninstall dcos-monitoring
+```

--- a/pages/services/dcos-monitoring/0.2.1/uninstall/index.md
+++ b/pages/services/dcos-monitoring/0.2.1/uninstall/index.md
@@ -8,7 +8,7 @@ excerpt: Instructions for removing the DC/OS Monitoring Service from a DC/OS clu
 
 # Uninstall the DC/OS Monitoring service
 
-You can simply uninstall the service using the following command:
+You can uninstall the service using the following command:
 
 ```bash
 dcos package uninstall dcos-monitoring


### PR DESCRIPTION
## Description
Documentation for dcos-monitoring package v0.2.1 release - only change in this patch release is updating the docs to have the correct set of permissions required to run the package

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
