### PR TITLE
ss/DCOS-44364 Editing link to monitoring and logging.

### DIFF
--- a/pages/services/spark/2.3.1-2.2.1-2/quickstart/index.md
+++ b/pages/services/spark/2.3.1-2.2.1-2/quickstart/index.md
@@ -161,5 +161,5 @@ Figure 1. Services tab showing Spark
 ## Next Steps
 
 - To view the status of your job, run the `dcos spark webui` command and then visit the Spark cluster dispatcher UI at `http://<dcos-url>/service/spark/` .
-- To view the logs, the Mesos UI at `http://<your-master-ip>/mesos`.
+- To view the logs, see the documentation for [Mesosphere DC/OS monitoring](https://docs.mesosphere.com/1.12/monitoring/logging/).
 - To view details about your Spark job, run the `dcos task log --completed <submissionId>` command.

--- a/pages/services/spark/2.4.0-2.2.1-3/quickstart/index.md
+++ b/pages/services/spark/2.4.0-2.2.1-3/quickstart/index.md
@@ -150,5 +150,5 @@ This introduction will get you up and running in minutes with {{ model.techShort
 ## Next Steps
 
 - To view the status of your job, run the `dcos spark webui` command and then visit the {{ model.techShortName }} cluster dispatcher UI at `http://<dcos-url>/service/spark/` .
-- To view the logs, the Mesos UI at `http://<your-master-ip>/mesos`.
+- To view the logs, see the documentation for [Mesosphere DC/OS monitoring](https://docs.mesosphere.com/1.12/monitoring/logging/).
 - To view details about your {{ model.techShortName }} job, run the `dcos task log --completed <submissionId>` command.

--- a/pages/services/spark/2.5.0-2.2.1/quickstart/index.md
+++ b/pages/services/spark/2.5.0-2.2.1/quickstart/index.md
@@ -148,5 +148,5 @@ This introduction will get you up and running in minutes with {{ model.techShort
 ## Next steps
 
 - To view the status of your job, run the `dcos spark webui` command then visit the {{ model.techShortName }} cluster dispatcher UI at `http://<dcos-url>/service/spark/` .
-- To view the logs using the Mesos UI, see `http://<your-master-ip>/mesos`.
+- To view the logs, see the documentation for [Mesosphere DC/OS monitoring](https://docs.mesosphere.com/1.12/monitoring/logging/).
 - To view details about your {{ model.techShortName }} job, run the `dcos task log --completed <submissionId>` command.

--- a/pages/services/spark/2.6.0-2.3.2/quickstart/index.md
+++ b/pages/services/spark/2.6.0-2.3.2/quickstart/index.md
@@ -148,5 +148,5 @@ You can view the example source [here](https://downloads.mesosphere.com/spark/as
 ## Next steps
 
 - To view the status of your job, run the `dcos spark webui` command then visit the {{ model.techShortName }} cluster dispatcher UI at `http://<dcos-url>/service/spark/` .
-- To view the logs using the Mesos UI, see `http://<your-master-ip>/mesos`.
+- To view the logs, see the documentation for [Mesosphere DC/OS monitoring](https://docs.mesosphere.com/1.12/monitoring/logging/).
 - To view details about your {{ model.techShortName }} job, run the `dcos task log --completed <submissionId>` command.

--- a/pages/services/spark/2.7.0-2.4.0/quickstart/index.md
+++ b/pages/services/spark/2.7.0-2.4.0/quickstart/index.md
@@ -16,11 +16,11 @@ This page explains how to install the DC/OS {{ model.techName }} service.
 * [DC/OS and DC/OS CLI installed](/1.12/installing/) with a minimum of {{ model.install.nodeDescription }}
 * Depending on your [security mode](/1.12/security/ent/), {{ model.techShortName }} requires service authentication for access to DC/OS. See [Provisioning a service account](/services/spark/2.7.0-2.4.0/security/#provision-a-service-account) for more information.
 
-| Security mode  | Service account  |
-|---------------|-----------------|
-| Disabled      | Not available   |
-| Permissive    | Optional   |
-| Strict        | Required |
+    | Security mode  | Service account  |
+    |---------------|-----------------|
+    | Disabled      | Not available   |
+    | Permissive    | Optional   |
+    | Strict        | Required |
 
 1. Install the {{ model.techShortName }} package. This may take a few minutes. This step installs the {{ model.techShortName }} DC/OS service, {{ model.techShortName }} CLI, dispatcher, and, optionally, the history server. See the [History Server](/services/spark/2.7.0-2.4.0/history-server/#installing-hdfs) section for information about how to install the history server.
 
@@ -145,5 +145,5 @@ This page explains how to install the DC/OS {{ model.techName }} service.
 ## Next steps
 
 - To view the status of your job, run the `dcos spark webui` command then visit the {{ model.techShortName }} cluster dispatcher UI at `http://<dcos-url>/service/spark/` .
-- To view the logs using the Mesos UI, see `http://<your-master-ip>/mesos`.
+- To view the logs, see the documentation for [Mesosphere DC/OS monitoring](https://docs.mesosphere.com/1.12/monitoring/logging/).
 - To view details about your {{ model.techShortName }} job, run the `dcos task log --completed <submissionId>` command.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-44364

In this tutorial for Spark:
https://docs.mesosphere.com/services/spark/2.3.1-2.2.1-2/quickstart/

At the bottom we state:
To view the logs, the Mesos UI at http://<your-master-ip>/mesos

But that's obsolete. We should give directions of how to get the logs from the DC/OS ui, unless there's something in the mesos logs that are missing (I'm not aware of this). We need to have somebody on the data services team review this and verify that we can and should remove the mesos gui from the tutorials.

We also need to check other tutorials and see if they are referencing the mesos logs.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium
- [x] Low


Corrected link to monitoring in versions 2.3.0 onward. I did not search for other references to Mesos logs; that job is large enough to require another JIRA ticket.