### PR TITLE
ss/DCOS-45629 Editing Edge-LB uninstall instructions for DC/OS 1.10.

### DIFF
--- a/pages/1.10/deploying-services/uninstall/index.md
+++ b/pages/1.10/deploying-services/uninstall/index.md
@@ -8,9 +8,8 @@ excerpt: Uninstalling DC/OS services from the CLI
 enterprise: false
 ---
 
+Most services can be uninstalled from the CLI or the DC/OS web interface. If a Universe service has any reserved resources that could not be be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
-
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources that could not be be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
 # Uninstalling Universe services
 
@@ -30,6 +29,8 @@ dcos package uninstall chronos
 
 ## Web interface
 
+<p class="message--note"><strong>NOTE: </strong>The Edge-LB service cannot be uninstalled using this procedure. Please follow the steps in the <a href="/services/edge-lb/1.2/uninstalling/">Edge-LB uninstall documentation</a>.</p>
+
 You can uninstall services from the DC/OS web interface from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
 1.  Navigate to the [**Services**](/1.10/gui/services/) tab in the DC/OS web interface.
@@ -41,7 +42,7 @@ You can uninstall services from the DC/OS web interface from the **Services** ta
 
 1.  Copy and run the displayed command.
 
-## Troubleshooting
+# Troubleshooting
 
 It is possible for an uninstall to fail with the following error message:
 
@@ -77,7 +78,7 @@ For more information, see the [command reference](/1.10/cli/command-reference/dc
 
 ### Web interface
 
-You can uninstall services from the DC/OS web interface, from the **Services**. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
+You can uninstall services from the DC/OS web interface, from the **Services** tab. The Services tab provides a full-featured interface to the native DC/OS Marathon instance.
 
 ### Services tab
 

--- a/pages/services/edge-lb/1.2/release-notes/index.md
+++ b/pages/services/edge-lb/1.2/release-notes/index.md
@@ -35,7 +35,7 @@ Released on November 27, 2018.
 
 ## Known Issues
 
-* The steps provided in the DC/OS web interface to uninstall Edge-LB are incorrect. Follow these steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.2/uninstalling/).
+* The steps provided in the DC/OS 1.10 web interface to uninstall Edge-LB are incorrect. In order to correctly uninstall Edge-LB for any given DC/OS version, please follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.2/uninstalling/).
 * Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
 * If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion. It must be removed manually.
 
@@ -84,7 +84,7 @@ Released on November 15, 2018.
 
 ## Known Issues
 
-* The steps provided in the DC/OS web interface to uninstall Edge-LB are incorrect. Follow these steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.2/uninstalling/).
+* The steps provided in the DC/OS 1.10 web interface to uninstall Edge-LB are incorrect. In order to correctly uninstall Edge-LB for any given DC/OS version, please follow the steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.2/uninstalling/).
 * Edge-LB running on a CentOS/RHEL 7.2 node where `/var/lib/mesos` is formatted with ext4 may have connection issues.
 * If a pool is configured with invalid constraints, that pool will not be properly created and will not respect pool deletion. It must be removed manually.
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-45629
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium
Under “Known Limitation”, I see “The steps provided in the DC/OS web interface to uninstall Edge-LB are incorrect. Follow these steps in the [Edge-LB uninstall documentation](/services/edge-lb/1.2/uninstalling/).”

Do you think you could change it to:

The steps provided in the DC/OS 1.10 web interface to uninstall Edge-LB are incorrect. In order to correctly uninstall Edge-LB for any given DC/OS version, please follow the steps in the Edge-LB uninstall documentation. (the link of course stays :slightly_smiling_face: ). 
The problem is that the warning message is broken only for 1.10. The 1.11+ does not have any message, but still - the uninstall instructions should be followed. As the Edge-LB cannot be simply uninstalled via the UI.

The changes need to be done for release notes for all Edge-LB versions.
