### PR TITLE
Update mesos metrics docs in 1.13

### DIFF
--- a/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
@@ -118,7 +118,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 
 | Parameter                    | Description                                                                                                                                                       |
 |------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [enable_mesos_input_plugin](#enable-mesos-input-plugin)    | Indicates whether to enable Telegraf's Mesos input plugin to collect Mesos metrics from Mesos masters and agents. Default value is `false`. |
+| [enable_mesos_input_plugin](#enable-mesos-input-plugin)    | Indicates whether to enable Telegraf's Mesos input plugin to collect Mesos metrics from Mesos masters and agents. Default value is `true`. **NOTE:** DC/OS 1.13 supports the Mesos input plugin by default. |
 
 # Parameter Descriptions
 
@@ -348,7 +348,7 @@ Indicates whether to run the [docker-gc](https://github.com/spotify/docker-gc#ex
 
 ### enable_mesos_input_plugin
 
-Indicates whether to enable Telegraf's Mesos input plugin to collect Mesos metrics from Mesos masters and agents. Options: `true` or `false`. Default value is `false`. For more information, see the [documentation](/1.13/metrics/mesos/).
+Indicates whether to enable Telegraf's Mesos input plugin to collect Mesos metrics from Mesos masters and agents. Options: `true` or `false`. Default value is `true`. For more information, see the [documentation](/1.13/metrics/mesos/).
 
 <a name="exhibitor_storage_backend"></a>
 

--- a/pages/1.13/metrics/architecture/index.md
+++ b/pages/1.13/metrics/architecture/index.md
@@ -16,6 +16,7 @@ By default, DC/OS enables the following Telegraf plugins:
  1. `system` input plugin collects information about the node, for example, CPU, memory, and disk usage.
  1. `statsd` input plugin collects `statsd` metrics from DC/OS components.
  1. `prometheus` input plugin collects metrics from DC/OS components and `mesos` tasks.
+ 1. `mesos` input plugin collects metrics about the `mesos` process itself.
  1. `dcos_statsd` input plugin starts a new `statsd` server for each `mesos` task.
  1. `dcos_containers` collects resource information about containers from the `mesos` process.
  1. `override` plugin is used to add **node-level** metadata, for example, the cluster name.

--- a/pages/1.13/metrics/mesos/index.md
+++ b/pages/1.13/metrics/mesos/index.md
@@ -1,15 +1,15 @@
 ---
 layout: layout.pug
-title: Enable Mesos Metrics
-navigationTitle: Enable Mesos Metrics
+title: Mesos Metrics
+navigationTitle: Mesos Metrics
 menuWeight: 3
 excerpt: Monitoring Mesos with Telegraf
 enterprise: false
 ---
 
-You can configure DC/OS, version 1.12 or newer, to gather [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. 
+The Mesos input plugin in Telegraf gathers [observability metrics](http://mesos.apache.org/documentation/latest/monitoring/) from each Mesos agent and master. The plugin is enabled by default in DC/OS 1.13 version or newer.
 
-The Mesos input plugin in Telegraf is controlled by an option in the `config.yaml` file called `enable_mesos_input_plugin`. To enable the plugin, `enable_mesos_input_plugin` needs to be set to `true` (it is currently defaulted to `false`). Instructions on how to create a configuration file for on-prem installation can be found [here](/1.13/installing/production/deploying-dcos/installation/#create-a-configuration-file). To modify a configuration file on an existing on-prem cluster, you must [patch the existing DC/OS version](/1.13/installing/production/patching/#modifying-dcos-configuration). For cloud installations, configuration and installation instructions for each supported cloud provider can be found [here](/1.13/installing/evaluation/).
+The Mesos input plugin is controlled by an option in the `config.yaml` file called `enable_mesos_input_plugin`. To disable the plugin, `enable_mesos_input_plugin` needs to be set to `false`. Instructions on how to create a configuration file for on-prem installation can be found [here](/1.13/installing/production/deploying-dcos/installation/#create-a-configuration-file). To modify a configuration file on an existing on-prem cluster, you must [patch the existing DC/OS version](/1.13/installing/production/patching/#modifying-dcos-configuration). For cloud installations, configuration and installation instructions for each supported cloud provider can be found [here](/1.13/installing/evaluation/).
 
 # Viewing metrics for Mesos masters and agents
  


### PR DESCRIPTION
## Description
Noticed that 1.13 docs came up on the repo, so went in to make the 1.13 relevant docs updates for mesos metrics (plugin is not enabled by default in 1.12, but is in 1.13)

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
