### PR TITLE
LG/COPS-4202 Remove Network metrics from 1.10 and 1.11 per Support re…

### DIFF
--- a/pages/1.10/metrics/reference/index.md
+++ b/pages/1.10/metrics/reference/index.md
@@ -110,24 +110,6 @@ The following per-container resource utilization metrics are collected.
 | mem.limit    | Hard memory limit for a container. |
 | mem.total    | Total memory of a process in RAM (as opposed to in swap). |   
 
-<a name="ConNetwork">
-
-## Network metrics
-   <!-- http://mesos.apache.org/documentation/latest/port-mapping-isolator -->
-
-| Metric            | Description                  |
-|-------------------|------------------------------|
-| net.rx.bytes    | Bytes received. |
-| net.rx.dropped    | Packets dropped on receive.  |
-| net.rx.errors    | Errors reported on receive. |
-| net.rx.packets    |  Packets received.  |
-| net.tx.bytes    |  Bytes sent. |
-| net.tx.dropped    | Packets dropped on send.  |
-| net.tx.errors    | Errors reported on send. |
-| net.tx.packets    | Packets sent. |
-
-<a name="Dimensions">
-
 # Dimensions
 
 Dimensions are metadata about the metrics. The following table lists the available dimensions and the entities where they appear.

--- a/pages/1.11/metrics/reference/index.md
+++ b/pages/1.11/metrics/reference/index.md
@@ -109,22 +109,6 @@ The following per-container resource utilization metrics are collected.
 | mem.limit    | Hard memory limit for a container. |
 | mem.total    | Total memory of a process in RAM (as opposed to in swap). |   
 
-<a name="ConNetwork">
-
-## Network metrics
-   <!-- http://mesos.apache.org/documentation/latest/port-mapping-isolator -->
-
-| Metric            | Description                  |
-|-------------------|------------------------------|
-| net.rx.bytes    | Bytes received. |
-| net.rx.dropped    | Packets dropped on receive.  |
-| net.rx.errors    | Errors reported on receive. |
-| net.rx.packets    |  Packets received.  |
-| net.tx.bytes    |  Bytes sent. |
-| net.tx.dropped    | Packets dropped on send.  |
-| net.tx.errors    | Errors reported on send. |
-| net.tx.packets    | Packets sent. |
-
 <a name="Dimensions">
 
 # Dimensions


### PR DESCRIPTION
…quest

## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/COPS-4202

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
