### PR TITLE
ss/COPS-2138 Added warning about maintenance endpoints to 1.9 and 1.10

### DIFF
--- a/pages/1.10/administering-clusters/update-a-node/index.md
+++ b/pages/1.10/administering-clusters/update-a-node/index.md
@@ -13,9 +13,11 @@ enterprise: false
 
 You can update agent nodes in an active DC/OS cluster by using maintenance windows or by manually killing agents. Maintenance windows are the preferred method since this is generally more stable and less error prone.
 
+<p class="message--note"><strong>NOTE: </strong>Maintenance endpoints are disabled in strict mode.</p>
+
 These steps are useful if you are downsizing a cluster, reconfiguring agent nodes, or moving a node to a new IP. When you change Mesos attributes (`⁠⁠⁠⁠/var/lib/dcos/mesos-slave-common`⁠⁠⁠⁠) or resources (⁠⁠⁠⁠`/var/lib/dcos/mesos-resources`⁠⁠⁠⁠), you must remove the agent node and re-register it with the master node under a new UUID. The master will then recognize the new attributes and resources specification.
 
-**Warning:** ⁠⁠⁠All tasks that are running on the agent will be killed because you are changing agent attributes or resources. Mesos treats a re-registered agent as a new agent.
+<p class="message--warning"><strong>WARNING: </strong> ⁠⁠⁠All tasks that are running on the agent will be killed because you are changing agent attributes or resources. Mesos treats a re-registered agent as a new agent.</p>
 
 ### Prerequisites:
 

--- a/pages/1.9/administering-clusters/update-a-node/index.md
+++ b/pages/1.9/administering-clusters/update-a-node/index.md
@@ -13,9 +13,11 @@ enterprise: false
 
 You can update agent nodes in an active DC/OS cluster by using maintenance windows or by manually killing agents. Maintenance windows are the preferred method since this is generally more stable and less error prone.
 
+<p class="message--note"><strong>NOTE: </strong>Maintenance endpoints are disabled in strict mode.</p>
+
 These steps are useful if you are downsizing a cluster, reconfiguring agent nodes, or moving a node to a new IP. When you change Mesos attributes (`⁠⁠⁠⁠/var/lib/dcos/mesos-slave-common`⁠⁠⁠⁠) or resources (⁠⁠⁠⁠`/var/lib/dcos/mesos-resources`⁠⁠⁠⁠), you must remove the agent node and re-register it with the master node under a new UUID. The master will then recognize the new attributes and resources specification.
 
-**Warning:** ⁠⁠⁠All tasks that are running on the agent will be killed because you are changing agent attributes or resources. Mesos treats a re-registered agent as a new agent.
+<p class="message--warning"><strong>WARNING: </strong>All tasks that are running on the agent will be killed because you are changing agent attributes or resources. Mesos treats a re-registered agent as a new agent.</p>
 
 ### Prerequisites:
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-2138

Please update the documentation https://docs.mesosphere.com/1.9/administering-clusters/update-a-node/ (and any other relevant places in DC/OS docs ) to mention that maintenance endpoints are disabled in strict mode.



## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x Medium

Added warning to relevant docs in 1.9 and 1.10.