### PR TITLE
ss/DCOS_OSS-3598 Changed apps to app in all versions from 1.10 forward.

### DIFF
--- a/pages/1.10/api/marathon.yaml
+++ b/pages/1.10/api/marathon.yaml
@@ -394,7 +394,7 @@ paths:
           examples:
             text/plain: >
               {
-                "apps": [
+                "app": [
                   {
                     "id": "/myapp",
                     "cmd": "env && sleep 60",

--- a/pages/1.11/api/marathon.yaml
+++ b/pages/1.11/api/marathon.yaml
@@ -394,7 +394,7 @@ paths:
           examples:
             text/plain: >
               {
-                "apps": [
+                "app": [
                   {
                     "id": "/myapp",
                     "cmd": "env && sleep 60",

--- a/pages/1.12/api/marathon.yaml
+++ b/pages/1.12/api/marathon.yaml
@@ -394,7 +394,7 @@ paths:
           examples:
             text/plain: >
               {
-                "apps": [
+                "app": [
                   {
                     "id": "/myapp",
                     "cmd": "env && sleep 60",

--- a/pages/1.13/api/marathon.yaml
+++ b/pages/1.13/api/marathon.yaml
@@ -394,7 +394,7 @@ paths:
           examples:
             text/plain: >
               {
-                "apps": [
+                "app": [
                   {
                     "id": "/myapp",
                     "cmd": "env && sleep 60",


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS_OSS-3598

It is suggested that this endpoint can return multiple apps, though it returns only one app for the given ID. The JSON example given is wrong and starts with

```
{
  "apps": [
```
But there should be just app, not apps.


## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Changed in following versions:

- [x] 1.10
- [x] 1.11
- [x] 1.12
- [x] 1.13