### PR TITLE
Update metrics docs

### DIFF
--- a/pages/1.12/metrics/architecture/index.md
+++ b/pages/1.12/metrics/architecture/index.md
@@ -24,7 +24,7 @@ By default, DC/OS enables the following Telegraf plugins:
  1. `dcos_api` output plugin serves the `dcos-metrics` JSON API, which is used by the CLI.
  1. `prometheus_client` output plugin serves metrics in Prometheus format.
 
-When Telegraf starts on a node, it loads a configuration file and the contents of a configuration directory. You can specify the plugins you want to enable by creating a configuration file with the appropriate settings and copying the file into the `/opt/mesosphere/etc/telegraf/telegraf.d` directory before restarting Telegraf. 
+When Telegraf starts on a node, it loads a configuration file and the contents of a configuration directory or directories. You can specify the plugins you want to enable by creating a configuration file with the appropriate settings and copying the file into the `/var/lib/dcos/telegraf/telegraf.d` directory before restarting Telegraf. Only files ending with `.conf` will be included in the Telegraf configuration. Note: Any mistakes in the configuration files will prevent Telegraf from starting up successfully.
 
 Telegraf abstracts the complexity of collecting metrics from every process running in the cluster by providing a single source for metrics on each node. Telegraf also adds identifying metadata--such as the originating task name--to the metrics it collects to make the metric more human-readable. Without this metadata, metrics for tasks running on Mesos would be difficult to identify by their originating container ID, which is a long random hash. 
 

--- a/pages/1.12/metrics/datadog/index.md
+++ b/pages/1.12/metrics/datadog/index.md
@@ -10,8 +10,6 @@ beta: true
 
 DC/OS 1.12 sends metrics via [Telegraf](/1.12/overview/architecture/components/#telegraf), which may be configured to export metrics to Datadog. There is no need to install a metrics plugin, as in DC/OS 1.9, 1.10, and 1.11. This page explains how to add the appropriate configuration to DC/OS.
 
-<p class="message--note"><strong>NOTE: </strong>This functionality is experimental, and modifying files in `/opt/mesosphere` is not supported. </p>
- 
 
 **Prerequisite:**
 
@@ -34,6 +32,6 @@ DC/OS 1.12 sends metrics via [Telegraf](/1.12/overview/architecture/components/#
 
 1. On every node in your cluster, do the following tasks:
 
-   1. Upload the `datadog.conf` file to `/opt/mesosphere/etc/telegraf/telegraf.d/datadog.conf`.
+   1. Upload the `datadog.conf` file to `/var/lib/dcos/telegraf/telegraf.d/datadog.conf`.
    1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
    1. Check the Datadog UI to see the incoming DC/OS metrics. 

--- a/pages/1.12/metrics/mesos/index.md
+++ b/pages/1.12/metrics/mesos/index.md
@@ -9,8 +9,6 @@ enterprise: false
 
 You can configure DC/OS, version 1.12 or newer, to gather [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. This page explains how to add the appropriate configuration to DC/OS.
 
-<p class="message--note"><strong>NOTE: </strong>This functionality is experimental, and modifying files in `/opt/mesosphere` is not supported. </p>
-
 
 **Prerequisite:**
 
@@ -33,9 +31,9 @@ You can configure DC/OS, version 1.12 or newer, to gather [observability metrics
 
 1. On every master node in your cluster, do the following tasks:
 
-   1. Upload the `mesos-master.conf` file to `/opt/mesosphere/etc/telegraf/telegraf.d/mesos-master.conf`.
+   1. Upload the `mesos-master.conf` file to `/var/lib/dcos/telegraf/telegraf.d/mesos-master.conf`.
    1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
-   
+
 # Collecting metrics from Mesos agent with Telegraf
 
 1. Create a file named `mesos-agent.conf` with the following content:
@@ -53,7 +51,7 @@ You can configure DC/OS, version 1.12 or newer, to gather [observability metrics
 
 1. On every agent node in your cluster, do the following tasks:
 
-   1. Upload the `mesos-agent.conf` file to `/opt/mesosphere/etc/telegraf/telegraf.d/mesos-agent.conf`.
+   1. Upload the `mesos-agent.conf` file to `/var/lib/dcos/telegraf/telegraf.d/mesos-agent.conf`.
    1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
 
 # Viewing metrics for Mesos masters and agents


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-42214
Updates the metrics docs with the user-editable telegraf config dir that can now be used to add settings to telegraf.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
