### PR TITLE
DCOS-47317 Update template for AWS universal installer

### DIFF
--- a/pages/1.10/installing/evaluation/aws/index.md
+++ b/pages/1.10/installing/evaluation/aws/index.md
@@ -17,10 +17,18 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Amazon CLI

--- a/pages/1.10/installing/evaluation/aws/index.md
+++ b/pages/1.10/installing/evaluation/aws/index.md
@@ -151,7 +151,6 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
       source  = "dcos-terraform/dcos/aws"
       version = "~> 0.1"
 
-      dcos_instance_os    = "coreos_1855.5.0"
       cluster_name        = "my-dcos-demo"
       ssh_public_key_file = "<path-to-public-key-file>"
       admin_ips           = ["${data.http.whatismyip.body}/32"]
@@ -161,6 +160,12 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
       num_public_agents  = "1"
 
       dcos_version = "1.10.8"
+
+      dcos_instance_os    = "centos_7.5"
+      bootstrap_instance_type = "t2.medium"
+      masters_instance_type  = "t2.medium"
+      private_agents_instance_type = "t2.medium"
+      public_agents_instance_type = "t2.medium"
 
       # dcos_variant              = "ee"
       # dcos_license_key_contents = "${file("./license.txt")}"

--- a/pages/1.10/installing/evaluation/azure/index.md
+++ b/pages/1.10/installing/evaluation/azure/index.md
@@ -16,10 +16,18 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Azure CLI

--- a/pages/1.10/installing/evaluation/gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/index.md
@@ -20,21 +20,21 @@ If you are new to Terraform and want to deploy DC/OS on GCP with minimal configu
 - Cloud credentials
 - SSH keys
 
-## Install using Terraform
-1) Run the following command if you are on a Mac environment with [homebrew](https://brew.sh/) installed:
+## Install Terraform
 
-  ```bash
-  brew install terraform
-  ```
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
 
-2) Run the following command to verify the output is consistent with the version of Terraform you have installed:
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
-  ```bash
-  $ terraform version
-  Terraform v0.11.8
-  ```
+    ```bash
+    brew install terraform
+    ```
 
