### PR TITLE
Updated UCR doc for the docker manifest v2 schema2 support.

### DIFF
--- a/pages/1.13/deploying-services/containerizers/ucr/index.md
+++ b/pages/1.13/deploying-services/containerizers/ucr/index.md
@@ -13,7 +13,7 @@ The [Universal Container Runtime (UCR)](http://mesos.apache.org/documentation/la
 
 ## Docker Registry Support
 
-UCR uses [Docker v2 registry API](https://docs.docker.com/registry/spec/api/) to fetch Docker images/layers. Both docker manifest [v1 schema1](https://docs.docker.com/registry/spec/manifest-v2-1/) and [v2 schema2](https://docs.docker.com/registry/spec/manifest-v2-2/) are supported (v2 schema2 is supported starting from DC/OS 1.13.0).
+UCR uses [Docker v2 registry API](https://docs.docker.com/registry/spec/api/) to fetch Docker images/layers. Both docker manifest [v2 schema1](https://docs.docker.com/registry/spec/manifest-v2-1/) and [v2 schema2](https://docs.docker.com/registry/spec/manifest-v2-2/) are supported (v2 schema2 is supported starting from DC/OS 1.13.0).
 
 # DC/OS web interface
 Use this procedure to provision a container with the UCR from the DC/OS web interface.

--- a/pages/1.13/deploying-services/containerizers/ucr/index.md
+++ b/pages/1.13/deploying-services/containerizers/ucr/index.md
@@ -11,6 +11,10 @@ enterprise: false
 
 The [Universal Container Runtime (UCR)](http://mesos.apache.org/documentation/latest/container-image) launches Mesos containers from binary executables and extends the Mesos container runtime to support provisioning [Docker](https://docker.com/) images. The UCR has many [advantages](/1.13/deploying-services/containerizers/) over the Docker Engine for running Docker images. Use the Docker Engine only if you need specific [features](/1.13/deploying-services/containerizers/#container-runtime-features) of the Docker package.
 
+## Docker Registry Support
+
+UCR uses [Docker v2 registry API](https://docs.docker.com/registry/spec/api/) to fetch Docker images/layers. Both docker manifest [v1 schema1](https://docs.docker.com/registry/spec/manifest-v2-1/) and [v2 schema2](https://docs.docker.com/registry/spec/manifest-v2-2/) are supported (v2 schema2 is supported starting from DC/OS 1.13.0).
+
 # DC/OS web interface
 Use this procedure to provision a container with the UCR from the DC/OS web interface.
 


### PR DESCRIPTION
Docker manifest v2 schema2 is supported starting from DC/OS 1.13.0,
while it is still compatible with the manifest v2 schema1.

## Description
[DCOS-50641](https://jira.mesosphere.com/browse/DCOS-50641)
[DCOS-50124](https://jira.mesosphere.com/browse/DCOS-50124)

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
