### PR TITLE
LG/DCOS-46168 Fix 'the the' to be 'the' in 91 occurrences

### DIFF
--- a/pages/1.10/api/iam.yaml
+++ b/pages/1.10/api/iam.yaml
@@ -1004,7 +1004,7 @@ paths:
             Configuration has been persisted. Basic validation tests passed,
             but the directory service was not contacted. You're encouraged to
             now perform a basic feature check against the directory backend
-            with the newly set configuration by using the the config test
+            with the newly set configuration by using the config test
             endpoint.
 
         400:

--- a/pages/1.10/installing/evaluation/community-supported-methods/azure/index.md
+++ b/pages/1.10/installing/evaluation/community-supported-methods/azure/index.md
@@ -144,7 +144,7 @@ Figure 2. Outputs section
 
 ### Case 1:
 
-In order to visit the the DC/OS Dashboard, you will need to access TCP port 80 or 443 of the master node. You can add an inbound security rule and an inbound NAT rule.
+In order to visit the DC/OS Dashboard, you will need to access TCP port 80 or 443 of the master node. You can add an inbound security rule and an inbound NAT rule.
 
 1. Find the network security group resource of the master node,
 

--- a/pages/1.11/api/iam.yaml
+++ b/pages/1.11/api/iam.yaml
@@ -1004,7 +1004,7 @@ paths:
             Configuration has been persisted. Basic validation tests passed,
             but the directory service was not contacted. You're encouraged to
             now perform a basic feature check against the directory backend
-            with the newly set configuration by using the the config test
+            with the newly set configuration by using the config test
             endpoint.
 
         400:

--- a/pages/1.11/installing/evaluation/community-supported-methods/azure/index.md
+++ b/pages/1.11/installing/evaluation/community-supported-methods/azure/index.md
@@ -144,7 +144,7 @@ Figure 2. Outputs section
 
 ### Case 1:
 
-In order to visit the the DC/OS Dashboard, you will need to access TCP port 80 or 443 of the master node. You can add an inbound security rule and an inbound NAT rule.
+In order to visit the DC/OS Dashboard, you will need to access TCP port 80 or 443 of the master node. You can add an inbound security rule and an inbound NAT rule.
 
 1. Find the network security group resource of the master node,
 

--- a/pages/1.11/overview/design/overlay/index.md
+++ b/pages/1.11/overview/design/overlay/index.md
@@ -115,7 +115,7 @@ Once the DC/OS module retrieves the subnet information from the master DC/OS mod
 
 For `MesosContainerizer`, the DC/OS module can generate a CNI config at a specified location. The CNI config will have the bridge information and IPAM information for the network/cni isolator to configure containers on the `m-<virtual network name>` bridge.
 
-For `DockerContainerizer`, the DC/OS module will retrieve the the subnet, and then will create a `docker network` with the canonical name `d-<virtual network name>`. It will do so using the following Docker command:
+For `DockerContainerizer`, the DC/OS module will retrieve the subnet, and then will create a `docker network` with the canonical name `d-<virtual network name>`. It will do so using the following Docker command:
 
 ```sh
 docker network create \

--- a/pages/1.12/api/iam.yaml
+++ b/pages/1.12/api/iam.yaml
@@ -1004,7 +1004,7 @@ paths:
             Configuration has been persisted. Basic validation tests passed,
             but the directory service was not contacted. You're encouraged to
             now perform a basic feature check against the directory backend
-            with the newly set configuration by using the the config test
+            with the newly set configuration by using the config test
             endpoint.
 
         400:

--- a/pages/1.12/installing/evaluation/community-supported-methods/azure/index.md
+++ b/pages/1.12/installing/evaluation/community-supported-methods/azure/index.md
@@ -144,7 +144,7 @@ Figure 2. Outputs section
 
 ### Case 1:
 
-In order to visit the the DC/OS Dashboard, you will need to access TCP port 80 or 443 of the master node. You can add an inbound security rule and an inbound NAT rule.
+In order to visit the DC/OS Dashboard, you will need to access TCP port 80 or 443 of the master node. You can add an inbound security rule and an inbound NAT rule.
 
 1. Find the network security group resource of the master node,
 

--- a/pages/1.12/overview/design/overlay/index.md
+++ b/pages/1.12/overview/design/overlay/index.md
@@ -113,7 +113,7 @@ Once the DC/OS module retrieves the subnet information from the master DC/OS mod
 
 For `MesosContainerizer`, the DC/OS module can generate a CNI config at a specified location. The CNI config will have the bridge information and IPAM information for the network/cni isolator to configure containers on the `m-<virtual network name>` bridge.
 
-For `DockerContainerizer`, the DC/OS module will retrieve the the subnet, and then will create a `docker network` with the canonical name `d-<virtual network name>`. It will do so using the following Docker command:
+For `DockerContainerizer`, the DC/OS module will retrieve the subnet, and then will create a `docker network` with the canonical name `d-<virtual network name>`. It will do so using the following Docker command:
 
 ```sh
 docker network create \

