### PR TITLE
Added OS Qualification for RunC Vulnerability to Version Policy Page.

### DIFF
--- a/pages/version-policy/index.md
+++ b/pages/version-policy/index.md
@@ -56,10 +56,16 @@ The following matrix shows the platform components and operating environments on
     <th><strong>DC/OS 1.10 Latest Stable</strong></th>
     </tr>
     <tr>
+        <td>CentOS 7.6</td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.09.2</li></ul></p></td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.09.2</li></ul></p></td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.09.2</li></ul></p></td>
+    </tr>
+    <tr>
         <td>CentOS 7.5</td>
-        <td><p style="text-align: center;"><ul><li>RH Fork of Docker CE 1.13.1<sup>*</sup></li></ul></p></td>
-        <td><p style="text-align: center;"><ul><li>RH Fork of Docker CE 1.13.1<sup>*</sup></li></ul></p></td>
-        <td><p style="text-align: center;"><ul><li>RH Fork of Docker CE 1.13.1<sup>*</sup></li></ul></p></td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.09.2</li></ul></p></td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.09.2</li></ul></p></td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.09.2</li></ul></p></td>
     </tr>
     <tr>
         <td>CentOS 7.4</td>
@@ -96,6 +102,12 @@ The following matrix shows the platform components and operating environments on
         <td><p style="text-align: center;"><ul><li>RH Fork of Docker CE 1.13.1<sup>*</sup></li></ul></p></td>
         <td><p style="text-align: center;"><ul><li>RH Fork of Docker CE 1.13.1<sup>*</sup></li></ul></p></td>
         <td><p style="text-align: center;"><ul><li>RH Fork of Docker CE 1.13.1<sup>*</sup></li></ul></p></td>
+    </tr>
+    <tr>
+        <td>CoreOS 1976.5.0</td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.06.1</li></ul></p></td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.06.1</li></ul></p></td>
+        <td><p style="text-align: center;"><ul><li>Docker CE 18.06.1</li></ul></p></td>
     </tr>
     <tr>
         <td>CoreOS 1911.5.0</td>


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-48368

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
