### PR TITLE
Updating GCP Instructions for new Provider Version

### DIFF
--- a/pages/1.10/installing/evaluation/gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/index.md
@@ -115,7 +115,7 @@ Password: `deleteme`
 
   module "dcos" {
     source = "dcos-terraform/dcos/gcp"
-    version = "~> 0.1"
+    version = "~> 0.1.0"
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.10/installing/evaluation/gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/index.md
@@ -100,7 +100,7 @@ Password: `deleteme`
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   # Used to determine your public IP for forwarding rules
@@ -219,7 +219,7 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   variable "dcos_install_mode" {
@@ -311,7 +311,7 @@ To perform an upgrade:
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   variable "dcos_install_mode" {

--- a/pages/1.10/installing/evaluation/gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/index.md
@@ -99,6 +99,15 @@ Password: `deleteme`
   - ```public-agent-loadbalancer``` - Specifies the URL of your Public routable services.
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
+  # Used to determine your public IP for forwarding rules
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
@@ -106,15 +115,21 @@ Password: `deleteme`
 
   module "dcos" {
     source = "dcos-terraform/dcos/gcp"
+    version = "~> 0.1"
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"
+    admin_ips           = ["${data.http.whatismyip.body}/32"]
 
     num_masters        = "1"
     num_private_agents = "2"
     num_public_agents  = "1"
 
     dcos_version = "1.10.8"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"
@@ -184,6 +199,10 @@ You have successfully installed a DC/OS cluster on GCP with minimal configuratio
 <p align=center>
 <img src="./images/install/dcos-login.png" />
 </p>
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
+  }
+
 
 After you log in, the DC/OS dashboard is displayed.
 
@@ -199,9 +218,17 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 1) Increase the value for the `num_private_agents` and/or `num_public_agents` in your `main.tf` file. In this example, you will scale the cluster from `two` private agents to `three` private agents.
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
+  }
+
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
   }
 
   module "dcos" {
@@ -209,12 +236,17 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"
+    admin_ips           = ["${data.http.whatismyip.body}/32"]
 
     num_masters        = "1"
     num_private_agents = "3"
     num_public_agents  = "1"
 
     dcos_version = "1.10.8"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"
@@ -278,6 +310,10 @@ To perform an upgrade:
     <p class="message--important"><strong>IMPORTANT: </strong>Do not change the number of masters, agents, or public agents while performing an upgrade.</p>
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
@@ -299,6 +335,10 @@ To perform an upgrade:
     num_public_agents  = "1"
 
     dcos_version = "1.10.9"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"

--- a/pages/1.11/installing/evaluation/gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/index.md
@@ -115,7 +115,7 @@ Password: `deleteme`
 
   module "dcos" {
     source = "dcos-terraform/dcos/gcp"
-    version = "~> 0.1"
+    version = "~> 0.1.0"
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.11/installing/evaluation/gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/index.md
@@ -99,6 +99,15 @@ Password: `deleteme`
   - ```public-agent-loadbalancer``` - Specifies the URL of your Public routable services.
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
+  # Used to determine your public IP for forwarding rules
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
@@ -106,15 +115,21 @@ Password: `deleteme`
 
   module "dcos" {
     source = "dcos-terraform/dcos/gcp"
+    version = "~> 0.1"
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"
+    admin_ips           = ["${data.http.whatismyip.body}/32"]
 
     num_masters        = "1"
     num_private_agents = "2"
     num_public_agents  = "1"
 
     dcos_version = "1.11.7"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"
@@ -184,6 +199,10 @@ You have successfully installed a DC/OS cluster on GCP with minimal configuratio
 <p align=center>
 <img src="./images/install/dcos-login.png" />
 </p>
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
+  }
+
 
 After you log in, the DC/OS dashboard is displayed.
 
@@ -199,9 +218,17 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 1) Increase the value for the `num_private_agents` and/or `num_public_agents` in your `main.tf` file. In this example, you will scale the cluster from `two` private agents to `three` private agents.
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
+  }
+
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
   }
 
   module "dcos" {
@@ -209,12 +236,17 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"
+    admin_ips           = ["${data.http.whatismyip.body}/32"]
 
     num_masters        = "1"
     num_private_agents = "3"
     num_public_agents  = "1"
 
     dcos_version = "1.11.7"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"
@@ -240,7 +272,7 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
   ```bash
   terraform plan -out=plan.out
-  ```
+GG  ```
 
     This step ensures that the state is stable and confirms that you can create the resources necessary to scale the private agents to the desired number. Executing the plan adds the following resources as a result of scaling up the cluster’s private agents:
     - One instance resource
@@ -278,6 +310,10 @@ To perform an upgrade:
     <p class="message--important"><strong>IMPORTANT: </strong>Do not change the number of masters, agents, or public agents while performing an upgrade.</p>
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
@@ -299,6 +335,10 @@ To perform an upgrade:
     num_public_agents  = "1"
 
     dcos_version = "1.11.8"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"

--- a/pages/1.11/installing/evaluation/gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/index.md
@@ -100,7 +100,7 @@ Password: `deleteme`
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   # Used to determine your public IP for forwarding rules
@@ -219,7 +219,7 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   variable "dcos_install_mode" {
@@ -311,7 +311,7 @@ To perform an upgrade:
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   variable "dcos_install_mode" {

--- a/pages/1.11/installing/evaluation/gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/index.md
@@ -272,7 +272,7 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
   ```bash
   terraform plan -out=plan.out
-GG  ```
+  ```
 
     This step ensures that the state is stable and confirms that you can create the resources necessary to scale the private agents to the desired number. Executing the plan adds the following resources as a result of scaling up the cluster’s private agents:
     - One instance resource

--- a/pages/1.12/installing/evaluation/gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/index.md
@@ -99,6 +99,15 @@ Password: `deleteme`
   - ```public-agent-loadbalancer``` - Specifies the URL of your Public routable services.
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
+  # Used to determine your public IP for forwarding rules
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
@@ -106,15 +115,21 @@ Password: `deleteme`
 
   module "dcos" {
     source = "dcos-terraform/dcos/gcp"
+    version = "~> 0.1"
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"
+    admin_ips           = ["${data.http.whatismyip.body}/32"]
 
     num_masters        = "1"
     num_private_agents = "2"
     num_public_agents  = "1"
 
     dcos_version = "1.12.0"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"
@@ -196,9 +211,17 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 1)  Increase the value for the `num_private_agents` and/or `num_public_agents` in your `main.tf` file. In this example, you will scale the cluster from `two` private agents to `three` private agents.
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
+  }
+
+  data "http" "whatismyip" {
+    url = "http://whatismyip.akamai.com/"
   }
 
   module "dcos" {
@@ -206,12 +229,17 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"
+    admin_ips           = ["${data.http.whatismyip.body}/32"]
 
     num_masters        = "1"
     num_private_agents = "3"
     num_public_agents  = "1"
 
     dcos_version = "1.12.0"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"
@@ -275,6 +303,10 @@ To perform an upgrade:
     <p class="message--important"><strong>IMPORTANT: </strong>Do not change the number of masters, agents, or public agents while performing an upgrade.</p>
 
   ```hcl
+  provider "google" {
+    version = "~> 1.0"
+  }
+
   variable "dcos_install_mode" {
     description = "specifies which type of command to execute. Options: install or upgrade"
     default = "install"
@@ -296,6 +328,10 @@ To perform an upgrade:
     num_public_agents  = "1"
 
     dcos_version = "1.12.1"
+
+    providers = {
+      google = "google"
+    }
 
     # dcos_variant              = "ee"
     # dcos_license_key_contents = "${file("./license.txt")}"

--- a/pages/1.12/installing/evaluation/gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/index.md
@@ -115,7 +115,7 @@ Password: `deleteme`
 
   module "dcos" {
     source = "dcos-terraform/dcos/gcp"
-    version = "~> 0.1"
+    version = "~> 0.1.0"
 
     cluster_name        = "my-open-dcos"
     ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.12/installing/evaluation/gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/index.md
@@ -100,7 +100,7 @@ Password: `deleteme`
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   # Used to determine your public IP for forwarding rules
@@ -212,7 +212,7 @@ Terraform makes it easy to scale your cluster to add additional agents (public o
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   variable "dcos_install_mode" {
@@ -304,7 +304,7 @@ To perform an upgrade:
 
   ```hcl
   provider "google" {
-    version = "~> 1.0"
+    version = "~> 1.18.0"
   }
 
   variable "dcos_install_mode" {


### PR DESCRIPTION
This PR is to update the GCP instructions for the new provider that will pin the version of the GCP provider to 1.X along with the version of the Universal Installer to 0.1.X so that they are both compatable. The universal installer currently does support GCP 2.X however this will need to be run with the Universal Installer version of 0.2.0 which will no longer support the GCP labels beta feature as Google has deprecated this but is quite useful from the Universal Installer side.


https://jira.mesosphere.com/browse/COPS-4521
<!-- Link to JIRA issue -->

- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X] Medium

- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).