--- a/pages/1.8/administration/installing/ent/local/index.md
+++ b/pages/1.8/administration/installing/ent/local/index.md
@@ -21,7 +21,7 @@ Minimum 5 GB of memory to run DC/OS.
 
 ### Software
 - [DC/OS Enterprise setup file](https://support.mesosphere.com/hc/en-us/articles/213198586-Mesosphere-Enterprise-DC-OS-Downloads). Contact your sales representative or <a href="mailto:sales@mesosphere.com">sales@mesosphere.com</a> for access to this file.
-- DC/OS Vagrant. The installation and usage instructions are maintained in the [dcos-vagrant](https://github.com/dcos/dcos-vagrant/) GitHub repository. Follow the the deploy instructions to set up your host machine correctly and to install DC/OS.
+- DC/OS Vagrant. The installation and usage instructions are maintained in the [dcos-vagrant](https://github.com/dcos/dcos-vagrant/) GitHub repository. Follow the deploy instructions to set up your host machine correctly and to install DC/OS.
 
     - For the latest bug fixes, use the [master branch](https://github.com/dcos/dcos-vagrant/).
     - For increased stability, use the [latest official release](https://github.com/dcos/dcos-vagrant/releases/latest/).

--- a/pages/1.8/api/iam.yaml
+++ b/pages/1.8/api/iam.yaml
@@ -1004,7 +1004,7 @@ paths:
             Configuration has been persisted. Basic validation tests passed,
             but the directory service was not contacted. You're encouraged to
             now perform a basic feature check against the directory backend
-            with the newly set configuration by using the the config test
+            with the newly set configuration by using the config test
             endpoint.
 
         400:

--- a/pages/1.9/api/iam.yaml
+++ b/pages/1.9/api/iam.yaml
@@ -1004,7 +1004,7 @@ paths:
             Configuration has been persisted. Basic validation tests passed,
             but the directory service was not contacted. You're encouraged to
             now perform a basic feature check against the directory backend
-            with the newly set configuration by using the the config test
+            with the newly set configuration by using the config test
             endpoint.
 
         400:

--- a/pages/1.9/installing/ent/local/index.md
+++ b/pages/1.9/installing/ent/local/index.md
@@ -18,7 +18,7 @@ Minimum 5 GB of memory to run DC/OS.
 
 ### Software
 - DC/OS Enterprise setup file. Contact your sales representative or <a href="mailto:sales@mesosphere.com">sales@mesosphere.com</a> to obtain this file.
-- DC/OS Vagrant. The installation and usage instructions are maintained in the [dcos-vagrant](https://github.com/dcos/dcos-vagrant/) GitHub repository. Follow the the deploy instructions to set up your host machine correctly and to install DC/OS.
+- DC/OS Vagrant. The installation and usage instructions are maintained in the [dcos-vagrant](https://github.com/dcos/dcos-vagrant/) GitHub repository. Follow the deploy instructions to set up your host machine correctly and to install DC/OS.
 
     - For the latest bug fixes, use the [master branch](https://github.com/dcos/dcos-vagrant/).
     - For increased stability, use the [latest official release](https://github.com/dcos/dcos-vagrant/releases/latest/).

--- a/pages/cn/1.11/api/iam.yaml
+++ b/pages/cn/1.11/api/iam.yaml
@@ -1004,7 +1004,7 @@ paths:
             Configuration has been persisted. Basic validation tests passed,
             but the directory service was not contacted. You're encouraged to
             now perform a basic feature check against the directory backend
-            with the newly set configuration by using the the config test
+            with the newly set configuration by using the config test
             endpoint.
 
         400:

--- a/pages/services/beta-cassandra/1.0.32-3.0.14-beta/managing/index.md
+++ b/pages/services/beta-cassandra/1.0.32-3.0.14-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos beta-cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-cassandra/2.1.0-3.0.15-beta/managing/index.md
+++ b/pages/services/beta-cassandra/2.1.0-3.0.15-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos beta-cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-cassandra/2.1.1-3.0.15-beta/managing/index.md
+++ b/pages/services/beta-cassandra/2.1.1-3.0.15-beta/managing/index.md
@@ -49,7 +49,7 @@ $ dcos beta-cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-cassandra/2.1.2-3.0.15-beta/managing/index.md
+++ b/pages/services/beta-cassandra/2.1.2-3.0.15-beta/managing/index.md
@@ -49,7 +49,7 @@ $ dcos beta-cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-confluent-kafka-zookeeper/2.1.1-4.0.0e-beta/quick-start/index.md
+++ b/pages/services/beta-confluent-kafka-zookeeper/2.1.1-4.0.0e-beta/quick-start/index.md
@@ -62,7 +62,7 @@ You will use the values in the `address` field for the final step.
    curl -O http://www.trieuvan.com/apache/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz
    tar -xzf zookeeper-3.4.11.tar.gz
    ```
-1. Run the the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
+1. Run the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
 
    ```
    docker run -it zookeeper zkCli.sh -server 10.0.3.206:1140

--- a/pages/services/beta-confluent-kafka/2.1.0-4.0.0e-beta/managing/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.0-4.0.0e-beta/managing/index.md
@@ -53,7 +53,7 @@ $ dcos confluent-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-confluent-kafka/2.1.1-4.0.0e-beta/managing/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.1-4.0.0e-beta/managing/index.md
@@ -53,7 +53,7 @@ $ dcos confluent-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/managing/index.md
+++ b/pages/services/beta-confluent-kafka/2.1.2-4.0.0e-beta/managing/index.md
@@ -53,7 +53,7 @@ $ dcos confluent-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-confluent-kafka/v1.2.3-3.2.2e-beta/troubleshooting/index.md
+++ b/pages/services/beta-confluent-kafka/v1.2.3-3.2.2e-beta/troubleshooting/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 # Accessing Logs
 
-You can find logs for the scheduler and all service pods on the the DC/OS web interface.
+You can find logs for the scheduler and all service pods on the DC/OS web interface.
 
 - Scheduler logs are useful for determining why a pod isn't being launched (this is under the purview of the scheduler).
 - Pod logs are useful for examining problems in the service itself.

--- a/pages/services/beta-confluent-kafka/v1.2.4-3.3.0e-beta/troubleshooting/index.md
+++ b/pages/services/beta-confluent-kafka/v1.2.4-3.3.0e-beta/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 # Accessing Logs
 
-You can find logs for the scheduler and all service pods on the the DC/OS web interface.
+You can find logs for the scheduler and all service pods on the DC/OS web interface.
 
 - Scheduler logs are useful for determining why a pod isn't being launched (this is under the purview of the scheduler).
 - Pod logs are useful for examining problems in the service itself.

--- a/pages/services/beta-dse/2.1.0-5.1.2-beta/managing/index.md
+++ b/pages/services/beta-dse/2.1.0-5.1.2-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos datastax-dse describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-dse/2.1.2-5.1.2-beta/managing/index.md
+++ b/pages/services/beta-dse/2.1.2-5.1.2-beta/managing/index.md
@@ -49,7 +49,7 @@ $ dcos datastax-dse describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-elastic/2.0.0-5.5.1/managing/index.md
+++ b/pages/services/beta-elastic/2.0.0-5.5.1/managing/index.md
@@ -52,7 +52,7 @@ $ dcos elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-elastic/2.1.0-5.6.4-beta/install/index.md
+++ b/pages/services/beta-elastic/2.1.0-5.6.4-beta/install/index.md
@@ -203,7 +203,7 @@ $ dcos beta-elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-elastic/2.1.0-5.6.4-beta/managing/index.md
+++ b/pages/services/beta-elastic/2.1.0-5.6.4-beta/managing/index.md
@@ -52,7 +52,7 @@ $ dcos beta-elastic --name="elastic" describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-elastic/2.1.1-5.6.5-beta/install/index.md
+++ b/pages/services/beta-elastic/2.1.1-5.6.5-beta/install/index.md
@@ -202,7 +202,7 @@ $ dcos beta-elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-elastic/2.1.1-5.6.5-beta/managing/index.md
+++ b/pages/services/beta-elastic/2.1.1-5.6.5-beta/managing/index.md
@@ -51,7 +51,7 @@ $ dcos beta-elastic --name="elastic" describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-elastic/2.1.2-5.6.5-beta/install/index.md
+++ b/pages/services/beta-elastic/2.1.2-5.6.5-beta/install/index.md
@@ -248,7 +248,7 @@ $ dcos beta-elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-elastic/2.1.2-5.6.5-beta/managing/index.md
+++ b/pages/services/beta-elastic/2.1.2-5.6.5-beta/managing/index.md
@@ -51,7 +51,7 @@ $ dcos beta-elastic --name="elastic" describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/install/index.md
+++ b/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/install/index.md
@@ -326,7 +326,7 @@ $ dcos beta-hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/managing/index.md
+++ b/pages/services/beta-hdfs/2.1.0-2.6.0-cdh5.11.0-beta/managing/index.md
@@ -51,7 +51,7 @@ $ dcos beta-hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/install/index.md
+++ b/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/install/index.md
@@ -325,7 +325,7 @@ $ dcos beta-hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/managing/index.md
+++ b/pages/services/beta-hdfs/2.1.1-2.6.0-cdh5.11.0-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos beta-hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/install/index.md
+++ b/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/install/index.md
@@ -355,7 +355,7 @@ $ dcos beta-hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <p class="message--note"><strong>NOTE: </strong>You must specify all configuration values in the <code>options.json</code> file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating <code>options.json</code>" section below for information on recovering these values.</p>
 

--- a/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/managing/index.md
+++ b/pages/services/beta-hdfs/2.1.2-2.6.0-cdh5.11.0-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos beta-hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/v1.3.3-2.6.0-cdh5.11.0-beta/configure/index.md
+++ b/pages/services/beta-hdfs/v1.3.3-2.6.0-cdh5.11.0-beta/configure/index.md
@@ -44,7 +44,7 @@ $ dcos beta-hdfs --name=hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/v1.3.3-2.6.0-cdh5.11.0-beta/managing/index.md
+++ b/pages/services/beta-hdfs/v1.3.3-2.6.0-cdh5.11.0-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos beta-hdfs --name=hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-hdfs/v2.0.0-2.6.0-cdh5.11.0/managing/index.md
+++ b/pages/services/beta-hdfs/v2.0.0-2.6.0-cdh5.11.0/managing/index.md
@@ -51,7 +51,7 @@ $ dcos beta-hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-jupyter/example/index.md
+++ b/pages/services/beta-jupyter/example/index.md
@@ -36,7 +36,7 @@ The technologies used in this section are as follows:
 - [DC/OS CLI](https://docs.mesosphere.com/latest/cli/install/) installed
 
 ## Optional: Terraform
-If you plan to use GPU support we recommend that you use the [dcos-terraform project](https://github.com/dcos/terraform-dcos/blob/master/aws/README.md#adding-gpu-private-agents) to provision DC/OS. Please refer to the the [GPU Cluster Provisioning section](https://github.com/dcos/examples/tree/master/{{ model.packageName }}/1.11#install-{{ model.packageName }}-with-gpu-support) in the README for more details.
+If you plan to use GPU support we recommend that you use the [dcos-terraform project](https://github.com/dcos/terraform-dcos/blob/master/aws/README.md#adding-gpu-private-agents) to provision DC/OS. Please refer to the [GPU Cluster Provisioning section](https://github.com/dcos/examples/tree/master/{{ model.packageName }}/1.11#install-{{ model.packageName }}-with-gpu-support) in the README for more details.
 
 # Installation
 This section will describe how to install the HDFS service and the Marathon-LB service.

--- a/pages/services/beta-kafka-zookeeper/2.1.0-3.4.11-beta/quick-start/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.0-3.4.11-beta/quick-start/index.md
@@ -66,7 +66,7 @@ You will use the values in the `address` field for the final step.
    curl -O http://www.trieuvan.com/apache/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz
    tar -xzf zookeeper-3.4.11.tar.gz
    ```
-1. Run the the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
+1. Run the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
 
    ```
    docker run -it zookeeper zkCli.sh -server 10.0.3.206:1140

--- a/pages/services/beta-kafka-zookeeper/2.1.1-3.4.11-beta/quick-start/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.1-3.4.11-beta/quick-start/index.md
@@ -64,7 +64,7 @@ You will use the values in the `address` field for the final step.
    curl -O http://www.trieuvan.com/apache/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz
    tar -xzf zookeeper-3.4.11.tar.gz
    ```
-1. Run the the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
+1. Run the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
 
    ```
    docker run -it zookeeper zkCli.sh -server 10.0.3.206:1140

--- a/pages/services/beta-kafka-zookeeper/2.1.2-3.4.11-beta/quick-start/index.md
+++ b/pages/services/beta-kafka-zookeeper/2.1.2-3.4.11-beta/quick-start/index.md
@@ -65,7 +65,7 @@ You will use the values in the `address` field for the final step.
    curl -O http://www.trieuvan.com/apache/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz
    tar -xzf zookeeper-3.4.11.tar.gz
    ```
-1. Run the the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
+1. Run the `zkCli.sh` script with the proper arguments, including one of the IPs that you found earlier.
 
    ```
    docker run -it zookeeper zkCli.sh -server 10.0.3.206:1140

--- a/pages/services/beta-kafka/1.1.27-0.11.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/1.1.27-0.11.0-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos beta-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-kafka/2.1.0-1.0.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/2.1.0-1.0.0-beta/managing/index.md
@@ -50,7 +50,7 @@ $ dcos beta-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-kafka/2.1.1-1.0.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/2.1.1-1.0.0-beta/managing/index.md
@@ -49,7 +49,7 @@ $ dcos beta-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/beta-kafka/2.1.2-1.0.0-beta/managing/index.md
+++ b/pages/services/beta-kafka/2.1.2-1.0.0-beta/managing/index.md
@@ -49,7 +49,7 @@ $ dcos beta-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/cassandra/2.0.1-3.0.14/managing/index.md
+++ b/pages/services/cassandra/2.0.1-3.0.14/managing/index.md
@@ -48,7 +48,7 @@ $ dcos cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/cassandra/2.0.2-3.0.14/managing/index.md
+++ b/pages/services/cassandra/2.0.2-3.0.14/managing/index.md
@@ -49,7 +49,7 @@ $ dcos cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/cassandra/2.0.3-3.0.14/managing/index.md
+++ b/pages/services/cassandra/2.0.3-3.0.14/managing/index.md
@@ -48,7 +48,7 @@ $ dcos cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/cassandra/v1.0.25-3.0.10/managing/index.md
+++ b/pages/services/cassandra/v1.0.25-3.0.10/managing/index.md
@@ -24,7 +24,7 @@ It is sometimes useful to retrieve information about a Cassandra node for troubl
 dcos cassandra --name=<service-name> node status <nodeid>
 ```
 
-This command queries the node status directly from the node. If the command fails to return, it may indicate that the node is troubled. Here, `nodeid` is the the sequential integer identifier of the node (e.g. 0, 1, 2 , ..., n).
+This command queries the node status directly from the node. If the command fails to return, it may indicate that the node is troubled. Here, `nodeid` is the sequential integer identifier of the node (e.g. 0, 1, 2 , ..., n).
 
 Result:
 

--- a/pages/services/cassandra/v2.0.0-3.0.14/managing/index.md
+++ b/pages/services/cassandra/v2.0.0-3.0.14/managing/index.md
@@ -48,7 +48,7 @@ $ dcos cassandra describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/confluent-kafka/2.0.1-3.3.0e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.1-3.3.0e/managing/index.md
@@ -50,7 +50,7 @@ $ dcos confluent-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/confluent-kafka/2.0.1.1-3.3.0e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.1.1-3.3.0e/managing/index.md
@@ -51,7 +51,7 @@ dcos confluent-kafka describe--name=confluent-kafka > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/confluent-kafka/2.0.2-3.3.0e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.2-3.3.0e/managing/index.md
@@ -50,7 +50,7 @@ $ $ dcos confluent-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/confluent-kafka/2.0.3-3.3.1e/managing/index.md
+++ b/pages/services/confluent-kafka/2.0.3-3.3.1e/managing/index.md
@@ -50,7 +50,7 @@ $ dcos confluent-kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/confluent-kafka/v2.0.0.1-3.3.0e/troubleshooting/index.md
+++ b/pages/services/confluent-kafka/v2.0.0.1-3.3.0e/troubleshooting/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 # Accessing Logs
 
-You can find logs for the scheduler and all service pods on the the DC/OS web interface.
+You can find logs for the scheduler and all service pods on the DC/OS web interface.
 
 - Scheduler logs are useful for determining why a pod isn't being launched (this is under the purview of the scheduler).
 - Pod logs are useful for examining problems in the service itself.

--- a/pages/services/dse/2.0.2-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.2-5.1.2/managing/index.md
@@ -50,7 +50,7 @@ $ dcos datastax-dse describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/dse/2.0.3-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.3-5.1.2/managing/index.md
@@ -50,7 +50,7 @@ $ dcos datastax-dse describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/dse/2.0.4-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.4-5.1.2/managing/index.md
@@ -50,7 +50,7 @@ $ dcos datastax-dse describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/dse/2.0.5-5.1.2/managing/index.md
+++ b/pages/services/dse/2.0.5-5.1.2/managing/index.md
@@ -50,7 +50,7 @@ $ dcos datastax-dse describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/dse/v2.0.0-5.1.2/managing/index.md
+++ b/pages/services/dse/v2.0.0-5.1.2/managing/index.md
@@ -50,7 +50,7 @@ $ dcos datastax-dse describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/elastic/2.0.1-5.5.1/managing/index.md
+++ b/pages/services/elastic/2.0.1-5.5.1/managing/index.md
@@ -52,7 +52,7 @@ $ dcos elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/elastic/2.0.2-5.6.2/managing/index.md
+++ b/pages/services/elastic/2.0.2-5.6.2/managing/index.md
@@ -52,7 +52,7 @@ $ dcos elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/elastic/2.1.0-5.6.2/managing/index.md
+++ b/pages/services/elastic/2.1.0-5.6.2/managing/index.md
@@ -52,7 +52,7 @@ $ dcos elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/elastic/2.1.1-5.6.5/managing/index.md
+++ b/pages/services/elastic/2.1.1-5.6.5/managing/index.md
@@ -51,7 +51,7 @@ $ dcos elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/elastic/v2.0.0-5.5.1/managing/index.md
+++ b/pages/services/elastic/v2.0.0-5.5.1/managing/index.md
@@ -52,7 +52,7 @@ $ dcos elastic describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/hdfs/2.0.1-2.6.0-cdh5.11.0/managing/index.md
+++ b/pages/services/hdfs/2.0.1-2.6.0-cdh5.11.0/managing/index.md
@@ -51,7 +51,7 @@ $ dcos hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/hdfs/2.0.2-2.6.0-cdh5.11.0/managing/index.md
+++ b/pages/services/hdfs/2.0.2-2.6.0-cdh5.11.0/managing/index.md
@@ -51,7 +51,7 @@ $ dcos hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/hdfs/2.0.3-2.6.0-cdh5.11.0/managing/index.md
+++ b/pages/services/hdfs/2.0.3-2.6.0-cdh5.11.0/managing/index.md
@@ -51,7 +51,7 @@ $ dcos hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/hdfs/2.0.4-2.6.0-cdh5.11.0/managing/index.md
+++ b/pages/services/hdfs/2.0.4-2.6.0-cdh5.11.0/managing/index.md
@@ -50,7 +50,7 @@ $ dcos hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/hdfs/v2.0.0-2.6.0-cdh5.11.0/managing/index.md
+++ b/pages/services/hdfs/v2.0.0-2.6.0-cdh5.11.0/managing/index.md
@@ -51,7 +51,7 @@ $ dcos hdfs describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/include/managing.tmpl
+++ b/pages/services/include/managing.tmpl
@@ -39,7 +39,7 @@ $ dcos {{ model.packageName }} --name={{ model.serviceName }} describe > options
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when installing the service.
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when installing the service.
 
 <p class="message--note"><strong>NOTE: </strong>You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating options.json" section below for information on recovering these values.</p>
 

--- a/pages/services/kafka/2.0.1-0.11.0/managing/index.md
+++ b/pages/services/kafka/2.0.1-0.11.0/managing/index.md
@@ -50,7 +50,7 @@ $ dcos kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/kafka/2.0.2-0.11.0/managing/index.md
+++ b/pages/services/kafka/2.0.2-0.11.0/managing/index.md
@@ -50,7 +50,7 @@ $ dcos kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/kafka/2.0.3-0.11.0/managing/index.md
+++ b/pages/services/kafka/2.0.3-0.11.0/managing/index.md
@@ -50,7 +50,7 @@ $ dcos kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/kafka/2.0.4-1.0.0/managing/index.md
+++ b/pages/services/kafka/2.0.4-1.0.0/managing/index.md
@@ -46,7 +46,7 @@ $ dcos kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 **Note:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/kafka/v2.0.0-0.11.0/managing/index.md
+++ b/pages/services/kafka/v2.0.0-0.11.0/managing/index.md
@@ -50,7 +50,7 @@ $ dcos kafka describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
+If you installed the service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://docs.mesosphere.com/latest/deploying-services/config-universe-service/).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/kubernetes/2.0.0-1.12.1/operations/exposing-the-kubernetes-api/index.md
+++ b/pages/services/kubernetes/2.0.0-1.12.1/operations/exposing-the-kubernetes-api/index.md
@@ -307,7 +307,7 @@ frontend frontend_all
     use_backend backend_devkubernetes02 if { ssl_fc_sni devkubernetes02.example.com }
 ```
 
-Notice how `backend_devkubernetes01` and `backend_devkubernetes02` match the the names of the backends defined in the first step.
+Notice how `backend_devkubernetes01` and `backend_devkubernetes02` match the names of the backends defined in the first step.
 Additional forwarding rules can be set up for other domains as required, regardless of whether they correspond to other instances of the Kubernetes API or to completely different services.
 For further information, refer to the [HAProxy documentation](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html).
 

--- a/pages/services/kubernetes/2.0.0-1.12.1/operations/troubleshooting/index.md
+++ b/pages/services/kubernetes/2.0.0-1.12.1/operations/troubleshooting/index.md
@@ -77,7 +77,7 @@ com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter:subscribe(115): S
 ## A restarting or unhealthy DC/OS task
 
 In rare situations a DC/OS Kubernetes task may become unstable and require manual intervention.
-In this case use the the `dcos kubernetes cluster debug pod` [CLI](../cli#debug-pod-1) to assist in debugging and recovering failed, flapping or otherwise misbehaving tasks.
+In this case use the `dcos kubernetes cluster debug pod` [CLI](../cli#debug-pod-1) to assist in debugging and recovering failed, flapping or otherwise misbehaving tasks.
 
 First run `dcos kubernetes cluster debug pod restart <pod> --cluster-name <cluster-name>` to simply restart the task on the same agent.
 If that does not work or you know that specific agent is unhealthy, run `dcos kubernetes cluster debug pod replace <pod> --cluster-name <cluster-name>` to force the pod to be scheduled on a new agent.

--- a/pages/services/kubernetes/2.0.1-1.12.2/operations/exposing-the-kubernetes-api/index.md
+++ b/pages/services/kubernetes/2.0.1-1.12.2/operations/exposing-the-kubernetes-api/index.md
@@ -307,7 +307,7 @@ frontend frontend_all
     use_backend backend_devkubernetes02 if { ssl_fc_sni devkubernetes02.example.com }
 ```
 
-Notice how `backend_devkubernetes01` and `backend_devkubernetes02` match the the names of the backends defined in the first step.
+Notice how `backend_devkubernetes01` and `backend_devkubernetes02` match the names of the backends defined in the first step.
 Additional forwarding rules can be set up for other domains as required, regardless of whether they correspond to other instances of the Kubernetes API or to completely different services.
 For further information, refer to the [HAProxy documentation](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html).
 

--- a/pages/services/kubernetes/2.0.1-1.12.2/operations/troubleshooting/index.md
+++ b/pages/services/kubernetes/2.0.1-1.12.2/operations/troubleshooting/index.md
@@ -77,7 +77,7 @@ com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter:subscribe(115): S
 ## A restarting or unhealthy DC/OS task
 
 In rare situations a DC/OS Kubernetes task may become unstable and require manual intervention.
-In this case use the the `dcos kubernetes cluster debug pod` [CLI](../cli#debug-pod-1) to assist in debugging and recovering failed, flapping or otherwise misbehaving tasks.
+In this case use the `dcos kubernetes cluster debug pod` [CLI](../cli#debug-pod-1) to assist in debugging and recovering failed, flapping or otherwise misbehaving tasks.
 
 First run `dcos kubernetes cluster debug pod restart <pod> --cluster-name <cluster-name>` to simply restart the task on the same agent.
 If that does not work or you know that specific agent is unhealthy, run `dcos kubernetes cluster debug pod replace <pod> --cluster-name <cluster-name>` to force the pod to be scheduled on a new agent.

--- a/pages/services/kubernetes/2.1.0-1.12.3/operations/exposing-the-kubernetes-api/index.md
+++ b/pages/services/kubernetes/2.1.0-1.12.3/operations/exposing-the-kubernetes-api/index.md
@@ -307,7 +307,7 @@ frontend frontend_all
     use_backend backend_devkubernetes02 if { ssl_fc_sni devkubernetes02.example.com }
 ```
 
-Notice how `backend_devkubernetes01` and `backend_devkubernetes02` match the the names of the backends defined in the first step.
+Notice how `backend_devkubernetes01` and `backend_devkubernetes02` match the names of the backends defined in the first step.
 Additional forwarding rules can be set up for other domains as required, regardless of whether they correspond to other instances of the Kubernetes API or to completely different services.
 For further information, refer to the [HAProxy documentation](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html).
 

--- a/pages/services/kubernetes/2.1.0-1.12.3/operations/troubleshooting/index.md
+++ b/pages/services/kubernetes/2.1.0-1.12.3/operations/troubleshooting/index.md
@@ -77,7 +77,7 @@ com.mesosphere.mesos.HTTPAdapter.MesosToSchedulerDriverAdapter:subscribe(115): S
 ## A restarting or unhealthy DC/OS task
 
 In rare situations a DC/OS Kubernetes task may become unstable and require manual intervention.
-In this case use the the `dcos kubernetes cluster debug pod` [CLI](../cli#debug-pod-1) to assist in debugging and recovering failed, flapping or otherwise misbehaving tasks.
+In this case use the `dcos kubernetes cluster debug pod` [CLI](../cli#debug-pod-1) to assist in debugging and recovering failed, flapping or otherwise misbehaving tasks.
 
 First run `dcos kubernetes cluster debug pod restart <pod> --cluster-name <cluster-name>` to simply restart the task on the same agent.
 If that does not work or you know that specific agent is unhealthy, run `dcos kubernetes cluster debug pod replace <pod> --cluster-name <cluster-name>` to force the pod to be scheduled on a new agent.

--- a/pages/services/marathon-lb/mlb-auth/index.md
+++ b/pages/services/marathon-lb/mlb-auth/index.md
@@ -29,7 +29,7 @@ This topic describes how to provision a Marathon-LB instance that interacts with
 
 **Note:** This document assumes the following:
 * `marathon-lb` as the `marathon-lb` `marathon` service name; if you are installing `marathon-lb` in a different location, you will have to change the secret location accordingly.
-* `marathon-lb/service-account-secret` as the the full path for the secret used to store the credentials for the Marathon-LB service account; if you change the `marathon-lb` service name, you will have to change this.
+* `marathon-lb/service-account-secret` as the full path for the secret used to store the credentials for the Marathon-LB service account; if you change the `marathon-lb` service name, you will have to change this.
 * `mlb-private-key.pem` as the name of the file containing the private key.
 * `mlb-public-key.pem` as the name of the file containing the public key.
 

--- a/pages/services/nifi/0.1.0-1.5.0/managing/index.md
+++ b/pages/services/nifi/0.1.0-1.5.0/managing/index.md
@@ -47,7 +47,7 @@ dcos nifi describe > options.json
 ```
 Make any configuration changes to the `options.json` file.
 
-If you installed DC/OS NiFi Service with an earlier version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://github.com/mesosphere/dcos-nifi/blob/ServiceGuide/docs/install.md).
+If you installed DC/OS NiFi Service with an earlier version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://github.com/mesosphere/dcos-nifi/blob/ServiceGuide/docs/install.md).
 
 **Caution:** You must specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values revert to the default values specified by the DC/OS NiFi Service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/nifi/0.2.0-1.5.0/managing/index.md
+++ b/pages/services/nifi/0.2.0-1.5.0/managing/index.md
@@ -48,7 +48,7 @@ dcos nifi describe > options.json
 
 Make any configuration changes to the `options.json` file.
 
-If you installed this service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://github.com/mesosphere/dcos-nifi/blob/ServiceGuide/docs/install.md).
+If you installed this service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](https://github.com/mesosphere/dcos-nifi/blob/ServiceGuide/docs/install.md).
 
 <strong>Note:</strong> You need to specify all configuration values in the `options.json` file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the "Recreating `options.json`" section below for information on recovering these values.
 

--- a/pages/services/percona-server-mongodb/0.4.0-3.6.6/managing/index.md
+++ b/pages/services/percona-server-mongodb/0.4.0-3.6.6/managing/index.md
@@ -47,7 +47,7 @@ dcos percona-server-mongodb describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed this service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](#initial-service-configuration).
+If you installed this service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](#initial-service-configuration).
 
 <table class=“table” bgcolor=#858585>
 <tr> 

--- a/pages/services/percona-server-mongodb/0.4.1-3.6.8/managing/index.md
+++ b/pages/services/percona-server-mongodb/0.4.1-3.6.8/managing/index.md
@@ -47,7 +47,7 @@ dcos {{ model.serviceName }} describe > options.json
 
 Make any configuration changes to this `options.json` file.
 
-If you installed this service with a prior version of DC/OS, this configuration will not have been persisted by the the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](#initial-service-configuration).
+If you installed this service with a prior version of DC/OS, this configuration will not have been persisted by the DC/OS package manager. You can instead use the `options.json` file that was used when [installing the service](#initial-service-configuration).
 
 <p class="message--important"><strong>IMPORTANT: </strong> You must specify all configuration values in the <tt>options.json</tt> file when performing a configuration update. Any unspecified values will be reverted to the default values specified by the DC/OS service. See the <tt>Recreating options.json</tt> section below for information on recovering these values.</pd> 
 


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS-46168?filter=-2

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
