### PR TITLE
Add pattern for setting IAM permissions using the API

### DIFF
--- a/pages/1.11/security/ent/perms-management/index.md
+++ b/pages/1.11/security/ent/perms-management/index.md
@@ -36,3 +36,14 @@ To manage permissions for **users** from the DC/OS Enterprise CLI, use the follo
 
 * `dcos security org users grant [OPTIONS] UID RID ACTION`
 * `dcos security org users revoke [OPTIONS] UID RID ACTION`
+
+### Managing permissions using the API
+
+The [IAM HTTP API](/1.11/security/ent/iam-api/) provides operations to manage permissions for users and groups.
+
+Note that all entities must exist when creating a permission.
+
+A typical pattern to create a permission is:
+
+1. call `PUT /acls/{rid}` to create the access control list for the protected resource `{rid}`, ignoring any returned `409` status code (that indicates that it already exists); then
+1. call `PUT /acls/{rid}/users/{uid}/{action}`  or `PUT /acls/{rid}/groups/{gid}/{action}` to create the specific user or group access control entry.

--- a/pages/1.12/security/ent/perms-management/index.md
+++ b/pages/1.12/security/ent/perms-management/index.md
@@ -36,3 +36,14 @@ To manage permissions for **users** from the DC/OS Enterprise CLI, use the follo
 
 * `dcos security org users grant [OPTIONS] UID RID ACTION`
 * `dcos security org users revoke [OPTIONS] UID RID ACTION`
+
+### Managing permissions using the API
+
+The [IAM HTTP API](/1.12/security/ent/iam-api/) provides operations to manage permissions for users and groups.
+
+Note that all entities must exist when creating a permission.
+
+A typical pattern to create a permission is:
+
+1. call `PUT /acls/{rid}` to create the access control list for the protected resource `{rid}`, ignoring any returned `409` status code (that indicates that it already exists); then
+1. call `PUT /acls/{rid}/users/{uid}/{action}`  or `PUT /acls/{rid}/groups/{gid}/{action}` to create the specific user or group access control entry.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-46180

Add the typical pattern used to create a permission in the IAM.

This is in response to clarification provided for https://jira.mesosphere.com/browse/COPS-4026

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
