### PR TITLE
DCOS-47356: Expose Kibana 6.3.2 without Adminrouter.

### DIFF
--- a/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
@@ -1,0 +1,262 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt:
+title: How-To Guides
+menuWeight: 120
+model: /services/elastic/data.yml
+render: mustache
+---
+
+# Expose Kibana using EdgeLB
+
+## 1. Install EdgeLB
+
+First, check if EdgeLB is available on your DC/OS cluster by running:
+
+```bash
+dcos package search edgelb
+```
+
+The output should look something like:
+
+```text
+$ dcos package search edgelb
+NAME         VERSION  SELECTED  FRAMEWORK  DESCRIPTION
+edgelb       v1.3.0   True      False      EdgeLB on DC/OS
+edgelb-pool  v1.3.0   True      True       EdgeLB Pool on DC/OS
+```
+
+If it does, you can skip the `dcos package repo add` commands below.
+
+*Otherwise*, if you see a `No packages found` message you'll need to
+add a couple of package repositories to your cluster. These are for
+EdgeLB version 1.3.0, which is the latest at the time of writing. Take
+a look at the [EdgeLB service
+documentation](https://docs.mesosphere.com/services/edge-lb/) to check
+if that's the latest version.
+
+```bash
+dcos package repo add edgelb https://downloads.mesosphere.com/edgelb/v1.3.0/assets/stub-universe-edgelb.json
+dcos package repo add edgelb-pool https://downloads.mesosphere.com/edgelb-pool/v1.3.0/assets/stub-universe-edgelb-pool.json
+```
+
+Now install EdgeLB with:
+
+```bash
+dcos package install edgelb
+```
+
+For more details please check out the [EdgeLB installation
+instructions](https://docs.mesosphere.com/services/edge-lb/1.3/installing/).
+
+The installation will take a moment. The following command can be
+used to determine if EdgeLB is up and running:
+
+```bash
+dcos edgelb --name edgelb ping
+```
+
+An output of `pong` means that it's ready.
+
+## 2. Create an EdgeLB pool for Kibana
+
+The following command will create an EdgeLB pool task running on one
+of your DC/OS cluster's public agents, which will allow Kibana to be
+accessed from outside the cluster network, given that the selected
+port on the agent machine is open.
+
+In this example we'll expose a Kibana service named
+`/production/kibana` through HTTP, on port `80`. It will be accessible
+on http://$public_agent_ip_or_url:80.
+
+Note that in this example:
+- the EdgeLB pool that will be created is named `kibana`
+- its backend name is `kibana-backend`
+
+It is not a requirement that these match any configuration options
+related to the actual Kibana service, so one could name them
+differently.
+
+The pool fields that actually map to the actual Kibana service are
+under `haproxy.backends`:
+- `rewriteHttp.path.fromPath` should match the Kibana Marathon app
+service path
+- `services.endpoint.portName` should match the Kibana Marathon app
+port name
+- `services.marathon.serviceID` should match the Kibana service name
+
+Let's get the remaining configuration parameters that will map the
+EdgeLB pool to the actual Kibana service. We'll use them in the pool
+configuration. Make sure to use a different name or port based on your
+needs.
+
+```bash
+kibana_service_name="/production/kibana"
+kibana_proxy_port=80
+kibana_service_path="/service/${kibana_service_name}"
+kibana_port_name="$(dcos marathon app show "${kibana_service_name}" | jq -r '.portDefinitions[0].name')"
+```
+
+```bash
+echo "{
+  \"apiVersion\": \"V2\",
+  \"role\": \"slave_public\",
+  \"name\": \"kibana\",
+  \"count\": 1,
+  \"haproxy\": {
+    \"stats\": {
+      \"bindPort\": 9090
+    },
+    \"frontends\": [
+      {
+        \"bindPort\": ${kibana_proxy_port},
+        \"linkBackend\": {
+          \"defaultBackend\": \"kibana-backend\"
+        },
+        \"protocol\": \"HTTP\"
+      }
+    ],
+    \"backends\": [
+      {
+        \"name\": \"kibana-backend\",
+        \"protocol\": \"HTTP\",
+        \"rewriteHttp\": {
+          \"path\": {
+            \"fromPath\": \"${kibana_service_path}\",
+            \"toPath\": \"/\"
+          }
+        },
+        \"services\": [
+          {
+            \"marathon\": {
+              \"serviceID\": \"${kibana_service_name}\"
+            },
+            \"endpoint\": {
+              \"portName\": \"${kibana_port_name}\"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}"
+```
+
+Which will end up looking like:
+
+`kibana_pool.json`
+```json
+{
+  "apiVersion": "V2",
+  "role": "slave_public",
+  "name": "kibana",
+  "count": 1,
+  "haproxy": {
+    "stats": {
+      "bindPort": 9090
+    },
+    "frontends": [
+      {
+        "bindPort": 80,
+        "linkBackend": {
+          "defaultBackend": "kibana-backend"
+        },
+        "protocol": "HTTP"
+      }
+    ],
+    "backends": [
+      {
+        "name": "kibana-backend",
+        "protocol": "HTTP",
+        "rewriteHttp": {
+          "path": {
+            "fromPath": "/service//production/kibana",
+            "toPath": "/"
+          }
+        },
+        "services": [
+          {
+            "marathon": {
+              "serviceID": "/production/kibana"
+            },
+            "endpoint": {
+              "portName": "kibana"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Now you can install the Kibana EdgeLB pool with:
+
+```bash
+dcos edgelb create kibana_pool.json
+```
+
+Again, installation will take a moment. If `TASK_RUNNING` appears in
+the output of the following command it means that the pool is up and
+running.
+
+```bash
+dcos edgelb status kibana
+```
+
+At this point, Kibana should already be accessible through
+http://$public_agent_ip_or_url:80.
+
+## 3. Accessing Kibana
+
+If you only have one public agent and you know its IP address, it
+should be easy to access Kibana. If not, there's a few commands that
+might help you out.
+
+### Get IP address of public agent running Kibana pool
+
+This step requires that you have SSH access to the DC/OS cluster
+nodes. Make sure you do before proceding.
+
+Here we're using the `kibana` pool name in the `dcos edgelb status`
+command. If you named the pool something else make sure to use it
+instead.
+
+```bash
+agent_private_ip="$(dcos edgelb status kibana --json | jq -r '.[0].status.containerStatus.networkInfos[0].ipAddresses[0].ipAddress')"
+agent_public_ip="$(dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --private-ip="${agent_private_ip}" "curl -s ifconfig.co")"
+```
+### Authenticate with Kibana
+
+Now that we have the public agent IP address where the EdgeLB Kibana
+pool task is running we should be able to access Kibana.
+
+If Kibana has X-Pack Security enabled you'll first need access
+http://$public_agent_ip_or_address/login to authenticate with the
+Kibana server. Use credentials that are stored in your Elasticsearch
+cluster.
+
+```bash
+kibana_url="http://${agent_public_ip}"
+```
+
+```bash
+kibana_login_url="${kibana_url}/login"
+```
+
+```bash
+command -v xdg-open && xdg-open "${kibana_login_url}" || open "${kibana_login_url}"
+```
+
+*After authenticating*, or if Kibana doesn't have X-Pack Security
+enabled, Kibana should be available at
+http://$public_agent_ip_or_url/service/kibana/app/kibana.
+
+```bash
+kibana_authenticated_url="${kibana_url}/service/${kibana_service_name}/app/kibana"
+```
+
+```bash
+command -v xdg-open && xdg-open "${kibana_authenticated_url}" || open "${kibana_authenticated_url}"
+```

--- a/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
@@ -68,7 +68,7 @@ port on the agent machine is open.
 
 In this example we'll expose a Kibana service named
 `/production/kibana` through HTTP, on port `80`. It will be accessible
-on http://$public_agent_ip_or_url:80.
+on `http://$public_agent_ip_or_url:80`.
 
 Note that in this example:
 - the EdgeLB pool that will be created is named `kibana`
@@ -206,7 +206,7 @@ dcos edgelb status kibana
 ```
 
 At this point, Kibana should already be accessible through
-http://$public_agent_ip_or_url:80.
+`http://$public_agent_ip_or_url:80`.
 
 ## 3. Accessing Kibana
 
@@ -233,7 +233,7 @@ Now that we have the public agent IP address where the EdgeLB Kibana
 pool task is running we should be able to access Kibana.
 
 If Kibana has X-Pack Security enabled you'll first need access
-http://$public_agent_ip_or_address/login to authenticate with the
+`http://$public_agent_ip_or_address/login` to authenticate with the
 Kibana server. Use credentials that are stored in your Elasticsearch
 cluster.
 
@@ -251,7 +251,7 @@ command -v xdg-open && xdg-open "${kibana_login_url}" || open "${kibana_login_ur
 
 *After authenticating*, or if Kibana doesn't have X-Pack Security
 enabled, Kibana should be available at
-http://$public_agent_ip_or_url/service/kibana/app/kibana.
+`http://$public_agent_ip_or_url/service/kibana/app/kibana`.
 
 ```bash
 kibana_authenticated_url="${kibana_url}/service/${kibana_service_name}/app/kibana"

--- a/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
@@ -29,12 +29,7 @@ edgelb-pool  v1.3.0   True      True       EdgeLB Pool on DC/OS
 
 If it does, you can skip the `dcos package repo add` commands below.
 
-*Otherwise*, if you see a `No packages found` message you'll need to
-add a couple of package repositories to your cluster. These are for
-EdgeLB version 1.3.0, which is the latest at the time of writing. Take
-a look at the [EdgeLB service
-documentation](https://docs.mesosphere.com/services/edge-lb/) to check
-if that's the latest version.
+*Otherwise*, if you see a `No packages found` message you'll need to add a couple of package repositories to your cluster. These are for EdgeLB version 1.3.0, which is the latest at the time of writing. Take a look at the [EdgeLB service documentation](https://docs.mesosphere.com/services/edge-lb/) to check if that's the latest version.
 
 ```bash
 dcos package repo add edgelb https://downloads.mesosphere.com/edgelb/v1.3.0/assets/stub-universe-edgelb.json
@@ -47,11 +42,9 @@ Now install EdgeLB with:
 dcos package install edgelb
 ```
 
-For more details please check out the [EdgeLB installation
-instructions](https://docs.mesosphere.com/services/edge-lb/1.3/installing/).
+For more details please check out the [EdgeLB installation instructions](https://docs.mesosphere.com/services/edge-lb/1.3/installing/).
 
-The installation will take a moment. The following command can be
-used to determine if EdgeLB is up and running:
+The installation will take a moment. The following command can be used to determine if EdgeLB is up and running:
 
 ```bash
 dcos edgelb --name edgelb ping
@@ -61,35 +54,22 @@ An output of `pong` means that it's ready.
 
 ## 2. Create an EdgeLB pool for Kibana
 
-The following command will create an EdgeLB pool task running on one
-of your DC/OS cluster's public agents, which will allow Kibana to be
-accessed from outside the cluster network, given that the selected
-port on the agent machine is open.
+The following command will create an EdgeLB pool task running on one of your DC/OS cluster's public agents, which will allow Kibana to be accessed from outside the cluster network, given that the selected port on the agent machine is open.
 
-In this example we'll expose a Kibana service named
-`/production/kibana` through HTTP, on port `80`. It will be accessible
-on `http://$public_agent_ip_or_url:80`.
+In this example we'll expose a Kibana service named `/production/kibana` through HTTP, on port `80`. It will be accessible on `http://$public_agent_ip_or_url:80`.
 
 Note that in this example:
 - the EdgeLB pool that will be created is named `kibana`
 - its backend name is `kibana-backend`
 
-It is not a requirement that these match any configuration options
-related to the actual Kibana service, so one could name them
-differently.
+It is not a requirement that these match any configuration options related to the actual Kibana service, so one could name them differently.
 
-The pool fields that actually map to the actual Kibana service are
-under `haproxy.backends`:
-- `rewriteHttp.path.fromPath` should match the Kibana Marathon app
-service path
-- `services.endpoint.portName` should match the Kibana Marathon app
-port name
+The pool fields that actually map to the actual Kibana service are under `haproxy.backends`:
+- `rewriteHttp.path.fromPath` should match the Kibana Marathon app service path
+- `services.endpoint.portName` should match the Kibana Marathon app port name
 - `services.marathon.serviceID` should match the Kibana service name
 
-Let's get the remaining configuration parameters that will map the
-EdgeLB pool to the actual Kibana service. We'll use them in the pool
-configuration. Make sure to use a different name or port based on your
-needs.
+Let's get the remaining configuration parameters that will map the EdgeLB pool to the actual Kibana service. We'll use them in the pool configuration. Make sure to use a different name or port based on your needs.
 
 ```bash
 kibana_service_name="/production/kibana"
@@ -197,31 +177,23 @@ Now you can install the Kibana EdgeLB pool with:
 dcos edgelb create kibana_pool.json
 ```
 
-Again, installation will take a moment. If `TASK_RUNNING` appears in
-the output of the following command it means that the pool is up and
-running.
+Again, installation will take a moment. If `TASK_RUNNING` appears in the output of the following command it means that the pool is up and running.
 
 ```bash
 dcos edgelb status kibana
 ```
 
-At this point, Kibana should already be accessible through
-`http://$public_agent_ip_or_url:80`.
+At this point, Kibana should already be accessible through `http://$public_agent_ip_or_url:80`.
 
 ## 3. Accessing Kibana
 
-If you only have one public agent and you know its IP address, it
-should be easy to access Kibana. If not, there's a few commands that
-might help you out.
+If you only have one public agent and you know its IP address, it should be easy to access Kibana. If not, there's a few commands that might help you out.
 
 ### Get IP address of public agent running Kibana pool
 
-This step requires that you have SSH access to the DC/OS cluster
-nodes. Make sure you do before proceding.
+This step requires that you have SSH access to the DC/OS cluster nodes. Make sure you do before proceding.
 
-Here we're using the `kibana` pool name in the `dcos edgelb status`
-command. If you named the pool something else make sure to use it
-instead.
+Here we're using the `kibana` pool name in the `dcos edgelb status` command. If you named the pool something else make sure to use it instead.
 
 ```bash
 agent_private_ip="$(dcos edgelb status kibana --json | jq -r '.[0].status.containerStatus.networkInfos[0].ipAddresses[0].ipAddress')"
@@ -229,13 +201,9 @@ agent_public_ip="$(dcos node ssh --option StrictHostKeyChecking=no --option LogL
 ```
 ### Authenticate with Kibana
 
-Now that we have the public agent IP address where the EdgeLB Kibana
-pool task is running we should be able to access Kibana.
+Now that we have the public agent IP address where the EdgeLB Kibana pool task is running we should be able to access Kibana.
 
-If Kibana has X-Pack Security enabled you'll first need access
-`http://$public_agent_ip_or_address/login` to authenticate with the
-Kibana server. Use credentials that are stored in your Elasticsearch
-cluster.
+If Kibana has X-Pack Security enabled you'll first need access `http://$public_agent_ip_or_address/login` to authenticate with the Kibana server. Use credentials that are stored in your Elasticsearch cluster.
 
 ```bash
 kibana_url="http://${agent_public_ip}"
@@ -249,9 +217,7 @@ kibana_login_url="${kibana_url}/login"
 command -v xdg-open && xdg-open "${kibana_login_url}" || open "${kibana_login_url}"
 ```
 
-*After authenticating*, or if Kibana doesn't have X-Pack Security
-enabled, Kibana should be available at
-`http://$public_agent_ip_or_url/service/kibana/app/kibana`.
+*After authenticating*, or if Kibana doesn't have X-Pack Security enabled, Kibana should be available at `http://$public_agent_ip_or_url/service/kibana/app/kibana`.
 
 ```bash
 kibana_authenticated_url="${kibana_url}/service/${kibana_service_name}/app/kibana"

--- a/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md
@@ -140,7 +140,7 @@ echo "{
       }
     ]
   }
-}"
+}" > kibana_pool.json
 ```
 
 Which will end up looking like:

--- a/pages/services/elastic/2.5.0-6.3.2/limitations/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/limitations/index.md
@@ -28,7 +28,7 @@ Upgrades and rolling configuration updates do not wait for a cluster green healt
 
 ## Security
 
-Elasticsearch's native authentication and authorization mechanisms are not *officially* supported at this time.
+Elasticsearch's built-in authentication mechanisms ([realms](https://www.elastic.co/guide/en/elastic-stack-overview/6.6/setting-up-authentication.html)) cannot currently be configured through service configuration options (e.g. on package installs or service updates). However, since the [native](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/configuring-native-realm.html) realm is enabled by default by Elasticsearch it's possible to configure it through the [security APIs](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/security-api.html). These APIs include both authentication and authorization mechanisms.
 
 ### Transport Encryption
 

--- a/pages/services/elastic/2.5.0-6.3.2/limitations/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/limitations/index.md
@@ -12,6 +12,12 @@ render: mustache
 
 Elasticsearch provides two ways of updating settings: persistent (through `elasticsearch.yml` file) and transient (through [Elasticsearch Cluster Update Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html)). The service's Configuration Options are carried over to the tasks' `elasticsearch.yml` file automatically. Out-of-band configuration changes (either via Elasticsearch's Cluster Update Settings API or externally modifying `elasticsearch.yml` files) will not persist in case of a restart, failure recovery, or upgrade.
 
+## Kibana configured with X-Pack Security enabled
+
+If Kibana is configured with `kibana.elasticsearch_xpack_security_enabled` set to `true` the default DC/OS service link (`https://<cluster-url>/service/<kibana-service-name>`) will not work. This is due to a change in how Kibana deals with `Authorization` HTTP headers starting in version 6.3.
+
+As a workaround, you should be able to expose Kibana using [EdgeLB](https://docs.mesosphere.com/services/edge-lb/) by following the following how-to: [Expose Kibana using EdgeLB](/services/elastic/2.5.0-6.3.2/how-to-guides#expose-kibana-using-edgelb).
+
 #include /services/include/limitations.tmpl
 #include /services/include/limitations-zones.tmpl
 #include /services/include/limitations-regions.tmpl
@@ -27,26 +33,3 @@ Elasticsearch's native authentication and authorization mechanisms are not *offi
 ### Transport Encryption
 
 Toggling Transport Encryption requires doing a full-cluster restart. This is an [Elasticsearch limitation](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-tls.html). The service's default update strategy is a rolling upgrade (`serial`). If you change its configuration to enable or disable transport encryption, nodes that have been configured with TLS will be unable to communicate with nodes configured with unencrypted networking, and vice-versa. A full-cluster restart is required, using the `parallel` update strategy. Make sure you have backups, and plan for some downtime. Afterwards, you should set the update strategy back to `serial` for future updates.
-
-## Kibana configured with X-Pack Security enabled
-
-Currently, the default service link for Kibana 6.3.2 does not work. For now, you can expose the Kibana web server with a Marathon app:
-
-```json
-{
-  "id": "/kibana-passthrough",
-  "cmd": "tail -f /dev/null",
-  "instances": 1,
-  "cpus": 0.01,
-  "mem": 16,
-  "container": {
-    "type": "MESOS"
-  },
-  "labels": {
-    "HAPROXY_GROUP": "external",
-    "HAPROXY_0_MODE": "http",
-    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  reqirep \"^([^ :]*)\\ /service/kibana/[/]?(.*)\" \"\\1\\ /\\2\" \n  server kibana web.kibana.marathon.l4lb.thisdcos.directory:80",
-    "HAPROXY_0_PORT": "5061"
-  }
-}
-```

--- a/pages/services/elastic/2.5.0-6.3.2/limitations/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/limitations/index.md
@@ -10,7 +10,7 @@ render: mustache
 
 ## Configuration via elasticsearch.yml and/or Elastic APIs
 
-Elasticsearch provides two ways of updating settings: persistent (through `elasticsearch.yml` file) and transient (through Elastic Settings Update API). The service's Configuration Options are carried over to the tasks' `elasticsearch.yml` file automatically. Out-of-band configuration changes (either via Elasticsearch's Update API or externally modifying `elasticsearch.yml` files) will not persist in case of a restart, failure recovery, or upgrade.
+Elasticsearch provides two ways of updating settings: persistent (through `elasticsearch.yml` file) and transient (through [Elasticsearch Cluster Update Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html)). The service's Configuration Options are carried over to the tasks' `elasticsearch.yml` file automatically. Out-of-band configuration changes (either via Elasticsearch's Cluster Update Settings API or externally modifying `elasticsearch.yml` files) will not persist in case of a restart, failure recovery, or upgrade.
 
 #include /services/include/limitations.tmpl
 #include /services/include/limitations-zones.tmpl
@@ -18,11 +18,11 @@ Elasticsearch provides two ways of updating settings: persistent (through `elast
 
 ## Upgrades and configuration updates
 
-Upgrades and rolling configuration updates do not wait for a green status. During deployment and upgrades, the `serial` strategy does not wait for the Elastic service to reach green before proceeding to the next node.
+Upgrades and rolling configuration updates do not wait for a cluster green health status. During deployment and upgrades, the `serial` strategy does not wait for the Elasticsearch cluster to reach green health before proceeding to the next node.
 
 ## Security
 
-Elastic's native authentication and authorization mechanisms are not supported at this time.
+Elasticsearch's native authentication and authorization mechanisms are not *officially* supported at this time.
 
 ### Transport Encryption
 


### PR DESCRIPTION
This PR is related to [DCOS-47356: Expose Kibana 6.3.2 without Adminrouter](https://jira.mesosphere.com/browse/DCOS-47356).

In addition to doing some general documentation improvements (https://github.com/mesosphere/dcos-docs-site/pull/2054/commits/64e7c7ec929041a5b4215e9dd56cc3dd1d305fba), a new major section named "How-To Guides" was added, with an initial entry for exposing Kibana using EdgeLB ([link](https://github.com/mesosphere/dcos-docs-site/blob/expose-kibana-with-edgelb/pages/services/elastic/2.5.0-6.3.2/how-to-guides/index.md)).

## Urgency
- [X] Blocker
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).