### PR TITLE
correct the regular expression of task name pattern

### DIFF
--- a/pages/cn/services/edge-lb/1.1/pool-configuration/v2-examples/index.md
+++ b/pages/cn/services/edge-lb/1.1/pool-configuration/v2-examples/index.md
@@ -237,7 +237,7 @@ DC/OS 服务通常作为 Marathon 框架上的应用程序运行。要为 Marath
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",
-          "taskNamePattern": "^broker-*$"
+          "taskNamePattern": "^broker-.*$"
         },
         "endpoint": {
           "port": 1025

--- a/pages/services/edge-lb/1.0/pool-configuration/v2-examples/index.md
+++ b/pages/services/edge-lb/1.0/pool-configuration/v2-examples/index.md
@@ -239,7 +239,7 @@ For Mesos frameworks and DC/OS services that run tasks which are not managed by 
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",
-          "taskNamePattern": "^broker-*$"
+          "taskNamePattern": "^broker-.*$"
         },
         "endpoint": {
           "port": 1025

--- a/pages/services/edge-lb/1.1/pool-configuration/v2-examples/index.md
+++ b/pages/services/edge-lb/1.1/pool-configuration/v2-examples/index.md
@@ -239,7 +239,7 @@ For Mesos frameworks and DC/OS services that run tasks which are not managed by 
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",
-          "taskNamePattern": "^broker-*$"
+          "taskNamePattern": "^broker-.*$"
         },
         "endpoint": {
           "port": 1025

--- a/pages/services/edge-lb/1.2/pool-configuration/v2-examples/index.md
+++ b/pages/services/edge-lb/1.2/pool-configuration/v2-examples/index.md
@@ -239,7 +239,7 @@ For Mesos frameworks and DC/OS services that run tasks which are not managed by 
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",
-          "taskNamePattern": "^broker-*$"
+          "taskNamePattern": "^broker-.*$"
         },
         "endpoint": {
           "port": 1025

--- a/pages/services/edge-lb/1.3/pool-configuration/v2-examples/index.md
+++ b/pages/services/edge-lb/1.3/pool-configuration/v2-examples/index.md
@@ -239,7 +239,7 @@ For Mesos frameworks and DC/OS services that run tasks which are not managed by 
       "services": [{
         "mesos": {
           "frameworkName": "beta-confluent-kafka",
-          "taskNamePattern": "^broker-*$"
+          "taskNamePattern": "^broker-.*$"
         },
         "endpoint": {
           "port": 1025


### PR DESCRIPTION
## Description
Regular expression used to identify a task name `"^broker-*$"` shown in an example does not reache the original goal to match the task starting with `broker-` and ending with combination of any letters.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
