### PR TITLE
ss/COPS-3816 Edited config permissions file.

### DIFF
--- a/pages/services/confluent-kafka/2.4.0-4.1.1/configuration/index.md
+++ b/pages/services/confluent-kafka/2.4.0-4.1.1/configuration/index.md
@@ -16,27 +16,24 @@ render: mustache
 
 {{ model.techName }} requires a running ZooKeeper ensemble to perform its own internal accounting. By default, the DC/OS {{ model.techName }} Service uses the ZooKeeper ensemble made available on the Mesos masters of a DC/OS cluster at `master.mesos:2181/dcos-service-<servicename>`. At install time, you can configure an alternate ZooKeeper for {{ model.techName }} to use. This enables you to increase {{ model.techName }}'s capacity and removes the DC/OS System ZooKeeper ensemble's involvement in running it.
 
+<p class="message--note"><strong>NOTE: </strong>If you are using the <a href="/services/confluent-zookeeper/">DC/OS Apache ZooKeeper service</a>, use the DNS addresses provided by the <tt>dcos confluent-zookeeper endpoints clientport</tt> command as the value of <tt>kafka_zookeeper_uri</tt>.</p>
 To configure an alternate Zookeeper instance:
 
-1. Create a file named `options.json` with the following contents.
+1. Create a file named `options.json` with the following contents. Here is an example `options.json` which points to a `confluent-zookeeper` instance named `confluent-zookeeper`:
 
-<p class="message--note"><strong>NOTE: </strong>If you are using the <a href="/services/confluent-zookeeper/">DC/OS Apache ZooKeeper service</a>, use the DNS addresses provided by the <tt>dcos confluent-zookeeper endpoints clientport</tt> command as the value of <tt>kafka_zookeeper_uri</tt>.</p>
-
-   Here is an example `options.json` which points to a `confluent-zookeeper` instance named `confluent-zookeeper`:
-
-```json
-{
-  "kafka": {
-    "kafka_zookeeper_uri": "zookeeper-0-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140"
-  }
-}
-```
+    ```json
+    {
+      "kafka": {
+        "kafka_zookeeper_uri": "zookeeper-0-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140"
+      }
+    }
+    ```
 
 1. Install {{ model.techName }} with the options file you created.
 
-```bash
-$ dcos package install {{ model.packageName }} --options="options.json"
-```
+    ```bash
+    $ dcos package install {{ model.packageName }} --options="options.json"
+    ```
 
 You can also update an already-running {{ model.techName }} instance from the DC/OS CLI, in case you need to migrate your ZooKeeper data elsewhere.
 

--- a/pages/services/include/configuration-install-with-options.tmpl
+++ b/pages/services/include/configuration-install-with-options.tmpl
@@ -92,6 +92,7 @@ In Enterprise DC/OS, DC/OS access controls can be used to restrict access to you
 ```
 dcos:adminrouter:service:marathon full
 dcos:service:marathon:marathon:<service-name> full
+dcos:service:adminrouter:<service-name> full
 dcos:adminrouter:ops:mesos full
 dcos:adminrouter:ops:slave full
 ```


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-3816

> From the adminrouter logs in a bundle I was able to determine that the missing permission they needed was:
> 
> dcos:adminrouter:service:kafka-confluent full
> The purpose of this JIRA is to request that we improve the documentation in this regard, particularly adding some content which describes the permissions which will enable a non-superuser access to the subcommand.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Response:
The permissions are listed in "Integration with DC/OS access controls: 

### Integration with DC/OS access controls

In Enterprise DC/OS, DC/OS access controls can be used to restrict access to your service. To give a non-superuser complete access to a service, grant them the following list of permissions:

```
dcos:adminrouter:service:marathon full
dcos:service:marathon:marathon:<service-name> full
dcos:adminrouter:ops:mesos full
dcos:adminrouter:ops:slave full
```

Where `<service-name>` is your full service name, including the folder if it is installed in one.

(NOTE: The package/service name for Confluent Kafka is confluent-kafka, NOT kafka-confluent.)

This list of permissions is not exclusive to the Confluent-Kafka docs, but is part of an /include/ file: configuration-install-with-options.tmpl. This file is called by several document sets; changes to it will affect many other documents. 

We have two options:

Add a sentence below the above section:
"To provide superuser access for confluent-kafka, add the following permission:

`dcos:adminrouter:service:confluent-kafka full`

OR

Edit the /include/ file to the following:

```
dcos:adminrouter:service:marathon full
dcos:service:marathon:marathon:<service-name> full
dcos:service:adminrouter:<service-name> full
dcos:adminrouter:ops:mesos full
dcos:adminrouter:ops:slave full
```

Editing the /include/ file will affect MANY other documents, so if this option is chosen I will need assurance that this will not have an adverse effect.

I have adopted Option 2 above, and added a line to the /include/configuration-install-with-options.tmpl file. This change will affect ALL versions of ALL of the following documents:

- Cassandra
- Beta-Confluent-Kafka
- Confluent-Kafka
- Confluent-Zookeeper
- Couchbase
- DSE
- Elastic
- HDFS
- Kafka
- Kafka-Zookeeper
- Prometheus
- Spinnaker