### PR TITLE
ss/DCOS_OSS-3181 Editing HDFS pages.

### DIFF
--- a/pages/services/spark/2.1.0-2.2.0-1/hdfs/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/hdfs/index.md
@@ -3,12 +3,12 @@ layout: layout.pug
 navigationTitle:  Configure Spark for HDFS
 title: Configure Spark for HDFS
 menuWeight: 20
-excerpt:
+excerpt: Configure Spark on HDFS and Kerberos
 featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
+# Spark on HDFS
 
 
 You can configure Spark for a specific HDFS cluster.
@@ -45,11 +45,11 @@ ssc.checkpoint(checkpointDirectory)
 ```
 That hdfs directory will be automatically created on hdfs and spark streaming app will work from checkpointed data even in the presence of application restarts/failures.
 
-# HDFS Kerberos
+# Spark on HDFS Kerberos
 
 You can access external (i.e. non-DC/OS) Kerberos-secured HDFS clusters from Spark on Mesos.
 
-## HDFS Configuration
+## Configuration
 
 After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect to it. See instructions [here](#hdfs).
 
@@ -69,7 +69,9 @@ After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect 
            }
         }
 
-1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
+1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  
+
+    **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
 
     Base64 encode your keytab:
 

--- a/pages/services/spark/2.1.0-2.2.1-1/hdfs/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/hdfs/index.md
@@ -1,12 +1,11 @@
 ---
 layout: layout.pug
-excerpt:
+excerpt: Configure Spark on HDFS and Kerberos
 title: Integration with HDFS
 navigationTitle: HDFS
 menuWeight: 20
 ---
-
-<!-- This source repo for this topic is https://github.com/mesosphere/dcos-commons -->
+# Spark on HDFS
 
 
 You can configure Spark for a specific HDFS cluster.
@@ -42,11 +41,11 @@ ssc.checkpoint(checkpointDirectory)
 ```
 That hdfs directory will be automatically created on hdfs and spark streaming app will work from checkpointed data even in the presence of application restarts/failures.
 
-# HDFS Kerberos
+# Spark on HDFS Kerberos
 
 You can access external (i.e. non-DC/OS) Kerberos-secured HDFS clusters from Spark on Mesos.
 
-## HDFS Configuration
+## Configuration
 
 After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect to it. See instructions [here](#hdfs).
 
@@ -66,7 +65,9 @@ After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect 
            }
         }
 
-1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
+1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  
+
+    **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
 
     Base64 encode your keytab:
 

--- a/pages/services/spark/v1.0.9-2.1.0-1/hdfs/index.md
+++ b/pages/services/spark/v1.0.9-2.1.0-1/hdfs/index.md
@@ -3,14 +3,13 @@ layout: layout.pug
 navigationTitle:  Configure Spark for HDFS
 title: Configure Spark for HDFS
 menuWeight: 20
-excerpt:
+excerpt: Configure Spark on HDFS and Kerberos
 featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
 
-
+# Spark on HDFS
 To configure Spark for a specific HDFS cluster, configure `hdfs.config-url` to be a URL that serves your `hdfs-site.xml` and `core-site.xml`. For example:
 
     {
@@ -24,11 +23,9 @@ where `http://mydomain.com/hdfs-config/hdfs-site.xml` and `http://mydomain.com/h
 
 For DC/OS HDFS, these configuration files are served at `http://api.<hdfs>.marathon.l4lb.thisdcos.directory/v1/endpoints` where `<hdfs>` is the name of the HDFS package configured at installation.
 
-# HDFS Kerberos
+# Spark on HDFS Kerberos
 
 You can access external (i.e. non-DC/OS) Kerberos-secured HDFS clusters from Spark on Mesos.
-
-## HDFS Configuration
 
 Once you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect to it. See instructions [here](#hdfs).
 
@@ -48,7 +45,9 @@ Once you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect t
            }
         }
 
-1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Spark.
+1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  
+
+    **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Spark.
 
     Base64 encode your keytab:
 

--- a/pages/services/spark/v1.1.0-2.1.1/hdfs/index.md
+++ b/pages/services/spark/v1.1.0-2.1.1/hdfs/index.md
@@ -3,14 +3,12 @@ layout: layout.pug
 navigationTitle:  Configure Spark for HDFS
 title: Configure Spark for HDFS
 menuWeight: 20
-excerpt:
+excerpt: Configure Spark on HDFS and Kerberos
 featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
-
-
+# Spark on HDFS
 To configure Spark for a specific HDFS cluster, configure `hdfs.config-url` to be a URL that serves your `hdfs-site.xml` and `core-site.xml`. For example:
 
     {
@@ -24,17 +22,15 @@ where `http://mydomain.com/hdfs-config/hdfs-site.xml` and `http://mydomain.com/h
 
 For DC/OS HDFS, these configuration files are served at `http://api.<hdfs>.marathon.l4lb.thisdcos.directory/v1/endpoints` where `<hdfs>` is the name of the HDFS package configured at installation.
 
-# HDFS Kerberos
+# Spark on HDFS Kerberos
 
 You can access external (i.e. non-DC/OS) Kerberos-secured HDFS clusters from Spark on Mesos.
-
-## HDFS Configuration
 
 Once you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect to it. See instructions [here](#hdfs).
 
 ## Installation
 
-1.  A krb5.conf file tells Spark how to connect to your KDC.  Base64 encode this file:
+1.  A `krb5.conf` file tells Spark how to connect to your KDC.  Base64 encode this file:
 
         $ cat krb5.conf | base64
 
@@ -48,7 +44,9 @@ Once you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect t
            }
         }
 
