### PR TITLE
Remove Cassandra 2.3.0 from main menu

### DIFF
--- a/pages/services/cassandra/2.3.0-3.0.16/index.md
+++ b/pages/services/cassandra/2.3.0-3.0.16/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Cassandra 2.3.0-3.0.16
 excerpt:
 title: Cassandra 2.3.0-3.0.16
-menuWeight: 3
+menuWeight: -1
 model: /services/cassandra/data.yml
 render: mustache
 ---

--- a/pages/services/cassandra/2.5.0-3.11.3/release-notes/index.md
+++ b/pages/services/cassandra/2.5.0-3.11.3/release-notes/index.md
@@ -7,7 +7,7 @@ menuWeight: 10
 model: /services/cassandra/data.yml
 render: mustache
 ---
-#Version 2.5.0-3.11.3
+# Version 2.5.0-3.11.3
 
 ## Upgrades
 

--- a/pages/version-policy/index.md
+++ b/pages/version-policy/index.md
@@ -228,13 +228,13 @@ B - This package combination is *beta*.
         <td><p style="text-align: center;">◯</p></td>
     </tr>
     <tr>
-        <td>Cassandra 2.3.x-3.0.16</td>
+        <td>Cassandra 2.4.x-3.0.16</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
-        <td>Cassandra 2.4.x-3.0.16 (Recommended)</td>
+        <td>Cassandra 2.5.x-3.11.3 (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>


### PR DESCRIPTION
## Description
Removes Cassandra `2.3.0` package from main menu
- also small markdown fix

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
