### PR TITLE
universal installer: pinning the existing version to only 0.1.X

### DIFF
--- a/pages/1.10/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.10/installing/evaluation/aws/aws-advanced/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.10/installing/evaluation/aws/index.md
+++ b/pages/1.10/installing/evaluation/aws/index.md
@@ -123,7 +123,7 @@ Terraform will need to send out SSH keys to connect securely to the nodes it cre
 
     module "dcos" {
       source  = "dcos-terraform/dcos/aws"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       cluster_name        = "my-dcos-demo"
       ssh_public_key_file = "<path-to-public-key-file>"

--- a/pages/1.10/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.10/installing/evaluation/azure/advanced-azure/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.10/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.10/installing/evaluation/gcp/advanced-gcp/index.md
@@ -12,7 +12,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.11/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.11/installing/evaluation/aws/aws-advanced/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.11/installing/evaluation/aws/index.md
+++ b/pages/1.11/installing/evaluation/aws/index.md
@@ -123,7 +123,7 @@ Terraform will need to send out SSH keys to connect securely to the nodes it cre
 
     module "dcos" {
       source  = "dcos-terraform/dcos/aws"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
 
       cluster_name        = "my-dcos-demo"

--- a/pages/1.11/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.11/installing/evaluation/azure/advanced-azure/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.11/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.11/installing/evaluation/gcp/advanced-gcp/index.md
@@ -12,7 +12,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.12/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.12/installing/evaluation/aws/aws-advanced/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.12/installing/evaluation/aws/index.md
+++ b/pages/1.12/installing/evaluation/aws/index.md
@@ -123,7 +123,7 @@ Terraform will need to send out SSH keys to connect securely to the nodes it cre
 
     module "dcos" {
       source  = "dcos-terraform/dcos/aws"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       cluster_name        = "my-dcos-demo"
       ssh_public_key_file = "<path-to-public-key-file>"

--- a/pages/1.12/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.12/installing/evaluation/azure/advanced-azure/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.12/installing/evaluation/dcos-ansible/index.md
+++ b/pages/1.12/installing/evaluation/dcos-ansible/index.md
@@ -24,7 +24,7 @@ Mesosphere supports the use of a combination of the [Universal Installer](/1.12/
 ```hcl
 module "dcos-ansible-bridge" {
   source  = "dcos-terraform/dcos-ansible-bridge/local_file"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   bootstrap_ip         = "${module.dcos-infrastructure.bootstrap.public_ip}"
   master_ips           = ["${module.dcos-infrastructure.masters.public_ips}"]
@@ -37,7 +37,7 @@ module "dcos-ansible-bridge" {
 
 module "dcos-infrastructure" {
   source  = "dcos-terraform/infrastructure/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   [...]
 

--- a/pages/1.12/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.12/installing/evaluation/gcp/advanced-gcp/index.md
@@ -12,7 +12,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.13/installing/evaluation/aws/index.md
+++ b/pages/1.13/installing/evaluation/aws/index.md
@@ -123,7 +123,7 @@ Terraform will need to send out SSH keys to connect securely to the nodes it cre
 
     module "dcos" {
       source  = "dcos-terraform/dcos/aws"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       cluster_name        = "my-dcos-demo"
       ssh_public_key_file = "<path-to-public-key-file>"

--- a/pages/1.13/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.13/installing/evaluation/azure/advanced-azure/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.13/installing/evaluation/azure/index.md
+++ b/pages/1.13/installing/evaluation/azure/index.md
@@ -160,7 +160,7 @@ To use the Mesosphere Universal Installer with Azure, the Azure command line int
 
     module "dcos" {
       source  = "dcos-terraform/dcos/azurerm"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       dcos_instance_os    = "coreos_1855.5.0"
       cluster_name        = "my-dcos"

--- a/pages/1.13/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.13/installing/evaluation/gcp/advanced-gcp/index.md
@@ -12,7 +12,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/cn/1.11/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/cn/1.11/installing/evaluation/aws/aws-advanced/index.md
@@ -13,7 +13,7 @@ Mesosphere Universal 安装工具支持各种输入/变量，以便添加到您�
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/cn/1.11/installing/evaluation/aws/index.md
+++ b/pages/cn/1.11/installing/evaluation/aws/index.md
@@ -138,7 +138,7 @@ menuWeight: 0
 
     module "dcos" {
       source  = "dcos-terraform/dcos/aws"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
 
       cluster_name        = "my-dcos-demo"

--- a/pages/cn/1.11/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/cn/1.11/installing/evaluation/azure/advanced-azure/index.md
@@ -13,7 +13,7 @@ Mesosphere Universal 安装工具支持各种输入/变量，以便添加到您�
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/cn/1.11/installing/evaluation/azure/index.md
+++ b/pages/cn/1.11/installing/evaluation/azure/index.md
@@ -161,7 +161,7 @@ menuWeight: 2
 
     module "dcos" {
       source  = "dcos-terraform/dcos/azurerm"
-      version = "~> 0.1"
+      version = "~> 0.1.0"
 
       dcos_instance_os    = "coreos_1855.5.0"
       cluster_name        = "my-dcos"

--- a/pages/cn/1.11/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/cn/1.11/installing/evaluation/gcp/advanced-gcp/index.md
@@ -12,7 +12,7 @@ Mesosphere Universal 安装工具支持各种输入/变量，以便添加到您�
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/services/beta-storage/0.5.2-beta/install/provision-extra-volumes/index.md
+++ b/pages/services/beta-storage/0.5.2-beta/install/provision-extra-volumes/index.md
@@ -24,7 +24,7 @@ All agent nodes will have the same volume configurations specified.
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   # ......
 

--- a/pages/services/beta-storage/0.5.3-beta/install/provision-extra-volumes/index.md
+++ b/pages/services/beta-storage/0.5.3-beta/install/provision-extra-volumes/index.md
@@ -22,7 +22,7 @@ All agent nodes will have the same volume configurations specified.
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   # ......
 


### PR DESCRIPTION
Source: https://docs.mesosphere.com/1.12/installing/evaluation/aws

In the section "Creating a DC/OS Cluster" Item 3 has the example main.ft.

The version is inconsistent with the documentation for Azure and GCP.  version = "> 0.1" means from 0.1 to 0.X including all version less than 1.0.  It should read version = "> 0.1.0" which means at least 0.1.0 and up to 0.1.X but less that 0.2.X.  

```
{{module "dcos" { }}

{{source = "dcos-terraform/dcos/aws" }}

version = "~> 0.1"
```
 

This is causing users to use the 0.1.0 main.tf that is no longer compatible with 0.2.0 module version.

## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS_OSS-5038

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).