### PR TITLE
ss/COPS-4595 Corrected links to DSS upgrade doc from release notes.

### DIFF
--- a/pages/1.12/release-notes/1.12.1/index.md
+++ b/pages/1.12/release-notes/1.12.1/index.md
@@ -125,7 +125,7 @@ The issues that have been fixed in DC/OS 1.12.1 are grouped by feature, function
 - DCOS-21998, DCOS-44367 - You can install DC/OS cluster nodes with custom RSA-based CA certificates that are signed using an Elastic Cloud (EC) based private key. Previously, a custom CA certificate signed using a trusted EC-based private key would generate a transport security layer (TLS) security alert.
 
 ## Upgrade
-- Upgrading from 1.12.0 to 1.12.1 requires you to first follow the storage upgrade instructions provided in [Manually upgrade the DSS package to 0.5.x from 0.4.x](https://github.com/mesosphere/dcos-storage/blob/master/docs/upgrades/index.md). You must upgrade DC/OS storage before you upgrade cluster nodes to 1.12.1 to prevent Mesos agents from crashing after the upgrade.
+- If you have installed the optional DC/OS Storage Service package, then upgrading from 1.12.0 to 1.12.1 requires you to first follow the storage upgrade instructions provided in [Manually upgrade the DSS package to 0.5.x from 0.4.x](/services/beta-storage/0.5.2-beta/upgrades/). You must upgrade DC/OS storage **before** you upgrade cluster nodes to 1.12.1 to prevent Mesos agents from crashing after the upgrade.
 
 # Known Issues and Limitations
 This section covers any known issues or limitations that don’t necessarily affect all customers, but might require changes to your environment to address specific scenarios. The issues are grouped by feature, functional area, or component. Where applicable, issue descriptions include one or more issue tracking identifiers.

--- a/pages/1.12/release-notes/1.12.2/index.md
+++ b/pages/1.12/release-notes/1.12.2/index.md
@@ -153,6 +153,7 @@ DC/OS 1.12 includes many new features and capabilities. The key features and enh
 - Officially recommended as a Mesosphere supported installation method with best practices built-in (i.e sequential masters & parallel agents in upgrade).
 - Restructured [Mesosphere installation documentation](https://docs.mesosphere.com/1.12/installing/evaluation/) to organize Mesosphere supported installation methods and Community supported installation methods.
 - Expanded DC/OS upgrade paths enable Mesosphere to skip specific [upgrade paths](https://docs.mesosphere.com/1.12/installing/production/upgrading/#supported-upgrade-paths) within a supported patch version of DC/OS (i.e upgrade from 1.11.1 => 1.11.5 in one move) and to skip upgrade paths between supported major to major versions of DC/OS (for example, enabling you to upgrade from 1.11.7 to 1.12.1 in one move).
+- If you have installed the optional DC/OS Storage Service package, then upgrading from 1.12.0 to 1.12.1 requires you to first follow the storage upgrade instructions provided in [Manually upgrade the DSS package to 0.5.x from 0.4.x](/services/beta-storage/0.5.2-beta/upgrades/). You must upgrade DC/OS storage **before** you upgrade cluster nodes to 1.12.1 to prevent Mesos agents from crashing after the upgrade.
 
 <a name="ldap-net"></a>
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/COPS-4595

> The 1.12.1 release notes have this entry:
> 
> https://docs.mesosphere.com/1.12/release-notes/1.12.1/#upgrade
> 
> One issue with this note is that it is a bit ambiguous and doesn't make it clear that this note ONLY applies if you are using the beta DSS package.  Perhaps it could be improved to start with something like this?
> 
> "If you have installed the optional DC/OS Storage Service package...  "
> 
> A bigger issue is that the link in this note points to Mesosphere private github page, and thus is not reachable by customers.   It should instead point at this page:
> 
> https://docs.mesosphere.com/services/beta-storage/0.5.1-beta/upgrades

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Replaced link with link to /beta-storage/ upgrade docs for 0.5.2 (newest release). Link replacements in release notes for 

1.12.1
1.12.2