### PR TITLE
Added note about disabling custom options in task log handling.

### DIFF
--- a/pages/1.12/monitoring/logging/configure-task-logs/index.md
+++ b/pages/1.12/monitoring/logging/configure-task-logs/index.md
@@ -70,6 +70,12 @@ value (for example, 2^64 TB) will lead to undetermined results.</p>
 
 ## Logrotate Options
 
+<p class="message--important"><strong>IMPORTANT: </strong>
+As of DC/OS 1.12.4, these custom options are disabled to prevent abuse
+of <code>postrotate</code> clauses and other injection attacks.
+See <a href="https://issues.apache.org/jira/browse/MESOS-9564">MESOS-9564</a>
+for more information.</p>
+
 The `CONTAINER_LOGGER_LOGROTATE_STDOUT_OPTIONS` and
 `CONTAINER_LOGGER_LOGROTATE_STDERR_OPTIONS` options control the parameters
 passed to `logrotate` for each rotation.  There are no restrictions on

--- a/pages/1.13/monitoring/logging/configure-task-logs/index.md
+++ b/pages/1.13/monitoring/logging/configure-task-logs/index.md
@@ -70,6 +70,12 @@ value (for example, 2^64 TB) will lead to undetermined results.</p>
 
 ## Logrotate Options
 
+<p class="message--important"><strong>IMPORTANT: </strong>
+As of DC/OS 1.13.0, these custom options are disabled to prevent abuse
+of <code>postrotate</code> clauses and other injection attacks.
+See <a href="https://issues.apache.org/jira/browse/MESOS-9564">MESOS-9564</a>
+for more information.</p>
+
 The `CONTAINER_LOGGER_LOGROTATE_STDOUT_OPTIONS` and
 `CONTAINER_LOGGER_LOGROTATE_STDERR_OPTIONS` options control the parameters
 passed to `logrotate` for each rotation.  There are no restrictions on


### PR DESCRIPTION
## Description
[DCOS-47733](https://jira.mesosphere.com/browse/DCOS-47733)

This documents that two options will have no effect starting in 1.12.4 and 1.13.0, because of security concerns.

This change lands in the following PRs:
1.13) https://github.com/dcos/dcos/pull/4892
1.12) https://github.com/dcos/dcos/pull/4893

DOCS TICKET: https://jira.mesosphere.com/browse/DCOS-55727

## Urgency
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- [x] Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
