### PR TITLE
Update metrics docs wrt new enable_mesos_input_plugin config options

### DIFF
--- a/pages/1.12/installing/evaluation/index.md
+++ b/pages/1.12/installing/evaluation/index.md
@@ -6,7 +6,7 @@ menuWeight: 10
 excerpt: Guide to Installing DC/OS on cloud environments using the Mesosphere Universal Installer
 ---
 
-<strong>The Mesosphere Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on the the following cloud providers. Jump to the guide for the cloud provider of your choice to get started: </strong>
+<strong>The Mesosphere Universal Installer is the recommended tool for provisioning, deploying, installing, and upgrading DC/OS on the following cloud providers. Jump to the guide for the cloud provider of your choice to get started: </strong>
 
 #### [DC/OS on Amazon Web Services](/1.12/installing/evaluation/mesosphere-supported-methods/aws/)
 

--- a/pages/1.12/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.12/installing/production/advanced-configuration/configuration-reference/index.md
@@ -115,6 +115,12 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [ssh_user](#ssh-user)                                    | The SSH username, for example `centos`. |
 | [telemetry_enabled](#telemetry-enabled)                  | Indicates whether to enable sharing of anonymous data for your cluster.  |
 
+# Metrics
+
+| Parameter                    | Description                                                                                                                                                       |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [enable_mesos_input_plugin](#enable-mesos-input-plugin)    | Indicates whether to enable Telegraf's Mesos input plugin to collect Mesos metrics from Mesos masters and agents. Default value is `false`. |
+
 # Parameter Descriptions
 
 ### adminrouter_auth_cache_enabled [enterprise type="inline" size="small" /]
@@ -341,6 +347,11 @@ Indicates whether to run the [docker-gc](https://github.com/spotify/docker-gc#ex
 
 *  `enable_docker_gc: 'true'` Run the docker-gc scripts once every hour. This is the default value for [cloud](/1.12/installing/ent/cloud/) template installations.
 *  `enable_docker_gc: 'false'` Do not run the docker-gc scripts once every hour. This is the default value for [custom](/1.12/installing/ent/custom/) installations.
+
+
+### enable_mesos_input_plugin
+
+Indicates whether to enable Telegraf's Mesos input plugin to collect Mesos metrics from Mesos masters and agents. Options: `true` or `false`. Default value is `false`. For more information, see the [documentation](/1.12/metrics/mesos/).
 
 <a name="exhibitor_storage_backend"></a>
 

--- a/pages/1.12/installing/production/patching/index.md
+++ b/pages/1.12/installing/production/patching/index.md
@@ -58,6 +58,7 @@ Here is a list of the parameters that you can modify:
     - [`http_proxy`](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)
     - [`https_proxy`](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)
     - [`no_proxy`](/1.12/installing/production/advanced-configuration/configuration-reference/#use-proxy)
+- [`enable_mesos_input_plugin`](/1.12/installing/production/advanced-configuration/configuration-reference/#enable-mesos-input-plugin)
 
 The security mode (`security`) can be changed but only to a stricter security mode. Security downgrades are not supported. For example, if your cluster is in `strict` mode and you want to downgrade to `permissive` mode, you must reinstall the cluster and terminate all running workloads.
 

--- a/pages/1.12/metrics/architecture/index.md
+++ b/pages/1.12/metrics/architecture/index.md
@@ -16,7 +16,6 @@ By default, DC/OS enables the following Telegraf plugins:
  1. `system` input plugin collects information about the node, for example, CPU, memory, and disk usage.
  1. `statsd` input plugin collects `statsd` metrics from DC/OS components.
  1. `prometheus` input plugin collects metrics from DC/OS components and `mesos` tasks.
- 1. `mesos` input plugin collects metrics about the `mesos` process itself.
  1. `dcos_statsd` input plugin starts a new `statsd` server for each `mesos` task.
  1. `dcos_containers` collects resource information about containers from the `mesos` process.
  1. `override` plugin is used to add **node-level** metadata, for example, the cluster name.

--- a/pages/1.12/metrics/mesos/index.md
+++ b/pages/1.12/metrics/mesos/index.md
@@ -7,52 +7,9 @@ excerpt: Monitoring Mesos with Telegraf
 enterprise: false
 ---
 
-You can configure DC/OS, version 1.12 or newer, to gather [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. This page explains how to add the appropriate configuration to DC/OS.
+You can configure DC/OS, version 1.12 or newer, to gather [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. 
 
-
-**Prerequisite:**
-
-- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser by running the `dcos auth login` command.
-
-# Collecting metrics from Mesos masters with Telegraf
-
-1. Create a file named `mesos-master.conf` with the following content:
-
-    ```
-    # Gathers all Mesos metrics
-    [[inputs.mesos]]
-      # The interval at which to collect metrics
-      interval = "60s"
-      # Timeout, in ms.
-      timeout = 30000
-      # A list of Mesos masters.
-      masters = ["http://$DCOS_NODE_PRIVATE_IP:5050"]
-    ```
-
-1. On every master node in your cluster, do the following tasks:
-
-   1. Upload the `mesos-master.conf` file to `/var/lib/dcos/telegraf/telegraf.d/mesos-master.conf`.
-   1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
-
-# Collecting metrics from Mesos agent with Telegraf
-
-1. Create a file named `mesos-agent.conf` with the following content:
-
-    ```
-    # Gathers all Mesos metrics
-    [[inputs.mesos]]
-      # The interval at which to collect metrics
-      interval = "60s"
-      # Timeout, in ms.
-      timeout = 30000
-      # A list of Mesos slaves.
-      slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
-    ```
-
-1. On every agent node in your cluster, do the following tasks:
-
-   1. Upload the `mesos-agent.conf` file to `/var/lib/dcos/telegraf/telegraf.d/mesos-agent.conf`.
-   1. Restart the Telegraf process with your new configuration by running `sudo systemctl restart dcos-telegraf` command.
+The Mesos input plugin in Telegraf is controlled by an option in the `config.yaml` file called `enable_mesos_input_plugin`. To enable the plugin, `enable_mesos_input_plugin` needs to be set to `true` (it is currently defaulted to `false`). Instructions on how to create a configuration file for on-prem installation can be found [here](/1.12/installing/production/deploying-dcos/installation/#create-a-configuration-file). To modify a configuration file on an existing on-prem cluster, you must [patch the existing DC/OS version](/1.12/installing/production/patching/#modifying-dcos-configuration). For cloud installations, configuration and installation instructions for each supported cloud provider can be found [here](/1.12/installing/evaluation/).
 
 # Viewing metrics for Mesos masters and agents
  


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-47300
We've added a new config.yaml option called `enable_mesos_input_plugin` that takes `true` or `false` to enable/disable the mesos input plugin in Telegraf. In 1.12, it is defaulted to `false` (defaults to `true` in 1.13). Please let me know if I've missed any other pages that need to be updated with this new config option! And feel free to directly edit as well :)

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
