### PR TITLE
ss/DCOS_OSS-4835 Fixed broken links to images and URLs.

### DIFF
--- a/pages/1.12/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.12/tutorials/autoscaling/cpu-memory/index.md
@@ -36,7 +36,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
     ```
 
-    **Tip:** Run `dcos node` to get the available node IDs.
+    Run `dcos node` to get the available node IDs.
 
 1.  Clone the [autoscale Github repository](https://github.com/mesosphere/marathon-autoscale) to your node.
 

--- a/pages/1.12/tutorials/autoscaling/microscaling-queue/index.md
+++ b/pages/1.12/tutorials/autoscaling/microscaling-queue/index.md
@@ -15,60 +15,63 @@ This tutorial walks you through setting up a microscaling demonstration from [Mi
 This allows your infrastructure to automatically reallocate
 resources from lower to higher priority tasks, reacting within seconds to a change in demand.
 Microscaling monitors whether the higher priority task is meeting a performance target. In this tutorial, the performance target is maintaining the length of a configured queue value. The higher priority task is scaled up when the target is not met,
-and down when it is exceeded. The lower priority tasks can use the spare resources.  
+and scaled down when it is exceeded. The lower priority tasks can use the spare resources.  
 
 **Time Estimate**:
 
-If you already have the [prerequisites](#prerequisites) setup, you'll have the microscaling demo running in around 10-15 minutes.
+If you already have the [prerequisites](#prerequisites) set up, you can have the microscaling demo running in 10-15 minutes.
 
 **Scope**:
 
 In this tutorial, microscaling adjusts the balance between two tasks - one high priority and one background - based on the number of items in  an Azure Storage Queue.
 
-![microscaling-queue.png](/img/microscaling-queue.png)
+![microscaling-queue.png](/1.12/img/microscaling-queue.png)
  
  Figure 1. - Microscaling queue
 
 The demo creates four Marathon apps that run as Docker containers.
 
-* **Producer** instances add items to the queue. The more producers there are, the faster the queue fills up. We start 3 producers on startup and you can scale these manually using the Marathon UI.
+* **Producer** instances add items to the queue. The more producers there are, the faster the queue fills up. We start three producers on startup, and you can scale these manually using the Marathon UI.
 * **Consumer** instances remove items from the queue and are scaled by the Microscaling Engine.
 * **Remainder** is a background task. Any spare capacity is used for this background task. You can change the Docker image to use your own using the Marathon UI.
-* **Microscaling** is the engine that monitors the queue length, and scales the Consumer and Remainder tasks. It also sends data to our Microscaling-in-a-Box site so you can see what's happening.
+* **Microscaling** is the engine that monitors the queue length, and scales the Consumer and Remainder tasks. It also sends data to our Microscaling-in-a-Box site so you can see what is happening.
 
 # <a name="prerequisites"></a>Prerequisites
 
-* A [Microsoft Azure][3] account. Your DC/OS cluster can be running anywhere (it doesn't have to be running on Azure)
-but the demo uses an Azure Storage Queue. If you don't already have an account you can get a [free trial][4].
-* A [running DC/OS cluster][5]. If you don't already have one, you can follow these [instructions for setting up a DC/OS cluster on Azure][6].
+* A [Microsoft Azure][3] account. Your DC/OS cluster can be running anywhere (it does not have to be running on Azure) but the demo uses an Azure Storage Queue. If you do not already have an account you can get a [free trial][4].
+* A [running DC/OS cluster][5]. If you do not already have one, you can follow these [instructions for setting up a DC/OS cluster on Azure][6].
 * The Marathon API address. If you set up an SSH tunnel on port 80 to your Marathon master node, you can access the Marathon API at `http://localhost/marathon`.
 * [Ruby][8] on your local machine to run the demo scripts.
 
 # Set up an Azure Storage Account
 
 * Sign in to the [Azure Portal][9].
-* Navigate to New -> Data + Storage -> Storage Account.
+* Navigate to **New -> Data + Storage -> Storage Account**.
 * Create a storage account with the following settings:
 
-![microscaling-azure-storage.png](/img/microscaling-azure-storage.png)
+![microscaling-azure-storage.png](/1.12/img/microscaling-azure-storage.png)
 
-* **Name** - this must be globally unique across all Azure Storage Accounts. Make a note of this - you will use this as the environment variable `AZURE_STORAGE_ACCOUNT_NAME` later.
-* **Replication** - choose Locally-redundant storage for the queue.
-* **Resource Group** - create a new resource group for the queue.
+Figure 2. Azure storage account
 
-After the storage account has been created, navigate to Settings -> Access Keys and make a note of your access key. You'll use this as the environment variable `AZURE_STORAGE_ACCOUNT_KEY` later.
+* **Name** - This must be globally unique across all Azure Storage Accounts. Make a note of this - you will use this as the environment variable `AZURE_STORAGE_ACCOUNT_NAME` later.
+* **Replication** - Choose Locally-redundant storage for the queue.
+* **Resource Group** - Create a new resource group for the queue.
+
+After the storage account has been created, navigate to **Settings -> Access Keys** and make a note of your access key. You will use this as the environment variable `AZURE_STORAGE_ACCOUNT_KEY` later.
 
 # Set up Microscaling-in-a-box
 
-* Go to the [Microscaling-in-a-box][10] site and sign up for an account if you don't have one already.
+* Go to the [Microscaling-in-a-box][10] site and sign up for an account if you do not have one already.
 * In Step 1, pick the Mesos/Marathon option
 
-![microscaling-step-1.png](/img/microscaling-step-1.png)
+![microscaling-step-1.png](/1.12/img/microscaling-step-1.png)
 
-* Skip through steps 2 & 3 to use the default values.
-* Navigate to the step 4 (Run) page and find your user ID and the default value for the queue we'll be using in the demo. You will use these as the values for environment variables `MSS_USER_ID` and `AZURE_STORAGE_QUEUE_NAME` later.
+Figure 3. Microscaling step 1
 
-![microscaling-step-4.png](/img/microscaling-step-4.png)
+* Skip through steps 2 and 3 to use the default values.
+* Navigate to the step 4 (Run) page and find your user ID and the default value for the queue we will be using in the demo. You will use these as the values for environment variables `MSS_USER_ID` and `AZURE_STORAGE_QUEUE_NAME` later.
+
+![microscaling-step-4.png](/1.12/img/microscaling-step-4.png)
 
 Figure 4. User ID and queue name
 
@@ -97,24 +100,26 @@ export AZURE_STORAGE_QUEUE_NAME=<queue name>
 export MSS_USER_ID=<user ID>
 export MSS_MARATHON_API=http://localhost/marathon
 ```
-You're now ready to run the demo:
+You are now ready to run the demo:
 ``` bash
 ./marathon-install
 ```
 
-This script starts all four tasks. You can view these in the DC/OS web interface.  
+This script starts all four tasks. You can view these in the DC/OS GUI.  
 
-After Marathon has launched the apps, the results will start to appear in the Microscaling-in-a-Box UI. You'll see the Microscaling Engine scaling the consumer and remainder containers to maintain the target queue length.
+After Marathon has launched the apps, the results will start to appear in the Microscaling-in-a-Box UI. You will see the Microscaling Engine scaling the consumer and remainder containers to maintain the target queue length.
 
-![microscaling-chart-ui.png](/img/microscaling-chart-ui.png)
+![microscaling-chart-ui.png](/1.12/img/microscaling-chart-ui.png)
 
-You can use the DC/OS web interface to scale the number of Producer tasks up or down and see how Microscaling reacts to keep the queue length under control.
+Figure 5. Microscaling chart
+
+You can use the DC/OS GUI to scale the number of Producer tasks up or down and see how Microscaling reacts to keep the queue length under control.
 
 # Cleanup
 
 ## Uninstall the Marathon Apps
 
-You can use the `marathon-uninstall` command to remove the demo apps from your cluster. (This command requires the `MSS_MARATHON_API` environment variable to be set as above.)
+You can use the `marathon-uninstall` command to remove the demo apps from your cluster. (This command requires the `MSS_MARATHON_API` environment variable to be set [as above](#run-the-microscaling-install-script).)
 
 ``` bash
 ./marathon-uninstall
@@ -122,12 +127,12 @@ You can use the `marathon-uninstall` command to remove the demo apps from your c
 
 ## Delete the Azure Resources
 
-After you've finished with the demo you should delete the Azure resources so that you don't get charged.
+After you have finished with the demo, you should delete the Azure resources so that you do not get charged.
 
 * Sign in to the [Azure Portal][9].
-* Select Resource Groups from the left hand menu.
+* Select **Resource Groups** from the left hand menu.
 * Find and delete the Resource Group you created for the Azure Queue.
-* If you created an ACS cluster for this demo, you'll want to delete the Resource Group for that too.
+* If you created an ACS cluster for this demo, delete the Resource Group for that too.
 
 # Next Steps
 

--- a/pages/1.12/tutorials/create-service/index.md
+++ b/pages/1.12/tutorials/create-service/index.md
@@ -11,18 +11,18 @@ enterprise: false
 #include /include/tutorial-disclaimer.tmpl
 
 
-This tutorial shows how to create and deploy a simple one-command service and a containerized service using both the DC/OS web interface and the CLI.
+This tutorial shows how to create and deploy a simple one-command service and a containerized service using both the DC/OS GUI and the CLI.
 
 ### Prerequisites
 - [A DC/OS cluster](/1.12/installing/)
 
 # One-command service
 
-## DC/OS web interface
+## DC/OS GUI
 
-Create and run a simple service from the DC/OS web interface:
+Create and run a simple service from the DC/OS GUI:
 
-1. Click the **Services** tab of the DC/OS web interface, then click **RUN A SERVICE**.
+1. Click the **Services** tab of the DC/OS GUI, then click **RUN A SERVICE**.
 1. Click **Single Container**.
 
    1. In the **SERVICE ID** field, enter a name for your service.
@@ -38,13 +38,13 @@ Create and run a simple service from the DC/OS web interface:
 
     ![Create a service in the DC/OS UI](/1.12/img/deploy-svs-ui.png)
 
-    Figure 1. Create a service in the web interface
+    Figure 1. Create a service in the GUI
 
 1. Click the name of your service in the **Services** view to see it running and monitor health.
 
     ![Running service in the DC/OS UI](/1.12/img/GUI-Services-Running_Services_View-1_12.png)
 
-    Figure 2. Viewing a running service in the web interface
+    Figure 2. Viewing a running service in the GUI
 
 ## DC/OS CLI
 
@@ -81,29 +81,29 @@ Create and run a simple service from the DC/OS CLI:
     dcos marathon app list
     ```
 
-    You can also click the name of your service in the **Services** view of the DC/OS web interface to see it running and monitor health.
+    You can also click the name of your service in the **Services** view of the DC/OS GUI to see it running and monitor health.
 
 # Containerized service
 
-## DC/OS web interface
+## DC/OS GUI
 
-Create and run a containerized service from the DC/OS web interface:
+Create and run a containerized service from the DC/OS GUI:
 
 1.  Go to the `hello-dcos` page of the [Mesosphere Docker Hub repository](https://hub.docker.com/r/mesosphere/hello-dcos/tags/) and note down the latest image tag.
-1.  Click the **Services** tab of the DC/OS web interface, then click the **RUN A SERVICE**.
+1.  Click the **Services** tab of the DC/OS GUI, then click the **RUN A SERVICE**.
 1.  Click **Single Container** and enter a name for your service in the **SERVICE ID** field.
 1.  Click the **Container Settings** tab and enter the following in the **CONTAINER IMAGE** field: `mesosphere/hello-dcos:<image-tag>`. Replace `<image-tag>` with the tag you copied in step 1.
 
     ![Containerized service in the DC/OS UI](/1.12/img/deploy-container-ui.png)
 
-    Figure 3. Containerized service in the web interface
+    Figure 3. Containerized service in the GUI
 
 1.  Click **REVIEW & RUN** and **RUN SERVICE**.
 1.  In the **Services** tab, click the name of your service, then choose one of the task instances. Click **Logs**, then toggle to the **STDERR** and **STDOUT** to see the output of the service.
 
     ![Running containerized service in the DC/OS UI](/1.12/img/container-running-ui.png)
 
-    Figure 4. Viewing a containerized service in the web interface
+    Figure 4. Viewing a containerized service in the GUI
 
 ## DC/OS CLI
 
@@ -150,5 +150,5 @@ Create and run a containerized service from the CLI:
     dcos marathon app list
     ```
 
-1. In the **Services** tab of the DC/OS web interface, click the name of your service, then choose one of the task instances.
+1. In the **Services** tab of the DC/OS GUI, click the name of your service, then choose one of the task instances.
 1. Click **Logs**, then toggle to the **OUTPUT (STDOUT)** view to see the output of the service.

