### PR TITLE
Fix confluent zoo keeper navmenu

### DIFF
--- a/pages/services/confluent-zookeeper/2.3.0-4.0.0e/getting-started/index.md
+++ b/pages/services/confluent-zookeeper/2.3.0-4.0.0e/getting-started/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 excerpt:
 title: Getting Started
-menuWeight: 10
+menuWeight: 12
 model: /services/kafka-zookeeper/data.yml
 render: mustache
 ---

--- a/pages/services/confluent-zookeeper/2.3.0-4.0.0e/index.md
+++ b/pages/services/confluent-zookeeper/2.3.0-4.0.0e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.3.0-4.0.0e
 title: Confluent ZooKeeper 2.3.0-4.0.0e
-menuWeight: 2
+menuWeight: 5
 excerpt:
 
 model: /services/confluent-zookeeper/data.yml

--- a/pages/services/confluent-zookeeper/2.3.0-4.0.0e/release-notes/index.md
+++ b/pages/services/confluent-zookeeper/2.3.0-4.0.0e/release-notes/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 excerpt: Discover the new features, updates, and known limitations in this release of the Confluent ZooKeeper Service
 title: Release Notes
-menuWeight: 120
+menuWeight: 10
 model: /services/kafka-zookeeper/data.yml
 render: mustache
 ---

--- a/pages/services/confluent-zookeeper/2.4.0-4.0.0e/getting-started/index.md
+++ b/pages/services/confluent-zookeeper/2.4.0-4.0.0e/getting-started/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 excerpt:
 title: Getting Started
-menuWeight: 10
+menuWeight: 120
 model: /services/kafka-zookeeper/data.yml
 render: mustache
 ---

--- a/pages/services/confluent-zookeeper/2.4.0-4.0.0e/index.md
+++ b/pages/services/confluent-zookeeper/2.4.0-4.0.0e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.4.0-4.0.0e
 title: Confluent ZooKeeper 2.4.0-4.0.0e
-menuWeight: 1
+menuWeight: 4
 excerpt:
 
 model: /services/confluent-zookeeper/data.yml

--- a/pages/services/confluent-zookeeper/2.4.0-4.0.0e/release-notes/index.md
+++ b/pages/services/confluent-zookeeper/2.4.0-4.0.0e/release-notes/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 excerpt: Discover the new features, updates, and known limitations in this release of the Confluent ZooKeeper Service
 title: Release Notes
-menuWeight: 120
+menuWeight: 10
 model: /services/confluent-zookeeper/data.yml
 render: mustache
 ---

--- a/pages/services/confluent-zookeeper/2.5.0-4.1.3e/getting-started/index.md
+++ b/pages/services/confluent-zookeeper/2.5.0-4.1.3e/getting-started/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Getting Started
 excerpt: Creating a test cluster
 title: Getting Started
-menuWeight: 10
+menuWeight: 12
 model: /services/confluent-zookeeper/data.yml
 render: mustache
 ---

--- a/pages/services/confluent-zookeeper/2.5.0-4.1.3e/index.md
+++ b/pages/services/confluent-zookeeper/2.5.0-4.1.3e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.5.0-4.1.3e 
 title: Confluent ZooKeeper 2.5.0-4.1.3e 
-menuWeight: 1
+menuWeight: 3
 excerpt: Confluent ZooKeeper is a centralized service for maintaining configuration and naming information
 model: /services/confluent-zookeeper/data.yml
 render: mustache

--- a/pages/services/confluent-zookeeper/2.5.0-4.1.3e/release-notes/index.md
+++ b/pages/services/confluent-zookeeper/2.5.0-4.1.3e/release-notes/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Release Notes
 excerpt: Release Notes for Confluent ZooKeeper Service version 2.5.0-4.1.3e 
 title: Release Notes
-menuWeight: 120
+menuWeight: 10
 model: /services/confluent-zookeeper/data.yml
 render: mustache
 ---

--- a/pages/services/confluent-zookeeper/2.6.0-5.1.2e/getting-started/index.md
+++ b/pages/services/confluent-zookeeper/2.6.0-5.1.2e/getting-started/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 excerpt:
 title: Getting Started
-menuWeight: 10
+menuWeight: 12
 model: /services/confluent-zookeeper/data.yml
 render: mustache
 ---

--- a/pages/services/confluent-zookeeper/2.6.0-5.1.2e/index.md
+++ b/pages/services/confluent-zookeeper/2.6.0-5.1.2e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.6.0-5.1.2e
 title: Confluent ZooKeeper 2.6.0-5.1.2e
-menuWeight: 5
+menuWeight: 1
 excerpt: Confluent ZooKeeper is a centralized service for maintaining configuration and naming information
 model: /services/confluent-zookeeper/data.yml
 render: mustache

--- a/pages/services/confluent-zookeeper/2.6.0-5.1.2e/release-notes/index.md
+++ b/pages/services/confluent-zookeeper/2.6.0-5.1.2e/release-notes/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:
 excerpt:
 title: Release Notes
-menuWeight: 120
+menuWeight: 10
 model: /services/confluent-zookeeper/data.yml
 render: mustache
 ---


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->
1. Confluent ZooKeeper versions not displayed in order on nav menu
2. Release Notes not at top of nav menu
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

Corrected following versions:
2.3.0-4.0.0e
2.4.0-4.0.0e
2.5.0-4.1.3e
2.6.0-5.1.2e
