### PR TITLE
var: updating dcos_exhibitor_storage_backend desc

### DIFF
--- a/pages/1.10/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.10/installing/evaluation/aws/aws-advanced/index.md
@@ -175,7 +175,7 @@ dcos_instance_os = "centos_7.5"
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (Not recommended but required with `exhibitor_storage_backend` set to `zookeeper `. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data (not recommended but required with exhibitor_storage_backend set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.10/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.10/installing/evaluation/azure/advanced-azure/index.md
@@ -169,7 +169,7 @@ dcos_instance_os = "centos_7.5"
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper`. (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper`. (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.10/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/advanced-gcp/index.md
@@ -169,7 +169,7 @@ dcos_instance_os = "centos_7.5"
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.12/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.12/installing/evaluation/aws/aws-advanced/index.md
@@ -176,7 +176,7 @@ dcos_instance_os = "centos_7.5"
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (Not recommended but required with `exhibitor_storage_backend` set to `zookeeper `. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data (not recommended but required with exhibitor_storage_backend set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.12/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.12/installing/evaluation/azure/advanced-azure/index.md
@@ -171,7 +171,7 @@ Here is a list of all the variables that are currently supported on the Universa
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper`. (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper`. (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.12/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/advanced-gcp/index.md
@@ -169,7 +169,7 @@ dcos_instance_os = "centos_7.5"
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
@@ -176,7 +176,7 @@ dcos_instance_os = "centos_7.5"
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (Not recommended but required with `exhibitor_storage_backend` set to `zookeeper `. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data (not recommended but required with exhibitor_storage_backend set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.13/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.13/installing/evaluation/azure/advanced-azure/index.md
@@ -171,7 +171,7 @@ Here is a list of all the variables that are currently supported on the Universa
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper`. (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper`. (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |

--- a/pages/1.13/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.13/installing/evaluation/gcp/advanced-gcp/index.md
@@ -169,7 +169,7 @@ dcos_instance_os = "centos_7.5"
 | dcos_exhibitor_azure_account_name | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_azure_prefix | The Azure account name for Exhibitor storage. (optional but required with `dcos_exhibitor_address`) | string | `` | no |
 | dcos_exhibitor_explicit_keys | Set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | Options are `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | Options are `static`, `aws_s3`, `azure`, or `zookeeper` (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | A comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | The filepath that Exhibitor uses to store data. (not recommended but required with `exhibitor_storage_backend` set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] Fault domain script contents. Optional but required if no `fault-domain-detect` script present. | string | `` | no |


### PR DESCRIPTION
The description was missing the static option for the dcos_exhibitor_storage_backend variable. This commit fixes this across the repositories.

Related to these links below:
https://github.com/dcos-terraform/terraform-aws-dcos/pull/49
https://github.com/dcos-terraform/terraform-aws-remote-region/pull/5
https://github.com/dcos-terraform/terraform-azurerm-dcos/pull/18
https://github.com/dcos-terraform/terraform-gcp-dcos/pull/23
https://github.com/dcos-terraform/terraform-null-dcos-install-bootstrap-remote-exec/pull/5
https://github.com/dcos-terraform/terraform-null-dcos-install-remote-exec/pull/5
https://github.com/dcos-terraform/terraform-template-dcos-core/pull/4


<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS-47936

- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X] Medium

- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).