--- a/pages/1.12/tutorials/dcos-101/app1/index.md
+++ b/pages/1.12/tutorials/dcos-101/app1/index.md
@@ -21,26 +21,63 @@ You now have a working persistence layer - [Redis](https://redislabs.com/) - run
 In this section you will deploy a simple app connecting to Redis.
 
 # Steps
-1. Review app
-  * Let us first take a short look at the [app](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.py). It is very simple and just checks whether it can reach Redis and then prints the total number of keys stored there.
-2. Deploy app
-  * The python script has a dependency on the [redis-py](https://pypi.python.org/pypi/redis) Python library, which you cannot assume to be present on all agent nodes. Because of this, you should run it in the `mesosphere/dcos-101` Docker container that provides all of the dependencies. Feel free to take a look at the [DOCKERFILE](https://github.com/joerg84/dcos-101/blob/master/app1/DOCKERFILE), which was used to create the `mesosphere/dcos-101` image.
-  * Have a look at the [app definition](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.json). The app definition is the configuration which Marathon will use to deploy and manage the application. This app definition will download the python script and then run it inside the `mesosphere/dcos-101` Docker container.
-  * Add app1 to Marathon using the app definition: `dcos marathon app add https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.json`
-3. Check that app1 is running:
-    * By looking at all DC/OS tasks: `dcos task`. Here you should look at the state this task is currently in, which probably is either *S*taging or *R*unning.
-    * By looking at all Marathon apps: `dcos marathon app list`.
-    * By checking the logs: `dcos task log app1`. Here you should see on which node and port app1 is running, and the output from the app showing the number of keys in Redis. The node and ports  might vary between different runs and even during the lifetime of the app, depending on events in the cluster.
+1. Let us first take a short look at the [app](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.py). It is very simple and just checks whether it can reach Redis and then prints the total number of keys stored there.
+
+    ```python
+    import os
+    import redis
+    import time
+
+    print("Running on node '"+  os.getenv("HOST") + "' and port '" + os.getenv("PORT0"))
+    r = redis.StrictRedis(host='redis.marathon.l4lb.thisdcos.directory', port=6379, db=0)
+    if r.ping():
+            print("Redis Connected. Total number of keys:", len(r.keys()))
+    else:
+            print("Could not connect to redis")
+    time.sleep(5)
+    ```
+1. The Python script has a dependency on the [redis-py](https://pypi.python.org/pypi/redis) Python library, which you cannot assume to be present on all agent nodes. Because of this, you should run it in the `mesosphere/dcos-101` Docker container that provides all of the dependencies. Feel free to take a look at the [DOCKERFILE](https://github.com/joerg84/dcos-101/blob/master/app1/DOCKERFILE), which was used to create the `mesosphere/dcos-101` image.
+
+    Have a look at the [app definition](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.json). The app definition is the configuration which Marathon will use to deploy and manage the application. This app definition will download the python script and then run it inside the `mesosphere/dcos-101` Docker container.
+1. Add `app1` to Marathon using the app definition: 
+  
+    ```bash
+    dcos marathon app add https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.json
+    ```
+1. Check that `app1` is running 
+
+  * By looking at all DC/OS tasks: 
+
+    ```
+    dcos task
+    ```
+    Here you should look at the state this task is currently in, which probably is either `staging` or `running`.
+      
+  * By looking at all Marathon apps:
+
+    ```
+    dcos marathon app list
+    ```
+
+  * By checking the logs: 
+
+    ```
+    dcos task log app1
+    ```
+    Here you should see which node and port `app1` is running on, and the output from the app showing the number of keys in Redis. The node and ports  might vary between different runs and even during the lifetime of the app, depending on events in the cluster.
 
 # Outcome
-You have deployed your first app inside a Docker container using Marathon.
-You verified the app is running and successfully connected to the previously deployed Redis service.
+- You have deployed your first app inside a Docker container using Marathon.
+- You have verified that the app is running and successfully connected to the previously deployed Redis service.
 
 # Deep Dive
 You have just deployed your first app using [Marathon](https://mesosphere.github.io/marathon/) directly. Also note that the Redis service itself is running via Marathon.
+
 Marathon is referred to as the init system of DC/OS, as its main job is to support long running services.
 Marathon also allows for scaling or uninstalling of applications.
 There are multiple options to deploy and maintain apps on Marathon besides the DC/OS GUI:
 
 * DC/OS CLI: You have just used this option to deploy your app. To get more information on the marathon CLI use `dcos marathon app --help`.
 * HTTP endpoints: Marathon also comes with an extensive [REST API](http://mesosphere.github.io/marathon/api-console/index.html)
+
+In [the next section](/1.12/tutorials/dcos-101/service-discovery/), you will learn about DC/OS service discovery by exploring the different options available for apps in DC/OS.

--- a/pages/1.12/tutorials/dcos-101/app2/index.md
+++ b/pages/1.12/tutorials/dcos-101/app2/index.md
@@ -12,28 +12,38 @@ Welcome to part 5 of the DC/OS 101 Tutorial
 
 
 # Prerequisites
-* A [running DC/OS cluster](/tutorials/dcos-101/cli/) with [the DC/OS CLI installed](/tutorials/dcos-101/cli/).
-* [app1](/tutorials/dcos-101/app1/) deployed and running in your cluster.
+* A [running DC/OS cluster](/1.12/tutorials/dcos-101/cli/) with [the DC/OS CLI installed](/1.12/tutorials/dcos-101/cli/).
+* [app1](/1.12/tutorials/dcos-101/app1/) deployed and running in your cluster.
 
 
 # Objective
-[Earlier](/tutorials/dcos-101/app1/) in this tutorial you deployed an app that operates internally in your cluster, interfacing with other applications in the cluster as opposed to interacting externally. In this part you will deploy an app which provides a GUI to users. You will also deploy this app natively, without relying on Docker as a dependency and therefore reducing complexity.
+[Earlier](/1.12/tutorials/dcos-101/app1/) in this tutorial you deployed an app that operates internally in your cluster, interfacing with other applications in the cluster as opposed to interacting externally. In this part you will deploy an app which provides a GUI to users. You will also deploy this app natively, without relying on Docker as a dependency and therefore reducing complexity.
 
 # Steps
-  * Understand the application
-    * Take a short look at [app2](https://github.com/joerg84/dcos-101/blob/master/app2/app2.go). App2 is a [Go](https://golang.org/) based HTTP server that exposes a very simple interface to Redis.
-  * Deploy app2
-    * Take a short look at the [app definition](https://raw.githubusercontent.com/joerg84/dcos-101/master/app2/app2.json). In this case, the app is a binary without external dependencies.
-    Because of this, you no longer need to deploy it in a Docker container.
-    * Deploy app2: `dcos marathon app add https://raw.githubusercontent.com/joerg84/dcos-101/master/app2/app2.json`
-  * You have multiple options to check app 2 is sucessfully running:
-    * By looking at all DC/OS tasks: `dcos task`
-    * By looking at all Marathon apps: `dcos marathon app list`
-    * Curl the http server from within the cluster (in this case from the leading master):
-       * `dcos node ssh --master-proxy --leader`
-       * `curl dcos-101app2.marathon.l4lb.thisdcos.directory:10000`
+1. Take a short look at [app2](https://github.com/joerg84/dcos-101/blob/master/app2/app2.go). App2 is a [Go](https://golang.org/) based HTTP server that exposes a very simple interface to Redis.
+1. Deploy app2. Take a short look at the [app definition](https://raw.githubusercontent.com/joerg84/dcos-101/master/app2/app2.json). In this case, the app is a binary without external dependencies.
+  Because of this, you no longer need to deploy it in a Docker container.
+    ```
+    dcos marathon app add https://raw.githubusercontent.com/joerg84/dcos-101/master/app2/app2.json
+    ```
+1. You have multiple options to verify that `app2` is sucessfully running:
+  * By looking at all DC/OS tasks: 
+    ```
+    dcos task
+    ```
+  * By looking at all Marathon apps: 
+    ```
+    dcos marathon app list
+    ```
+  * Curl the http server from within the cluster (in this case from the leading master):
+    ```
+    dcos node ssh --master-proxy --leader
+    ```
+    ```
+    curl dcos-101app2.marathon.l4lb.thisdcos.directory:10000
+    ```
 
-      This should return you the raw HTML response from app2's webserver.
+    This should return you the raw HTML response from `app2`'s webserver.
 
 
 Accessing the app from within the cluster and viewing the raw HTML response proves our application is running, but in the real world you want to expose the app to the public. In the next part of this tutorial you will do exactly that.
@@ -49,9 +59,11 @@ You have now deployed apps in two different ways:
 
 Let's explore the differences in some more detail.
 
-DC/OS uses [containerizers](/deploying-services/containerizers/) to run tasks in containers. Running tasks in containers offers a number of benefits, including the ability to isolate tasks from one another and control task resources programmatically. DC/OS supports two types of containerizers - the DC/OS Universal Container Runtime, and the Docker containerizer.
+DC/OS uses [containerizers](/1.12/deploying-services/containerizers/) to run tasks in containers. Running tasks in containers offers a number of benefits, including the ability to isolate tasks from one another and control task resources programmatically. DC/OS supports two types of containerizers - the DC/OS Universal Container Runtime, and the Docker containerizer.
 
-For your first app, you used a Docker container image to package app1's dependencies ( Remember: never rely on dependencies being installed on an agent! ) and then used the Docker containerizer to execute it. Because the Docker containerizer internally uses the [Docker runtime](https://docs.docker.com/engine/userguide/intro/), you also used the Docker runtime.
+For your first app, you used a Docker container image to package `app1`'s dependencies ( Remember: never rely on dependencies being installed on an agent! ) and then used the Docker containerizer to execute it. Because the Docker containerizer internally uses the [Docker runtime](https://docs.docker.com/engine/userguide/intro/), you also used the Docker runtime.
 
 For your second app, you did not have any dependencies and therefore could rely on the default DC/OS Universal Container Runtime. Internally, both runtimes use the same OS features for isolation, namely [cgroups](https://en.wikipedia.org/wiki/Cgroups) and [namespaces](https://en.wikipedia.org/wiki/Linux_namespaces).
-This actually makes it possible to use the DC/OS Universal Container Runtime for running Docker images - check the [DC/OS Universal Container Runtime](/deploying-services/containerizers/) documentation for details.
+This actually makes it possible to use the DC/OS Universal Container Runtime for running Docker images - check the [DC/OS Universal Container Runtime](/1.12/deploying-services/containerizers/) documentation for details.
+
+In [the next part](/1.12/tutorials/dcos-101/marathon-lb/) of this tutorial you will expose your app to the public. 

--- a/pages/1.12/tutorials/dcos-101/cli/index.md
+++ b/pages/1.12/tutorials/dcos-101/cli/index.md
@@ -11,7 +11,7 @@ menuWeight: 1
 Welcome to part 1 of the DC/OS 101 Tutorial.
 
 # Prerequisites
-To get started with this tutorial, you should have access to a running DC/OS cluster with at least a single master node and 3 agent nodes (of which one is a public agent node). If you don't have these requirements set up, please follow the [setup instructions](/latest/installing/) for various cloud providers, on-premise, or vagrant setups.
+To get started with this tutorial, you should have access to a running DC/OS cluster with at least a single master node and 3 agent nodes (of which one is a public agent node). If you don't have these requirements set up, please follow the [setup instructions](/1.12/installing/) for various cloud providers, on-premise, or Vagrant setups.
 If you are unsure which option to choose, then we recommend using the <a href="https://downloads.dcos.io/dcos/stable/aws.html" target="_blank">AWS templates</a>. For this tutorial a setup with a single master node is sufficient, but for running production workloads you should have multiple master nodes.
 
 # Objective
@@ -19,15 +19,15 @@ You have access to your cluster and have already taken a first look at the GUI. 
 
 # Steps
   * Install the DC/OS CLI
-    * Follow the steps [here](/cli/install/) or the `Install CLI` instruction in the lower left corner of the DC/OS GUI.
+    * Follow the steps [here](/1.12/cli/install/).
     * Make sure you are authorized to connect to your cluster by running `dcos auth login`. This is necessary to prevent access from unauthorized people to your cluster.
-    * You can also add/invite friends and co-workers to your cluster. See [user management documentation](/security/ent/users-groups/) for details
+    * You can also add/invite friends and co-workers to your cluster. See the [user management documentation](/1.12/security/ent/users-groups/) for details.
 
   * Explore the cluster:
       * Check the running services with `dcos service`. Unless you already installed additional services, there should be two services running on your cluster: Marathon (basically the DC/OS init system) and metronome (basically the DC/OS cron scheduler).
       * Check the connected nodes with `dcos node`. You should be able to see your connected agents nodes (i.e., not the master nodes) in your cluster.
       * Explore the logs of the leading mesos master with `dcos node log --leader`. Mesos is basically the kernel of DC/OS and this tutorial explores the Mesos logs at multiple times during this tutorial.
-      * To explore more CLI options, enter the `dcos help` command. There are also help options of the individual commands available e.g., `dcos node --help`. Alternatively, check the [CLI documentation](/cli/).
+      * To explore more CLI options, enter the `dcos help` command. There are also help options of the individual commands available e.g., `dcos node --help`. Alternatively, check the [CLI documentation](/1.12/cli/).
 
 # Outcome
 Congratulations! You have successfully connected to your cluster using the DC/OS CLI, and started exploring some of the CLI commands.
@@ -38,10 +38,12 @@ You have already encountered several DC/OS components (including Mesos, Marathon
 But what other components make up DC/OS?
 
 ## DC/OS components
-Here are the DC/OS components that are relevant to this tutorial. A full description of all components can be found in the [documentation](/overview/architecture/components/).
-* [Marathon](/overview/architecture/components/#marathon) starts and monitors DC/OS applications and services.
-* Apache [Mesos](/overview/architecture/components/#apache-mesos) is the kernel of DC/OS and responsible for low-level task maintenance.
-* [Mesos DNS](/overview/architecture/components/#mesos-dns) provides service discovery within the cluster.
-* [Minuteman](/overview/architecture/components/#minuteman) is the internal layer 4 load balancer.
-* [Admin Router](/overview/architecture/components/#admin-router) is an open source NGINX configuration that provides central authentication and proxy to DC/OS services.
-* [Universe](/overview/architecture/components/#dcos-package-manager) is the package repository that holds the DC/OS services (e.g. Apache Spark or Apache Cassandra) that you can install on your cluster directly from the DC/OS GUI and CLI.
+Here are the DC/OS components that are relevant to this tutorial. A full description of all components can be found in the [documentation](/1.12/overview/architecture/components/).
+* [Marathon](/1.12/overview/architecture/components/#marathon) starts and monitors DC/OS applications and services.
+* Apache [Mesos](/1.12/overview/architecture/components/#apache-mesos) is the kernel of DC/OS and responsible for low-level task maintenance.
+* [Mesos DNS](/1.12/overview/architecture/components/#mesos-dns) provides service discovery within the cluster.
+* [Minuteman](/1.12/overview/architecture/components/#minuteman) is the internal layer 4 load balancer.
+* [Admin Router](/1.12/overview/architecture/components/#admin-router) is an open source NGINX configuration that provides central authentication and proxy to DC/OS services.
+* [Catalog](/1.12/overview/architecture/components/#dcos-package-manager) is the package repository that holds the DC/OS services (such as Apache Spark or Apache Cassandra) that you can install on your cluster directly from the DC/OS GUI and CLI.
+
+Go to [Part 2](/1.12/tutorials/dcos-101/redis-package/) of this tutorial to start installing your first package.

--- a/pages/1.12/tutorials/dcos-101/loadbalancing/index.md
+++ b/pages/1.12/tutorials/dcos-101/loadbalancing/index.md
@@ -13,7 +13,7 @@ Welcome to part 8 of the DC/OS 101 Tutorial.
 
 
 # Prerequisites
-* A [running DC/OS cluster](/tutorials/dcos-101/cli/) with [the DC/OS CLI installed](/cli/install/).
+* A [running DC/OS cluster](/1.12/tutorials/dcos-101/cli/) with [the DC/OS CLI installed](/1.12/cli/install/).
 * [app2](/1.12/tutorials/dcos-101/app2/) and [Marathon-LB](/services/marathon-lb/) deployed and running in your cluster.
 
 # Objective
@@ -23,25 +23,34 @@ In this session, you will scale your application to multiple instances and learn
 Load-balancers decide which instance of an app internal or external services should use. With DC/OS, you have two different built-in load-balancer options:
 
 1. [Marathon-LB](/services/marathon-lb/)
-1. [Named VIPs](/1.12/networking/load-balancing-vips/).
+1. [Named virtual IP addresses (VIPs)](/1.12/networking/load-balancing-vips/).
 
 You have already explored these load balancing mechanisms in the context of [service discovery](/1.12/tutorials/dcos-101/service-discovery/), and in a [previous](/1.12/tutorials/dcos-101/marathon-lb/) tutorial you used Marathon-LB to publicly expose app2. Now let's explore them a bit more.
-* First, scale app2 to two instances:
+1. First, scale `app2` to two instances:
 
-  `dcos marathon app update /dcos-101/app2 instances=2`
+    ```
+    dcos marathon app update /dcos-101/app2 instances=2
+    ```
 * **Marathon-LB**
-    * Check app2 as before via `http://<public-node>10000`. When you do this repeatedly you should see the request being served by different instances of app2.
+    * Check `app2` as before via `http://<public-node>10000`. When you do this repeatedly you should see the request being served by different instances of `app2`.
     * You can also check the Marathon-LB stats via `http://<public-node>:9090/haproxy?stats`
 * **Named VIPs**
-    * SSH to the leading master node: `dcos node ssh --master-proxy --leader`
+    * SSH to the leading master node: 
+        ```
+        dcos node ssh --master-proxy --leader
+        ```
     * Use curl to get the raw HTML output from the app:
 
-      `curl dcos-101app2.marathon.l4lb.thisdcos.directory:10000`
+      ```
+      curl dcos-101app2.marathon.l4lb.thisdcos.directory:10000
+      ```
 
       When you do this repeatedly you should see the request being served by different instances.
-* Scale app2 back to one instance:
+2. Scale `app2` back to one instance:
 
-  `dcos marathon app update /dcos-101/app2 instances=1`
+    ```
+    dcos marathon app update /dcos-101/app2 instances=1
+    ```
 
 # Outcome
 You used Marathon-LB and VIPs to load balance requests for two different instances of your app.

--- a/pages/1.12/tutorials/dcos-101/marathon-lb/index.md
+++ b/pages/1.12/tutorials/dcos-101/marathon-lb/index.md
@@ -18,13 +18,13 @@ Welcome to part 6 of the DC/OS 101 Tutorial.
 
 
 # Objective
-In this section you will make app2 available from outside the cluster by running it on a public agent node with Marathon-LB.
+In this section you will make `app2` available from outside the cluster by running it on a public agent node with Marathon-LB.
 
 # Steps
 DC/OS has two different node types:
 
-1. Private agent nodes
-1. Public agent nodes
+- Private agent nodes
+- Public agent nodes
 
 Private agent nodes are usually only accessible inside the cluster, while public agent nodes allow for ingress access from outside the cluster.
 
@@ -32,26 +32,53 @@ By default, Marathon starts applications and services on private agent nodes, wh
 
 You will revisit the topic of load balancing and the different choices for load balancers later in this tutorial, but for now, you will use [Marathon-LB](/1.12/tutorials/dcos-101/loadbalancing/) as the load balancer. Marathon-LB uses [HA-Proxy](http://www.haproxy.org/) on a public agent node to provide external access and load balancing for applications running internally in the cluster.
 
-  * Install Marathon-LB: `dcos package install marathon-lb`
-  * Check that it is running using `dcos task` and identify the IP address of the public agent node (Host) where Marathon-LB is running
+1. Install Marathon-LB: 
+  
+    ```
+    dcos package install marathon-lb
+    ```
+1. Verify that it is running using `dcos task` and identify the IP address of the public agent node (Host) where Marathon-LB is running.
+
     <p class="message--warning"><strong>WARNING: </strong>If you started your cluster using a cloud provider (especially AWS) <code>dcos task</code> might show you the private IP address of the host, which is not resolvable from outside the cluster. If the marathon-lb task has an <a href="https://en.wikipedia.org/wiki/Private_network"> RFC1918 address</a> beginning with 192.168 or 10, then this is the private IP address.</p>
 
     In that case, you need to retrieve the public IP from your cloud provider. For AWS, go to the EC2 dashboard and search using the search box for the private IP assigned to the marathon-lb task shown by `dcos task`. The public IP will be listed in the IPv4 Public IP field for the returned instance.
 
-  * Connect to the webapp (from your local machine) via `<Public IP>:10000`. You should see a rendered version of the web page including the physical node and port app2 is running on.
-  * Use the web form to add a new Key:Value pair
-  * You can verify the new key was added in two ways:
-    1. Check the total number of keys using app1: `dcos task log app1`
-    2. Check redis directly
+1. Connect to the webapp (from your local machine) via `<Public IP>:10000`. You should see a rendered version of the web page including the physical node and port `app2` is running on.
+1. Use the web form to add a new Key:Value pair
+1. You can verify the new key was added in two ways:
+    1. Check the total number of keys using `app1`:
+        ```
+        dcos task log app1
+        ```
+    1. Check `redis` directly:
        *  [SSH](/1.12/administering-clusters/sshcluster/) into node where redis is running:
 
            ```bash
            dcos node ssh --master-proxy --mesos-id=$(dcos task  redis --json |  jq -r '.[] | .slave_id')
            ```
-       * Because Redis is running in a Docker container you can list all the Docker containers using `docker ps` and get the ContainerID of the redis task.
-       * Create a bash session in the running container using the ContainerID from the previous step: `sudo docker exec -i -t CONTAINER_ID  /bin/bash`.
-       * Start the Redis CLI: `redis-cli`.
-       * Check the value is there: `get <newkey>`.
+       * Because Redis is running in a Docker container, you can list all the Docker containers using the `docker ps` command and get the ContainerID of the Redis task.
+
+          ```
+          docker ps
+          ```
+
+1. Create a bash session in the running container using the ContainerID from the previous step: 
+       
+      ```
+      sudo docker exec -i -t CONTAINER_ID  /bin/bash
+      ```
+1. Start the Redis CLI: 
+       
+      ```
+      redis-cli
+      ```
+1. Check the value is there: 
+       
+      ```
+      get <newkey>
+      ```
 
 # Outcome
 Congratulations! You have used Marathon-LB to expose your application to the public and added a new key to Redis using the web frontend.
+
+ In [the next section](/1.12/tutorials/dcos-101/resources/), you will learn how to monitor and understand your resource utilization, how resource limits are enforced, and how to debug resource management issues.

--- a/pages/1.12/tutorials/dcos-101/redis-package/index.md
+++ b/pages/1.12/tutorials/dcos-101/redis-package/index.md
@@ -13,7 +13,7 @@ Welcome to part 2 of the DC/OS 101 Tutorial.
 
 
 # Prerequisites
-By now, you should have a running DC/OS cluster and the DC/OS CLI installed and configured. If that isn't the case, please follow the [first](/tutorials/dcos-101/cli/) part of this tutorial.
+By now, you should have a running DC/OS cluster and the DC/OS CLI installed and configured. If that isn't the case, please follow the [first](/1.12/tutorials/dcos-101/cli/) part of this tutorial.
 The next stage of this tutorial uses [jq](https://stedolan.github.io/jq/), a command line JSON processor to simplify some of the commands. Follow the instructions [here](https://stedolan.github.io/jq/download/) to install JQ for your operating system.
 
 # Objective
@@ -21,7 +21,7 @@ By the end of this session you will have installed your first service - [Redis](
 
 # Steps
   * Install Redis
-      * Search the Universe repository for redis packages:
+      * Search the Universe repository for Redis packages:
 
         ```bash
         dcos package search redis
@@ -29,25 +29,25 @@ By the end of this session you will have installed your first service - [Redis](
 
         This should return two entries (mr-redis and redis).
 
-      * You are interested in the redis package, which installs a single Redis container. Install the package with this command:
+      * You are interested in the `redis` package, which installs a single Redis container. Install the package with this command:
 
         ```bash
         dcos package install redis
         ```
 
-  * You can use any of the following methods to check that redis is running:
+  * You can use any of the following methods to check that Redis is running:
       * By looking at the GUI: The Redis task should be displayed in the Service Health tab along with the health status.
       * By looking at all DC/OS tasks with the `dcos task` command. This command will show us all running DC/OS tasks (i.e. Mesos tasks).
-      * By looking at all Marathon apps: `dcos marathon app list`. This command will show us all running Marathon apps. Since services are started via Marathon, you should see Redis here as well. Note that the health status (i.e. 1/1) is also shown here.
-      * By looking at the Redis log: `dcos task log redis`. This command will show us the logs (stdout and stderr) of the redis task. This allows you to check whether the actual startup was successful. You can increase the number of log lines displayed by using the `--lines=` argument, the default is 10.  
-  * Let's use Redis by storing a key manually via the redis-cli command
-      * [SSH](/administering-clusters/sshcluster/) into the node where redis is running:
+      * By looking at all Marathon apps: `dcos marathon app list`. This command will show us all running Marathon apps. Since services are started via Marathon, you should see Redis here as well. Note that the health status (i.e., 1/1) is also shown here.
+      * By looking at the Redis log: `dcos task log redis`. This command will show us the logs (`stdout` and `stderr`) of the redis task. This allows you to check whether the actual startup was successful. You can increase the number of log lines displayed by using the `--lines=` argument; the default is 10.  
+  * Let's use Redis by storing a key manually via the `redis-cli` command
+      * [SSH](/1.12/administering-clusters/sshcluster/) into the node where redis is running:
 
         ```bash
         dcos node ssh --master-proxy --mesos-id=$(dcos task  redis --json |  jq -r '.[] | .slave_id')
         ```
 
-      * Because Redis is running in a Docker container, you can list all Docker containers using `docker ps` and get the ContainerID of the container running the redis service.
+      * Because Redis is running in a Docker container, you can list all Docker containers using `docker ps` and get the ContainerID of the container running the Redis service.
       * Start a bash session in the running container, substituting CONTAINER_ID with the ContainerID you got from the previous command:
 
         ```bash
@@ -73,14 +73,16 @@ By the end of this session you will have installed your first service - [Redis](
         ```
 
 # Outcome
-  You have just successfully installed your first service from the Universe repository and verified it is running!
+  You have just successfully installed your first service from the Catalog and verified it is running!
 
 # Deep Dive
-  [Universe](https://github.com/mesosphere/universe) is a package repository made available for DC/OS Clusters.
-  It enables you to easily install services such as Apache Spark or Apache Cassandra in your cluster without having to deal with manual configuration. Universe packages are developed and maintained by many different contributors.
+  [Catalog](https://github.com/mesosphere/universe) is a package repository made available for DC/OS Clusters.
+  It enables you to easily install services such as Apache Spark or Apache Cassandra in your cluster without having to deal with manual configuration. Catalog packages are developed and maintained by many different contributors.
 
   There are currently two categories of packages:
   1. Curated packages that have undergone testing and certification.
   1. Community contributed packages, which may not be as well tested.
 
-  You can also add your own repo that includes your custom packages. See the [documentation](/administering-clusters/repo/) for details.
+  You can also add your own repo that includes your custom packages. See the [documentation](/1.12/administering-clusters/repo/) for details.
+
+In [the next section](/1.12/tutorials/dcos-101/app1/) you will deploy a simple app connecting to Redis.

--- a/pages/1.12/tutorials/dcos-101/resources/index.md
+++ b/pages/1.12/tutorials/dcos-101/resources/index.md
@@ -14,7 +14,7 @@ Welcome to part 7 of the DC/OS 101 Tutorial.
 
 # Prerequisites
 * A [running DC/OS cluster](/1.12/tutorials/dcos-101/cli/) with [the DC/OS CLI installed](/1.12/tutorials/dcos-101/cli/).
-* [app2](/1.12/tutorials/dcos-101/app2/) deployed and running in your cluster.
+* [`app2`](/1.12/tutorials/dcos-101/app2/) deployed and running in your cluster.
 
 # Objective
 
@@ -24,7 +24,7 @@ Resource management and resource isolation between tasks are core functions of a
 
 ## Review App Definition
 
-* Take another look at the app defintion for [app2](https://github.com/joerg84/dcos-101/blob/master/app2/app2.go).
+* Take another look at the definition for [app2](https://github.com/joerg84/dcos-101/blob/master/app2/app2.go).
 
 ```
   {
@@ -43,7 +43,7 @@ Resource management and resource isolation between tasks are core functions of a
 
 * The `cpus`, `mem`, `disk`, and `gpus` parameters above specify the allocated resources and therefore define the maximum amount of resources a task can use. This number is not necessarily the same as the amount of resources a task actually uses. That number is usually lower.
 
-* You will notice that the id assigned in the app definitions for both [app1](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.json) and [app2](https://github.com/joerg84/dcos-101/blob/master/app2/app2.go) is prefixed by `/dcos-101/`. This defines the [application group](https://mesosphere.github.io/marathon/docs/application-groups.html) that the apps belong to. Application groups allow configuration and dependencies to be applied to a group of applications at the same time.
+* You will notice that the id assigned in the app definitions for both [`app1`](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.json) and [`app2`](https://github.com/joerg84/dcos-101/blob/master/app2/app2.go) is prefixed by `/dcos-101/`. This defines the [application group](https://mesosphere.github.io/marathon/docs/application-groups.html) that the apps belong to. Application groups allow configuration and dependencies to be applied to a group of applications at the same time.
 
 ## Scaling Applications
 
@@ -58,39 +58,53 @@ Horizontal scaling involves increasing the number of instances of an application
 
 **Scale dcos-101 application group:**
 
-Since both appl and app2 share the same app group, we can scale them together.
+Since both `app1` and `app2` share the same app group, we can scale them together.
 
-* Scale up by a factor of 2:
+1. Scale up by a factor of 2:
+    ```
+    dcos marathon group scale dcos-101 2
+    ```
+1. Check that both `app1` and `app2` have scaled up:
+    ```
+    dcos marathon app list
+    ```
+1. Scale down again:
 
-`dcos marathon group scale dcos-101 2`
-* Check that both app1 and app2 have scaled up:
+    ```
+    dcos marathon group scale dcos-101 0.5
+    ```
+1. Check that both `app1` and `app2` have scaled down:
 
-`dcos marathon app list`
-* Scale down again:
-
-`dcos marathon group scale dcos-101 0.5`
-* Check that both app1 and app2 have scaled down:
-
-`dcos marathon app list`
+    ```
+    dcos marathon app list
+    ```
 
 **Set instance count for app2 directly:**
 
-This is useful is you want to scale a single app independently
+This is useful if you want to scale a single app independently.
 
-* Scale app2 to 3 instances:
+1. Scale `app2` to 3 instances:
 
-`dcos marathon app update /dcos-101/app2 instances=3`
+    ```
+    dcos marathon app update /dcos-101/app2 instances=3
+    ```
 
-Note that these are applied incrementally to an existing app definition.
-* Check that app2 has scaled:
+    Note that these are applied incrementally to an existing app definition.
 
-`dcos marathon app list`
-* Rescale app2 to 1 instance:
+1. Check that `app2` has scaled:
+    ```
+    dcos marathon app list
+    ```
+1. Rescale `app2` to 1 instance:
 
-`dcos marathon app update /dcos-101/app2 instances=1`
-* Check that app2 has scaled:
+    ```
+    dcos marathon app update /dcos-101/app2 instances=1
+    ```
+1. Check that `app2` has scaled:
 
-`dcos marathon app list`
+    ```
+    dcos marathon app list
+    ```
 
 
 ### Scale vertically by increasing allocated resources
@@ -99,15 +113,23 @@ Vertical scaling involves increasing the amount of resources like CPU or RAM all
 
 <p class="message--warning"><strong>WARNING: </strong>This causes a restart of the app!</p>
 
-* Scale up to 2 CPU's for the app2 instance:
+1. Scale up to 2 CPUs for the `app2` instance:
 
-`dcos marathon app update /dcos-101/app2 cpus=2`
-* Check that app2 has scaled:
+    ```
+    dcos marathon app update /dcos-101/app2 cpus=2
+    ```
 
-`dcos marathon app list`
-* Scale back down to 1 CPU for the app2 instance:
+1. Check that `app2` has scaled:
 
-`dcos marathon app update /dcos-101/app2 cpus=1`
+    ```
+    dcos marathon app list
+    ```
+
+1. Scale back down to 1 CPU for the `app2` instance:
+
+    ```
+    dcos marathon app update /dcos-101/app2 cpus=1
+    ```
 
 # Debugging Resource Problems
 
@@ -115,23 +137,28 @@ Vertical scaling involves increasing the amount of resources like CPU or RAM all
 
 To simulate this:
 
-* Increase app2 instances to 100
+1. Increase `app2` instances to 100:
 
-`dcos marathon app update /dcos-101/app2 instances=100`
+    ```
+    dcos marathon app update /dcos-101/app2 instances=100
+    ```
 
-You may have to increase this number if you have a large cluster.
-* Use `dcos marathon app list` to check that the `scale` deployment is stuck.
-* `dcos marathon deployment list`
+    You may have to increase this number if you have a large cluster.
+1. Use `dcos marathon app list` to check that the `scale` deployment is stuck.
+    ```
+    dcos marathon deployment list
+    ```
+The problem here is that there are no matching resources available. For example, there might be resources left for the public-agent role, but not for the default role.
 
-The problem here is that there no matching resources available. For example, there might be resources left for the public-slave role, but not for the default role.
+**Solution**:
 
-Solution:
+Add nodes or scale the app to a level at which resources are available.
 
-* Add nodes or scale the app to a level at which resources are available.
+  ```
+  dcos marathon app update /dcos-101/app2 --force instances=1
+  ```
 
-`dcos marathon app update /dcos-101/app2 --force instances=1`
-
-Note you must use the `--force` flag here as the previous deployment is ongoing.
+Note that you must use the `--force` flag here, since the previous deployment is ongoing.
 
 ## Too few resources on a single node
 
@@ -139,21 +166,28 @@ As each app is started on a single node, task resources must also fit onto a sin
 
 To simulate this:
 
-* Update app2 to use 100 CPUs:
+1. Update `app2` to use 100 CPUs:
 
-`dcos marathon app update /dcos-101/app2 cpus=100`
-* Use `dcos marathon app list` to check that the `restart` deployment is stuck.
-* `dcos marathon deployment list`
+    ```
+    dcos marathon app update /dcos-101/app2 cpus=100
+    ```
+
+1.   Use `dcos marathon app list` to check that the `restart` deployment is stuck.
+      ```
+      dcos marathon deployment list
+      ```
 
 The problem here is that there are no resource offers large enough to match the request.
 
-Solution:
+**Solution**:
 
-* Provision larger nodes or scale the app down to a level where it fits onto the free resources on a single node:
+Provision larger nodes or scale the app down to a level where it fits onto the free resources on a single node:
 
-`dcos marathon app update /dcos-101/app2 --force cpus=1`
+```
+dcos marathon app update /dcos-101/app2 --force cpus=1
+```
 
-Note that you must use the force flag again.
+Note that you must use the `--force` flag again.
 
 # Debugging resource isolation
 
@@ -161,40 +195,51 @@ What happens if an app tries to use more resources then it is allocated? The mos
 
 To simulate this:
 
-* Deploy the [memory eater](https://github.com/joerg84/dcos-101/blob/master/oomApp/oomApp.go) app.
+1. Deploy the [memory eater](https://github.com/joerg84/dcos-101/blob/master/oomApp/oomApp.go) app.
 
-`dcos marathon app add https://raw.githubusercontent.com/joerg84/dcos-101/master/oomApp/oomApp.json`
+    ```
+    dcos marathon app add https://raw.githubusercontent.com/joerg84/dcos-101/master/oomApp/oomApp.json
+    ```
 
-* You will see it restarting over and over again...
+1. You will see it restarting over and over again...
 
-Check the Marathon log. Potentially you will see the Out of Memory error here, but unfortunately not always - since the kernel is killing the app, this may not always be visible to DC/OS.
+    Check the Marathon log. Potentially you will see the Out of Memory error here, but unfortunately not always - since the kernel is killing the app, this may not always be visible to DC/OS.
 
-* SSH to an agent where the app has been running:
+1. SSH to an agent where the app has been running:
 
-`dcos node ssh --master-proxy --mesos-id=$(dcos task oom-app --json | jq -r '.[] | .slave_id')`
-* Check the kernel log:
+    ```
+    dcos node ssh --master-proxy --mesos-id=$(dcos task oom-app --json | jq -r '.[] | .slave_id')
+    ```
 
-`journalctl -f _TRANSPORT=kernel`
+1. Check the kernel log:
 
-Here you see something like:
+    ```
+    journalctl -f _TRANSPORT=kernel
+    ```
 
-```
-    Memory cgroup out of memory: Kill process 10106 (oomApp) score 925 or sacrifice child; Killed process 10390 (oomApp) total-vm:3744760kB, anon-rss:60816kB, file-rss:1240kB, shmem-rss:0kB`
-```
+    Here you see something like:
 
-Solution:
+    ```
+        Memory cgroup out of memory: Kill process 10106 (oomApp) score 925 or sacrifice child; Killed process 10390 (oomApp) total-vm:3744760kB, anon-rss:60816kB, file-rss:1240kB, shmem-rss:0kB`
+    ```
+
+**Solution**:
 
 There are two potential reasons for your application using too much memory:
 
-1. Your app uses too much memory by accident e.g. a memory leak in the code.
-1. You have allocated too little memory for it.
+- Your app uses too much memory by accident e.g. a memory leak in the code.
+- You have allocated too little memory for it.
 
 So, check your app for correct behavior and/or increase the allocated memory.
 
-* Remove the app:
+Remove the app:
 
-`dcos marathon app remove /dcoc-101/oom-app`
+  ```
+  dcos marathon app remove /dcoc-101/oom-app
+  ```
 
 # Outcome
 
 Congratulations! You've now learned how to deploy apps to DC/OS, network those apps, expose them to the outside of the cluster with a load-balancer, scale them, and debug potential resource issues! You're practically a pro!
+
+In [the next part](/1.12/tutorials/dcos-101/loadbalancing/), you will scale your application to multiple instances and learn how internal and external services choose which instance to use once the application has been scaled.

--- a/pages/1.12/tutorials/dcos-101/service-discovery/index.md
+++ b/pages/1.12/tutorials/dcos-101/service-discovery/index.md
@@ -12,8 +12,8 @@ Welcome to part 4 of the DC/OS 101 Tutorial
 
 
 # Prerequisites
-* A [running DC/OS cluster](/tutorials/dcos-101/cli/) with [the DC/OS CLI installed](/tutorials/dcos-101/cli/).
-* [app1](/tutorials/dcos-101/app1/) deployed and running in your cluster.
+* A [running DC/OS cluster](/1.12/tutorials/dcos-101/cli/) with [the DC/OS CLI installed](/1.12/tutorials/dcos-101/cli/).
+* [app1](/1.12/tutorials/dcos-101/app1/) deployed and running in your cluster.
 
 
 # Objective
@@ -22,7 +22,7 @@ Your [app](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.p
 In this section, you will learn about DC/OS service discovery by exploring the different options available for apps in DC/OS.
 
 # Service Discovery
-  [Service discovery](/networking/) enables addressing of applications independently of where they are running in the cluster, which is particularly useful in cases where applications may fail and be restarted on a different host.
+  [Service discovery](/1.12/networking/) enables addressing of applications independently of where they are running in the cluster, which is particularly useful in cases where applications may fail and be restarted on a different host.
 
   DC/OS provides two options for service discovery:
 
@@ -32,17 +32,21 @@ In this section, you will learn about DC/OS service discovery by exploring the d
 
 SSH into the Mesos master node in your cluster to see how these different service discovery methods work:
 
-`dcos node ssh --master-proxy --leader`
+```
+dcos node ssh --master-proxy --leader
+```
 
 # Mesos-DNS
 
-  [Mesos-DNS](/networking/mesos-dns/) assigns DNS entries for every task, which are resolvable from any node in the cluster. The naming pattern for these entries is  *task.scheduler.mesos*
+  [Mesos-DNS](/1.12/networking/DNS/mesos-dns/) assigns DNS entries for every task, which are resolvable from any node in the cluster. The naming pattern for these entries is `task.scheduler.mesos`.
 
-  The default scheduler for jobs is [Marathon](/overview/architecture/components/#marathon), so the Mesos-DNS name for your Redis service is *redis.marathon.mesos*.
+  The default scheduler for jobs is [Marathon](/1.12/overview/architecture/components/#marathon), so the Mesos-DNS name for your Redis service is **redis.marathon.mesos**.
 
   Let's use the [dig](https://linux.die.net/man/1/dig) command to retrieve the address record (also called the A record). Dig is a command line utility to query DNS servers. When used without argument, it will use the system-wide configured DNS servers to query against, which in a DC/OS cluster is configured to point at Mesos-DNS:
 
-  `dig redis.marathon.mesos`
+  ```bash
+  dig redis.marathon.mesos
+  ```
 
   The answer should be similar to this response:
 
@@ -57,7 +61,9 @@ SSH into the Mesos master node in your cluster to see how these different servic
 
   Use the following dig command to access the SRV record:
 
-  `dig srv _redis._tcp.marathon.mesos`
+  ```
+  dig srv _redis._tcp.marathon.mesos
+  ```
 
   The answer should look similar to this response:
 
@@ -73,7 +79,7 @@ SSH into the Mesos master node in your cluster to see how these different servic
 
 # Named Virtual IPs
 
-  * [Named VIPs](/networking/load-balancing-vips/) allow you to assign name/port pairs to your apps, which means you can give your apps meaningful names with a predictable port. They also provide built-in load balancing when using multiple instances of an application.
+  * [Named VIPs](/1.12/networking/load-balancing-vips/) allow you to assign name/port pairs to your apps, which means you can give your apps meaningful names with a predictable port. They also provide built-in load balancing when using multiple instances of an application.
   For example, you can assign a named VIP to your Redis service by adding the following to the package definition:
 
   ```
@@ -81,7 +87,7 @@ SSH into the Mesos master node in your cluster to see how these different servic
   ```
 
   The full name is then generated using the following schema:
-  *vip-name.scheduler.l4lb.thisdcos.directory:vip-port*.
+  `vip-name.scheduler.l4lb.thisdcos.directory:vip-port`.
 
   As we can see from the example [application](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.py), this is the mechanism used by the redis package, and so you can access the Redis service from within the cluster at `redis.marathon.l4lb.thisdcos.directory:6379`.
 
@@ -100,3 +106,5 @@ Mesos-DNS is a simple solution to finding applications inside the cluster. While
 
 ## Named VIPs
 Named VIPs load balance the IP address/port pair using an intelligent algorithm to ensure optimal routing of the traffic in relation to the original requestor, and also provide a local caching layer for high perfornance. They also allow you to give your apps meaningful names and select a specific port. Because of these advantages over Mesos-DNS, we suggest using Named VIPs as the default service discovery method in DC/OS.
+
+In [the next section](/1.12/tutorials/dcos-101/app2/), you will deploy an app which provides a GUI to users.

--- a/pages/1.12/tutorials/dcos-debug/gen-strat/index.md
+++ b/pages/1.12/tutorials/dcos-debug/gen-strat/index.md
@@ -11,11 +11,13 @@ menuWeight: 21
 
 # General Strategy: Debugging Application Deployment on DC/OS
 
-Now that we have defined a [toolset for debugging applications on DC/OS](#tools), let us consider a step-by-step general troubleshooting strategy for actually implementing these tools in a application debugging scenario. Once we have gone over this general strategy, we will consider a few concrete scenarios of how to apply this strategy in the [practice section](/tutorials/dcos-debug/scenarios/).
+Now that we have defined a [set of tools](/1.12/tutorials/dcos-debug/tools/) for debugging applications on DC/OS, let us consider a step-by-step general troubleshooting strategy for actually implementing pir available tools in an application debugging scenario. Once we have gone over this general strategy, we will consider a few concrete scenarios of how to apply this strategy in the [practice section](/1.12/tutorials/dcos-debug/scenarios/).
 
-Beyond considering any information special to your scenario, a reasonable approach to debugging an application deployment issue is to apply [our debugging tools](#tools) in the following order:
+Beyond considering any information special to your scenario, a reasonable approach to debugging an application deployment issue is to apply our debugging tools in the following order:
 
-- 1: [Check web interfaces](#GUI-strat)
+<a name="tools"></a>
+
+- 1: [Check GUIs](#GUI-strat)
 - 2: [Check Task Logs](#task-strat)
 - 3: [Check Scheduler Logs](#schedule-strat)
 - 4: [Check Agent Logs](#agent-strat)
@@ -26,44 +28,44 @@ Beyond considering any information special to your scenario, a reasonable approa
 
 <a name="GUI-strat"></a>
 
-### Step 1: Check the web interfaces
+### Step 1: Check the GUIs
 
-Start by examining the [DC/OS web interface](#dcos-ui) (or use the CLI) to [check the status](/latest/deploying-services/task-handling/) of the task. If the task has an associated [health check](/latest/deploying-services/creating-services/health-checks/), it is also a good idea to check the task’s health status.
+Start by examining the [DC/OS GUI](/1.12/gui/) or use the CLI to [check the status](/1.12/deploying-services/task-handling/) of the task. If the task has an associated [health check](/1.12/deploying-services/creating-services/health-checks/), it is also a good idea to check the task’s health status.
 
-If it could be relevant, check the [Mesos web interface](/tutorials/dcos-debug/tools/#mesos-ui) or [Exhibitor/ZooKeeper web interface](/tutorials/dcos-debug/tools/#zoo-ui) for potentially relevant debugging information there.
+If relevant, check the [Mesos GUI](/1.12/tutorials/dcos-debug/tools/#mesos-ui) or [Exhibitor/ZooKeeper GUI](/1.12/tutorials/dcos-debug/tools/#zoo-ui) for potentially relevant debugging information there.
 
 <a name="task-strat"></a>
 
 ### Step 2: Check the Task Logs
 
-If the web interfaces cannot provide sufficient information, next check the [task logs](/tutorials/dcos-debug/tools/#task-logs) using the DC/OS web interface or the CLI. This helps a better understanding of what might have happened to the application. If the issue is related to our app not deploying (for example, the task status continues to wait indefinitely), try looking at the ['Debug' page](/monitoring/debugging/gui-debugging/#debugging-page). It could be helpful in getting a better understanding of the resources being offered by Mesos.
+If the GUIs cannot provide sufficient information, next check the [task logs](/1.12/tutorials/dcos-debug/tools/#task-logs) using the DC/OS GUI or the CLI. This provides a better understanding of what might have happened to the application. If the issue is related to our app not deploying (for example, the task status continues to wait indefinitely), try looking at the ['Debug' page](/1.12/monitoring/debugging/gui-debugging/#debugging-page). It could be helpful in understanding the resources being offered by Mesos.
 
 <a name="schedule-strat"></a>
 
 ### Step 3: Check the Scheduler Logs
 
-Next, when there is a deployment problem and the task logs do not provide enough information to fix the issue, it can be helpful to double-check the app definition. Then, after confirming the app definition, check the Marathon log or web interface to better understand how it was scheduled or why not.
+Next, when there is a deployment problem and the task logs do not provide enough information to fix the issue, it can be helpful to double-check the app definition. Then, after confirming the app definition, check the Marathon log or GUI to understand how it was scheduled or why not.
 
 <a name="agent-strat"></a>
 
 ### Step 4: Check the Agent Logs
 
-The [Mesos Agent logs](/tutorials/dcos-debug/tools/#mesos-agent-logs) provide information regarding how the task and that task's environment are being started. Recall that increasing the log level can be helpful in some cases to obtain more information with which to work.
+The [Mesos Agent logs](/1.12/tutorials/dcos-debug/tools/#mesos-agent-logs) provide information regarding how the task and that task's environment are being started. Recall that increasing the log level can be helpful in some cases to obtain more information with which to work.
 
 <a name="interactive-strat"></a>
 
 ### Step 5: Test the Task Interactively
 
-The next step is to [interactively look at the task running inside the container](/tutorials/dcos-debug//tools/#interactive). If the task is still running, `dcos task exec` or `docker exec` can be helpful to start an interactive debugging session. If the application is based on a Docker container image, manually starting it using `docker run` followed by `docker exec` can also get you started in the right direction.
+The next step is to [interactively look at the task running inside the container](/1.12/tutorials/dcos-debug/tools/#interactive). If the task is still running, `dcos task exec` or `docker exec` can be helpful to start an interactive debugging session. If the application is based on a Docker container image, manually starting it using `docker run` followed by `docker exec` can also get you started in the right direction.
 
 <a name="master-strat"></a>
 
 ### Step 6: Check the Master Logs
 
-If you want to understand why a particular scheduler has received certain resources or a particular status, then [the master logs can be very helpful](/tutorials/dcos-debug/tools/#master-logs). Recall that the master is forwarding all status updates between the agents and scheduler, so it might even be helpful in cases where the agent node might not be reachable (for example, network partition or node failure).
+If you want to understand why a particular scheduler has received certain resources or a particular status, then [the master logs can be very helpful](/1.12/tutorials/dcos-debug/tools/#master-logs). Recall that the master is forwarding all status updates between the agents and scheduler, so it might even be helpful in cases where the agent node might not be reachable (for example, network partition or node failure).
 
 <a name="community-strat"></a>
 
 ### Step 7:  Ask the Community
 
-As mentioned above, [the community can be very helpful](/tutorials/dcos-debug/tools/#community) by either using the [DC/OS Slack](http://chat.dcos.io/?_ga=2.29995196.285985511.1525709518-600356888.1525372520) or the [mailing list](https://groups.google.com/a/dcos.io/forum/#!forum/users) can be very helpful in debugging further.
+As mentioned above, [the community can be very helpful](/1.12/tutorials/dcos-debug/tools/#community) by either using the [DC/OS Slack](http://chat.dcos.io/?_ga=2.29995196.285985511.1525709518-600356888.1525372520) or the [mailing list](https://groups.google.com/a/dcos.io/forum/#!forum/users) can be very helpful in debugging further.

--- a/pages/1.12/tutorials/dcos-debug/index.md
+++ b/pages/1.12/tutorials/dcos-debug/index.md
@@ -6,20 +6,16 @@ excerpt: Debugging application deployment issues in distributed systems
 menuWeight: 55
 ---
 
-<!-- i. Support Disclaimer -->
-
 #include /include/tutorial-disclaimer.tmpl
 
-<!-- ii. Intro/Set Expectations for this Tutorial -->
+This tutorial provides a top-down introduction to debugging applications during and after their deployment on DC/OS. It should not be considered an exhaustive resource for debugging on DC/OS, but rather a starting point.
 
-This tutorial merely aims to provide a top-down introduction to debugging applications during and after their deployment on DC/OS. It should not be considered an exhaustive resource for debugging on DC/OS, but rather a starting point.
-
-Debugging application deployment issues in distributed systems is often a challenging task. While DC/OS provides a number of tools for debugging, it might be difficult to choose which tool to apply in your particular situation. You should have a working knowledge of DC/OS in order to complete this tutorial. However, if needed there are plenty of other [tutorials to get you up and running](/latest/tutorials/).
+Debugging application deployment issues in distributed systems is often a challenging task. While DC/OS provides a number of tools for debugging, it might be difficult to choose which tool to apply in your particular situation. You should have a working knowledge of DC/OS in order to complete this tutorial. However, if needed there are plenty of other [tutorials to get you up and running](/1.12/tutorials/).
 
 It can be encouraging to keep in mind that failures are highly likely when working with distributed systems. Many components must be configured to precise specifications to function together as intended. This takes detailed  preparation and awareness during installation and initial configuration. Fortunately, this also means that by putting extra care in the general design of the application architecture can potentially prevent many bugs from even arising:
 
 - [Design your applications for debuggability](https://schd.ws/hosted_files/mesosconeu17/a6/MesosCon%20EU%202017%20University%20Slides.pdf)
 - [Follow best practices for deployments](https://mesosphere.com/blog/improving-your-deployments/)
-- [Set up monitoring and alerts so you can resolve issues as early as possible](https://docs.mesosphere.com/1.10/cli/command-reference/dcos-node/dcos-node-diagnostics/)
+- [Set up monitoring and alerts so you can resolve issues as early as possible](https://docs.mesosphere.com/1.12/cli/command-reference/dcos-node/dcos-node-diagnostics/)
 
-We will first look at [some potential problems](/tutorials/dcos-debug/problems/) you might face when deploying an application on DC/OS. Next, we will look at the [standard set of tools](/tutorials/dcos-debug/tools/) for debugging. Then, after introducing [a general strategy for using those tools](/tutorials/dcos-debug/gen-strat/), we have two [concrete examples](/tutorials/dcos-debug/scenarios/) to illustrate how the strategy works in practice. We encourage you to first try debugging these challenges yourself, but we also provide detailed guidance for debugging them as well. There are even more scenarios like these in the [dcos-debugging github repository](https://github.com/dcos-labs/dcos-debugging/tree/master/1.10/). Also please feel free to contribute your own debugging scenarios to this repository.
+We will first look at [some potential problems](/1.12/tutorials/dcos-debug/problems/) you might face when deploying an application on DC/OS. Next, we will look at the [standard set of tools](/1.12/tutorials/dcos-debug/tools/) for debugging. Then, after introducing [a general strategy for using those tools](/1.12/tutorials/dcos-debug/gen-strat/), we have two [concrete examples](/1.12/tutorials/dcos-debug/scenarios/) to illustrate how the strategy works in practice. We encourage you to first try debugging these challenges yourself, but we also provide detailed guidance for debugging them as well. There are even more scenarios like these in the [dcos-debugging github repository](https://github.com/dcos-labs/dcos-debugging/tree/master/1.10/). Also please feel free to contribute your own debugging scenarios to this repository.

--- a/pages/1.12/tutorials/dcos-debug/problems/index.md
+++ b/pages/1.12/tutorials/dcos-debug/problems/index.md
@@ -6,7 +6,6 @@ excerpt: Tutorial - Troubleshooting issues on DC/OS deployments
 menuWeight: 1
 ---
 
-<!-- I. Problems Section -->
 #include /include/tutorial-disclaimer.tmpl
 
 <a name="problems"></a>
@@ -21,6 +20,6 @@ Some of the problems that may need troubleshooting on DC/OS include applications
 - Restarting repeatedly
 - Not being reachable inside (or outside) of the DC/OS cluster
 
-DC/OS consists of [a number of different components](https://docs.mesosphere.com/1.12/overview/architecture/components/) - most notably [Apache Mesos](http://mesos.apache.org/) and [Marathon](https://mesosphere.github.io/marathon/). As any of these components could be involved in the issue you are encountering, it can be difficult to even locate the component causing your issue. Accordingly, this tutorial aims to cover several types of such issues.
+DC/OS consists of [a number of different components](/1.12/overview/architecture/components/) - most notably [Apache Mesos](http://mesos.apache.org/) and [Marathon](https://mesosphere.github.io/marathon/). As any of these components could be involved in the issue you are encountering, it can be difficult to even locate the component causing your issue. Accordingly, this tutorial aims to cover several types of such issues.
 
 Of course, there are a several other categories of problems that can affect your cluster besides application-related failures; networking problems, DC/OS installation issues, and DC/OS internal configuration issues could each be causing issues on your cluster. Although these are out of scope for this tutorial, we encourage you to reach out via our [Community channels](https://dcos.io/community/) with ideas and feedback.

--- a/pages/1.12/tutorials/dcos-debug/scenarios/index.md
+++ b/pages/1.12/tutorials/dcos-debug/scenarios/index.md
@@ -7,8 +7,6 @@ menuWeight: 31
 ---
 #include /include/tutorial-disclaimer.tmpl
 
-<!-- IV. Hands On Examples Section -->
-
 <a name=hands-on></a>
 
 # Practice Deployment Debugging on DC/OS

--- a/pages/1.12/tutorials/dcos-debug/scenarios/scen-2/index.md
+++ b/pages/1.12/tutorials/dcos-debug/scenarios/scen-2/index.md
@@ -45,7 +45,7 @@ The log output “Eating Memory” is a pretty generous hint that the issue migh
 As suspected, this might be an application-related issue, and this application is scheduled via Marathon. So let’s check the Marathon logs using the CLI:
 
 ```bash
-$ dcos service log marathon
+dcos service log marathon
 ```
 We see a log entry similar to:
 
@@ -54,9 +54,9 @@ Mar 27 00:46:37 ip-10-0-6-109.us-west-2.compute.internal marathon.sh[5866]: [201
 ```
 <p class="message--note"><strong>NOTE: </strong> One helpful time-saving tip can be to <code>grep</code> for </code>TASK_FAILED</code>.</p>
 
-**Now we have confirmed that we exceeded the previously set container memory limit in [`app-oom.json`](https://github.com/dcos-labs/dcos-debugging/blob/master/1.10/app-oom.json#L6)**
+Now we have confirmed that we exceeded the previously set container memory limit in [`app-oom.json`](https://github.com/dcos-labs/dcos-debugging/blob/master/1.10/app-oom.json#L6).
 
-If you’ve been paying close attention you might shout now “wait a sec” because you noticed that the memory limit we set in the app definition is 32 MB, but the error message mentions 64MB. DC/OS automatically reserves some overhead memory for the [executor](/1.12/overview/architecture/task-types/#executors) which in this case is 32 MB.
+You might have noticed that the memory limit we set in the app definition is 32 MB, but the error message mentions 64MB. DC/OS automatically reserves some overhead memory for the [executor](/1.12/overview/architecture/task-types/#executors) which in this case is 32 MB.
 
 Please note that OOM `kill` is performed by the Linux kernel itself, hence we can also check the kernel logs directly:
 
@@ -93,5 +93,5 @@ As we are dealing with a failing task it is good to check the application and sc
 Remove the application with
 
 ```bash
-$ dcos marathon app remove /app-oom
+dcos marathon app remove /app-oom
 ```

--- a/pages/1.12/tutorials/dcos-debug/scenarios/scen-3/index.md
+++ b/pages/1.12/tutorials/dcos-debug/scenarios/scen-3/index.md
@@ -14,7 +14,7 @@ menuWeight: 21
 Start by deploying this [`dockerimage.json`](https://raw.githubusercontent.com/dcos-labs/dcos-debugging/master/1.10/dockerimage.json) file:
 
 ```bash
-$ dcos marathon app add https://raw.githubusercontent.com/dcos-labs/dcos-debugging/master/1.10/dockerimage.json
+dcos marathon app add https://raw.githubusercontent.com/dcos-labs/dcos-debugging/master/1.10/dockerimage.json
 ```
 
 We see the app fail almost immediately:
@@ -25,61 +25,65 @@ Figure 1. Task log showing failures
 
 ## Resolution
 
-As we learned [earlier](/tutorials/dcos-debug/gen-strat/), with application failures the [first step](/tutorials/dcos-debug/gen-strat/#task-strat) is to check the [task logs](/tutorials/dcos-debug/tools/#task-logs).
+1. As we learned [earlier](/1.12/tutorials/dcos-debug/gen-strat/), with application failures the [first step](/1.12/tutorials/dcos-debug/gen-strat/#task-strat) is to check the [task logs](/1.12/tutorials/dcos-debug/tools/#task-logs).
 
-![Pic of empty log output](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-18.png)
+    ![Pic of empty log output](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-18.png)
 
-Figure 2. Empty task log
+    Figure 2. Empty task log
 
-Unfortunately, it is completely empty. **Normally we would at least see some output from the setup of the task**. This is especially peculiar behavior.
+    Unfortunately, it is completely empty. Normally we would at least see some output from the setup of the task. This is especially peculiar behavior.
 
-So Step 2 is to check the scheduler logs --- in this case Marathon:
+1. So Step 2 is to check the scheduler logs --- in this case Marathon:
 
-```bash
-$ dcos service log marathon
-```
+    ```bash
+    dcos service log marathon
+    ```
 
-which should produce something like the following output in response:
+    which should produce something like the following output in response:
 
-```bash
-Mar 27 21:21:11 ip-10-0-5-226.us-west-2.compute.internal marathon.sh[5954]: [2018-03-27 21:21:11,297] INFO  Received status update for task docker-image.c4cdf565-3204-11e8-8a20-82358f3033d1: TASK_FAILED (
+    ```bash
+    Mar 27 21:21:11 ip-10-0-5-226.us-west-2.compute.internal marathon.sh[5954]: [2018-03-27 21:21:11,297] INFO  Received status update for task docker-image.c4cdf565-3204-11e8-8a20-82358f3033d1: TASK_FAILED (
 
-Mar 27 21:21:11 ip-10-0-5-226.us-west-2.compute.internal marathon.sh[5954]: ') (mesosphere.marathon.MarathonScheduler:Thread-1723)
-```
+    Mar 27 21:21:11 ip-10-0-5-226.us-west-2.compute.internal marathon.sh[5954]: ') (mesosphere.marathon.MarathonScheduler:Thread-1723)
+    ```
 
-However, this does not shed much light on why the task failed. So then to [Step 3](/tutorials/dcos-debug/gen-strat/#agent-strat) of our [strategy](/tutorials/dcos-debug/gen-strat/): check the [Mesos agent logs](/tutorials/dcos-debug/tools/#agent-logs) using:
+1. However, this does not shed much light on why the task failed. So then to [Step 3](/1.12/tutorials/dcos-debug/gen-strat/#agent-strat) of our [strategy](/1.12/tutorials/dcos-debug/gen-strat/): check the [Mesos agent logs](/1.12/tutorials/dcos-debug/tools/#agent-logs) using:
 
-```bash
-$ dcos node log --mesos-id=$(dcos task docker-image  --json | jq -r '.[] | .slave_id') --lines=100
-```
+    ```bash
+    dcos node log --mesos-id=$(dcos task docker-image  --json | jq -r '.[] | .slave_id') --lines=100
+    ```
 
-to output something resembling the following:
+    to output something resembling the following:
 
-```bash
-8-4520-af33-53cade35e8f9-0001 failed to start: Failed to run 'docker -H unix:///var/run/docker.sock pull noimage:idonotexist': exited with status 1; stderr='Error: image library/noimage:idonotexist not found
+    ```bash
+    8-4520-af33-53cade35e8f9-0001 failed to start: Failed to run 'docker -H unix:///var/run/docker.sock pull noimage:idonotexist': exited with status 1; stderr='Error: image library/noimage:idonotexist not found
 
-2018-03-27 21:27:15: '
+    2018-03-27 21:27:15: '
 
-2018-03-27 21:27:15: I0327 21:27:15.325984  4765 slave.cpp:6227] Executor 'docker-image.9dc468b5-3205-11e8-8a20-82358f3033d1' of framework 6512d7cc-b7f8-4520-af33-53cade35e8f9-0001 has terminated with unknown status
-```
+    2018-03-27 21:27:15: I0327 21:27:15.325984  4765 slave.cpp:6227] Executor 'docker-image.9dc468b5-3205-11e8-8a20-82358f3033d1' of framework 6512d7cc-b7f8-4520-af33-53cade35e8f9-0001 has terminated with unknown status
+    ```
 
-It looks like **the specific Docker image could not be found**, perhaps because it doesn’t exist. Does the image exist in the specified location (in this case `noimage:idonotexist` in Dockerhub)? If it does not, you will have to correct the location or move the file to the specified location. Furthermore, was there an error in the specified location or file name? Lastly, check whether the container image registry is accessible (especially when using a private registry).
-s
+It looks like **the specific Docker image could not be found**, perhaps because it doesn’t exist. Does the image exist in the specified location (in this case `noimage:idonotexist` in Dockerhub)? If it does not; you will have to correct the location or move the file to the specified location. 
+
+Furthermore, was there an error in the specified location or file name? Lastly, check whether the container image registry is accessible (especially when using a private registry).
+
 ### General Pattern
 
 Being an application error, we again start by looking at task logs, followed by scheduler logs.
 
-In this case we have a Docker daemon-specific issue. Many such issues can be uncovered by examining the Mesos Agent logs. In some cases, where we need to dig deeper, accessing the Docker daemon logs is required. First, ssh into the master node:
+In this case we have a Docker daemon-specific issue. Many such issues can be uncovered by examining the Mesos Agent logs. In some cases, where we need to dig deeper, accessing the Docker daemon logs is required. 
 
-```bash
-$ dcos node ssh --master-proxy --mesos-id=$(dcos task --all | grep docker-image | head -n1 | awk '{print $6}')
-```
+1. First, ssh into the master node:
 
-then to get the logs:
+    ```bash
+    dcos node ssh --master-proxy --mesos-id=$(dcos task --all | grep docker-image | head -n1 | awk '{print $6}')
+    ```
 
-```bash
-$ journalct1 -u docker
-```
+1. Get the logs:
+
+    ```bash
+    journalct1 -u docker
+    ```
 
 Please note the more complex pattern used here to retrieve the `mesos-id` in comparison to the earlier example. This pattern lists previously failed tasks as well as running tasks, whereas **the earlier pattern only lists running tasks**.
 
@@ -88,5 +92,5 @@ Please note the more complex pattern used here to retrieve the `mesos-id` in com
 Run:
 
 ```bash
-$ dcos marathon app remove docker-image
+dcos marathon app remove docker-image
 ```

--- a/pages/1.12/tutorials/dcos-debug/tools/index.md
+++ b/pages/1.12/tutorials/dcos-debug/tools/index.md
@@ -4,7 +4,6 @@ title: Tools
 excerpt: Tutorial - Tools for debugging applications on DC/OS
 menuWeight: 11
 ---
-<!-- II. Tools Section -->
 
 #include /include/tutorial-disclaimer.tmpl
 
@@ -14,7 +13,7 @@ menuWeight: 11
 
 DC/OS comes with several tools relevant for application debugging:
 
-- [DC/OS web interfaces](#dcos-web)
+- [DC/OS GUIs](#guis)
 
 - [Logs](#logs)
 
@@ -28,51 +27,51 @@ DC/OS comes with several tools relevant for application debugging:
 
 - [Other tools](#other-tools)
 
-<a name="dcos-web"></a>
+<a name="guis"></a>
 
-## DC/OS web interfaces
+## DC/OS GUIs
 
-DC/OS provides many web interfaces for various components, these are particularly when debugging application deployment issues:
+DC/OS provides many GUIs for various components, these are particularly when debugging application deployment issues:
 
-- [DC/OS web interface](#dcos-ui)
+- [DC/OS GUI](#dcos-gui)
 
-- [Mesos web interface](#mesos-ui)
+- [Mesos GUI](#mesos-gui)
 
-- [Zookeeper/Exhibitor web interface](#zoo-ui)
+- [Zookeeper/Exhibitor GUI](#zoo-gui)
 
-<a name="dcos-ui"></a>
+<a name="dcos-gui"></a>
 
-### DC/OS web interface
+### DC/OS GUI
 
-The **DC/OS web interface** is a great place to start debugging as it provides quick access to:
+The **DC/OS GUI** is a great place to start debugging as it provides quick access to:
 
 - **Cluster Resource Allocation** to provide an overview of available cluster resources
 - **Task Logs** to provide insight into tasks failures
 - **Task Debug Information** to provide information about the most recent task offers and/or why a task did not start
 
-![Pic of DC/OS web interface](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-21.png)
+![Pic of DC/OS GUI](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-21.png)
 
 Figure 1. Task debug interface
 
-<a name="mesos-ui"></a>
+<a name="mesos-gui"></a>
 
-### Mesos web interface
+### Mesos GUI
 
-The DC/OS web interface shows the majority of the information you need for debugging. However, sometimes going a step further and accessing the Mesos web interface can be helpful -- especially when checking failed tasked or registered frameworks. The Mesos web interface can be accessed via `https://<cluster-address>/mesos`.
+The DC/OS GUI shows the majority of the information you need for debugging. However, sometimes going a step further and accessing the Mesos GUI can be helpful -- especially when checking failed tasked or registered frameworks. The Mesos GUI can be accessed via `https://<cluster-address>/mesos`.
 
-![Pic of Mesos web interface](https://mesosphere.com/wp-content/uploads/2018/04/Screen-Shot-2018-04-15-at-17.56.16.png)
+![Pic of Mesos GUI](https://mesosphere.com/wp-content/uploads/2018/04/Screen-Shot-2018-04-15-at-17.56.16.png)
 
-Figure 2. Mesos web interface
+Figure 2. Mesos GUI
 
-<a name="zoo-ui"></a>
+<a name="zoo-gui"></a>
 
-### ZooKeeper web interface
+### ZooKeeper GUI
 
-As much of the cluster and framework state is stored in Zookeeper, it can sometimes be helpful to check these states using the ZooKeeper/Exhibitor web interface. Frameworks such as Marathon, Kafka, and Cassandra store information with Zookeeper, so this resource can be particularly useful when debugging such frameworks. For example, a failure while uninstalling of one of these frameworks can leave entries behind. So then for sure, if you experience difficulties when reinstalling a framework you have uninstalled earlier, checking this web interface could be very helpful. You can access it via `https://<cluster-address>/exhibitor`.
+As much of the cluster and framework state is stored in Zookeeper, it can sometimes be helpful to check these states using the ZooKeeper/Exhibitor GUI. Frameworks such as Marathon, Kafka, and Cassandra store information with Zookeeper, so this resource can be particularly useful when debugging such frameworks. For example, a failure while uninstalling of one of these frameworks can leave entries behind. So then for sure, if you experience difficulties when reinstalling a framework you have uninstalled earlier, checking this GUI could be very helpful. You can access it via [https://<cluster-address>/exhibitor](https://<cluster-address>/exhibitor).
 
-![Pic of ZooKeeper/Exhibitor web interface](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-13.png)
+![Pic of ZooKeeper/Exhibitor GUI](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-13.png)
 
-Figure 3. ZooKeeper/Exhibitor web interface
+Figure 3. ZooKeeper/Exhibitor GUI
 
 <a name="logs"></a>
 
@@ -88,7 +87,7 @@ DC/OS has a number of different sources for logs. In general, these are the most
 - [Mesos Master Logs](#master-logs)
 - [System Logs](#system-logs)
 
-In DC/OS, there are multiple options for accessing any of these logs: the **DC/OS web interface** the **DC/OS CLI**, or HTTP endpoints. Moreover, DC/OS rotate logs by default to prevent utilizing all available disk space.
+In DC/OS, there are multiple options for accessing any of these logs: the **DC/OS GUI** the **DC/OS CLI**, or HTTP endpoints. Moreover, DC/OS rotate logs by default to prevent utilizing all available disk space.
 
 <p class="message--note"><strong>NOTE: </strong>Need a scalable way to manage and search your logs? It could be worth building an <a href="/1.12/monitoring/logging/aggregating/filter-elk/">ELK stack</a> for log aggregation and filtering.</p>
 
@@ -97,20 +96,20 @@ Sometimes it can help to increase the level of detail written to a log temporari
 ##### Connect to Master Node
 
 ```bash
-$ dcos node ssh --master-proxy --leader
+dcos node ssh --master-proxy --leader
 ```
 
 ##### Raise Log Level on Mesos Agent 10.0.2.219
 
 ```bash
-$ curl -X POST 10.0.2.219:5051/logging/toggle?level=3&duration=5mins
+curl -X POST 10.0.2.219:5051/logging/toggle?level=3&duration=5mins
 ```
 
 <a name="task-logs"></a>
 
 ### Task/Application Logs
 
-Task/application logs are often helpful in understanding the state of the problematic application. By default, applications logs are written (together with execution logs) to the `STDERR` and `STDOUT` files in the task work directory. When looking at the task in the DC/OS web interface, you can just simply view the logs as shown below.
+Task/application logs are often helpful in understanding the state of the problematic application. By default, applications logs are written (together with execution logs) to the `STDERR` and `STDOUT` files in the task work directory. When looking at the task in the DC/OS GUI, you can just simply view the logs as shown below.
 
 ![Pic of task log](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-16.png)
 
@@ -119,7 +118,7 @@ Figure 4. Task log
 You can also do the same from the DC/OS CLI:
 
 ```bash
-$ dcos task log --follow <service-name>
+dcos task log --follow <service-name>
 ```
 
 <a name="scheduler-logs"></a>
@@ -128,10 +127,10 @@ $ dcos task log --follow <service-name>
 
 [Marathon](https://mesosphere.github.io/marathon/) is DC/OS's default scheduler when starting an application. Scheduler logs, and Marathon logs in particular, are a great source of information to help you understand why or how something was scheduled (or not) on which node. Recall that the scheduler matches tasks to available resources. So then because the scheduler also receives task status updates, the log also contains detailed information about task failures.
 
-You can retrieve and view a scheduler log about a specific service through the list of services found in the DC/OS web interface, or via the following command:
+You can retrieve and view a scheduler log about a specific service through the list of services found in the DC/OS GUI, or via the following command:
 
 ```bash
-$ dcos service log --follow <scheduler-service-name>
+dcos service log --follow <scheduler-service-name>
 ```
 
 Note that since Marathon is the “Init” system of DC/OS, it is running as a SystemD unit (same with respect to the other DC/OS system components). Due to this fact, you need the CLI command to access its logs.
@@ -140,7 +139,7 @@ Note that since Marathon is the “Init” system of DC/OS, it is running as a S
 
 ### Mesos Agent Logs
 
-Mesos agent logs are helpful for understanding how an application was started by the agent and how it may have failed. You can launch the Mesos web interface by navigating to `https://<cluster_name>/mesos` and examining the agent logs as shown below.
+Mesos agent logs are helpful for understanding how an application was started by the agent and how it may have failed. You can launch the Mesos GUI by navigating to `https://<cluster_name>/mesos` and examining the agent logs as shown below.
 
 ![Pic of Mesos agent UI](https://mesosphere.com/wp-content/uploads/2018/04/pasted-image-0-23.png)
 
@@ -149,7 +148,7 @@ Figure 5. Mesos agent interface
 Alternatively, you can view the agent logs by first using `dcos node log --mesos-id=<node-id>` from the DC/OS CLI to locate the corresponding node `ID`. Enter:
 
 ```bash
-$ dcos node
+dcos node
 ```
 
 where you will see something similar to the following output:
@@ -173,7 +172,7 @@ master.mesos.  10.0.4.215    ffc913d8-4012-4953-b693-1acc33b400ce   master (lead
 Then, in this case, you can enter:
 
 ```bash
-$ dcos node log --mesos-id=ffc913d8-4012-4953-b693-1acc33b400ce-S0 --follow
+dcos node log --mesos-id=ffc913d8-4012-4953-b693-1acc33b400ce-S0 --follow
 ```
 
 and get the following log output:
@@ -192,7 +191,7 @@ The Mesos Master is responsible for matching available resources to the schedule
 
 Be aware that there are typically multiple Mesos Masters for a single cluster. So you should **identify the current leading Mesos Master to get the most recent logs**. In fact, in some cases it might even make sense to retrieve logs from another Mesos master as well: e.g., a master node failed and you want to understand why.
 
-You can either retrieve the master logs from the Mesos web interface via `<cluster-name>/mesos`, via `dcos node log --leader`, or for a specific master node using `ssh master` and `journalctl -u dcos-mesos-master`.
+You can either retrieve the master logs from the Mesos GUI via `<cluster-name>/mesos`, via `dcos node log --leader`, or for a specific master node using `ssh master` and `journalctl -u dcos-mesos-master`.
 
 <a name="system-logs"></a>
 
@@ -205,13 +204,13 @@ As an example, consider the system unit for the docker daemon on the Mesos agent
 First, we can SSH into that agent using the corresponding SSH key:
 
 ```bash
-$ dcos node ssh --master-proxy --mesos-id=ffc913d8-4012-4953-b693-1acc33b400ce-S0
+dcos node ssh --master-proxy --mesos-id=ffc913d8-4012-4953-b693-1acc33b400ce-S0
 ```
 
 Then we can use `journatlctl`, to look at the Docker logs:
 
 ```bash
-$ journalctl -u docker
+journalctl -u docker
 ```
 
 which outputs something like this:

--- a/pages/1.12/tutorials/deploy-on-marathon/index.md
+++ b/pages/1.12/tutorials/deploy-on-marathon/index.md
@@ -16,53 +16,50 @@ This tutorial shows how to deploy applications on [Marathon][1] using Jenkins fo
 **Prerequisite:**
 This tutorial assumes that you have a working Jenkins installation and permission to launch applications on Marathon. Jenkins for DC/OS must be installed as described on the [Jenkins Quickstart](/services/jenkins/quickstart/) page.
 
-
-
 # The Example Project
 
 The project used in this tutorial is taken from the [cd-demo][4] repository and runs a Jekyll website inside a Docker container. The required files for this tutorial are `Dockerfile`, `conf/cd-demo-appn.json`, and the `site` directory. Copy those items to a new project and push to a new Git repository on the host of your choice. This tutorial uses [Docker Hub][6] to store the created image and requires account information to perform this task.
 
 ## Accessing Jenkins for DC/OS
 
-Jenkins for DC/OS can be accessed through the Dashboard or Services navigation menu’s within the [DC/OS web interface](/gui/).
+Jenkins for DC/OS can be accessed through the Dashboard or Services navigation menus within the [DC/OS GUI](/gui/).
 
-Click the “Jenkins” service and then "Open Service" to access the Jenkins web interface.
+Click the “Jenkins” service and then "Open Service" to access the Jenkins GUI.
 
-![dcos-velocity-jenkins-ui.png](/img/dcos-velocity-jenkins-ui.png)
+![Jenkins GUI](/1.12/img/dcos-velocity-jenkins-ui.png)
 
-Figure 1. Jenkins web interface
+Figure 1. Jenkins GUI 
 
 ## Adding Docker Hub Credentials
 
-Jenkins stores account credentials within its Credential Store, which allows jobs to use credentials in a secure manner. From the main Jenkins page, click **Credentials** from the left-hand menu. From there, select **System** (also from the left-hand menu) and finally the *Global credentials* (unrestricted) link presented in the main viewing area. The left-hand menu should now have an **Add Credentials** option.
+Jenkins stores account credentials within its Credential Store, which allows jobs to use credentials in a secure manner. 
 
-Click **Add Credentials** to create a new credential for Docker Hub. The **Kind** drop-down menu should have the "Username with password" option selected. Fill out the rest of the information to match your Docker Hub account.
+1. From the main Jenkins page, click **Credentials** from the left-hand menu. 
+1. From there, select **System** (also from the left-hand menu) and finally the **Global credentials** (unrestricted) link presented in the main viewing area. The left-hand menu should now have an **Add Credentials** option.
 
-![dcos-velocity-jenkins-creds-new.png](/img/dcos-velocity-jenkins-creds-new.png)
+1. Click **Add Credentials** to create a new credential for Docker Hub. The **Kind** drop-down menu should have the "Username with password" option selected. Fill out the rest of the information to match your Docker Hub account.
 
-Figure 2. Add Jenkins credentials
+    ![Kind drop-down menu](/1.12/img/dcos-velocity-jenkins-creds-new.png)
+
+    Figure 2. Kind drop-down menu
 
 # The Job
 
 We will create a new Jenkins job that performs several operations with Docker Hub and then either update or create a Marathon application.
 
-Create a new **Freestyle** job with a name that includes only lowercase letters and hyphens. This name will be used later in the Docker image name and possibly as the Marathon application ID.
+1. Create a new **Freestyle** job with a name that includes only lowercase letters and hyphens. This name will be used later in the Docker image name and possibly as the Marathon application ID.
 
-![dcos-jenkins-new-freestyle.png](/img/dcos-jenkins-new-freestyle.png)
+    ![Freestyle page](/1.12/img/dcos-jenkins-new-freestyle.png)
 
-Figure 3. Freestyle project
+    Figure 3. Freestyle project
 
-## SCM/Git
+1. SCM/Git. From the **Example Project** section above, fill in the Git repository URL with the newly created Git repository. This must be accessible to Jenkins and may require adding credentials to the Jenkins instance.
 
-From the **Example Project** section above, fill in the Git repository URL with the newly created Git repository. This must be accessible to Jenkins and may require adding credentials to the Jenkins instance.
+    ![dcos-jenkins-repourl.png](/1.12/img/dcos-jenkins-repourl.png)
 
-![dcos-jenkins-repourl.png](/img/dcos-jenkins-repourl.png)
+    Figure 4. Source Code Management credentials
 
-Figure 4. Source Code Management credentials
-
-## Build Triggers
-
-Select the **Poll SCM** build trigger with a schedule of: `*/5 * * * *`. This will check the Git repository every five minutes for changes.
+1. Build Triggers. Select the **Poll SCM** build trigger with a schedule of: `*/5 * * * *`. This will check the Git repository every five minutes for changes.
 
 # Build Steps
 
@@ -71,47 +68,49 @@ The Jenkins job performs these actions:
 1. Build a new Docker image.
 1. Push the new image to Docker Hub.
 
-These steps can be performed by a single build step using the **Docker Build and Publish** plugin, which is already included and ready for use. From the **Add build step** drop-down list, select the **Docker Build and Publish** option.
+These steps can be performed by a single build step using the **Docker Build and Publish** plugin, which is already included and ready for use. 
 
-![dcos-velocity-jenkins-build-docker.png](/img/dcos-velocity-jenkins-build-docker.png)
+1. From the **Add build step** drop-down list, select the **Docker Build and Publish** option.
 
-Figure 5. Docker "Add build step" options
+    ![dcos-velocity-jenkins-build-docker.png](/1.12/img/dcos-velocity-jenkins-build-docker.png)
 
-Fill in the following fields:
+    Figure 5. Docker "Add build step" options
+
+1. Fill in the following fields:
 
 * **Repository Name** with your Docker Hub username and `/${JOB_NAME}` as the suffix ("myusername/${JOB_NAME}")
-* **Tag** with `${GIT_COMMIT}`
+* **Tag** with `$GIT_COMMIT`
 * **Registry credentials** to the credentials for Docker Hub created above
 
-![dcos-velocity-jenkins-build-docker-config.png](/img/dcos-velocity-jenkins-build-docker-config.png)
+    ![dcos-velocity-jenkins-build-docker-config.png](/1.12/img/dcos-velocity-jenkins-build-docker-config.png)
 
-Figure 6. Docker Build and Publish screen
+    Figure 6. Docker Build and Publish screen
 
 # Marathon Deployment
 
-Add a Marathon Deployment post-build action by selecting the **Marathon Deployment** option from the **Add post-build action** drop-down.
+1. Add a Marathon Deployment post-build action by selecting the **Marathon Deployment** option from the **Add post-build action** drop-down.
 
-![dcos-jenkins-plugin-popup.png](/img/dcos-jenkins-plugin-popup.png)
+    ![dcos-jenkins-plugin-popup.png](/1.12/img/dcos-jenkins-plugin-popup.png)
 
-Figure 6. Marathon Deployment menu
+    Figure 7. Marathon Deployment menu
 
-Fill in the following fields:
+1. Fill in the following fields:
 
-* **Marathon URL** can be accessed within DC/OS using the URL `http://leader.mesos/service/marathon`
+* **Marathon URL** can be accessed within DC/OS using the URL [http://leader.mesos/service/marathon](http://leader.mesos/service/marathon)
 * **Application Definition** with the relative path to the marathon application file (`conf/cd-demo-app.json`)
 * **Docker Image** with the image created above (`myusername/${JOB_NAME}:${GIT_COMMIT}`)
 
-![dcos-velocity-marathon-config.png](/img/dcos-velocity-marathon-config.png)
+    ![dcos-velocity-marathon-config.png](/1.12/img/dcos-velocity-marathon-config.png)
 
-Figure 7. Post-Build Actions screen
+    Figure 8. Post-Build Actions screen
 
 ## How It Works
 
-The Marathon Deployment post-build action reads the application definition file, by default `marathon.json`, contained within the project’s Git repository. This is a JSON file and must contain a valid [Marathon application definition][3].
+1. The Marathon Deployment post-build action reads the application definition file, by default `marathon.json`, contained within the project’s Git repository. This is a JSON file and must contain a valid [Marathon application definition][3].
 
-The configurable fields in the post-build action will overwrite the content of matching fields from the file. For example, setting the "Application Id" will replace the `id` field in the file. In the configuration above, "Docker Image" is configured and will overwrite the `image` field contained within the [docker field][5].
+1. The configurable fields in the post-build action will overwrite the content of matching fields from the file. For example, setting the "Application Id" will replace the `id` field in the file. In the configuration above, "Docker Image" is configured and will overwrite the `image` field contained within the [docker field][5].
 
-The final JSON payload is sent to the configured Marathon instance and the application is updated or created.
+1. The final JSON payload is sent to the configured Marathon instance and the application is updated or created.
 
 # Save
 
@@ -121,13 +120,13 @@ Save the job configuration.
 
 Click **Build Now** and let the job build.
 
-![dcos-jenkins-build-now.png](/img/dcos-jenkins-build-now.png)
+![dcos-jenkins-build-now.png](/1.12/img/dcos-jenkins-build-now.png)
 
-Figure 8. Build the job
+Figure 9. Build the job
 
 # Deployment
 
-Upon a successful run in Jenkins, the application will begin deployment on DC/OS. You can visit the DC/OS web interface to monitor progress.
+Upon a successful run in Jenkins, the application will begin deployment on DC/OS. You can visit the DC/OS GUI to monitor progress.
 
 When the **Status** has changed to **Running**, the deployment is complete and you can visit the website.
 
@@ -135,9 +134,9 @@ When the **Status** has changed to **Running**, the deployment is complete and y
 
 Visit port `80` on the public DC/OS agent to display a Jekyll website.
 
-![dcos-jekyll-site1.png](/img/dcos-jekyll-site1.png)
+![dcos-jekyll-site1.png](/1.12/img/dcos-jekyll-site1.png)
 
-Figure 9. Jekyll demo
+Figure 10. Jekyll demo
 
 ## Adding a New Post
 
@@ -145,7 +144,9 @@ The content in the `_posts` directory generates a Jekyll website. For this examp
 
 Commit the new post to Git. Shortly after the new commit lands on the master branch, Jenkins will see the change and redeploy to Marathon.
 
-![dcos-jekyll-updated.png](/img/dcos-jekyll-updated.png)
+![dcos-jekyll-updated.png](/1.12/img/dcos-jekyll-updated.png)
+
+Figure 11. Jenkins updated
 
  [1]: https://mesosphere.github.io/marathon/
  [3]: https://mesosphere.github.io/marathon/docs/application-basics.html

--- a/pages/1.12/tutorials/index.md
+++ b/pages/1.12/tutorials/index.md
@@ -7,8 +7,9 @@ excerpt: Getting started with DC/OS
 
 enterprise: false
 ---
+#include /include/tutorial-disclaimer.tmpl
 
 Learn how to run services and operate services in production with this collection of tutorials about using DC/OS.
 
-#include /include/tutorial-disclaimer.tmpl
+
 

--- a/pages/1.12/tutorials/iot_pipeline/index.md
+++ b/pages/1.12/tutorials/iot_pipeline/index.md
@@ -53,7 +53,7 @@ Tweeter stores tweets in the DC/OS Cassandra service, streams tweets to the DC/O
 
 ## Install DC/OS services
 
-In this step you install Cassandra, Kafka, Marathon-LB, and Zeppelin from the DC/OS web interface [**Catalog**](/gui/catalog/) tab. You can also install DC/OS packages from the DC/OS CLI with the [`dcos package install`][11] command.
+In this step you install Cassandra, Kafka, Marathon-LB, and Zeppelin from the DC/OS GUI [**Catalog**](/gui/catalog/) tab. You can also install DC/OS packages from the DC/OS CLI with the [`dcos package install`][11] command.
 
 1.  Find and click the **cassandra** package, click **REVIEW & RUN**, and accept the default installation, by clicking **REVIEW & RUN** again, then **RUN SERVICE**. Cassandra spins up to 3 nodes. When prompted by the modal alert, click **OPEN SERVICE**.
 
@@ -69,7 +69,7 @@ If you are having trouble getting Marathon-LB up and running on an Enterprise cl
 
 5.  Click the **Services** tab to watch as your microservices are deployed on DC/OS. You will see the Health status go from Idle to Unhealthy, and finally to Healthy as the nodes come online. This may take several minutes.
 
-    ![Services tab with all services shown.](/img/tweeter-services6-ee.png)
+    ![Services tab with all services shown.](/1.12/img/tweeter-services6-ee.png)
 
     Figure 1. Services tab showing Tweeter services
 
@@ -126,7 +126,7 @@ In this step you deploy the containerized Tweeter app to a public node.
 
 4.  Go to the **Services** tab to verify your app is up and healthy.
 
-    ![Tweeter deployed](/img/tweeter-services7.png)
+    ![Tweeter deployed](/1.12/img/tweeter-services7.png)
 
     Figure 2. Tweeter deployed
 
@@ -150,7 +150,7 @@ In this step you deploy an app that automatically posts a large number of tweets
 
 3.  After the `post-tweets.json` is running, refresh your browser to see the incoming Shakespeare tweets.
 
-    ![Shakespeare tweets](/img/tweeter-shakespeare.png)
+    ![Shakespeare tweets](/1.12/img/tweeter-shakespeare.png)
 
     Figure 4. Shakespeare tweets
 
@@ -179,9 +179,9 @@ The Tweeter app uses the service discovery and load balancer service that is ins
 ...
 ```
 
-If you are using a DC/OS Enterprise cluster, click the **Networking** -> **Service Addresses** tab in the DC/OS web interface and select the `1.1.1.1:30000` virtual network to see the load balancing in action:
+If you are using a DC/OS Enterprise cluster, click the **Networking** -> **Service Addresses** tab in the DC/OS GUI and select the `1.1.1.1:30000` virtual network to see the load balancing in action:
 
-![Tweeter scaled](/1.10/img/tweeter-services8-ee.png)
+![Tweeter scaled](/1.12/img/tweeter-services8-ee.png)
 
 Figure 5. Scaled tweets
 
@@ -191,7 +191,7 @@ In this last step, youv will perform real-time analytics on the stream of tweets
 
 1. Navigate to the [Tweeter](https://github.com/mesosphere/tweeter/) GitHub repository and save the `tweeter/post-tweets.json` Marathon app definition file.
 
-2. Navigate to Zeppelin at `https://<master_ip>/service/zeppelin/`.  Your master IP address is the URL of the DC/OS web interface.
+2. Navigate to Zeppelin at `https://<master_ip>/service/zeppelin/`.  Your master IP address is the URL of the DC/OS GUI.
 
 3. Click **Import Note** and import `tweeter-analytics.json`. Zeppelin is preconfigured to execute Spark jobs on the DC/OS cluster, so there is no further configuration or setup required. Be sure to use `https://`, not `http://`.
 

--- a/pages/1.12/tutorials/stateful-services/index.md
+++ b/pages/1.12/tutorials/stateful-services/index.md
@@ -147,7 +147,7 @@ dcos marathon app remove postgres
 
 ## Appendix
 
-For further information on stateful services in DC/OS, visit the [Storage section of the documentation](/storage/).
+For further information on stateful services in DC/OS, visit the [Storage section of the documentation](/1.12/storage/).
 
 
 [1]: /1.12/installing/

--- a/pages/1.12/tutorials/task-labels/index.md
+++ b/pages/1.12/tutorials/task-labels/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Labeling Tasks and Jobs
 title: Labeling Tasks and Jobs
 menuWeight: 5
-excerpt: Tutorial - Defining labels using the DC/OS web interface and the Marathon HTTP API
+excerpt: Tutorial - Defining labels using the DC/OS GUI and the Marathon HTTP API
 
 enterprise: false
 ---
@@ -11,7 +11,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/dcos/dcos-docs-site -->
 #include /include/tutorial-disclaimer.tmpl
 
-This tutorial illustrates how labels can be defined using the DC/OS web interface and the Marathon HTTP API, and how information pertaining to applications and jobs that are running can be queried based on label value criteria.
+This tutorial illustrates how labels can be defined using the DC/OS GUI and the Marathon HTTP API, and how information pertaining to applications and jobs that are running can be queried based on label value criteria.
 
 When you deploy applications, containers, or jobs in a DC/OS cluster, you can associate a tag or label with your deployed components to track and report usage of the cluster by those components. For example, you may want to assign a cost center identifier or a customer number to a Mesos application and produce a summary report at the end of the month with usage metrics such as the amount of CPU and memory allocated to the applications by cost center or customer.
 
@@ -21,39 +21,40 @@ You can attach labels to tasks from the DC/OS CLI. You can specify more than one
 
 ## DC/OS CLI
 
-You can also specify label values in the `labels` parameter of your application definition.
-
+1. Specify label values in the `labels` parameter of your application definition.
+    ```
     vi myapp.json
-
-    {
-        "id": "myapp",
-        "cpus": 0.1,
-        "mem": 16.0,
-        "ports": [
-            0
-        ],
-        "cmd": "/opt/mesosphere/bin/python3 -m http.server $PORT0",
-        "instances": 2,
-        "labels": {
-            "COST_CENTER": "0001"
+    ```
+    ```json
+        {
+            "id": "myapp",
+            "cpus": 0.1,
+            "mem": 16.0,
+            "ports": [
+                0
+            ],
+            "cmd": "/opt/mesosphere/bin/python3 -m http.server $PORT0",
+            "instances": 2,
+            "labels": {
+                "COST_CENTER": "0001"
+            }
         }
-    }
+    ```
+1. Then, deploy from the DC/OS CLI:
 
-Then, deploy from the DC/OS CLI:
-
-```bash
-dcos marathon app add <myapp>.json
-```
+    ```bash
+    dcos marathon app add <myapp>.json
+    ```
 
 # Assigning Labels to Jobs
 
-You can attach labels to jobs either via the **Jobs** tab of the DC/OS web interface or from the DC/OS CLI. You can specify more than one label, but each label can have only one value.
+You can attach labels to jobs either via the **Jobs** tab of the DC/OS GUI or from the DC/OS CLI. You can specify more than one label, but each label can have only one value.
 
-## DC/OS Web Interface
+## DC/OS GUI
 
-From the DC/OS web interface, click the **Jobs** tab, then click on the name of the Job. This will take you to the individual Job page. Click **Edit** in the upper right corner. From the left hand side of the Edit Job page, select **Labels**.
+From the DC/OS GUI, click the **Jobs** tab, then click on the name of the Job. This will take you to the individual Job page. Click **Edit** in the upper right corner. From the left hand side of the Edit Job page, select **Labels**.
 
-![Job label](/img/job-label.png)
+![Job label](/1.12/img/job-label.png)
 
 Figure 1. Assign a job label
 
@@ -61,29 +62,29 @@ Figure 1. Assign a job label
 
 You can also specify label values in the `labels` parameter of your job definition.
 
-    vi myjob.json
+1.  Create a file `myjob.json`:
 
-     ```json
-        {
-          "id": "my-job",
-          "description": "A job that sleeps",
-          "labels": {
-            "department": "marketing"
-          },
-          "run": {
-            "cmd": "sleep 1000",
-            "cpus": 0.01,
-            "mem": 32,
-            "disk": 0
-          }
+    ```json
+      {
+        "id": "my-job",
+        "description": "A job that sleeps",
+        "labels": {
+          "department": "marketing"
+        },
+        "run": {
+          "cmd": "sleep 1000",
+          "cpus": 0.01,
+          "mem": 32,
+          "disk": 0
         }
-     ```
+      }
+    ```
 
-Then, deploy from the DC/OS CLI:
+1. Then, deploy from the DC/OS CLI:
 
-```bash
-dcos job add <myjob>.json
-```
+    ```bash
+    dcos job add <myjob>.json
+    ```
 
 # Displaying Label Information
 
@@ -98,6 +99,10 @@ The code snippet below shows an HTTP request issued to the Marathon HTTP API. Th
     > https://52.88.210.228/marathon/v2/apps?label=COST_CENTER==0001 \
     > | python -m json.tool | more
 
-You can also specify multiple label criteria like so: `?label=COST_CENTER==0001,COST_CENTER==0002`
+You can also specify multiple label criteria like so: 
+
+```
+?label=COST_CENTER==0001,COST_CENTER==0002
+```
 
 In the example above, the response you receive will include only the applications that have a label `COST_CENTER` defined with a value of `0001`. The resource metrics are also included, such as the number of CPU shares and the amount of memory allocated. At the bottom of the response, you can see the date/time this application was deployed, which can be used to compute the uptime for billing or charge-back purposes.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-4835
Broken links in DC/OS tutorials; images not displaying.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

Corrected links to images and URLs in 1.12 tutorials ONLY.