### PR TITLE
Fix some typos in metrics docs

### DIFF
--- a/pages/1.12/metrics/architecture/index.md
+++ b/pages/1.12/metrics/architecture/index.md
@@ -21,7 +21,7 @@ By default, DC/OS enables the following Telegraf plugins:
  1. `dcos_containers` collects resource information about containers from the `mesos` process.
  1. `override` plugin is used to add **node-level** metadata, for example, the cluster name.
  1. `dcos_metadata` plugin is used to add **task-level** metadata, for example, the executor name and task name.
- 1. `dcos_api` output plugin serves the `dcos-metrics` JSON API, which is used by the CLI.
+ 1. `dcos_metrics` output plugin serves the `dcos-metrics` JSON API, which is used by the CLI.
  1. `prometheus_client` output plugin serves metrics in Prometheus format.
 
 When Telegraf starts on a node, it loads a configuration file and the contents of a configuration directory or directories. You can specify the plugins you want to enable by creating a configuration file with the appropriate settings and copying the file into the `/var/lib/dcos/telegraf/telegraf.d` directory before restarting Telegraf. Only files ending with `.conf` will be included in the Telegraf configuration. Note: Any mistakes in the configuration files will prevent Telegraf from starting up successfully.

--- a/pages/1.12/metrics/index.md
+++ b/pages/1.12/metrics/index.md
@@ -15,14 +15,14 @@ Metrics in DC/OS, version 1.12 or newer, use [Telegraf](/1.12/overview/architect
 ## Overview
 DC/OS collects four types of metrics as follows:
 
-* **System:** - Metrics about each node in the DC/OS cluster.
-* **Component:** - Metrics about the components which make up DC/OS.
-* **Container:** - Metrics about `cgroup` allocations from tasks running in the DC/OS [Universal Container Runtime](/1.12/deploying-services/containerizers/ucr/) or [Docker Engine](/1.12/deploying-services/containerizers/docker-containerizer/) runtime.
-* **Application:** - Metrics emitted from any application running on the Universal Container Runtime.
+* **System:** Metrics about each node in the DC/OS cluster.
+* **Component:** Metrics about the components which make up DC/OS.
+* **Container:** Metrics about `cgroup` allocations from tasks running in the DC/OS [Universal Container Runtime](/1.12/deploying-services/containerizers/ucr/) or [Docker Engine](/1.12/deploying-services/containerizers/docker-containerizer/) runtime.
+* **Application:** Metrics emitted from any application running on the Universal Container Runtime.
 
-Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plug9n-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself. Telegraf collects application and custom metrics through the `statsd` process. A dedicated `statsd` server is started for each new task. Any metrics received by the `statsd` server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). 
+Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plugin-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself. Telegraf collects application and custom metrics through the `statsd` process. A dedicated `statsd` server is started for each new task. Any metrics received by the `statsd` server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). 
 
-For more informaiton about the list of metrics that are automatically collected by DC/OS, read [Metrics Reference](/1.12/metrics/reference/) documentation.
+For more information about the list of metrics that are automatically collected by DC/OS, read [Metrics Reference](/1.12/metrics/reference/) documentation.
 
 ## Upgrading from 1.11
 DC/OS 1.12 includes an updated `statsd` server implementation for application metrics. The `statsd` update fixes an issue with the `statsd` server implementation in 1.11, which treated all application metrics as gauges, regardless of `statsd` type. 


### PR DESCRIPTION
## Description
Fixes some minor typos in the metrics docs that were bothering me :)

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
