### PR TITLE
pn/dcos-44041 expanded metrics documentation

### DIFF
--- a/pages/1.12/metrics/architecture/index.md
+++ b/pages/1.12/metrics/architecture/index.md
@@ -1,0 +1,31 @@
+---
+layout: layout.pug
+title: The Metrics Pipeline
+navigationTitle: The Metrics Pipeline
+menuWeight: 3
+excerpt: How DC/OS manages metrics
+enterprise: false
+---
+
+DC/OS 1.12's metrics pipeline is based on [Telegraf](https://github.com/dcos/telegraf).
+
+Telegraf runs on each node in a DC/OS cluster, both masters and agents. By default, it gathers metrics from processes running on the same node, processes them, and sends them on to a central metrics database. 
+
+Telegraf has a plugin-driven architecture, and many plugins are available. Telegraf plugins are included at compile-time, and enabled via configuration files. By default, DC/OS' Telegraf enables the following plugins:
+
+ 1. `system` input plugin collects information about the node, eg CPU, memory, and disk usage.
+ 1. `statsd` input plugin collects statsd metrics from DC/OS components.
+ 1. `prometheus` input plugin collects metrics from DC/OS components and mesos tasks.
+ 1. `mesos` input plugin collects metrics about the mesos process.
+ 1. `dcos_statsd` input plugin starts a new statsd server for each mesos task.
+ 1. `dcos_containers` collects resource information about containers from mesos.
+ 1. `override` plugin is used to add node-level metadata, eg cluster name.
+ 1. `dcos_metadata` plugin is used to add task-level metadata, eg executor name and task name.
+ 1. `dcos_api` output plugin serves the dcos-metrics JSON API, used by the CLI.
+ 1. `prometheus_client` output plugin serves metrics in Prometheus format.
+
+Telegraf loads a configuration file and the contents of a configuration directory when it starts. Plugins may be enabled by creating the appropriate configuration and dropping it into `/opt/mesosphere/etc/telegraf/telegraf.d`, before restarting Telegraf. 
+
+The Telegraf pipeline is intended to abstract the complexity of collecting metrics from every process running in the cluster. It does this by providing a single source for metrics of all kinds on each node. It also resolves the identity of metrics arriving from tasks running on Mesos. These metrics are often identified by nothing more than their originating container ID, a long random hash. The Telegraf pipeline adds metadata such as the originating task name , in order to make them human-readable. 
+
+The [DC/OS fork of Telegraf](https://github.com/dcos/telegraf) includes technical documentation and sample configurations for each plugin.

--- a/pages/1.12/metrics/architecture/index.md
+++ b/pages/1.12/metrics/architecture/index.md
@@ -7,25 +7,25 @@ excerpt: How DC/OS manages metrics
 enterprise: false
 ---
 
-DC/OS 1.12's metrics pipeline is based on [Telegraf](https://github.com/dcos/telegraf).
+Metrics in DC/OS, version 1.12 and newer, are based on [Telegraf](https://github.com/dcos/telegraf). Telegraf provides an agent-based service that runs on each master and agent node in a DC/OS cluster. By default, Telegraf gathers metrics from all of the processes running on the same node, processes them, then sends the collected information to a central metrics database. 
 
-Telegraf runs on each node in a DC/OS cluster, both masters and agents. By default, it gathers metrics from processes running on the same node, processes them, and sends them on to a central metrics database. 
+Telegraf has a plugin-driven architecture. The plugin architecture enables Telegraf to collect information from any supported input plugin and write results to any supported output plugin. The plugins are compiled into the Telegraf binary for execution, and you can selectively enable and customize plugins using configuration file options. 
 
-Telegraf has a plugin-driven architecture, and many plugins are available. Telegraf plugins are included at compile-time, and enabled via configuration files. By default, DC/OS' Telegraf enables the following plugins:
+By default, DC/OS enables the following Telegraf plugins:
 
- 1. `system` input plugin collects information about the node, eg CPU, memory, and disk usage.
- 1. `statsd` input plugin collects statsd metrics from DC/OS components.
- 1. `prometheus` input plugin collects metrics from DC/OS components and mesos tasks.
- 1. `mesos` input plugin collects metrics about the mesos process.
- 1. `dcos_statsd` input plugin starts a new statsd server for each mesos task.
- 1. `dcos_containers` collects resource information about containers from mesos.
- 1. `override` plugin is used to add node-level metadata, eg cluster name.
- 1. `dcos_metadata` plugin is used to add task-level metadata, eg executor name and task name.
- 1. `dcos_api` output plugin serves the dcos-metrics JSON API, used by the CLI.
+ 1. `system` input plugin collects information about the node, for example, CPU, memory, and disk usage.
+ 1. `statsd` input plugin collects `statsd` metrics from DC/OS components.
+ 1. `prometheus` input plugin collects metrics from DC/OS components and `mesos` tasks.
+ 1. `mesos` input plugin collects metrics about the `mesos` process itself.
+ 1. `dcos_statsd` input plugin starts a new `statsd` server for each `mesos` task.
+ 1. `dcos_containers` collects resource information about containers from the `mesos` process.
+ 1. `override` plugin is used to add **node-level** metadata, for example, the cluster name.
+ 1. `dcos_metadata` plugin is used to add **task-level** metadata, for example, the executor name and task name.
+ 1. `dcos_api` output plugin serves the `dcos-metrics` JSON API, which is used by the CLI.
  1. `prometheus_client` output plugin serves metrics in Prometheus format.
 
-Telegraf loads a configuration file and the contents of a configuration directory when it starts. Plugins may be enabled by creating the appropriate configuration and dropping it into `/opt/mesosphere/etc/telegraf/telegraf.d`, before restarting Telegraf. 
+When Telegraf starts on a node, it loads a configuration file and the contents of a configuration directory. You can specify the plugins you want to enable by creating a configuration file with the appropriate settings and copying the file into the `/opt/mesosphere/etc/telegraf/telegraf.d` directory before restarting Telegraf. 
 
-The Telegraf pipeline is intended to abstract the complexity of collecting metrics from every process running in the cluster. It does this by providing a single source for metrics of all kinds on each node. It also resolves the identity of metrics arriving from tasks running on Mesos. These metrics are often identified by nothing more than their originating container ID, a long random hash. The Telegraf pipeline adds metadata such as the originating task name , in order to make them human-readable. 
+Telegraf abstracts the complexity of collecting metrics from every process running in the cluster by providing a single source for metrics on each node. Telegraf also adds identifying metadata--such as the originating task name--to the metrics it collects to make the metric more human-readable. Without this metadata, metrics for tasks running on Mesos would be difficult to identify by their originating container ID, which is a long random hash. 
 
 The [DC/OS fork of Telegraf](https://github.com/dcos/telegraf) includes technical documentation and sample configurations for each plugin.

--- a/pages/1.12/metrics/datadog/index.md
+++ b/pages/1.12/metrics/datadog/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Export DC/OS Metrics to Datadog
 navigationTitle: Export DC/OS Metrics to Datadog
-menuWeight: 3
+menuWeight: 4
 excerpt: Sending DC/OS metrics to Datadog
 beta: true
 ---

--- a/pages/1.12/metrics/index.md
+++ b/pages/1.12/metrics/index.md
@@ -13,9 +13,10 @@ enterprise: false
 The metrics pipeline for DC/OS 1.12 is [Telegraf](/1.12/overview/architecture/components/#telegraf). Telegraf provides metrics from DC/OS cluster hosts, containers running on those hosts, and from applications running on DC/OS via `statsd`. Telegraf is natively integrated with DC/OS. By default, it exposes metrics in Prometheus format, and in JSON format via an API.
 
 ## Overview
-DC/OS collects three types of metrics as follows:
+DC/OS collects four types of metrics as follows:
 
 * **System:** - Metrics about each node in the DC/OS cluster.
+* **Component:** - Metrics about the components which make up DC/OS.
 * **Container:** - Metrics about cgroup allocations from tasks running in the DC/OS [Universal Container Runtime](/1.12/deploying-services/containerizers/ucr/) or [Docker Engine](/1.12/deploying-services/containerizers/docker-containerizer/) runtime.
 * **Application:** - Metrics emitted from any application running on the Universal Container Runtime.
 

--- a/pages/1.12/metrics/index.md
+++ b/pages/1.12/metrics/index.md
@@ -10,28 +10,24 @@ enterprise: false
 
 <!-- The source repo for this topic is https://github.com/dcos/dcos-docs-site -->
 
-The metrics pipeline for DC/OS 1.12 is [Telegraf](/1.12/overview/architecture/components/#telegraf). Telegraf provides metrics from DC/OS cluster hosts, containers running on those hosts, and from applications running on DC/OS via `statsd`. Telegraf is natively integrated with DC/OS. By default, it exposes metrics in Prometheus format, and in JSON format via an API.
+Metrics in DC/OS, version 1.12 or newer, use [Telegraf](/1.12/overview/architecture/components/#telegraf) to collect and process data. Telegraf provides metrics from DC/OS cluster hosts, containers running on those hosts, and from applications running on DC/OS using the `statsd` process. Telegraf is natively integrated with DC/OS. By default, it exposes metrics in Prometheus format from `port 61091` on each node, and in JSON format through the DC/OS [Metrics API](/1.12/metrics/metrics-api/).
 
 ## Overview
 DC/OS collects four types of metrics as follows:
 
 * **System:** - Metrics about each node in the DC/OS cluster.
 * **Component:** - Metrics about the components which make up DC/OS.
-* **Container:** - Metrics about cgroup allocations from tasks running in the DC/OS [Universal Container Runtime](/1.12/deploying-services/containerizers/ucr/) or [Docker Engine](/1.12/deploying-services/containerizers/docker-containerizer/) runtime.
+* **Container:** - Metrics about `cgroup` allocations from tasks running in the DC/OS [Universal Container Runtime](/1.12/deploying-services/containerizers/ucr/) or [Docker Engine](/1.12/deploying-services/containerizers/docker-containerizer/) runtime.
 * **Application:** - Metrics emitted from any application running on the Universal Container Runtime.
 
-Metrics are tagged by origin and made available in Prometheus format on `port 61091` on each node. They are also available via the DC/OS [Metrics API](/1.12/metrics/metrics-api/).
-
-Telegraf is a metrics pipeline which is shipped as part of the DC/OS distribution to collect metrics from system, container, and application. Telegraf runs on every host in the cluster. It is designed around a pluggable architecture. Several custom plugins written especially for DC/OS provide metrics on the performance of DC/OS workloads and DC/OS itself. 
-
-Application metrics and custom metrics emitted by DC/OS applications are collected via `statsd`. A dedicated `statsd` server is started for each new task. Any metrics received by the `statsd` server are tagged with the task name and its service name. The address of the server is provided via environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). 
+Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plug9n-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself. Telegraf collects application and custom metrics through the `statsd` process. A dedicated `statsd` server is started for each new task. Any metrics received by the `statsd` server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). 
 
 For more informaiton about the list of metrics that are automatically collected by DC/OS, read [Metrics Reference](/1.12/metrics/reference/) documentation.
 
 ## Upgrading from 1.11
-DC/OS 1.12 includes an updated `statsd` server implementation for application metrics. This fixes an issue with the `statsd` server implementation in 1.11, which treated all application metrics as gauges, regardless of statsd type. 
+DC/OS 1.12 includes an updated `statsd` server implementation for application metrics. The `statsd` update fixes an issue with the `statsd` server implementation in 1.11, which treated all application metrics as gauges, regardless of `statsd` type. 
 
-Dashboards and alerts that rely on counters, histograms or sets will behave differently in 1.12 than in 1.11 as follows:
+Dashboards and alerts that rely on counters, histograms, or sets behave differently in 1.12 than in 1.11 as follows:
 - Gauges report the last received value. There is no change from 1.11 functionality. 
 - Counters report the sum of all received values. In 1.11, counters reported the last received value.
 - Histograms and timers report `_sum`, `_min` and `_max` metrics. In 1.11, histograms reported the last received value.
@@ -42,7 +38,6 @@ Additionally, multi-packet metrics and sampling are now available. In 1.11, they
 ## Troubleshooting
 Use the following troubleshooting guidelines to resolve errors:
 
-- Metrics about Telegraf's own performance may be collected by enabling the `inputs.internal` plugin. 
-- Telegraf runs as a `systemd` unit. The status of `systemd` unit may be examined via `systemctl status dcos-telegraf`. 
+- You can collect metrics about Telegraf's own performance by enabling the `inputs.internal` plugin. 
+- You can check the status of the Telegraf `systemd` unit by running `systemctl status dcos-telegraf`. 
 - Logs are available from journald via `journalctl -u dcos-telegraf`.
-

--- a/pages/1.12/metrics/mesos/index.md
+++ b/pages/1.12/metrics/mesos/index.md
@@ -1,0 +1,59 @@
+---
+layout: layout.pug
+title: Enable Mesos Metrics
+navigationTitle: Enable Mesos Metrics
+menuWeight: 3
+excerpt: Monitoring Mesos with Telegraf
+enterprise: false
+---
+
+DC/OS 1.12's metrics pipeline can be configured to gather [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. This page explains how to add the appropriate configuration to DC/OS.
+
+<p class="message--note"><strong>NOTE: </strong>This functionality is experimental, and modifying files in `/opt/mesosphere` is not supported. </p>
+
+
+**Prerequisite:**
+
+- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser via the `dcos auth login` command.
+
+# Configuring Telegraf to collect metrics from Mesos masters
+
+1. Create a file named `mesos-master.conf` with the following content:
+
+    ```
+    # Gathers all Mesos metrics
+    [[inputs.mesos]]
+      # The interval at which to collect metrics
+      interval = "60s"
+      # Timeout, in ms.
+      timeout = 30000
+      # A list of Mesos masters.
+      masters = ["http://$DCOS_NODE_PRIVATE_IP:5050"]
+    ```
+
+1. On every master node in your cluster, do the following tasks:
+
+   1. Upload the `mesos-master.conf` file to `/opt/mesosphere/etc/telegraf/telegraf.d/mesos-master.conf`.
+   1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
+
+1. Create a file named `mesos-agent.conf` with the following content:
+
+    ```
+    # Gathers all Mesos metrics
+    [[inputs.mesos]]
+      # The interval at which to collect metrics
+      interval = "60s"
+      # Timeout, in ms.
+      timeout = 30000
+      # A list of Mesos slaves.
+      slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
+    ```
+
+1. On every agent node in your cluster, do the following tasks:
+
+   1. Upload the `mesos-agent.conf` file to `/opt/mesosphere/etc/telegraf/telegraf.d/mesos-agent.conf`.
+   1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
+
+ 
+A complete list of the metrics produced by Mesos can be found in the Mesos documentation on [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/). Mesos metric names may be modified by the TSDB in which they are stored. For example, the forward-slash character is illegal in Prometheus metric names; the `master/uptime_secs` name is therefore available in Prometheus as `master_uptime_secs`. 
+

--- a/pages/1.12/metrics/mesos/index.md
+++ b/pages/1.12/metrics/mesos/index.md
@@ -7,16 +7,16 @@ excerpt: Monitoring Mesos with Telegraf
 enterprise: false
 ---
 
-DC/OS 1.12's metrics pipeline can be configured to gather [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. This page explains how to add the appropriate configuration to DC/OS.
+You can configure DC/OS, version 1.12 or newer, to gather [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. This page explains how to add the appropriate configuration to DC/OS.
 
 <p class="message--note"><strong>NOTE: </strong>This functionality is experimental, and modifying files in `/opt/mesosphere` is not supported. </p>
 
 
 **Prerequisite:**
 
-- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser via the `dcos auth login` command.
+- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser by running the `dcos auth login` command.
 
-# Configuring Telegraf to collect metrics from Mesos masters
+# Collecting metrics from Mesos masters with Telegraf
 
 1. Create a file named `mesos-master.conf` with the following content:
 
@@ -35,6 +35,8 @@ DC/OS 1.12's metrics pipeline can be configured to gather [observability metrics
 
    1. Upload the `mesos-master.conf` file to `/opt/mesosphere/etc/telegraf/telegraf.d/mesos-master.conf`.
    1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
+   
+# Collecting metrics from Mesos agent with Telegraf
 
 1. Create a file named `mesos-agent.conf` with the following content:
 
@@ -54,6 +56,6 @@ DC/OS 1.12's metrics pipeline can be configured to gather [observability metrics
    1. Upload the `mesos-agent.conf` file to `/opt/mesosphere/etc/telegraf/telegraf.d/mesos-agent.conf`.
    1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
 
+# Viewing metrics for Mesos masters and agents
  
-A complete list of the metrics produced by Mesos can be found in the Mesos documentation on [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/). Mesos metric names may be modified by the TSDB in which they are stored. For example, the forward-slash character is illegal in Prometheus metric names; the `master/uptime_secs` name is therefore available in Prometheus as `master_uptime_secs`. 
-
+You can review the complete list of the metrics produced by Mesos in the Mesos documentation on [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/). You should note that the database in which metrics are stored might require the metric names to be modified. For example, the forward-slash (/) character is illegal in Prometheus metric names, so the `master/uptime_secs` name is available in Prometheus as `master_uptime_secs`. 

--- a/pages/1.12/metrics/prometheus/index.md
+++ b/pages/1.12/metrics/prometheus/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Export DC/OS Metrics to Prometheus
 navigationTitle: Export DC/OS Metrics to Prometheus
-menuWeight: 4.5
+menuWeight: 5
 excerpt: Monitoring your workload with Prometheus and Grafana self-hosted instances
 enterprise: false
 ---


### PR DESCRIPTION
## Description
[DCOS-44041](https://jira.mesosphere.com/browse/DCOS-44041) - Document Mesos input plugin (replaced mesos_exporter)
[DCOS-45416](https://jira.mesosphere.com/browse/DCOS-45416) - Document how the telegraf pipe is wired and intended to be used.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
