### PR TITLE
ss/DCOS_OSS-3111 Adding disclaimer to Deploying a Local Universe pages.

### DIFF
--- a/pages/1.10/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.10/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -5,14 +5,14 @@ title: Deploying a Local Universe
 menuWeight: 1000
 excerpt:
 enterprise: false
-preview: true
+preview: false
 ---
 
 <!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
 
-You can install and run DC/OS services on a datacenter without internet access with a local [Universe](https://github.com/mesosphere/universe). You can deploy a local Universe that includes all Certified packages (easiest), or a local Universe that includes selected packages (advanced).
+You can install and run DC/OS services on a datacenter without Internet access with a local [Universe](https://github.com/mesosphere/universe). You can deploy a local Universe that includes all Certified packages (easiest), or a local Universe that includes selected packages (advanced).
 
 **Prerequisites:**
 
@@ -20,7 +20,9 @@ You can install and run DC/OS services on a datacenter without internet access w
 
 - Logged into the DC/OS CLI. On DC/OS Enterprise, you must be logged in as a user with the `dcos:superuser` permission.
 
-**Note:** As the Universe tarball is over two gigabytes in size it may take some time to download it to your local drive and upload it to each master.
+<p class="message--note"><strong>NOTE: </strong>Creation of a local universe on MacOS is not supported.</p>
+
+<p class="message--note"><strong>NOTE: </strong>As the Universe tarball is over two gigabytes in size, it may take some time to download it to your local drive and upload it to each master.</p>
 
 # <a name="certified"></a>Deploying a local Universe containing Certified Universe packages
 

--- a/pages/1.11/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.11/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -10,7 +10,6 @@ enterprise: false
 
 You can install and run DC/OS services on a datacenter without internet access with a local [Universe](https://github.com/mesosphere/universe).
 
-
 You can deploy a local Universe that includes all Certified packages (easiest), or a local Universe that includes selected packages (advanced).
 
 **Prerequisites:**
@@ -19,7 +18,9 @@ You can deploy a local Universe that includes all Certified packages (easiest), 
 
 - Logged into the DC/OS CLI. On DC/OS Enterprise, you must be logged in as a user with the `dcos:superuser` permission.
 
-**Note:** As the Universe tarball is over two gigabytes in size it may take some time to download it to your local drive and upload it to each master.
+<p class="message--note"><strong>NOTE: </strong>Creation of a local universe on MacOS is not supported.</p>
+
+<p class="message--note"><strong>NOTE: </strong>As the Universe tarball is over two gigabytes in size, it may take some time to download it to your local drive and upload it to each master.</p>
 
 # <a name="certified"></a>Deploying a local Universe containing Certified Universe packages
 

--- a/pages/1.12/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.12/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -8,14 +8,19 @@ enterprise: false
 ---
 
 
-You can install and run DC/OS services on a datacenter without internet access with a local [Universe](https://github.com/mesosphere/universe). You can deploy a local Universe that includes all Certified packages (easiest), or a local Universe that includes selected packages (advanced).
+You can install and run DC/OS services on a datacenter without internet access with a local [Universe](https://github.com/mesosphere/universe). 
+
+You can deploy a local Universe that includes all Certified packages (easiest), or a local Universe that includes selected packages (advanced).
 
 **Prerequisites:**
 
 - [DC/OS CLI installed](/1.12/cli/install/).
 
 - Logged into the DC/OS CLI. On DC/OS Enterprise, you must be logged in as a user with the `dcos:superuser` permission.
-<p class="message--note"><strong>NOTE: </strong>As the Universe tarball is over two gigabytes in size it may take some time to download it to your local drive and upload it to each master.</p>
+
+<p class="message--note"><strong>NOTE: </strong>As the Universe tarball is over two gigabytes in size, it may take some time to download it to your local drive and upload it to each master.</p>
+
+<p class="message--note"><strong>NOTE: </strong>Creation of a local universe on MacOS is not supported.</p>
 
 # <a name="certified"></a>Certified Universe packages
 

--- a/pages/1.9/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.9/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -16,7 +16,9 @@ You can install and run DC/OS services on a datacenter without internet access w
 
 - Logged into the DC/OS CLI via `dcos auth login`. On DC/OS Enterprise, you must be logged in as a user with the `dcos:superuser` permission.
 
-**Note:** As the Universe tarball is over two gigabytes in size it may take some time to download it to your local drive and upload it to each master.
+<p class="message--note"><strong>NOTE: </strong>Creation of a local universe on MacOS is not supported.</p>
+
+<p class="message--note"><strong>NOTE: </strong>As the Universe tarball is over two gigabytes in size, it may take some time to download it to your local drive and upload it to each master.</p>
 
 # <a name="default"></a>Installing the default Universe packages
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-3111

> Source: https://docs.mesosphere.com/1.10/administering-clusters/deploying-a-local-dcos-universe
> 
> It doesn't appear that we support creating a local universe on MacOS. Can we note that explicitly on the prerequisites section? Prospect was struggling with doing this and we later determined that we don't actually support this.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

Added the following disclaimer to all affected versions in Prerequisites section:

> NOTE: Creation of a local universe on MacOS is not supported.

Versions affected:

- 1.9
- 1.10
- 1.11
- 1.12

Also removed "Preview" tag from 1.9 page.