### PR TITLE
ss/DCOS-25910 Correcting field type of portName from integer to string.

### DIFF
--- a/pages/services/edge-lb/1.0/pool-configuration/v2-reference/index.md
+++ b/pages/services/edge-lb/1.0/pool-configuration/v2-reference/index.md
@@ -256,7 +256,7 @@ The pool contains information on resources that the pool needs. Changes made to 
 | check       | object    | Enable health checks. These are by default TCP health checks. For more options see "customCheck". These are required for DNS resolution to function properly. |
 | address     | string    | Server address override, can be used to specify a cluster internal address such as a VIP. Only allowed when using type `ADDRESS`. |
 | port   | integer | Port number.                                                                                  |
-| portName | integer | Name of port.                                                                      |
+| portName | string | Name of port.                                                                      |
 | allPorts  | boolean | Selects all ports defined in service when `true`.                     |
 
 <a name="service-endpoint-check-prop)"></a>

--- a/pages/services/edge-lb/1.1/pool-configuration/v2-reference/index.md
+++ b/pages/services/edge-lb/1.1/pool-configuration/v2-reference/index.md
@@ -256,7 +256,7 @@ The pool contains information on resources that the pool needs. Changes made to 
 | check       | object    | Enable health checks. These are by default TCP health checks. For more options see "customCheck". These are required for DNS resolution to function properly. |
 | address     | string    | Server address override, can be used to specify a cluster internal address such as a VIP. Only allowed when using type `ADDRESS`. |
 | port   | integer | Port number.                                                                                  |
-| portName | integer | Name of port.                                                                      |
+| portName | string | Name of port.                                                                      |
 | allPorts  | boolean | Selects all ports defined in service when `true`.                     |
 
 <a name="service-endpoint-check-prop)"></a>

--- a/pages/services/edge-lb/1.2/pool-configuration/v2-reference/index.md
+++ b/pages/services/edge-lb/1.2/pool-configuration/v2-reference/index.md
@@ -260,7 +260,7 @@ The pool contains information on resources that the pool needs. Changes made to 
 | check       | object    | Enable health checks. These are by default TCP health checks. For more options see "customCheck". These are required for DNS resolution to function properly. |
 | address     | string    | Server address override, can be used to specify a cluster internal address such as a VIP. Only allowed when using type `ADDRESS`. |
 | port   | integer | Port number.                                                                                  |
-| portName | integer | Name of port.                                                                      |
+| portName | string | Name of port.                                                                      |
 | allPorts  | boolean | Selects all ports defined in service when `true`.                     |
 
 <a name="service-endpoint-check-prop)"></a>


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-25910

https://docs.mesosphere.com/services/edge-lb/1.0.0/pool-configuration/v2-reference/#poolhaproxybackendserviceendpoint

portName type marked as integer when it should have been a string. other pages that references this might have the same issue.

* Please see Zendesk Support tab for further comments and attachments.

- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected in versions 1.0, 1.1, and 1.2