### PR TITLE
ss/DCOS_OSS-4520 Added note about relative paths to dcos task log pag…

### DIFF
--- a/pages/1.10/cli/command-reference/dcos-task/dcos-task-log/index.md
+++ b/pages/1.10/cli/command-reference/dcos-task/dcos-task-log/index.md
@@ -8,7 +8,7 @@ excerpt:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
+
 
 
 # Description
@@ -34,6 +34,16 @@ dcos task log <task> <file> [OPTION]
 |---------|-------------|-------------|
 | `<task>`   |             |  A full task ID, a partial task ID, or a regular expression. |
 | `<file>`   |  stdout  |  Specify the sandbox file to print. |
+
+The log file parameters should be paths relative to the Mesos sandbox. For example:
+```
+dcos task log [mesosID] /mnt/mesos/sandbox/exporter.log
+```
+will return an error message. Instead, use this format:
+
+```
+dcos task log [mesosID] exporter.log
+```
 
 # Parent command
 

--- a/pages/1.11/cli/command-reference/dcos-task/dcos-task-log/index.md
+++ b/pages/1.11/cli/command-reference/dcos-task/dcos-task-log/index.md
@@ -33,6 +33,16 @@ dcos task log <task> <file> [OPTION]
 | `<task>`   |             |  A full task ID, a partial task ID, or a regular expression. |
 | `<file>`   |  `stdout`  |  Specify the sandbox file to Displays. |
 
+The log file parameters should be paths relative to the Mesos sandbox. For example:
+```
+dcos task log [mesosID] /mnt/mesos/sandbox/exporter.log
+```
+will return an error message. Instead, use this format:
+
+```
+dcos task log [mesosID] exporter.log
+```
+
 # Parent command
 
 | Command | Description |

--- a/pages/1.12/cli/command-reference/dcos-task/dcos-task-log/index.md
+++ b/pages/1.12/cli/command-reference/dcos-task/dcos-task-log/index.md
@@ -33,6 +33,16 @@ dcos task log <task> <file> [OPTION]
 | `<task>`   |             |  A full task ID, a partial task ID, or a regular expression. |
 | `<file>`   |  `stdout`  |  Specify the sandbox file to Displays. |
 
+The log file parameters should be paths relative to the Mesos sandbox. For example:
+```
+dcos task log [mesosID] /mnt/mesos/sandbox/exporter.log
+```
+will return an error message. Instead, use this format:
+
+```
+dcos task log [mesosID] exporter.log
+```
+
 # Parent command
 
 | Command | Description |

--- a/pages/1.13/cli/command-reference/dcos-task/dcos-task-log/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/dcos-task-log/index.md
@@ -33,6 +33,16 @@ dcos task log <task> <file> [OPTION]
 | `<task>`   |             |  A full task ID, a partial task ID, or a regular expression. |
 | `<file>`   |  `stdout`  |  Specify the sandbox file to Displays. |
 
+The log file parameters should be paths relative to the Mesos sandbox. For example:
+```
+dcos task log [mesosID] /mnt/mesos/sandbox/exporter.log
+```
+will return an error message. Instead, use this format:
+
+```
+dcos task log [mesosID] exporter.log
+```
+
 # Parent command
 
 | Command | Description |

--- a/pages/1.9/cli/command-reference/dcos-task/dcos-task-log/index.md
+++ b/pages/1.9/cli/command-reference/dcos-task/dcos-task-log/index.md
@@ -8,7 +8,6 @@ excerpt:
 enterprise: false
 ---
 
-<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
 # Description
@@ -34,6 +33,16 @@ dcos task log <task> <file> [OPTION]
 |---------|-------------|-------------|
 | `<task>`   |             |  A full task ID, a partial task ID, or a regular expression. |
 | `<file>`   |  stdout  |  Specify the sandbox file to print. |
+
+The log file parameters should be paths relative to the Mesos sandbox. For example:
+```
+dcos task log [mesosID] /mnt/mesos/sandbox/exporter.log
+```
+will return an error message. Instead, use this format:
+
+```
+dcos task log [mesosID] exporter.log
+```
 
 # Parent command
 


### PR DESCRIPTION
…es for 1.9 - 1.13.

## Description
https://jira.mesosphere.com/browse/DCOS_OSS-4520

This documentation ticket was opened relative to https://jira.mesosphere.com/browse/DCOS_OSS-1409.

Description:

I tried this on the command line:

dcos task log [mesosID] /mnt/mesos/sandbox/exporter.log

Which resulted in the CLI telling me that the file did not exist. Using this format worked:

dcos task log [mesosID] exporter.log

The help text for the documentation should explain that the log file parameters should be paths relative to the mesos sandbox.


## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

I have added the following message to versions 1.9 - 1.13 of the CLI command reference entry for `dcos task log`.

The log file parameters should be paths relative to the Mesos sandbox. For example:
```dcos task log [mesosID] /mnt/mesos/sandbox/exporter.log```
will return an error message. Instead, use this format:
```dcos task log [mesosID] exporter.log```
 
However, I wonder if we should add a similar note to the /monitoring/logging/ and dcos-101 tutorials which describe use of the `dcos task log` command.

