### PR TITLE
ss/COPS-3895 Fixed typo in code block in run-job pages for all versions.

### DIFF
--- a/pages/services/spark/2.1.0-2.2.0-1/run-job/index.md
+++ b/pages/services/spark/2.1.0-2.2.0-1/run-job/index.md
@@ -38,7 +38,7 @@ Spark job settings are controlled by configuring [Spark properties][14].
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in Spark Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by Spark can be passed through the command-line with within the `--submit-args` string. 
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/2.1.0-2.2.1-1/run-job/index.md
+++ b/pages/services/spark/2.1.0-2.2.1-1/run-job/index.md
@@ -38,7 +38,7 @@ Spark job settings are controlled by configuring [Spark properties][14].
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in Spark Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by Spark can be passed through the command-line with within the `--submit-args` string. 
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/2.3.0-2.2.1-2/run-job/index.md
+++ b/pages/services/spark/2.3.0-2.2.1-2/run-job/index.md
@@ -38,7 +38,7 @@ Spark job settings are controlled by configuring [Spark properties][14].
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in Spark Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by Spark can be passed through the command-line with within the `--submit-args` string. 
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/2.3.1-2.2.1-2/run-job/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/run-job/index.md
@@ -35,7 +35,7 @@ render: mustache
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in {{ model.techShortName }} Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by {{ model.techShortName }} can be passed through the command-line with within the `--submit-args` string. 
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/2.4.0-2.2.1-3/run-job/index.md
+++ b/pages/services/spark/2.4.0-2.2.1-3/run-job/index.md
@@ -35,7 +35,7 @@ model: /services/spark/data.yml
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in {{ model.techShortName }} Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by {{ model.techShortName }} can be passed through the command-line with within the `--submit-args` string. 
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/2.5.0-2.2.1/run-job/index.md
+++ b/pages/services/spark/2.5.0-2.2.1/run-job/index.md
@@ -44,7 +44,7 @@ model: /services/spark/data.yml
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few options that are unique to DC/OS that are not in {{ model.techShortName }} Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by {{ model.techShortName }} can be passed through the command-line with within the `--submit-args` string.
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/2.6.0-2.3.2/run-job/index.md
+++ b/pages/services/spark/2.6.0-2.3.2/run-job/index.md
@@ -44,7 +44,7 @@ model: /services/spark/data.yml
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few options that are unique to DC/OS that are not in {{ model.techShortName }} Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by {{ model.techShortName }} can be passed through the command-line with within the `--submit-args` string.
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/v1.0.9-2.1.0-1/run-job/index.md
+++ b/pages/services/spark/v1.0.9-2.1.0-1/run-job/index.md
@@ -15,7 +15,7 @@ enterprise: false
 
 1.  Run the job.
 
-        $ dcos spark run --submit-args=`--class MySampleClass http://external.website/mysparkapp.jar 30`
+        $ dcos spark run --submit-args="--class MySampleClass http://external.website/mysparkapp.jar 30"
 
         $ dcos spark run --submit-args="--py-files mydependency.py http://external.website/mysparkapp.py 30"
 
@@ -43,7 +43,7 @@ All properties are submitted through the `--submit-args` option to `dcos spark r
 
 Certain common properties have their own special names. You can view these through `dcos spark run --help`. Here is an example of using `--supervise`:
 
-    $ dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    $ dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Configuration file
 

--- a/pages/services/spark/v1.1.0-2.1.1/run-job/index.md
+++ b/pages/services/spark/v1.1.0-2.1.1/run-job/index.md
@@ -15,7 +15,7 @@ enterprise: false
 
 1.  Run the job.
 
-        $ dcos spark run --submit-args=`--class MySampleClass http://external.website/mysparkapp.jar 30`
+        $ dcos spark run --submit-args="--class MySampleClass http://external.website/mysparkapp.jar 30"
 
         $ dcos spark run --submit-args="--py-files mydependency.py http://external.website/mysparkapp.py 30"
 
@@ -43,7 +43,7 @@ All properties are submitted through the `--submit-args` option to `dcos spark r
 
 Certain common properties have their own special names. You can view these through `dcos spark run --help`. Here is an example of using `--supervise`:
 
-    $ dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    $ dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Configuration file
 

--- a/pages/services/spark/v1.1.1-2.2.0/run-job/index.md
+++ b/pages/services/spark/v1.1.1-2.2.0/run-job/index.md
@@ -12,7 +12,7 @@ enterprise: false
 
 1.  Run the job.
 
-        dcos spark run --submit-args=`--class MySampleClass http://external.website/mysparkapp.jar 30`
+        dcos spark run --submit-args="--class MySampleClass http://external.website/mysparkapp.jar 30"
 
         dcos spark run --submit-args="--py-files mydependency.py http://external.website/mysparkapp.py 30"
 
@@ -45,7 +45,7 @@ Certain common properties have their own special names. You can view these throu
 using `--supervise`:
 
     dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass
-http://external.website/mysparkapp.jar 30`
+http://external.website/mysparkapp.jar 30"
 
 ## Configuration file
 

--- a/pages/services/spark/v2.0.0-2.2.0-1/run-job/index.md
+++ b/pages/services/spark/v2.0.0-2.2.0-1/run-job/index.md
@@ -15,7 +15,7 @@ enterprise: false
 
 1.  Run the job.
 
-        dcos spark run --submit-args=`--class MySampleClass http://external.website/mysparkapp.jar 30`
+        dcos spark run --submit-args="--class MySampleClass http://external.website/mysparkapp.jar 30"
 
         dcos spark run --submit-args="--py-files mydependency.py http://external.website/mysparkapp.py 30"
 
@@ -39,7 +39,7 @@ Spark job settings are controlled by configuring [Spark properties][14].
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in Spark Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by Spark can be passed through the command-line with within the `--submit-args` string. 
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 

--- a/pages/services/spark/v2.0.1-2.2.0-1/run-job/index.md
+++ b/pages/services/spark/v2.0.1-2.2.0-1/run-job/index.md
@@ -38,7 +38,7 @@ Spark job settings are controlled by configuring [Spark properties][14].
 
 All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few unique options to DC/OS that are not in Spark Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by Spark can be passed through the command-line with within the `--submit-args` string. 
 
-    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30`
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
 
 ## Setting automatic configuration defaults
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-3895
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium
Description
https://docs.mesosphere.com/services/spark/2.3.1-2.2.1-2/run-job/#submission

the end of the command is a ' instead of "
## Requirements

Fixed typo in all versions. 