### PR TITLE
COPS-3077 Update docker prereqs to inform don't use live-restore

### DIFF
--- a/pages/1.10/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.10/installing/production/system-requirements/docker-centos/index.md
@@ -13,6 +13,8 @@ A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory c
 
 ## Requirements and Recommendations
 
+Be sure that Docker's [`live-restore` setting is disabled](https://docs.docker.com/config/containers/live-restore/). It should be absent or set to false in a Docker configuration file.
+
 Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
 
 * OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.

--- a/pages/1.10/installing/production/system-requirements/index.md
+++ b/pages/1.10/installing/production/system-requirements/index.md
@@ -149,6 +149,8 @@ Docker must be installed on all bootstrap and cluster nodes. The supported Docke
 
 **Recommendations**
 
+- Be sure that Docker's [`live-restore` setting is disabled](https://docs.docker.com/config/containers/live-restore/). It should be absent or set to false in a Docker configuration file.
+
 - Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 
 - Prefer `OverlayFS` or `devicemapper` in `direct-lvm` mode when choosing a production storage driver. For more information, see Docker's <a href="https://docs.docker.com/engine/userguide/storagedriver/selectadriver/" target="_blank">Select a Storage Driver</a>.

--- a/pages/1.11/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.11/installing/production/system-requirements/docker-centos/index.md
@@ -13,6 +13,8 @@ A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory c
 
 # Requirements and Recommendations
 
+Be sure that Docker's [`live-restore` setting is disabled](https://docs.docker.com/config/containers/live-restore/). It should be absent or set to false in a Docker configuration file.
+
 Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
 
 * OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.

--- a/pages/1.11/installing/production/system-requirements/index.md
+++ b/pages/1.11/installing/production/system-requirements/index.md
@@ -147,6 +147,8 @@ Docker must be installed on all bootstrap and cluster nodes. The supported Docke
 
 **Recommendations**
 
+- Be sure that Docker's [`live-restore` setting is disabled](https://docs.docker.com/config/containers/live-restore/). It should be absent or set to false in a Docker configuration file.
+
 - Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 
 - Prefer `OverlayFS` or `devicemapper` in `direct-lvm` mode when choosing a production storage driver. For more information, see Docker's <a href="https://docs.docker.com/engine/userguide/storagedriver/selectadriver/" target="_blank">Select a Storage Driver</a>.

--- a/pages/1.12/installing/production/system-requirements/docker-centos/index.md
+++ b/pages/1.12/installing/production/system-requirements/docker-centos/index.md
@@ -13,6 +13,8 @@ A recently discovered bug in Docker 17.x’s handling of cgroups kernel memory c
 
 ## Requirements and Recommendations
 
+Be sure that Docker's [`live-restore` setting is disabled](https://docs.docker.com/config/containers/live-restore/). It should be absent or set to false in a Docker configuration file.
+
 Before installing Docker on CentOS/RHEL, review the general [requirements and recommendations for running Docker on DC/OS][1] and the following CentOS/RHEL-specific recommendations:
 
 * OverlayFS is now the default in Docker CE. There is no longer a need to specify or configure the overlay driver. Prefer the OverlayFS storage driver. OverlayFS avoids known issues with `devicemapper` in `loop-lvm` mode and allows containers to use docker-in-docker, if they want.
@@ -39,19 +41,19 @@ Follow the Docker [RHEL-specific installation instructions][3], keeping in mind 
 
 The following instructions demonstrate how to install Docker on CentOS 7.
 
-### Note: Uninstall the newer version of Docker (if present):
+1. Uninstall the newer version of Docker (if present):
 
     ```bash
     sudo yum remove docker-ce
     ```
 
-1.  Install Docker:
+1. Install Docker:
 
     ```bash
     sudo yum install docker
     ```
 
-1.  Start Docker:
+1. Start Docker:
 
     ```bash
     sudo systemctl start docker

--- a/pages/1.12/installing/production/system-requirements/index.md
+++ b/pages/1.12/installing/production/system-requirements/index.md
@@ -146,6 +146,8 @@ Docker must be installed on all bootstrap and cluster nodes. The supported Docke
 
 **Recommendations**
 
+- Be sure that Docker's [`live-restore` setting is disabled](https://docs.docker.com/config/containers/live-restore/). It should be absent or set to false in a Docker configuration file.
+
 - Do not use Docker `devicemapper` storage driver in `loop-lvm` mode. For more information, see [Docker and the Device Mapper storage driver](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 
 - Prefer `OverlayFS` or `devicemapper` in `direct-lvm` mode when choosing a production storage driver. For more information, see Docker's <a href="https://docs.docker.com/engine/userguide/storagedriver/selectadriver/" target="_blank">Select a Storage Driver</a>.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-3077
Adding advisory in 1.10, 1.11, 1.12 docs under system requirements and under the specific docker page that advises customers to not use the `live-restore` option.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
