### PR TITLE
COPS-4275 Fix fault_domain output format

### DIFF
--- a/pages/1.10/installing/production/deploying-dcos/installation/index.md
+++ b/pages/1.10/installing/production/deploying-dcos/installation/index.md
@@ -114,38 +114,38 @@ In this step, an IP detection script is created. This script reports the IP addr
 
         [enterprise type="inline" size="small" /]
 
-```bash
-#!/usr/bin/env bash
-set -o nounset -o errexit
-MASTER_IP=172.28.128.3
-echo $(/usr/sbin/ip route show to match 172.28.128.3 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | tail -1)
-```
+        ```bash
+        #!/usr/bin/env bash
+        set -o nounset -o errexit
+        MASTER_IP=172.28.128.3
+        echo $(/usr/sbin/ip route show to match 172.28.128.3 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | tail -1)
+        ```
 
-[oss type="inline" size="small" /]
+        [oss type="inline" size="small" /]
 
-```bash
-#!/usr/bin/env bash
-set -o nounset -o errexit -o pipefail
-export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
-MASTER_IP=$(dig +short master.mesos || true)
-MASTER_IP=${MASTER_IP:-172.28.128.3}
-INTERFACE_IP=$(ip r g ${MASTER_IP} | \
-awk -v master_ip=${MASTER_IP} '
-BEGIN { ec = 1 }
- {
-  if($1 == master_ip) {
-        print $7
-        ec = 0
- } else if($1 == "local") {
-        print $6
-        ec = 0
- }
-      if (ec == 0) exit;
-    }
-      END { exit ec }
-    ')
-    echo $INTERFACE_IP
-```
+        ```bash
+        #!/usr/bin/env bash
+        set -o nounset -o errexit -o pipefail
+        export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
+        MASTER_IP=$(dig +short master.mesos || true)
+        MASTER_IP=${MASTER_IP:-172.28.128.3}
+        INTERFACE_IP=$(ip r g ${MASTER_IP} | \
+        awk -v master_ip=${MASTER_IP} '
+        BEGIN { ec = 1 }
+        {
+        if($1 == master_ip) {
+                print $7
+                ec = 0
+        } else if($1 == "local") {
+                print $6
+                ec = 0
+        }
+            if (ec == 0) exit;
+            }
+            END { exit ec }
+            ')
+            echo $INTERFACE_IP
+        ```
 
 [enterprise]
 # Create a fault domain detection script
