### PR TITLE
ss/DCOS_OSS-4366 Fixed run-on command in configuration page. Added co…

### DIFF
--- a/pages/services/prometheus/0.1.0-2.3.2/configuration/prometheus-federation/index.md
+++ b/pages/services/prometheus/0.1.0-2.3.2/configuration/prometheus-federation/index.md
@@ -28,7 +28,8 @@ global:
 # Here it's Prometheus itself.# Alert Rules
 rule_files:
  - alert.rules.ymlscrape_configs:
- # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.    # Self Monitoring
+ # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.    
+ # Self Monitoring
  - job_name: prometheus
    static_configs:
      - targets: ['localhost:9090']  - job_name: agent-metrics
@@ -44,13 +45,13 @@ rule_files:
     - targets: ['Slave Prometheus endpoint1','Slave Prometheus endpoint2']
 ```
 
-## Use Case: Simple cluster service implementation (Global Prometheus servers)
+## Use Case
 
-Global prometheus Service: To federate data from two or more Prometheus servers, we must to launch the  Prometheus service as a Global Prometheus service and pass Global Prometheus server endpoints as targets to the `slave prometheus` service.
+Global Prometheus Service: To federate data from two or more Prometheus servers, we must to launch the  Prometheus service as a Global Prometheus service and pass Global Prometheus server endpoints as targets to the `slave prometheus` service.
 
 To launch a Global Prometheus server, check the template given in the previous section.
 
-**Note:** A Global Prometheus service will only help with federated data from other Prometheus servers and would not be monitoring anything, unlike another `-prometheus` server.
+<p class="message--note"><strong>NOTE: </strong> A Global Prometheus service will only help with federated data from other Prometheus servers and would not be monitoring anything, unlike another <code>-prometheus</code> server.</p>
 
 Prometheus Service1, Prometheus Service2: Cluster of two prometheus servers monitoring different targets and federating data to global prometheus servers.
 

--- a/pages/services/prometheus/0.1.1-2.3.2/configuration/prometheus-federation/index.md
+++ b/pages/services/prometheus/0.1.1-2.3.2/configuration/prometheus-federation/index.md
@@ -16,7 +16,7 @@ Federation allows you to pull aggregates up the hierarchy to a global Prometheus
 - **match:** match[] here requests all job-level time series.
 - **global prometheus:** The Prometheus server which will recieve data from slave Prometheus server.
 
-Template for global prometheus server configuration:
+Template for global Prometheus server configuration:
 
 ```
 # my global config
@@ -47,11 +47,11 @@ global:
     - targets: ['Slave Prometheus endpoint1','Slave Prometheus endpoint2']
 ```
 
-### Use Case: Simple cluster service implementation (Global Prometheus Service)
+### Use Case
 
 To federate data from two or more Prometheus servers, we must launch the Prometheus service as a Global Prometheus Service and pass Global Prometheus server endpoints as targets to the `slave prometheus` service. To launch a Global Prometheus server, check the template given in the previous section.
 
-**Note:** A Global Prometheus service will only help with federated data from other Prometheus servers and would not be monitoring anything, unlike another `-prometheus` server.
+<p class="message--note"><strong>NOTE: </strong> A Global Prometheus service will only help with federated data from other Prometheus servers and would not be monitoring anything, unlike another <code>-prometheus</code> server.</p>
 
 Prometheus Service1, Prometheus Service2: Cluster of two prometheus servers monitoring different targets and federating data to Global Prometheus servers.
 

--- a/pages/services/prometheus/0.1.1-2.3.2/index.md
+++ b/pages/services/prometheus/0.1.1-2.3.2/index.md
@@ -5,20 +5,22 @@ title: Prometheus 0.1.1-2.3.2
 menuWeight: 50
 excerpt: Overview of DC/OS Prometheus 0.1.1-2.3.2
 featureMaturity:
+render: mustache
+model: /services/prometheus/data.yml
 enterprise: false
 ---
 
-DC/OS Prometheus Service is an automated service that makes it easy to deploy and manage Prometheus on Mesosphere [DC/OS](https://mesosphere.com/product/). For more information on Prometheus, see the [Prometheus documentation](https://prometheus.io/docs/introduction/overview/).
+DC/OS {{ model.techName }} Service is an automated service that makes it easy to deploy and manage {{ model.techName }} on Mesosphere [DC/OS](https://mesosphere.com/product/). For more information on {{ model.techName }}, see the [{{ model.techName }} documentation](https://prometheus.io/docs/introduction/overview/).
 
 ## Benefits
-DC/OS Prometheus offers the following benefits :
+DC/OS {{ model.techName }} offers the following benefits :
 1. Designed for reliability
-2. Easily configurable to support all Prometheus design patterns
+2. Easily configurable to support all {{ model.techName }} design patterns
 3. Auto self health monitoring with provision for corrective action
 4. Flexible design to suit design requirement (with/without AlertManager)
 5. Supports wide range of integration for data collection,persistence, notification and dashboarding
 
-DC/OS Prometheus's main features are:
+DC/OS {{ model.techName }}'s main features are:
 1. Multi-dimensional data model with time series data identified by metric name and key/value pairs
 2. Flexible query language to leverage this dimensionality
 3. No reliance on distributed storage; single server nodes are autonomous


### PR DESCRIPTION
…rrect formatting for Note.

## Description
https://jira.mesosphere.com/browse/DCOS_OSS-4366
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Source: https://docs.mesosphere.com/services/prometheus/0.1.0-2.3.2/configuration/prometheus-federation

Hello,

It seems to me that your example configuration of Global Prometheus has bad format - at least on 13 line and 16 line you have joined two lines.

May be will be better do divide configuration for Global and Slave Prometheus. It will be better readable.

Thx for your sharing KNOW-HOW.

 

Jiri Valnoha

All this required was adding a carriage return in the middle of the code block comments. I also added correct formatting to Note on Configuration page in both 0.1.0 and 0.1.1 versions.
