### PR TITLE
Revert "ck/DCOS-45908 Remove upgrade paths matrix"

### DIFF
--- a/pages/1.12/installing/production/upgrading/index.md
+++ b/pages/1.12/installing/production/upgrading/index.md
@@ -31,7 +31,7 @@ If upgrading is performed on a supported OS with all prerequisites fulfilled, th
 - Task history in the Mesos UI will not persist through the upgrade.
 
 ## Supported upgrade paths matrix
-The following matrix table lists the supported upgrade paths for DC/OS 1.11.
+The following matrix table lists the supported upgrade paths for DC/OS 1.12.
 
 
 |**Display Icon** | **Service** |

--- a/pages/1.12/installing/production/upgrading/index.md
+++ b/pages/1.12/installing/production/upgrading/index.md
@@ -30,6 +30,97 @@ If upgrading is performed on a supported OS with all prerequisites fulfilled, th
 - An upgraded DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been upgraded. The DC/OS UI cannot be trusted until all masters are upgraded. There are multiple Marathon scheduler instances and multiple Mesos masters, each being upgraded, and the Marathon leader may not be the Mesos leader.
 - Task history in the Mesos UI will not persist through the upgrade.
 
+## Supported upgrade paths matrix
+The following matrix table lists the supported upgrade paths for DC/OS 1.11.
+
+
+|**Display Icon** | **Service** |
+|---------- | ------- |
+| ⚫| Supported |
+| ◯| Not Supported |
+
+
+<table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
+   <tr>
+    <th Rowspan = "20" Align = "center"><strong>Upgrade<br>From</strong></th>
+   <tr>
+    <th></th>
+    <th Colspan = "1" Align = "center"><strong>Upgrade To</strong></th>
+   </tr>
+    <th></th>
+    <th Align = "center">1.12.0</th>
+   </tr>
+   <tr>
+    <th>1.10.0</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.10.1</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.10.2</th>
+    <td Align = "center">◯</td>
+   </tr>
+    <tr>
+    <th>1.10.3</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.10.4</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.10.5</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.10.6</th>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.10.7</th>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.10.8</th>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.11.0</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.11.1</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.11.2</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.11.3</th>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.11.4</th>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.11.5</th>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.11.6</th>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.11.7</th>
+    <td Align = "center">⚫</td>
+   </tr>
+  </table>
+
+
 # Modifying DC/OS configuration [enterprise type="inline" size="small" /]
 
 You _cannot_ change your cluster configuration at the same time as upgrading to a new version. Cluster configuration changes must be done with a patch to an already installed version. For example, you cannot simultaneously upgrade a cluster from 1.10 to 1.11 and add more public agents. You can add more public agents with a patch to 1.11, and then upgrade to 1.12. Or you can upgrade to 1.12 and then add more public agents by [patching 1.12](/1.12/installing/production/patching/) after the upgrade.


### PR DESCRIPTION
This reverts commit e931f17eb748cb8393d4d4eb97e0abd7d01dad2a.

## Description
Replacing table as requested

## Urgency
- [ X] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
