### PR TITLE
LG/DCOS-25826 changed syntax from dcos:service:metronome:metronome:job…

### DIFF
--- a/pages/1.10/deploying-jobs/examples/index.md
+++ b/pages/1.10/deploying-jobs/examples/index.md
@@ -163,13 +163,13 @@ The jobs groups are then assigned permissions to users `Cory` and `Alice` to res
     
         ![Add permissions cory](/1.10/img/job-ex5.png)
         
-    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:/dev/batch/job1 read,update`.
+    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:/dev.batch.job1 read,update`.
     
         **Important:** Your [security mode](/1.10/security/ent/#security-modes) must be either `permissive` or `strict`.
         
         ```bash
         dcos:adminrouter:service:metronome full
-        dcos:service:metronome:metronome:jobs:dev/batch/job1 read
+        dcos:service:metronome:metronome:jobs:dev.batch.job1 read
         dcos:adminrouter:ops:mesos full
         dcos:adminrouter:ops:slave full
         dcos:mesos:master:framework:role:* read

--- a/pages/1.11/deploying-jobs/examples/index.md
+++ b/pages/1.11/deploying-jobs/examples/index.md
@@ -177,7 +177,7 @@ The jobs groups are then assigned permissions to users `Cory` and `Alice` to res
 
         Figure 7. Add permissions for user 'Cory'
 
-    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:/dev/batch/job1 read,update`.
+    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:dev.batch.job1 read,update`.
 
         <table class=“table” bgcolor=#858585>
         <tr> 
@@ -187,7 +187,7 @@ The jobs groups are then assigned permissions to users `Cory` and `Alice` to res
 
         ```bash
         dcos:adminrouter:service:metronome full
-        dcos:service:metronome:metronome:jobs:dev/batch/job1 read
+        dcos:service:metronome:metronome:jobs:dev.batch.job1 read
         dcos:adminrouter:ops:mesos full
         dcos:adminrouter:ops:slave full
         dcos:mesos:master:framework:role:* read

--- a/pages/1.12/deploying-jobs/examples/index.md
+++ b/pages/1.12/deploying-jobs/examples/index.md
@@ -176,11 +176,11 @@ The jobs groups are then assigned permissions to users `Cory` and `Alice` to res
 
         Figure 7. Add permissions for user 'Cory'
 
-    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:/dev/batch/job1 read,update`.
+    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:/dev.batch.job1 read,update`.
 
         ```bash
         dcos:adminrouter:service:metronome full
-        dcos:service:metronome:metronome:jobs:dev/batch/job1 read
+        dcos:service:metronome:metronome:jobs:dev.batch.job1 read
         dcos:adminrouter:ops:mesos full
         dcos:adminrouter:ops:slave full
         dcos:mesos:master:framework:role:* read

--- a/pages/1.9/deploying-jobs/examples/index.md
+++ b/pages/1.9/deploying-jobs/examples/index.md
@@ -164,13 +164,13 @@ The jobs groups are then assigned permissions to users `Cory` and `Alice` to res
 
         ![Add permissions cory](/1.9/img/job-ex5.png)
 
-    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:/dev/batch/job1 read,update`.
+    1.  Copy and paste the permissions in the **Permissions Strings** field. Specify your job group (`dev/batch`), job name (`job1`), and action (`read`). Actions can be either `create`, `read`, `update`, `delete`, or `full`. To permit more than one operation, use a comma to separate them, for example: `dcos:service:metronome:metronome:jobs:dev.batch.job1 read,update`.
 
         **Important:** Your [security mode](/1.9/security/ent/#security-modes) must be either `permissive` or `strict`.
 
         ```bash
         dcos:adminrouter:service:metronome full
-        dcos:service:metronome:metronome:jobs:dev/batch/job1 read
+        dcos:service:metronome:metronome:jobs:dev.batch.job1 read
         dcos:adminrouter:ops:mesos full
         dcos:adminrouter:ops:slave full
         dcos:mesos:master:framework:role:* read


### PR DESCRIPTION
…s:/dev/batch/job1 to dcos:service:metronome:metronome:jobs:dev.batch.job1

## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS-25826

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
