### PR TITLE
ck/DCOS-45545 Add Windows Instrs to universal installer guides

### DIFF
--- a/pages/1.10/installing/evaluation/aws/index.md
+++ b/pages/1.10/installing/evaluation/aws/index.md
@@ -17,10 +17,18 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Amazon CLI

--- a/pages/1.10/installing/evaluation/azure/index.md
+++ b/pages/1.10/installing/evaluation/azure/index.md
@@ -16,10 +16,18 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Azure CLI

--- a/pages/1.10/installing/evaluation/gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/index.md
@@ -20,21 +20,21 @@ If you are new to Terraform and want to deploy DC/OS on GCP with minimal configu
 - Cloud credentials
 - SSH keys
 
-## Install using Terraform
-1) Run the following command if you are on a Mac environment with [homebrew](https://brew.sh/) installed:
+## Install Terraform
 
-  ```bash
-  brew install terraform
-  ```
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
 
-2) Run the following command to verify the output is consistent with the version of Terraform you have installed:
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
-  ```bash
-  $ terraform version
-  Terraform v0.11.8
-  ```
+    ```bash
+    brew install terraform
+    ```
 
-For help installing Terraform on a different OS, the [Terraform download instructions](https://www.terraform.io/downloads.html):
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
+    ```
 
 ## Get Application Default Credentials for authentication
 You must have [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) for the GCP provider to authenticate against GCP.

--- a/pages/1.11/installing/evaluation/aws/index.md
+++ b/pages/1.11/installing/evaluation/aws/index.md
@@ -17,10 +17,18 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Amazon CLI

--- a/pages/1.11/installing/evaluation/azure/index.md
+++ b/pages/1.11/installing/evaluation/azure/index.md
@@ -16,10 +16,18 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Azure CLI

--- a/pages/1.11/installing/evaluation/gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/index.md
@@ -20,21 +20,21 @@ If you are new to Terraform and want to deploy DC/OS on GCP with minimal configu
 - Cloud credentials
 - SSH keys
 
-## Install using Terraform
-1) Run the following command if you are on a Mac environment with [homebrew](https://brew.sh/) installed:
+## Install Terraform
 
-  ```bash
-  brew install terraform
-  ```
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
 
-2) Run the following command to verify the output is consistent with the version of Terraform you have installed:
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
-  ```bash
-  $ terraform version
-  Terraform v0.11.8
-  ```
+    ```bash
+    brew install terraform
+    ```
 
-For help installing Terraform on a different OS, the [Terraform download instructions](https://www.terraform.io/downloads.html):
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
+    ```
 
 ## Get Application Default Credentials for authentication
 You must have [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) for the GCP provider to authenticate against GCP.

--- a/pages/1.12/installing/evaluation/aws/index.md
+++ b/pages/1.12/installing/evaluation/aws/index.md
@@ -17,10 +17,18 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+    
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Amazon CLI

--- a/pages/1.12/installing/evaluation/azure/index.md
+++ b/pages/1.12/installing/evaluation/azure/index.md
@@ -16,10 +16,18 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+    
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Azure CLI

--- a/pages/1.12/installing/evaluation/gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/index.md
@@ -21,20 +21,20 @@ If you are new to Terraform and want to deploy DC/OS on GCP with minimal configu
 - SSH keys
 
 ## Install using Terraform
-1) Run the following command if you are on a Mac environment with [homebrew](https://brew.sh/) installed:
 
-  ```bash
-  brew install terraform
-  ```
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+    
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
-2) Run the following command to verify the output is consistent with the version of Terraform you have installed:
+    ```bash
+    brew install terraform
+    ```
 
-  ```bash
-  $ terraform version
-  Terraform v0.11.8
-  ```
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
 
-For help installing Terraform on a different OS, the [Terraform download instructions](https://www.terraform.io/downloads.html):
+    ```bash
+    choco install terraform -y
+    ```
 
 ## Get Application Default Credentials for authentication
 You must have [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) for the GCP provider to authenticate against GCP.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-45545
Installer instructions added to the same level of support we provide mac/homebrew. There is a link to the terraform dl page for further dl's and support. 

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
