### PR TITLE
Correcting typo on CLI command ref page.

### DIFF
--- a/pages/1.12/cli/command-reference/dcos-cluster/dcos-cluster-list/index.md
+++ b/pages/1.12/cli/command-reference/dcos-cluster/dcos-cluster-list/index.md
@@ -22,7 +22,7 @@ dcos cluster list [flags]
 
 | Name | Description |
 |---------|-------------|
-| `--attached`   | Returnes attached clusters only. |
+| `--attached`   | Returns attached clusters only. |
 | `--json`   |  Displays a JSON-formatted list. |
 |  `-h`, `--help`  | Displays help for this command. |
 


### PR DESCRIPTION
## Description
Fixed a typo on CLI page
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