-For help installing Terraform on a different OS, the [Terraform download instructions](https://www.terraform.io/downloads.html):
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
+    ```
 
 ## Get Application Default Credentials for authentication
 You must have [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) for the GCP provider to authenticate against GCP.

--- a/pages/1.11/installing/evaluation/aws/index.md
+++ b/pages/1.11/installing/evaluation/aws/index.md
@@ -17,10 +17,18 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Amazon CLI

--- a/pages/1.11/installing/evaluation/aws/index.md
+++ b/pages/1.11/installing/evaluation/aws/index.md
@@ -151,7 +151,7 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
       source  = "dcos-terraform/dcos/aws"
       version = "~> 0.1"
 
-      dcos_instance_os    = "coreos_1855.5.0"
+
       cluster_name        = "my-dcos-demo"
       ssh_public_key_file = "<path-to-public-key-file>"
       admin_ips           = ["${data.http.whatismyip.body}/32"]
@@ -161,6 +161,12 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
       num_public_agents  = "1"
 
       dcos_version = "1.11.7"
+
+      dcos_instance_os    = "centos_7.5"
+      bootstrap_instance_type = "t2.medium"
+      masters_instance_type  = "t2.medium"
+      private_agents_instance_type = "t2.medium"
+      public_agents_instance_type = "t2.medium"
 
       # dcos_variant              = "ee"
       # dcos_license_key_contents = "${file("./license.txt")}"

--- a/pages/1.11/installing/evaluation/azure/index.md
+++ b/pages/1.11/installing/evaluation/azure/index.md
@@ -16,10 +16,18 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Azure CLI

--- a/pages/1.11/installing/evaluation/gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/index.md
@@ -20,21 +20,21 @@ If you are new to Terraform and want to deploy DC/OS on GCP with minimal configu
 - Cloud credentials
 - SSH keys
 
-## Install using Terraform
-1) Run the following command if you are on a Mac environment with [homebrew](https://brew.sh/) installed:
+## Install Terraform
 
-  ```bash
-  brew install terraform
-  ```
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
 
-2) Run the following command to verify the output is consistent with the version of Terraform you have installed:
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
-  ```bash
-  $ terraform version
-  Terraform v0.11.8
-  ```
+    ```bash
+    brew install terraform
+    ```
 
-For help installing Terraform on a different OS, the [Terraform download instructions](https://www.terraform.io/downloads.html):
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
+    ```
 
 ## Get Application Default Credentials for authentication
 You must have [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) for the GCP provider to authenticate against GCP.

--- a/pages/1.12/installing/evaluation/aws/index.md
+++ b/pages/1.12/installing/evaluation/aws/index.md
@@ -17,10 +17,18 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+    
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Amazon CLI

--- a/pages/1.12/installing/evaluation/aws/index.md
+++ b/pages/1.12/installing/evaluation/aws/index.md
@@ -151,7 +151,6 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
       source  = "dcos-terraform/dcos/aws"
       version = "~> 0.1"
 
-      dcos_instance_os    = "coreos_1855.5.0"
       cluster_name        = "my-dcos-demo"
       ssh_public_key_file = "<path-to-public-key-file>"
       admin_ips           = ["${data.http.whatismyip.body}/32"]
@@ -161,6 +160,12 @@ To use the Mesosphere Universal Installer with Amazon Web Services, the AWS Comm
       num_public_agents  = "1"
 
       dcos_version = "1.12.0"
+
+      dcos_instance_os    = "centos_7.5"
+      bootstrap_instance_type = "t2.medium"
+      masters_instance_type  = "t2.medium"
+      private_agents_instance_type = "t2.medium"
+      public_agents_instance_type = "t2.medium"
 
       # dcos_variant              = "ee"
       # dcos_license_key_contents = "${file("./license.txt")}"

--- a/pages/1.12/installing/evaluation/azure/index.md
+++ b/pages/1.12/installing/evaluation/azure/index.md
@@ -16,10 +16,18 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
 
 # Install Terraform
 
-1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. If you're on a Mac environment with [homebrew](https://brew.sh/) installed, simply run the following command:
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+    
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
     ```bash
     brew install terraform
+    ```
+
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
+
+    ```bash
+    choco install terraform -y
     ```
 
 # Install and configure the Azure CLI

--- a/pages/1.12/installing/evaluation/gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/index.md
@@ -21,20 +21,20 @@ If you are new to Terraform and want to deploy DC/OS on GCP with minimal configu
 - SSH keys
 
 ## Install using Terraform
-1) Run the following command if you are on a Mac environment with [homebrew](https://brew.sh/) installed:
 
-  ```bash
-  brew install terraform
-  ```
+1. Visit the the [Terraform download page](https://www.terraform.io/downloads.html) for bundled installations and support for Linux, macOS and Windows. 
+    
+    If you're on a Mac environment with [Homebrew](https://brew.sh/) installed, simply run the following command:
 
-2) Run the following command to verify the output is consistent with the version of Terraform you have installed:
+    ```bash
+    brew install terraform
+    ```
 
-  ```bash
-  $ terraform version
-  Terraform v0.11.8
-  ```
+    Windows users that have [Chocolatey](https://chocolatey.org/docs/installation) installed, run:
 
-For help installing Terraform on a different OS, the [Terraform download instructions](https://www.terraform.io/downloads.html):
+    ```bash
+    choco install terraform -y
+    ```
 
 ## Get Application Default Credentials for authentication
 You must have [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) for the GCP provider to authenticate against GCP.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-47317
A diff of the two files reveals the changes requested are:
- change the instance_os to be 'centos_7.5' (default val, but also important for MKE)
- change the instance sizes to be medium (default is xlarge)

Edit: **Note**: this update also includes the updates from #1882 in order to prevent merge conflicts, it should be merged prior to this one.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
