### PR TITLE
Node Image change from dep'd Jessie to LTS Stretch

### DIFF
--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -2,7 +2,7 @@
 # Build MS
 #
 
-FROM node:8.1.2-slim as ms-builder
+FROM node:8-stretch-slim as ms-builder
 
 ARG git_branch
 ARG algolia_update


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-50839

Docs site build fail due to deprecated image resources of our node image.
Upgraded to Debian Stretch and now up from Node 8.1.2 to Node 8.15.
Ran test build on docs-christina, server functions as expected, patching staging

## Urgency
- [ x] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
