### PR TITLE
universal installer: pinning azure api version

### DIFF
--- a/pages/1.10/installing/evaluation/azure/index.md
+++ b/pages/1.10/installing/evaluation/azure/index.md
@@ -158,9 +158,13 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
       url = "http://whatismyip.akamai.com/"
     }
 
+    provider "azurerm" {
+      version = "~> 1.16.0"
+    }
+
     module "dcos" {
       source  = "dcos-terraform/dcos/azurerm"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       dcos_instance_os    = "coreos_1855.5.0"
       cluster_name        = "my-dcos"
@@ -177,6 +181,10 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
       # dcos_variant              = "ee"
       # dcos_license_key_contents = "${file("./license.txt")}"
       dcos_variant = "open"
+
+      providers = {
+        azurerm = "azurerm"
+      }
 
       dcos_install_mode = "${var.dcos_install_mode}"
     }

--- a/pages/1.11/installing/evaluation/azure/index.md
+++ b/pages/1.11/installing/evaluation/azure/index.md
@@ -158,9 +158,13 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
       url = "http://whatismyip.akamai.com/"
     }
 
+    provider "azurerm" {
+      version = "~> 1.16.0"
+    }
+
     module "dcos" {
       source  = "dcos-terraform/dcos/azurerm"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       dcos_instance_os    = "coreos_1855.5.0"
       cluster_name        = "my-dcos"
@@ -177,6 +181,10 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
       # dcos_variant              = "ee"
       # dcos_license_key_contents = "${file("./license.txt")}"
       dcos_variant = "open"
+
+      providers = {
+        azurerm = "azurerm"
+      }
 
       dcos_install_mode = "${var.dcos_install_mode}"
     }

--- a/pages/1.12/installing/evaluation/azure/index.md
+++ b/pages/1.12/installing/evaluation/azure/index.md
@@ -158,9 +158,13 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
       url = "http://whatismyip.akamai.com/"
     }
 
+    provider "azurerm" {
+      version = "~> 1.16.0"
+    }
+
     module "dcos" {
       source  = "dcos-terraform/dcos/azurerm"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       dcos_instance_os    = "coreos_1855.5.0"
       cluster_name        = "my-dcos"
@@ -177,6 +181,10 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
       # dcos_variant              = "ee"
       # dcos_license_key_contents = "${file("./license.txt")}"
       dcos_variant = "open"
+
+      providers = {
+        azurerm = "azurerm"
+      }
 
       dcos_install_mode = "${var.dcos_install_mode}"
     }


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49976

This is to help pin the known working version of the Azure Provider backend with the version of the universal installer. This has been tested and confirmed to work against the latest supported version of the Azure provider before the warning message occur.

<!-- Link to JIRA issue -->

- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [X] High
- [ ] Medium

- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).