### PR TITLE
Fix links to DC/OS Enterprise CLI in Kubernetes docs.

### DIFF
--- a/pages/services/kubernetes/2.0.0-1.12.1/getting-started/install-basic/index.md
+++ b/pages/services/kubernetes/2.0.0-1.12.1/getting-started/install-basic/index.md
@@ -26,7 +26,7 @@ Prior to installing this package you must install the `kubernetes` package, refe
 
 In order to run the `kubernetes` package on DC/OS Enterprise, a [service account](/1.12/security/ent/service-auth/) with permissions to run tasks with the `kubernetes-role` is required.
 
-1. To provision such a service account, you must first install the [DC/OS Enterprise CLI](/1.12/cli/). Then, run the following:
+1. To provision such a service account, you must first install the [DC/OS Enterprise CLI](/1.12/cli/enterprise-cli/). Then, run the following:
 
     ```shell
     dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/2.0.0-1.12.1/operations/customizing-install/index.md
+++ b/pages/services/kubernetes/2.0.0-1.12.1/operations/customizing-install/index.md
@@ -155,7 +155,7 @@ When installing DC/OS Kubernetes on a DC/OS Enterprise cluster, a [service accou
 
 This service account must be setup with adequate permissions in order to manage CA and secrets, and it **MUST** be provisioned before installing DC/OS Kubernetes.
 
-1. In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.12/cli/). Then, run the following:
+1. In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.12/cli/enterprise-cli/). Then, run the following:
 
     ```shell
     dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/2.0.1-1.12.2/getting-started/install-basic/index.md
+++ b/pages/services/kubernetes/2.0.1-1.12.2/getting-started/install-basic/index.md
@@ -26,7 +26,7 @@ Prior to installing this package you must install the `kubernetes` package, refe
 
 In order to run the `kubernetes` package on DC/OS Enterprise, a [service account](/1.12/security/ent/service-auth/) with permissions to run tasks with the `kubernetes-role` is required.
 
-1. To provision such a service account, you must first install the [DC/OS Enterprise CLI](/1.12/cli/). Then, run the following:
+1. To provision such a service account, you must first install the [DC/OS Enterprise CLI](/1.12/cli/enterprise-cli/). Then, run the following:
 
     ```shell
     dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/2.0.1-1.12.2/operations/customizing-install/index.md
+++ b/pages/services/kubernetes/2.0.1-1.12.2/operations/customizing-install/index.md
@@ -155,7 +155,7 @@ When installing DC/OS Kubernetes on a DC/OS Enterprise cluster, a [service accou
 
 This service account must be setup with adequate permissions in order to manage CA and secrets, and it **MUST** be provisioned before installing DC/OS Kubernetes.
 
-1. In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.12/cli/). Then, run the following:
+1. In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.12/cli/enterprise-cli/). Then, run the following:
 
     ```shell
     dcos security org service-accounts keypair private-key.pem public-key.pem

--- a/pages/services/kubernetes/2.1.0-1.12.3/operations/customizing-install/index.md
+++ b/pages/services/kubernetes/2.1.0-1.12.3/operations/customizing-install/index.md
@@ -183,7 +183,7 @@ When installing DC/OS Kubernetes on a DC/OS Enterprise cluster, a [service accou
 
 This service account must be setup with adequate permissions in order to manage CA and secrets, and it **MUST** be provisioned before installing DC/OS Kubernetes.
 
-1. In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.12/cli/). Then, run the following:
+1. In order to provision such service account, first you need to install the [DC/OS Enterprise CLI](/1.12/cli/enterprise-cli/). Then, run the following:
 
     ```shell
     dcos security org service-accounts keypair private-key.pem public-key.pem


### PR DESCRIPTION
## Description
Fix links to DC/OS Enterprise CLI in Kubernetes docs.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
