### PR TITLE
Update command and removed $

### DIFF
--- a/pages/services/beta-storage/0.5.2-beta/install/package-registry-based/index.md
+++ b/pages/services/beta-storage/0.5.2-beta/install/package-registry-based/index.md
@@ -25,15 +25,15 @@ The `.dcos` package of the DC/OS Storage Service (DSS) can be downloaded from [M
 
 # Install the DSS package
 
-1. Assume that the downloaded package is called `beta-storage.dcos` in the current working directory. Run the `dcos registry add` command to add it.
+1. Assume that the downloaded package is called `beta-storage.dcos` in the current working directory. Run the `dcos package repo add` command to add it.
 
     ```bash
-    $ dcos registry add --dcos-file beta-storage.dcos
+    dcos package repo add Universe beta-storage.dcos
     ```
 1. Run the `dcos package install` command to install your beta-storage app:
 
     ```
-    $ dcos package install beta-storage --package-version=<VERSION>
+    dcos package install beta-storage --package-version=<VERSION>
     ```
 
 # Verify that the DSS is running
@@ -41,5 +41,5 @@ The `.dcos` package of the DC/OS Storage Service (DSS) can be downloaded from [M
 Run the `dcos storage version` command and wait for the DSS to be ready.
 
 ```bash
-$ dcos storage version
+dcos storage version
 ```


### PR DESCRIPTION
Updated the dcos repository addition command to use the dcos package repo add and removed all the $ which cause a problem when using the copy function.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
