### PR TITLE
ss/Fix-Cassandra-menuweight Correcting menuweights in most recent 3 v…

### DIFF
--- a/pages/services/cassandra/2.3.0-3.0.16/index.md
+++ b/pages/services/cassandra/2.3.0-3.0.16/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Cassandra 2.3.0-3.0.16
 excerpt:
 title: Cassandra 2.3.0-3.0.16
-menuWeight: 2
+menuWeight: 3
 model: /services/cassandra/data.yml
 render: mustache
 ---

--- a/pages/services/cassandra/2.4.0-3.0.16/index.md
+++ b/pages/services/cassandra/2.4.0-3.0.16/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Cassandra 2.4.0-3.0.16
 excerpt: DC/OS Apache Cassandra is an automated service that makes it easy to deploy and manage Apache Cassandra on DC/OS.
 title: Cassandra 2.4.0-3.0.16
-menuWeight: 1
+menuWeight: 2
 model: /services/cassandra/data.yml
 render: mustache
 ---

--- a/pages/services/cassandra/2.5.0-3.11.3/index.md
+++ b/pages/services/cassandra/2.5.0-3.11.3/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Cassandra 2.5.0-3.11.3
 excerpt: DC/OS Apache Cassandra is an automated service that makes it easy to deploy and manage Apache Cassandra on DC/OS.
 title: Cassandra 2.5.0-3.11.3
-menuWeight: 9
+menuWeight: 1
 model: /services/cassandra/data.yml
 render: mustache
 ---


### PR DESCRIPTION
…ersions.

## Description
Most recent Cassandra version is not the default on Service Docs landing page. 

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Fixed menuweights on versions 2.3.x, 2.4.x and 2.5.x to show 2.5.x at the top.