### PR TITLE
Add note about application metrics gather interval

### DIFF
--- a/pages/1.12/metrics/index.md
+++ b/pages/1.12/metrics/index.md
@@ -22,7 +22,7 @@ DC/OS collects four types of metrics as follows:
 
 Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plugin-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself.
 
-Telegraf collects application and custom metrics through the `dcos_statsd` plugin. A dedicated StatsD server is started for each new task. Any metrics received by the StatsD server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`).
+Telegraf collects application and custom metrics through the `dcos_statsd` plugin. A dedicated StatsD server is started for each new task. Any metrics received by the StatsD server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). Note that when a task finishes, any metrics it has emitted that haven't yet been gathered by Telegraf will be discarded. The metrics collected by `dcos_statsd` are gathered every 30 seconds. To ensure a task's metrics are gathered, the task must run for at least 30 seconds.
 
 For more information about the list of metrics that are automatically collected by DC/OS, read [Metrics Reference](/1.12/metrics/reference/) documentation.
 

--- a/pages/1.12/metrics/index.md
+++ b/pages/1.12/metrics/index.md
@@ -20,7 +20,9 @@ DC/OS collects four types of metrics as follows:
 * **Container:** Metrics about `cgroup` allocations from tasks running in the DC/OS [Universal Container Runtime](/1.12/deploying-services/containerizers/ucr/) or [Docker Engine](/1.12/deploying-services/containerizers/docker-containerizer/) runtime.
 * **Application:** Metrics emitted from any application running on the Universal Container Runtime.
 
-Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plugin-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself. Telegraf collects application and custom metrics through the `statsd` process. A dedicated `statsd` server is started for each new task. Any metrics received by the `statsd` server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). 
+Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plugin-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself.
+
+Telegraf collects application and custom metrics through the `dcos_statsd` plugin. A dedicated StatsD server is started for each new task. Any metrics received by the StatsD server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`).
 
 For more information about the list of metrics that are automatically collected by DC/OS, read [Metrics Reference](/1.12/metrics/reference/) documentation.
 

--- a/pages/1.13/metrics/index.md
+++ b/pages/1.13/metrics/index.md
@@ -20,7 +20,9 @@ DC/OS collects four types of metrics as follows:
 * **Container:** Metrics about `cgroup` allocations from tasks running in the DC/OS [Universal Container Runtime](/1.13/deploying-services/containerizers/ucr/) or [Docker Engine](/1.13/deploying-services/containerizers/docker-containerizer/) runtime.
 * **Application:** Metrics emitted from any application running on the Universal Container Runtime.
 
-Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plugin-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself. Telegraf collects application and custom metrics through the `statsd` process. A dedicated `statsd` server is started for each new task. Any metrics received by the `statsd` server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). 
+Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plugin-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself.
+
+Telegraf collects application and custom metrics through the `dcos_statsd` plugin. A dedicated StatsD server is started for each new task. Any metrics received by the StatsD server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`).
 
 For more information about the list of metrics that are automatically collected by DC/OS, read [Metrics Reference](/1.13/metrics/reference/) documentation.
 

--- a/pages/1.13/metrics/index.md
+++ b/pages/1.13/metrics/index.md
@@ -22,7 +22,7 @@ DC/OS collects four types of metrics as follows:
 
 Telegraf is included in the DC/OS distribution and runs on every host in the cluster. Because Telegraf provides a plugin-driven architecture, custom DC/OS plugins provide metrics on the performance of DC/OS workloads and DC/OS itself.
 
-Telegraf collects application and custom metrics through the `dcos_statsd` plugin. A dedicated StatsD server is started for each new task. Any metrics received by the StatsD server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`).
+Telegraf collects application and custom metrics through the `dcos_statsd` plugin. A dedicated StatsD server is started for each new task. Any metrics received by the StatsD server are tagged with the task name and its service name. The address of the server is provided by environment variables (`STATSD_UDP_HOST` and `STATSD_UDP_PORT`). Note that when a task finishes, any metrics it has emitted that haven't yet been gathered by Telegraf will be discarded. The metrics collected by `dcos_statsd` are gathered every 30 seconds. To ensure a task's metrics are gathered, the task must run for at least 30 seconds.
 
 For more information about the list of metrics that are automatically collected by DC/OS, read [Metrics Reference](/1.13/metrics/reference/) documentation.
 


### PR DESCRIPTION
## Description

This adds a note about the gather interval for task metrics. This is relevant to users because a task that lives for shorter than the interval may not have its metrics gathered and reported by Telegraf.

https://jira.mesosphere.com/browse/DCOS-49035

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
