### PR TITLE
Revert statsd-emitter URL

### DIFF
--- a/pages/1.12/metrics/quickstart/index.md
+++ b/pages/1.12/metrics/quickstart/index.md
@@ -22,7 +22,7 @@ This page explains how to get started with metrics in DC/OS. A metrics pipeline 
         {
           "id": "/test-metrics",
           "cmd": "./statsd-emitter",
-          "fetch": [{"uri": "https://downloads.mesosphere.com/dcos-metrics/1.12.0/statsd-emitter", "executable": true}],
+          "fetch": [{"uri": "https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter", "executable": true}],
           "cpus": 0.01,
           "instances": 1,
           "mem": 128


### PR DESCRIPTION
## Description
[DCOS_OSS-4670](https://jira.mesosphere.com/browse/DCOS_OSS-4670) - Statsd-emitter URL is wrong in 1.12 documentation	

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