@@ -156,18 +156,21 @@ By default, DC/OS clusters have [fault domain awareness](/1.12/deploying-service
 
 1. Create a fault domain detect script named `fault-domain-detect` to run on each node to detect the node's fault domain. During installation, the output of this script is passed to Mesos.
 
-   We recommend the format for the script output be:
+   The format for the script output is:
 
-```json
-  {
-    "fault_domain": {
-      "region": {
-        "name": <region>,
-        "zone": <zone>
-      }
+    ```json
+    {
+        "fault_domain": {
+            "region": {
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
+            }
+        }
     }
-  }
-```
+    ```
+
     We provide [fault domain detect scripts for AWS and Azure](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
 
    <p class="message--warning"><strong>WARNING: </strong>This script will not work if you use proxies in your environment. If you use a proxy, modifications will be required.</p>

--- a/pages/1.11/deploying-services/fault-domain-awareness/index.md
+++ b/pages/1.11/deploying-services/fault-domain-awareness/index.md
@@ -41,12 +41,14 @@ You must have less than 100ms latency between regions.
 
     ```json
     {
-      "fault_domain": {
-        "region": {
-          "name": <region>,
-          "zone": <zone>
+        "fault_domain": {
+            "region": {
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
+            }
         }
-      }
     }
     ```
 

--- a/pages/1.11/hybrid-cloud/capacity-extension-with-regions/index.md
+++ b/pages/1.11/hybrid-cloud/capacity-extension-with-regions/index.md
@@ -31,15 +31,18 @@ enterprise: true
     We recommend the format for the script output be:
 
     ```json
-      {
+    {
         "fault_domain": {
-          "region": {
-            "name": <region>,
-            "zone": <zone>
-          }
+            "region": {
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
+            }
         }
-      }
+    }
     ```
+    
     We provide [fault domain detect scripts for AWS and Azure nodes](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
 
     <p class="message--important"><strong>IMPORTANT: </strong>This script will not work if you use proxies in your environment. If you use a proxy, modifications will be required.</p>

--- a/pages/1.11/installing/production/deploying-dcos/installation/index.md
+++ b/pages/1.11/installing/production/deploying-dcos/installation/index.md
@@ -160,15 +160,18 @@ By default, DC/OS clusters have [fault domain awareness](/1.12/deploying-service
     We recommend the format for the script output be:
 
     ```json
-      {
+    {
         "fault_domain": {
-          "region": {
-            "name": <region>,
-            "zone": <zone>
-          }
+            "region": {
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
+            }
         }
-      }
+    }
     ```
+
     We provide [fault domain detect scripts for AWS and Azure nodes](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
 
     <p class="message--important"><strong>IMPORTANT: </strong>This script will not work if you use proxies in your environment. If you use a proxy, modifications will be required.</p>

--- a/pages/1.12/deploying-services/fault-domain-awareness/index.md
+++ b/pages/1.12/deploying-services/fault-domain-awareness/index.md
@@ -37,22 +37,24 @@ You must have less than 100ms latency between regions.
 
 1. Create a fault domain detect script to run on each node to detect the node's fault domain (Enterprise only). During installation, the output of this script is passed to Mesos.
 
-We recommend the format for the script output be:
+    We recommend the format for the script output be:
 
-```json
-  {
-    "fault_domain": {
-      "region": {
-        "name": <region>,
-        "zone": <zone>
-      }
+    ```json
+    {
+        "fault_domain": {
+            "region": {
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
+            }
+        }
     }
-  }
-```
+    ```
 
-We provide [fault domain detect scripts for AWS and Azure nodes](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
+    We provide [fault domain detect scripts for AWS and Azure nodes](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
 
-<p class="message--important"> <strong>IMPORTANT:</strong> This script will not work if you use proxies in your environment. If you use a proxy, modifications will be required.</p>
+    <p class="message--important"> <strong>IMPORTANT:</strong> This script will not work if you use proxies in your environment. If you use a proxy, modifications will be required.</p>
 
 2. Add this script to the `genconf` folder of your bootstrap node. [More information](/1.12/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script).
 

--- a/pages/1.12/hybrid-cloud/capacity-extension-with-regions/index.md
+++ b/pages/1.12/hybrid-cloud/capacity-extension-with-regions/index.md
@@ -32,12 +32,14 @@ enterprise: false
 
     ```json
     {
-      "fault_domain": {
-        "region": {
-          "name": <region>,
-          "zone": <zone>
+        "fault_domain": {
+            "region": {
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
+            }
         }
-      }
     }
     ```
 

--- a/pages/1.12/installing/production/deploying-dcos/installation/index.md
+++ b/pages/1.12/installing/production/deploying-dcos/installation/index.md
@@ -114,38 +114,38 @@ In this step, an IP detection script is created. This script reports the IP addr
 
         [enterprise type="inline" size="small" /]
 
-```bash
-#!/usr/bin/env bash
-set -o nounset -o errexit
-MASTER_IP=172.28.128.3
-echo $(/usr/sbin/ip route show to match 172.28.128.3 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | tail -1)
-```
+        ```bash
+        #!/usr/bin/env bash
+        set -o nounset -o errexit
+        MASTER_IP=172.28.128.3
+        echo $(/usr/sbin/ip route show to match 172.28.128.3 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | tail -1)
+        ```
 
-[oss type="inline" size="small" /]
+        [oss type="inline" size="small" /]
 
-```bash
-#!/usr/bin/env bash
-set -o nounset -o errexit -o pipefail
-export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
-MASTER_IP=$(dig +short master.mesos || true)
-MASTER_IP=${MASTER_IP:-172.28.128.3}
-INTERFACE_IP=$(ip r g ${MASTER_IP} | \
-awk -v master_ip=${MASTER_IP} '
-BEGIN { ec = 1 }
- {
-  if($1 == master_ip) {
-        print $7
-        ec = 0
- } else if($1 == "local") {
-        print $6
-        ec = 0
- }
-      if (ec == 0) exit;
-    }
-      END { exit ec }
-    ')
-    echo $INTERFACE_IP
-```
+        ```bash
+        #!/usr/bin/env bash
+        set -o nounset -o errexit -o pipefail
+        export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
+        MASTER_IP=$(dig +short master.mesos || true)
+        MASTER_IP=${MASTER_IP:-172.28.128.3}
+        INTERFACE_IP=$(ip r g ${MASTER_IP} | \
+        awk -v master_ip=${MASTER_IP} '
+        BEGIN { ec = 1 }
+        {
+        if($1 == master_ip) {
+                print $7
+                ec = 0
+        } else if($1 == "local") {
+                print $6
+                ec = 0
+        }
+            if (ec == 0) exit;
+            }
+            END { exit ec }
+            ')
+            echo $INTERFACE_IP
+        ```
 
 [enterprise]
 # Create a fault domain detection script
@@ -160,12 +160,14 @@ By default, DC/OS clusters have [fault domain awareness](/1.12/deploying-service
 
     ```json
     {
-      "fault_domain": {
-        "region": {
-          "name": <region>,
-          "zone": <zone>
+        "fault_domain": {
+            "region": {
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
+            }
         }
-      }
     }
     ```
 

--- a/pages/cn/1.11/deploying-services/fault-domain-awareness/index.md
+++ b/pages/cn/1.11/deploying-services/fault-domain-awareness/index.md
@@ -39,16 +39,18 @@ Mesos 管理节点必须位于同一分域，因为否则它们之间的延迟�
 
 脚本输出的推荐格式为：
 
-```json
+  ```json
   {
-    "fault_domain": {
-      "region": {
-        "name": <region>,
-        "zone": <zone>
+      "fault_domain": {
+          "region": {
+              "name": "<region-name>"
+          },
+          "zone": {
+              "name": "<zone-name>"
+          }
       }
-    }
   }
-```
+  ```
 
 我们提供 [AWS 和 Azure 节点的故障域检测脚本](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect)。对于具有 aws 节点和 azure 节点的集群，可将两者组合为一个脚本。可以使用这些模型为本地集群创建故障域检测脚本。
 

--- a/pages/cn/1.11/hybrid-cloud/features/capacity-extension-with-regions/index.md
+++ b/pages/cn/1.11/hybrid-cloud/features/capacity-extension-with-regions/index.md
@@ -30,16 +30,18 @@ enterprise: true
 
     推荐脚本输出的格式为
 
-      ```json
-        {
-          "fault_domain": {
+    ```json
+    {
+        "fault_domain": {
             "region": {
-              "name": <region>,
-              "zone": <zone>
+                "name": "<region-name>"
+            },
+            "zone": {
+                "name": "<zone-name>"
             }
-          }
         }
-      ```
+    }
+    ```
       
     我们提供 [AWS 和 Azure 节点的故障域检测脚本](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect)。对于具有 aws 节点和 azure 节点的集群，可将两者组合为一个脚本。可以使用这些模型为本地集群创建故障域检测脚本。
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-4275
Fault domain output example incorrectly formatted. 1.10-1.12

Additionally fixed code block formatting. 

## Urgency
- [X ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
