### PR TITLE
CK DCOS-49303 Update content-sections logic

### DIFF
--- a/layouts/components/content-sections.pug
+++ b/layouts/components/content-sections.pug
@@ -13,7 +13,7 @@ if (isHeadings || relatedPages)
               else
                 - var h_text = heading.text.trim()
                 - h_text = h_text.replace(/\s+/g, '-').toLowerCase()
-                a(href='#' + h_text)!=heading.text
+                a(href='#' + h_text)!= heading.text
 
       if (relatedPages)
         ul(class='content__sections-list')

--- a/layouts/components/content-sections.pug
+++ b/layouts/components/content-sections.pug
@@ -8,7 +8,12 @@ if (isHeadings || relatedPages)
           for heading in headings
             - var headClass = 'content__sections-item--' + heading.tag
             li(class=headClass + ' content__sections-item')
-              a(href='#' + heading.id)!= heading.text
+              if heading.id
+                a(href='#' + heading.id)!= heading.text
+              else
+                - var h_text = heading.text.trim()
+                - h_text = h_text.replace(/\s+/g, '-').toLowerCase()
+                a(href='#' + h_text)!=heading.text
 
       if (relatedPages)
         ul(class='content__sections-list')


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-49303

Problem addressed: ngindox does not create a heading.id that can be used by the pug layout, created a workaround to take the heading text and put into the proper href form of #lowercase-and-dashes

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
