### PR TITLE
Lg/cops 4239 upgrade Fix 1.10 to 1.11 upgrade table formatting.

### DIFF
--- a/pages/1.11/installing/production/upgrading/index.md
+++ b/pages/1.11/installing/production/upgrading/index.md
@@ -10,7 +10,7 @@ An upgrade is the process of moving between major releases to add new features o
 
 <p class="message--important"><strong>IMPORTANT: </strong>An upgrade is required only when changing the major or minor version of your DC/OS installation. Example: 1.10 --> 1.11</p>
 
-- To update to a newer maintenance version (e.g. 1.11.6 to 1.11.8), refer to the instructions for [patching](/1.11/installing/production/patching/).
+- To update to a newer maintenance version (for example, from 1.11.6 to 1.11.8), refer to the instructions for [patching](/1.11/installing/production/patching/).
 - To modify the cluster configuration, refer to the instructions for [patching](/1.11/installing/production/patching/).
 - The `disabled` security mode has been removed from DC/OS Enterprise 1.12. To upgrade a `disabled` mode 1.11 cluster to 1.12, first [patch the 1.11 cluster from disabled to permissive mode](/1.11/installing/production/patching/#patching-dcos-111-in-permissive-mode) as a separate step before upgrading from 1.11 to 1.12. [enterprise type="inline" size="small" /]
 
@@ -45,7 +45,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <th Rowspan = "20" Align = "center"><strong>Upgrade<br> From</strong></div></th>
    <tr>
     <th></th>
-    <th Colspan = "7" Align = "center"><strong>Upgrade To</strong></th>
+    <th Colspan = "10" Align = "center"><strong>Upgrade To</strong></th>
    </tr>
     <th></th>
     <th>1.11.0</th>
@@ -56,9 +56,13 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <th>1.11.5</th>
     <th>1.11.6</th>
     <th>1.11.7</th>
+    <th>1.11.8</th>
+    <th>1.11.9</th>
    </tr>
    <tr>
     <th>1.10.0</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -78,6 +82,8 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
     <td Align = "center">⚫</td>
     <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
    </tr>
    <tr>
     <th>1.10.2</th>
@@ -88,6 +94,8 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">⚫</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
     <td Align = "center">◯</td>
    </tr>
     <tr>
@@ -100,6 +108,8 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
     <td Align = "center">⚫</td>
     <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
    </tr>
    <tr>
     <th>1.10.4</th>
@@ -110,6 +120,8 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">⚫</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
     <td Align = "center">◯</td>
    </tr>
    <tr>
@@ -122,6 +134,8 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
     <td Align = "center">⚫</td>
     <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
    </tr>
    <tr>
     <th>1.10.6</th>
@@ -130,6 +144,8 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>
@@ -144,6 +160,8 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
    </tr>
    <tr>
     <th>1.10.8</th>
@@ -152,6 +170,34 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.10.9</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>1.10.10</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>
     <td Align = "center">⚫</td>

--- a/pages/1.11/installing/production/upgrading/index.md
+++ b/pages/1.11/installing/production/upgrading/index.md
@@ -40,13 +40,12 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
 | ⚫| Supported |
 | ◯| Not Supported |
 
-<table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
+<table class="table" style="table-layout: fixed; border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
    <tr>
-    <th Rowspan = "20" Align = "center"><strong>Upgrade<br> From</strong></div></th>
-   <tr>
+    <th Rowspan = "20" Align = "center"><strong>From</strong></div></th>
     <th></th>
     <th Colspan = "10" Align = "center"><strong>Upgrade To</strong></th>
-   </tr>
+    <tr style="font-size: smaller;">
     <th></th>
     <th>1.11.0</th>
     <th>1.11.1</th>
@@ -60,7 +59,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <th>1.11.9</th>
    </tr>
    <tr>
-    <th>1.10.0</th>
+    <th style="font-size: smaller;">1.10.0</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -73,7 +72,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
    </tr>
    <tr>
-    <th>1.10.1</th>
+    <th style="font-size: smaller;">1.10.1</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -86,7 +85,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
    </tr>
    <tr>
-    <th>1.10.2</th>
+    <th style="font-size: smaller;">1.10.2</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -99,7 +98,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
    </tr>
     <tr>
-    <th>1.10.3</th>
+    <th style="font-size: smaller;">1.10.3</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -112,7 +111,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
    </tr>
    <tr>
-    <th>1.10.4</th>
+    <th style="font-size: smaller;">1.10.4</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -125,7 +124,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
    </tr>
    <tr>
-    <th>1.10.5</th>
+    <th style="font-size: smaller;">1.10.5</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -138,7 +137,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">◯</td>
    </tr>
    <tr>
-    <th>1.10.6</th>
+    <th style="font-size: smaller;">1.10.6</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -151,7 +150,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">⚫</td>
    </tr>
    <tr>
-    <th>1.10.7</th>
+    <th style="font-size: smaller;">1.10.7</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -164,7 +163,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">⚫</td>
    </tr>
    <tr>
-    <th>1.10.8</th>
+    <th style="font-size: smaller;">1.10.8</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -177,7 +176,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">⚫</td>
    </tr>
    <tr>
-    <th>1.10.9</th>
+    <th style="font-size: smaller;">1.10.9</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
@@ -190,7 +189,7 @@ The following matrix table lists the supported upgrade paths for DC/OS 1.11.
     <td Align = "center">⚫</td>
    </tr>
    <tr>
-    <th>1.10.10</th>
+    <th style="font-size: smaller;">1.10.10</th>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>
     <td Align = "center">◯</td>


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/COPS-4239

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
