### PR TITLE
1.11, 1.12, and 1,13 feature maturity page: Fixed incorrect representation of GA to Retired

### DIFF
--- a/pages/1.11/overview/feature-maturity/index.md
+++ b/pages/1.11/overview/feature-maturity/index.md
@@ -58,7 +58,7 @@ A deprecated feature is a feature for which Mesosphere no longer provides enhanc
 <a name="retired"></a>
 ## Retired
 
-A retired feature is one that has reached the end of its maturity lifecycle within Mesosphere DC/OS but is still part of the product.  Customers using a retired feature are strongly urged to migrate away from the retired feature and instead employ a GA feature, as GA is the last state in the Mesosphere DC/OS lifecycle in which the feature is still present.
+A retired feature is one that has reached the end of its maturity lifecycle within Mesosphere DC/OS but is still part of the product. Customers using a retired feature are strongly urged to migrate away from the retired feature and instead employ a GA feature, as retired is the last state in the Mesosphere DC/OS lifecycle in which the feature is still present.
 
 1. Enhancements to the feature should not be expected.
 2. Bugs or defects should not be expected to be fixed.

--- a/pages/1.12/overview/feature-maturity/index.md
+++ b/pages/1.12/overview/feature-maturity/index.md
@@ -58,7 +58,7 @@ A deprecated feature is a feature for which Mesosphere no longer provides enhanc
 <a name="retired"></a>
 ## Retired
 
-A retired feature is one that has reached the end of its maturity lifecycle within Mesosphere DC/OS but is still part of the product.  Customers using a retired feature are strongly urged to migrate away from the retired feature and instead employ a GA feature, as GA is the last state in the Mesosphere DC/OS lifecycle in which the feature is still present.
+A retired feature is one that has reached the end of its maturity lifecycle within Mesosphere DC/OS but is still part of the product. Customers using a retired feature are strongly urged to migrate away from the retired feature and instead employ a GA feature, as retired is the last state in the Mesosphere DC/OS lifecycle in which the feature is still present.
 
 1. Enhancements to the feature should not be expected.
 2. Bugs or defects should not be expected to be fixed.

--- a/pages/1.13/overview/feature-maturity/index.md
+++ b/pages/1.13/overview/feature-maturity/index.md
@@ -58,7 +58,7 @@ A deprecated feature is a feature for which Mesosphere no longer provides enhanc
 <a name="retired"></a>
 ## Retired
 
-A retired feature is one that has reached the end of its maturity lifecycle within Mesosphere DC/OS but is still part of the product.  Customers using a retired feature are strongly urged to migrate away from the retired feature and instead employ a GA feature, as GA is the last state in the Mesosphere DC/OS lifecycle in which the feature is still present.
+A retired feature is one that has reached the end of its maturity lifecycle within Mesosphere DC/OS but is still part of the product. Customers using a retired feature are strongly urged to migrate away from the retired feature and instead employ a GA feature, as retired is the last state in the Mesosphere DC/OS lifecycle in which the feature is still present.
 
 1. Enhancements to the feature should not be expected.
 2. Bugs or defects should not be expected to be fixed.


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-51013

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
