### PR TITLE
docs: adding dcos_security to advance docs

### DIFF
--- a/pages/1.10/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.10/installing/evaluation/aws/aws-advanced/index.md
@@ -68,6 +68,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.10/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.10/installing/evaluation/azure/advanced-azure/index.md
@@ -66,6 +66,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.10/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/advanced-gcp/index.md
@@ -65,6 +65,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.11/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.11/installing/evaluation/aws/aws-advanced/index.md
@@ -68,6 +68,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.11/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.11/installing/evaluation/azure/advanced-azure/index.md
@@ -66,6 +66,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.11/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/advanced-gcp/index.md
@@ -65,6 +65,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.12/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.12/installing/evaluation/aws/aws-advanced/index.md
@@ -68,6 +68,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.12/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.12/installing/evaluation/azure/advanced-azure/index.md
@@ -66,6 +66,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }

--- a/pages/1.12/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/advanced-gcp/index.md
@@ -65,6 +65,7 @@ module "dcos" {
   EOF
 
   # dcos_variant              = "ee"
+  # dcos_security             = "permissive"
   # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
 }


### PR DESCRIPTION
This updates all the docs to add the dcos_security in the comment section if a user decides to change it.

<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS-47945

- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X] Medium

- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).