-1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Spark.
+1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  
+
+    **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Spark.
 
     Base64 encode your keytab:
 

--- a/pages/services/spark/v1.1.1-2.2.0/hdfs/index.md
+++ b/pages/services/spark/v1.1.1-2.2.0/hdfs/index.md
@@ -3,13 +3,12 @@ layout: layout.pug
 navigationTitle:  Configure Spark for HDFS
 title: Configure Spark for HDFS
 menuWeight: 20
-excerpt:
+excerpt: Configure Spark on HDFS and Kerberos
 featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
-
+# Spark on HDFS
 
 You can configure Spark for a specific HDFS cluster.
 
@@ -27,11 +26,11 @@ For more information, see [Inheriting Hadoop Cluster Configuration][8].
 
 For DC/OS HDFS, these configuration files are served at `http://api.<hdfs>.marathon.l4lb.thisdcos.directory/v1/endpoints` where `<hdfs>` is the name of the HDFS package configured at installation.
 
-# HDFS Kerberos
+# Spark on HDFS Kerberos
 
 You can access external (i.e. non-DC/OS) Kerberos-secured HDFS clusters from Spark on Mesos.
 
-## HDFS Configuration
+## Configuration
 
 After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect to it. See instructions [here](#hdfs).
 
@@ -51,7 +50,9 @@ After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect 
            }
         }
 
-1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
+1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  
+
+    **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
 
     Base64 encode your keytab:
 

--- a/pages/services/spark/v2.0.0-2.2.0-1/hdfs/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/hdfs/index.md
@@ -3,13 +3,12 @@ layout: layout.pug
 navigationTitle:  Configure Spark for HDFS
 title: Configure Spark for HDFS
 menuWeight: 20
-excerpt:
+excerpt: Configure Spark on HDFS and Kerberos
 featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
-
+# Spark on HDFS
 
 You can configure Spark for a specific HDFS cluster.
 
@@ -35,11 +34,11 @@ For DC/OS HDFS, these configuration files are served at `http://api.<hdfs>.marat
  },
 ````
 
-# HDFS Kerberos
+# Spark on HDFS Kerberos
 
 You can access external (i.e. non-DC/OS) Kerberos-secured HDFS clusters from Spark on Mesos.
 
-## HDFS Configuration
+## Configuration
 
 After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect to it. See instructions [here](#hdfs).
 
@@ -59,7 +58,9 @@ After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect 
            }
         }
 
-1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
+1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  
+
+    **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
 
     Base64 encode your keytab:
 

--- a/pages/services/spark/v2.0.1-2.2.0-1/hdfs/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/hdfs/index.md
@@ -3,13 +3,12 @@ layout: layout.pug
 navigationTitle:  Configure Spark for HDFS
 title: Configure Spark for HDFS
 menuWeight: 20
-excerpt:
+excerpt: Configure Spark on HDFS and Kerberos
 featureMaturity:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/mesosphere/spark-build -->
-
+# Spark on HDFS
 
 You can configure Spark for a specific HDFS cluster.
 
@@ -35,11 +34,11 @@ For DC/OS HDFS, these configuration files are served at `http://api.<hdfs>.marat
  },
 ````
 
-# HDFS Kerberos
+# Spark on HDFS Kerberos
 
 You can access external (i.e. non-DC/OS) Kerberos-secured HDFS clusters from Spark on Mesos.
 
-## HDFS Configuration
+## Configuration
 
 After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect to it. See instructions [here](#hdfs).
 
@@ -59,7 +58,9 @@ After you've set up a Kerberos-enabled HDFS cluster, configure Spark to connect 
            }
         }
 
-1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
+1. If you've enabled the history server via `history-server.enabled`, you must also configure the principal and keytab for the history server.  
+
+    **WARNING**: The keytab contains secrets, so you should ensure you have SSL enabled while installing DC/OS Apache Spark.
 
     Base64 encode your keytab:
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-3181
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium
DESCRIPTION
1. The Spark on HDFS chapter should be split into two chapters to avoid confusion.  The first chapter should cover the Spark on HDFS chapter and the second should cover SPARK on a Kerberorized HDFS cluster.  As presented it is confusing where one chapter ends and the Kerberos chapter begins.
2. Specifically, one more comment about the Spark on HDFS section.  For connecting to a DC/OS managed HDFS cluster where can a user find the dc/os dns URL and port numbers.  Just saying you should pull those values will leave many users scratching their head wondering what to do.  

EDITOR'S RESPONSE

1. The HDFS page is already divided between Spark on HDFS and Spark on HDFS Kerberos. However, I have added a section title to make the distinction clearer. Also edited some formatting issues.
2. It is not clear to me exactly what changes are requested here. Please clarify. Where WOULD users find the URL and port numbers?

VERSIONS AFFECTED:
1.0.9
1.1.0
1.1.1
2.0.0
2.0.1
2.1.0