### PR TITLE
Spark 2.8.0-2.4.0 release notes and site docs update

### DIFF
--- a/pages/services/spark/2.5.0-2.2.1/index.md
+++ b/pages/services/spark/2.5.0-2.2.1/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Spark 2.5.0-2.2.1
 navigationTitle: Spark 2.5.0-2.2.1
-menuWeight: 2
+menuWeight: -1
 excerpt: Documentation for DC/OS Apache Spark 2.5.0-2.2.1
 model: /services/spark/data.yml
 render: mustache

--- a/pages/services/spark/2.7.0-2.4.0/index.md
+++ b/pages/services/spark/2.7.0-2.4.0/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Spark 2.7.0-2.4.0
 navigationTitle: Spark 2.7.0-2.4.0
-menuWeight: 1
+menuWeight: 2
 excerpt: Documentation for DC/OS Apache Spark 2.7.0-2.4.0
 model: /services/spark/data.yml
 render: mustache
@@ -15,7 +15,7 @@ Welcome to the documentation for the DC/OS {{ model.techName }}. For more inform
 - {{ model.techShortName }} SQL for SQL and DataFrames
 - MLlib for machine learning
 - GraphX for graph processing
-- {{ model.techShortName }} Streaming for stream processing. 
+- {{ model.techShortName }} Streaming for stream processing.
 
 For more information, see the [{{ model.techName }} documentation][1].
 

--- a/pages/services/spark/2.8.0-2.4.0/custom-docker/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/custom-docker/index.md
@@ -1,0 +1,31 @@
+---
+layout: layout.pug
+navigationTitle: Custom Docker Images
+excerpt: Customizing the Docker image in which Spark runs
+title: Custom Docker Images
+menuWeight: 95
+featureMaturity:
+model: /services/spark/data.yml
+render: mustache
+---
+You can customize the Docker image in which {{ model.techShortName }} runs by extending the standard {{ model.techShortName }} Docker image. In this way, you can install your own libraries, such as a custom Python library.
+
+<p class="message--note"><strong>NOTE: </strong>Customizing the {{ model.techShortName }} image that Mesosphere provides is supported. However, customizations have the potential to adversely affect the integration between {{ model.techShortName }} and DC/OS. In situations where Mesosphere support suspects a customization may be adversely impacting {{ model.techShortName }} with DC/OS, Mesosphere support may request that the customer reproduce the issue with an unmodified {{ model.techShortName }} image. </p>
+
+To customize your Docker image:
+1. In your Dockerfile, extend from the standard {{ model.techShortName }} image and add your customizations:
+
+    ```
+    FROM mesosphere/{{ model.serviceName }}:2.8.0-2.4.0-hadoop-2.9
+    RUN apt-get install -y python-pip
+    RUN pip install requests
+    ```
+
+1. Build an image from the customized Dockerfile.
+
+        docker build -t username/image:tag .
+        docker push username/image:tag
+
+1. Reference the custom Docker image with the `--docker-image` option when running a {{ model.techShortName }} job.
+
+        dcos {{ model.serviceName }} run --docker-image=myusername/myimage:v1 --submit-args="http://external.website/mysparkapp.py 30"

--- a/pages/services/spark/2.8.0-2.4.0/fault-tolerance/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/fault-tolerance/index.md
@@ -1,0 +1,143 @@
+---
+layout: layout.pug
+navigationTitle: Fault Tolerance
+excerpt: Understanding DC/OS Apache Spark fault tolerance
+title: Fault Tolerance
+menuWeight: 100
+featureMaturity:
+model: /services/spark/data.yml
+render: mustache
+---
+
+Failures such as host, network, JVM, or application failures can affect the behavior of three types of {{ model.techShortName }} components:
+
+- DC/OS {{ model.techName }} service
+- Batch jobs
+- Streaming jobs
+
+# DC/OS {{ model.techName }} service
+
+The DC/OS {{ model.techName }} service runs in Marathon and includes the Mesos Cluster Dispatcher and the {{ model.techShortName }} history server.  The Dispatcher manages jobs you submit using `dcos spark run`.  Job data is persisted to Zookeeper. The {{ model.techShortName }} history server reads event logs from HDFS. If the service dies, Marathon restarts it, and reloads data from these highly available stores.
+
+# Batch jobs
+
+Batch jobs are resilient to executor failures, but not driver failures. The Dispatcher will restart a driver if you submit it with the `--supervise` option.
+
+## Driver
+
+When the driver fails, executors are terminated, and the entire {{ model.techShortName }} application fails.  If you submitted your job with the `--supervise` option, then the Dispatcher restarts the job.
+
+## Executors
+
+Batch jobs are resilient to executor failure.  Upon failure, cached data, shuffle files, and partially computed RDDs are lost.  However, {{ model.techShortName }} RDDs are fault-tolerant, and {{ model.techShortName }} will start a new executor to recompute lost data from the original data source, caches, or shuffle files.  There is a performance cost as data is recomputed, but an executor failure will not cause a job to fail.
+
+# Streaming jobs
+
+Whereas batch jobs run once and can usually be restarted upon failure, streaming jobs often need to run constantly.  The application must survive driver failures, often with no data loss.
+
+To experience no data loss, you must run streaming jobs with write-ahead logging (WAL) enabled. The one exception is that, if you're consuming from Kafka, you can use the Direct Kafka API.
+
+For **exactly-once** processing semantics, you must use the Direct Kafka API.  All other receivers provide **at least once** semantics.
+
+## Failures
+
+There are two types of failures:
+
+- Driver
+- Executor
+
+## Job features
+
+There are a few variables that affect the reliability of your job:
+
+- [WAL][1]
+- [Receiver reliability][2]
+- [Storage level][3]
+
+## Reliability features
+
+The two reliability features of a job are data loss and processing semantics.  Data loss occurs when the source sends data, but the job fails to process it.  Processing semantics describe how many times a received message is processed by the job.  It can be either "at least once" or "exactly once"
+
+### Data loss
+
+A {{ model.techShortName }} job loses data when delivered data does not get processed. The following is a list of configurations with increasing data preservation guarantees:
+
+- Unreliable receivers
+
+Unreliable receivers do not acknowledge the data they receive from the source. This means that buffered data in the receiver is lost if the executor fails.
+
+executor failure => **data loss** driver failure => **data loss**
+
+- Reliable receivers, unreplicated storage level
+
+This is an unusual configuration.  By default, {{ model.techShortName }} streaming receivers run with a replicated storage level.  But if you reduce the storage level to be unreplicated, data stored on the receiver but not yet processed will not survive executor failure.
+
+  executor failure => **data loss**  
+  driver failure => **data loss**
+
+- Reliable receivers, replicated storage level
+
+This is the default configuration.  Data stored in the receiver is replicated, and can thus survive a single executor failure.  Driver failures, however, result in all executors failing, and therefore result in data loss.
+
+  (single) executor failure => **no data loss**  
+  driver failure => **data loss**
+
+- Reliable receivers, write-ahead logging
+
+With write-ahead logging enabled, data stored in the receiver is written to a highly available store such as S3 or HDFS.  This means that an app can recover from even a driver failure.
+
+  executor failure => **no data loss**  
+  driver failure => **no data loss**
+
+- Direct Kafka consumer, no checkpointing
+
+Since {{ model.techShortName }} 1.3, the {{ model.techShortName }} + Kafka integration has supported an experimental direct consumer, which does not use traditional receivers.  With the direct consumer approach, RDDs read directly from kafka, rather than buffering data in receivers.
+
+However, when a driver restarts without checkpointing, the driver starts reading from the latest Kafka offset, rather than where the previous driver left off.
+
+  executor failure => **no data loss**  
+  driver failure => **data loss**
+
+- Direct Kafka consumer, checkpointing
+
+With checkpointing enabled, Kafka offsets are stored in a reliable store such as HDFS or S3.  This means that an application can restart exactly where it left off.
+
+  executor failure => **no data loss**  
+  driver failure => **no data loss**
+
+### Processing semantics
+
+Processing semantics apply to how many times received messages get processed.  With {{ model.techShortName }} streaming jobs, this can be either "at least once" or "exactly-once".
+
+The semantics below describe how "at least once" or "exactly-once" processing apply to {{ model.techShortName }} receipt of the data.  To provide an end-to-end exactly-once guarantee, you must additionally verify that your output operation provides exactly-once guarantees. More info [here][4].
+
+- Receivers
+
+  **at least once**
+
+Every {{ model.techShortName }} streaming consumer, with the exception of the direct Kafka consumer described below, uses receivers.  Receivers buffer blocks of data in memory, then write them according to the storage level of the job.  After writing out the data, receivers send an acknowledgement to the source so the source knows not to re-send the data.
+
+However, if this acknowledgement fails, or the node fails between writing out the data and sending the acknowledgement, then an inconsistency arises.  {{ model.techShortName }} believes that the data has been received, but the source does not.  This results in the source re-sending the data, and it being processed twice.
+
+- Direct Kafka consumer
+
+  **exactly-once**
+
+The direct Kafka consumer avoids the problem described above by reading directly from Kafka, and storing the offsets itself in the checkpoint directory.
+
+  More information [here][5].
+
+# Mesos checkpointing
+
+Enabling Mesos checkpointing allows {{ model.techName }} Driver and Executors to tolerate Mesos agent upgrades and unexpected crashes without experiencing any downtime. If checkpointing enabled, the Mesos agents that are running {{ model.techName }} Executors will write the framework pid, executor process IDs and status updates to disk. If the Agent exits (e.g., due to a crash or as part of upgrading Mesos), this checkpointed data allows the restarted Agent to reconnect to executors that were started by the old instance of the Agent. Enabling checkpointing improves fault tolerance, at the cost of a (usually small) increase in disk I/O.
+
+DC/OS {{ model.techName }} service runs with checkpointing enabled by default allowing {{ model.techName }} Drivers to tolerate agent restarts. To enable checkpointing for {{ model.techName }} Executors configuration property `spark.mesos.checkpoint` should be set to `true`.
+
+  More information about Mesos checkpointing [here][6]
+
+[1]: https://spark.apache.org/docs/2.4.0/streaming-programming-guide.html#requirements
+[2]: https://spark.apache.org/docs/2.4.0/streaming-programming-guide.html#with-receiver-based-sources
+[3]: http://spark.apache.org/docs/2.4.0/rdd-programming-guide.html#which-storage-level-to-choose
+[4]: http://spark.apache.org/docs/2.4.0/streaming-programming-guide.html#semantics-of-output-operations
+[5]: https://databricks.com/blog/2015/03/30/improvements-to-kafka-integration-of-spark-streaming.html
+[6]: http://mesos.apache.org/documentation/latest/agent-recovery/

--- a/pages/services/spark/2.8.0-2.4.0/hdfs/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/hdfs/index.md
@@ -1,0 +1,69 @@
+---
+layout: layout.pug
+excerpt: Integrating HDFS with DC/OS Apache Spark service
+title: Integration with HDFS
+navigationTitle: HDFS
+model: /services/spark/data.yml
+render: mustache
+menuWeight: 20
+---
+
+# HDFS
+
+If you plan to read and write from HDFS using {{ model.techShortName }}, there are two Hadoop configuration files that you should include in the {{ model.techShortName }} classpath:
+
+- `hdfs-site.xml`, which provides default behaviors for the HDFS client.
+- `core-site.xml`, which sets the default file system name.
+
+You can specify the location of these files at install time or for each job.
+
+## {{ model.techShortName }} installation
+Within the {{ model.techShortName }} service configuration, set `hdfs.config-url` to be a URL that serves your `hdfs-site.xml` and `core-site.xml`.
+The following example uses `http://mydomain.com/hdfs-config/hdfs-site.xml` and `http://mydomain.com/hdfs-config/core-site.xml` URLs:
+
+```json
+{
+  "hdfs": {
+    "config-url": "http://mydomain.com/hdfs-config"
+  }
+}
+```
+You can also specify the URLs through the UI. If you are using the default installation of HDFS from Mesosphere, this is probably `http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints`.
+
+## Adding HDFS configuration files per-job
+To add the configuration files manually for a job, use `--conf spark.mesos.uris=<location_of_hdfs-site.xml>,<location_of_core-site.xml>`. This setting downloads the files to the sandbox of the driver {{ model.techShortName }} application, and DC/OS {{ model.techShortName }} automatically loads these files into the correct location.
+
+<p class="message--important"><strong>IMPORTANT: </strong>It is important these files are called <code>hdfs-site.xml</code> and <code>core-site.xml</code>.</p>
+
+### {{ model.techShortName }} checkpointing
+
+To use {{ model.techShortName }} with checkpointing, make sure you follow the instructions [here](https://{{ model.serviceName }}.apache.org/docs/latest/streaming-programming-guide.html#checkpointing) and use an HDFS directory as the checkpointing directory. For example:
+```
+val checkpointDirectory = "hdfs://hdfs/checkpoint"
+val ssc = ...
+ssc.checkpoint(checkpointDirectory)
+```
+The HDFS directory is automatically created on HDFS. The {{ model.techShortName }} streaming app will work from checkpointed data, even in the event of an application restarts or failure.
+
+# S3
+You can read/write files to S3 using environment variable-based secrets to pass your AWS credentials.
+
+1. Upload your credentials to the DC/OS secret store:
+
+```
+dcos security secrets create <secret_path_for_key_id> -v <AWS_ACCESS_KEY_ID>
+dcos security secrets create <secret_path_for_secret_key> -v <AWS_SECRET_ACCESS_KEY>
+```
+1. After uploading your credentials, {{ model.techShortName }} jobs can get the credentials directly:
+
+```
+dcos {{ model.serviceName }} run --submit-args="\
+...
+--conf {{ model.serviceName }}.mesos.containerizer=mesos  # required for secrets
+--conf {{ model.serviceName }}.mesos.driver.secret.names=<secret_path_for_key_id>,<secret_path_for_secret_key>
+--conf {{ model.serviceName }}.mesos.driver.secret.envkeys=AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
+...
+```
+
+[8]: http://spark.apache.org/docs/latest/configuration.html#inheriting-hadoop-cluster-configuration
+[9]: https://docs.mesosphere.com/services/spark/2.8.0-2.4.0/limitations/

--- a/pages/services/spark/2.8.0-2.4.0/history-server/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/history-server/index.md
@@ -1,0 +1,66 @@
+---
+layout: layout.pug
+navigationTitle: History Server
+excerpt: Enabling the Spark History Server
+title: History Server
+model: /services/spark/data.yml
+render: mustache
+menuWeight: 30
+
+---
+
+DC/OS {{ model.techName }} includes the [{{ model.techShortName }} History Server][3]. Because the history server requires HDFS, you must explicitly enable it.
+
+# Installing HDFS
+
+<p class="message--note"><strong>NOTE: </strong>HDFS requires five private nodes.</p>
+
+1.  Install HDFS:
+
+        dcos package install hdfs
+
+1.  Create a history HDFS directory (default is `/history`). [SSH into your cluster][10] and run:
+
+        docker run -it mesosphere/hdfs-client:1.0.0-2.6.0 bash
+        ./bin/hdfs dfs -mkdir /history
+
+1. Create `spark-history-options.json`:
+
+        {
+          "service": {
+            "hdfs-config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+          }
+        }
+
+# Installing {{ model.techShortName }} history server
+
+1. To install the {{ model.techShortName }} history server:
+
+        dcos package install spark-history --options=spark-history-options.json
+
+1. Create `spark-dispatcher-options.json`:
+
+   ```json
+           {
+           "service": {
+           "spark-history-server-url": "http://<dcos_url>/service/spark-history"
+           },
+           "hdfs": {
+           "config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+           }
+           }
+   ```
+1.  Install the {{ model.techShortName }} dispatcher:
+
+        dcos package install spark --options=spark-dispatcher-options.json
+
+1.  Run jobs with the event log enabled:
+
+        dcos spark run --submit-args="--conf spark.eventLog.enabled=true --conf spark.eventLog.dir=hdfs://hdfs/history ... --class MySampleClass  http://external.website/mysparkapp.jar"
+
+# Confirm history server installation
+
+View your job in the dispatcher at `http://<dcos_url>/service/spark/`. The information displayed includes a link to the history server entry for that job.
+
+ [3]: http://spark.apache.org/docs/latest/monitoring.html#viewing-after-the-fact
+ [10]: /1.12/administering-clusters/sshcluster/

--- a/pages/services/spark/2.8.0-2.4.0/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/index.md
@@ -1,15 +1,15 @@
 ---
 layout: layout.pug
-title: Spark 2.6.0-2.3.2
-navigationTitle: Spark 2.6.0-2.3.2
-menuWeight: 3
-excerpt: Documentation for DC/OS Apache Spark 2.6.0-2.3.2
+title: Spark 2.8.0-2.4.0
+navigationTitle: Spark 2.8.0-2.4.0
+menuWeight: 1
+excerpt: Documentation for DC/OS Apache Spark 2.8.0-2.4.0
 model: /services/spark/data.yml
 render: mustache
 featureMaturity:
 ---
 
-Welcome to the documentation for the DC/OS {{ model.techName }}. For more information about new and changed features, see the [release notes](/services/spark/2.6.0-2.3.2/release-notes/).
+Welcome to the documentation for the DC/OS {{ model.techName }}. For more information about new and changed features, see the [release notes](/services/spark/2.8.0-2.4.0/release-notes/).
 
 {{ model.techName }} is a fast and general-purpose cluster computing system for big data. It provides high-level APIs in Scala, Java, Python, and R, and an optimized engine that supports general computation graphs for data analysis. It also supports a rich set of higher-level tools including the following:
 - {{ model.techShortName }} SQL for SQL and DataFrames

--- a/pages/services/spark/2.8.0-2.4.0/install/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/install/index.md
@@ -1,0 +1,391 @@
+---
+layout: layout.pug
+navigationTitle: Install and Customize
+excerpt: Installing and customizing your DC/OS Apache Spark service
+title: Install and Customize
+menuWeight: 12
+model: /services/spark/data.yml
+render: mustache
+featureMaturity:
+---
+
+{{ model.techShortName }} is available in the Universe and can be installed by using either the DC/OS GUI or the DC/OS CLI.
+
+**Prerequisites**
+
+- [DC/OS and DC/OS CLI installed](/1.12/installing/)
+- Depending on your [security mode](/1.12/security/ent/), {{ model.techShortName }} requires service authentication for access to DC/OS.
+
+| Security mode | Service account       |
+|---------------|-----------------------|
+| Disabled      | Not available         |
+| Permissive    | Optional              |
+| Strict        | **Required**          |
+
+For more information about service accounts, see [Security](/1.12/security/):  
+
+# Default installation
+To install the DC/OS {{ model.techName }} service, run the following command on the DC/OS CLI. This installs the {{ model.techShortName }} DC/OS service, {{ model.techShortName }} CLI, dispatcher, and, optionally, the history server. See [Custom installation][7] to install the history server.
+
+```bash
+dcos package install  {{ model.packageName }}
+```
+
+Go to the **Services** > **Deployments** tab of the DC/OS GUI to monitor the deployment. When it has finished deploying, visit {{ model.techShortName }} at `http://<dcos-url>/service/ {{ model.packageName }}/`.
+
+You can also [install {{ model.techShortName }} via the DC/OS GUI](/1.12/installing/).
+
+## {{ model.techShortName }} CLI
+You can install the {{ model.techShortName }} CLI with this command. This is useful if you already have a {{ model.techShortName }} cluster running, but need the {{ model.techShortName }} CLI.
+
+<p class="message--important"><strong>IMPORTANT: </strong>If you install {{ model.techShortName }} via the DC/OS GUI, you must install the {{ model.techShortName }} CLI as a separate step from the DC/OS CLI.</p>
+
+```bash
+dcos package install  {{ model.packageName }} --cli
+```
+
+<a name="custom"></a>
+
+# Custom installation
+
+You can customize the default configuration properties by creating a JSON options file and passing it to `dcos package install --options`. For example, to launch the Dispatcher using the Universal Container Runtime (UCR), create a file called `options.json`.
+
+To customize the installation:
+1. Create the `options.json` configuration file.
+
+    ```json
+    {
+      "service": {
+        "UCR_containerizer": true
+      }
+    }
+    ```
+
+1. Install {{ model.techShortName }} with the configuration specified in the `options.json` file:
+
+    ```bash
+    dcos package install --options=options.json  {{ model.packageName }}
+    ```
+
+1. Run this command to see all configuration options:
+
+    ```bash
+    dcos package describe  {{ model.packageName }} --config
+    ```
+<a name="custom-dist"></a>
+## Customize {{ model.techShortName }} distribution
+
+DC/OS {{ model.techName }} does not support arbitrary {{ model.techShortName }} distributions, but Mesosphere does provide multiple pre-built distributions, primarily used to select Hadoop versions.  
+
+To use one of these distributions, select your {{ model.techShortName }} distribution from [here](https://github.com/mesosphere/ {{ model.packageName }}-build/blob/master/docs/ {{ model.packageName }}-versions.md), then select the corresponding Docker image from [here](https://hub.docker.com/r/mesosphere/ {{ model.packageName }}/tags/), then use those values to set the following configuration variables:
+
+```json
+{
+  "service": {
+    "docker-image": "<docker-image>"
+  }
+}
+```
+
+<a name="custom-user"></a>
+## Customize {{ model.techShortName }} user
+DC/OS {{ model.techShortName }} user defaults to `nobody`, to override it set the following configuration variable:
+
+```json
+{
+  "service": {
+    "user": "<user>"
+  }
+}
+```
+
+{{ model.techShortName }} runs all of its components in Docker containers. Since the Docker image contains a full Linux userspace with
+its own `/etc/users` file, it is possible for the user `nobody` to have a different UID inside the
+container than on the host system. Although user `nobody` has UID 65534 by convention on many systems, this is not
+always the case. As Mesos does not perform UID mapping between Linux user namespaces for a Docker containerizer,
+specifying a service user of `nobody` in this case will cause access failures when the container user attempts to open or execute a filesystem
+resource owned by a user with a different UID, preventing the service from launching. If the hosts in your cluster
+have a UID for `nobody` other than 65534, you will need to a provide valid UID for `nobody` in the configuration to run the service
+successfully. For example, on RHEL/Centos based distributions:
+
+```json
+{
+  "service": {
+    "user": "nobody",
+    "docker_user": "99"
+  }
+}
+```
+
+<a name="custom-network"></a>
+
+## Configure {{ model.techShortName }} virtual network
+
+DC/OS {{ model.techShortName }} can be launched in a virtual network and configured with network labels.
+
+Here's an example of a {{ model.techShortName }} configuration for DC/OS overlay network:
+
+```json
+{
+  "service": {
+    "virtual_network_enabled": true,
+    "virtual_network_name": "dcos",
+    "virtual_network_plugin_labels": [
+        {"key": "key_1", "value": "value_1"},
+        {"key": "key_2", "value": "value_2"}
+    ]
+  }
+}
+```
+
+When DC/OS {{ model.techShortName }} is deployed in a virtual network, all submitted jobs will run in the same
+network until another network is specified in job submit arguments.
+
+You can check the existing limitations of virtual network support [here][20].
+
+# Minimal installation
+
+For development purposes, use [dcos-vagrant][16] to install {{ model.techShortName }} on a local DC/OS cluster.
+
+1. Install a minimal DC/OS Vagrant according to the instructions [here][16].
+
+1. Install {{ model.techShortName }}:
+
+   ```bash
+   dcos package install {{ model.packageName }}
+   ```
+
+1. Run a simple job:
+
+   ```bash
+   dcos {{ model.packageName }} run --submit-args="--class org.apache. {{ model.packageName }}.examples.SparkPi https://downloads.mesosphere.com/ {{ model.packageName }}/assets/ {{ model.packageName }}-examples_2.11-2.3.2.jar 30"
+   ```
+
+<p class="message--important"><strong>IMPORTANT: </strong>A limited resource environment such as DC/OS Vagrant restricts some of the features available in DC/OS {{ model.techName }}. For example, you must have enough resources to start up a 5-agent cluster, otherwise you will not be able to install DC/OS HDFS an enable the history server.</p>
+
+Also, a limited resource environment can restrict how you size your executors, for example with `{{ model.packageName }}.executor.memory`.
+
+# Multiple installations
+
+Installing multiple instances of the DC/OS {{ model.techName }} package provides basic multi-team support. Each dispatcher displays only the jobs submitted to it by a given team, and each team can be assigned different resources.
+
+To install multiple instances of the DC/OS {{ model.techName }} package, set each `service.name` to a unique name (for example, `{{ model.packageName }}-dev`) in your JSON configuration file during installation. For example, create a JSON options file name `multiple.json`:
+
+```json
+{
+  "service": {
+    "name": "{{ model.packageName }}-dev"
+  }
+}
+```
+
+1. Install {{ model.techShortName }} with the options file specified:
+
+    ```bash
+    dcos package install --options=multiple.json {{ model.packageName }}
+    ```
+
+1. To specify which instance of {{ model.techShortName }} to use add `--name=<service_name>` to your CLI, for example
+
+    ```bash
+    dcos {{ model.packageName }} --name={{ model.packageName }}-dev run ...
+    ```
+
+# Installation for strict mode
+
+If your cluster is set up for [strict](/1.12/security/ent/#strict) security then you will follow these steps to install and run {{ model.techShortName }}.
+
+## Service accounts and secrets
+
+1.  Install the `dcos-enterprise-cli` to get CLI security commands (if you have not already done so):
+
+    ```bash
+    dcos package install dcos-enterprise-cli
+    ```
+
+1.  Create a 2048-bit RSA public-private key pair using the Enterprise DC/OS CLI. Create a public-private key pair and save each value into a separate file within the current directory.
+
+    ```bash
+    dcos security org service-accounts keypair <your-private-key>.pem <your-public-key>.pem
+    ```
+
+    For example:
+
+    ```bash
+    dcos security org service-accounts keypair private-key.pem public-key.pem
+    ```
+
+1.  Create a new service account, `service-account-id` (for example, `{{ model.packageName }}-principal`) containing the public key,
+    `your-public-key.pem`.
+
+    ```bash
+    dcos security org service-accounts create -p <your-public-key>.pem -d "{{ model.techShortName }} service account" <service-account>
+    ```
+
+    For example:
+
+    ```bash
+    dcos security org service-accounts create -p public-key.pem -d "{{ model.techShortName }} service account" {{ model.packageName }}-principal
+    ```
+
+    In Mesos parlance, a `service-account` is called a `principal` and so we use the terms interchangeably here.
+
+    You can verify your new service account using the following command.
+
+    ```bash
+    dcos security org service-accounts show <service-account>
+    ```
+
+1.  Create a secret (for example, `{{ model.packageName }}/<secret-name>`) with your service account, `service-account`, and private key specified, `your-private-key.pem`.
+
+    ```bash
+    # permissive mode
+    dcos security secrets create-sa-secret <your-private-key>.pem <service-account> {{ model.packageName }}/<secret-name>
+    # strict mode
+    dcos security secrets create-sa-secret --strict <private-key>.pem <service-account> {{ model.packageName }}/<secret-name>
+    ```
+
+    For example, on a strict-mode DC/OS cluster:
+
+    ```bash
+    dcos security secrets create-sa-secret --strict private-key.pem sp{{ model.packageName }}ark-principal {{ model.packageName }}/{{ model.packageName }}-secret
+    ```
+
+1. Use the `dcos security secrets list /` command to verify that the secrets were created:
+
+    ```bash
+    dcos security secrets list /
+    ```
+
+## Assigning permissions
+Permissions must be created so that the {{ model.techShortName }} service will be able to start {{ model.techShortName }} jobs and so the jobs themselves can launch the executors that perform the work on their behalf. There are a few points to keep in mind depending on your cluster:
+
+*   {{ model.techShortName }} runs by default under the Mesos default role, which is represented by the `*` symbol. You can deploy multiple instances of {{ model.techShortName }} without modifying this default. If you want to override the default {{ model.techShortName }} role, you must modify these code samples accordingly. We use `{{ model.packageName }}-service-role` to designate the role used below.
+
+Permissions can also be assigned through the GUI.
+
+1.  Run the following to create the required permissions for {{ model.techShortName }}:
+    ```bash
+    dcos security org users grant <service-account> dcos:mesos:master:task:user:<user> create --description "Allows the Linux user to execute tasks"
+    dcos security org users grant <service-account> dcos:mesos:master:framework:role:< {{ model.packageName }}-service-role> create --description "Allows a framework to register with the Mesos master using the Mesos default role"
+    dcos security org users grant <service-account> dcos:mesos:master:task:app_id:/<service_name> create --description "Allows reading of the task state"
+    ```
+
+    Note that above the `dcos:mesos:master:task:app_id:/<service_name>` will likely be `dcos:mesos:master:task:app_id:/{{ model.packageName }}`
+
+    For example, continuing from above:
+
+    ```bash
+    dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:task:user:nobody create --description "Allows the Linux user to execute tasks"
+    dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:framework:role:* create --description "Allows a framework to register with the Mesos master using the Mesos default role"
+    dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:task:app_id:/{{ model.packageName }} create --description "Allows reading of the task state"
+
+    ```
+
+    Here, we are using the service account `{{ model.packageName }}-principal` and the user `nobody`.
+
+1.  If you are running the {{ model.techShortName }} service as `nobody` (as we are in this example) you will need to add an additional
+    permission for Marathon:
+
+    ```bash
+    dcos security org users grant dcos_marathon dcos:mesos:master:task:user:nobody create --description "Allow Marathon to launch containers as nobody"
+    ```
+
+## Install {{ model.techShortName }} with necessary configuration
+
+1.  Make a configuration file with the following before installing {{ model.techShortName }}, these settings can also be set through the GUI:
+    ```json
+    cat  {{ model.packageName }}-strict-options.json
+    {
+    "service": {
+            "service_account": "<service-account-id>",
+            "user": "<user>",
+            "service_account_secret": "{{ model.packageName }}/<secret_name>"
+            }
+    }
+    ```
+
+    A minimal example would be:
+
+    ```json
+    {
+    "service": {
+            "service_account": "{{ model.packageName }}-principal",
+            "user": "nobody",
+            "service_account_secret": "{{ model.packageName }}/{{ model.packageName }}-secret"
+            }
+    }
+    ```
+
+1. Then install:
+
+    ```bash
+    dcos package install {{ model.packageName }} --options={{ model.packageName }}-strict-options.json
+    ```
+
+# Additional configuration for {{ model.techShortName }} jobs
+
+You must add configuration parameters to your {{ model.techShortName }} jobs when submitting them.
+
+## Running jobs in strict mode cluster
+
+To run a job on a strict mode cluster, you must add the `principal` to the command line. For example:
+
+```bash
+dcos  {{ model.packageName }} run --verbose --submit-args=" \
+--conf  {{ model.packageName }}.mesos.principal=<service-account> \
+--conf  {{ model.packageName }}.mesos.containerizer=mesos \
+--class org.apache. {{ model.packageName }}.examples. {{ model.packageName }}Pi http://downloads.mesosphere.com/ {{ model.packageName }}/assets/ {{ model.packageName }}-examples_2.11-2.3.2.jar 100"
+```
+
+## Running jobs as a different user
+
+{{ model.techShortName }} Mesos Dispatcher uses the same user for running {{ model.techShortName }} jobs as itself and defaults to `nobody`.
+If you run Dispatcher as `root` and want to submit a job as a different user e.g. `nobody`, you must provide user property in the following way.
+
+### Universal Container Runtime
+For UCR containerizer it is sufficient to provide ` {{ model.packageName }}.mesos.driverEnv.SPARK_USER=nobody` configuration property when submitting a job:
+
+```bash
+dcos  {{ model.packageName }} run --verbose --submit-args="\
+--conf  {{ model.packageName }}.mesos.driverEnv.SPARK_USER=nobody \
+--class org.apache. {{ model.packageName }}.examples.SparkPi http://downloads.mesosphere.com/ {{ model.packageName }}/assets/ {{ model.packageName }}-examples_2.11-2.3.2.jar 100"
+```
+
+### Docker Engine
+If you want to use the [Docker Engine](/1.10/deploying-services/containerizers/docker-containerizer/) instead of the [Universal Container Runtime](/1.10/deploying-services/containerizers/ucr/), you must specify ` {{ model.packageName }}.mesos.executor.docker.parameters=user=nobody` in addition to ` {{ model.packageName }}.mesos.driverEnv.SPARK_USER=nobody` to run the Docker container as this user:
+
+```bash
+dcos  {{ model.packageName }} run --verbose --submit-args="\
+--conf  {{ model.packageName }}.mesos.driverEnv.SPARK_USER=nobody \
+--conf  {{ model.packageName }}.mesos.executor.docker.parameters=user=nobody \
+--class org.apache. {{ model.packageName }}.examples.SparkPi http://downloads.mesosphere.com/ {{ model.packageName }}/assets/ {{ model.packageName }}-examples_2.11-2.3.2.jar 100"
+```
+
+If the hosts in your cluster have a UID for `nobody` other than 65534 (see [Customize {{ model.techShortName }} user][19]), you will need to provide a valid UID as a parameter to Docker containerizer via
+`--conf  {{ model.packageName }}.mesos.executor.docker.parameters=user=UID`:
+
+```bash
+dcos  {{ model.packageName }} run --verbose --submit-args="\
+--conf  {{ model.packageName }}.mesos.driverEnv.SPARK_USER=nobody \
+--conf  {{ model.packageName }}.mesos.executor.docker.parameters=user=99 \
+--class org.apache. {{ model.packageName }}.examples.SparkPi http://downloads.mesosphere.com/ {{ model.packageName }}/assets/ {{ model.packageName }}-examples_2.11-2.3.2.jar 100"
+```
+<p class="message--note"><strong>NOTE: </strong>UID should typically be set to 99 when running as nobody (default) on RHEL/CentOS</p>
+
+## Running jobs in virtual network
+
+To run a job in a virtual network and/or with network plugin labels assigned, one need to specify network name and labels
+in submit arguments:
+
+```bash
+dcos  {{ model.packageName }} run --verbose --submit-args="\
+--conf  {{ model.packageName }}.mesos.network.name=dcos \
+--conf  {{ model.packageName }}.mesos.network.labels=key_1:value_1,key_2:value_2 \
+--class org.apache. {{ model.packageName }}.examples.GroupByTest http://downloads.mesosphere.com/ {{ model.packageName }}/assets/ {{ model.packageName }}-examples_2.11-2.3.2.jar"
+```
+
+ [7]: #custom
+ [16]: https://github.com/mesosphere/dcos-vagrant
+ [19]: #custom-user
+ [20]: https://docs.mesosphere.com/services/ {{ model.packageName }}/2.8.0-2.4.0/limitations/

--- a/pages/services/spark/2.8.0-2.4.0/job-scheduling/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/job-scheduling/index.md
@@ -1,0 +1,278 @@
+---
+layout: layout.pug
+navigationTitle: Job Scheduling  
+excerpt: Scheduling jobs with DC/OS Apache Spark
+title: Job Scheduling
+menuWeight: 110
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+This section is a simple overview of material described in greater detail in the Apache {{ model.techShortName }} documentation [here][1] and [here][2].
+
+# Modes
+
+{{ model.techShortName }} on Mesos supports two modes of operation: coarse-grained mode and fine-grained mode. Coarse-grained mode provides lower latency, whereas fine-grained mode provides higher utilization. You can find nore information [here][2].
+
+# Coarse-grained mode
+
+With the **Coarse-grained mode**, each {{ model.techShortName }} **executor** is represented by a single Mesos task. As a result, executors have a constant size throughout their lifetime.
+
+*   **Executor memory**: `spark.executor.memory`
+*   **Executor CPUs**: `spark.executor.cores`, or all the cores in the offer.
+*   **Number of Executors**: `spark.cores.max` / `spark.executor.cores`. Executors are brought up until
+    `spark.cores.max` is reached. Executors survive for duration of the job.
+*   **Executors per agent**: Multiple
+
+<p class="message--important"><strong>IMPORTANT: </strong>We highly recommend you set <code>spark.cores.max</code>. If you do not, your {{ model.techShortName }} job may consume all available resources in your cluster, resulting in unhappy peers.</p>
+
+# Quota for drivers and executors
+
+Setting [Mesos Quota](http://mesos.apache.org/documentation/latest/quota/) for the drivers prevents the Dispatcher from consuming too many resources and assists queueing behavior. 
+
+To control the number of drivers the {{ model.techShortName }} service runs concurrently, you should set a quota for the drivers. The quota guarantees that the {{ model.techShortName }} Dispatcher has resources available to launch drivers **and** limits the total impact on the cluster due to drivers. 
+
+Optionally, you can set a quota for the drivers to consume to ensure that drivers are not starved of resources by other frameworks and make sure they do not consume too much of the cluster. For more information, see [coarse-grained mode](#coarse-grained-mode) above.
+
+## Best practices for setting drivers
+
+The quota for the drivers allows the operator of the cluster to ensure that only a given number of drivers are concurrently running. As additional drivers are submitted, they are queued by the {{ model.techShortName }} Dispatcher.
+
+Use the following guidelines to achieve best results:
+- Set the quota conservatively, but be aware that the setting affects the number of jobs that can run concurrently.
+- Decide how much of your cluster's resources to allocate to running drivers. Allocated resources are only be used for the {{ model.techShortName }} drivers, meaning that you can decide roughly how many concurrent jobs you would like to have running at a time. As additional jobs are submitted, they are queued and run with first-in-first-out semantics.
+- For the most predictable behavior, enforce uniform driver resource requirements and a particular quota size for the Dispatcher. For example, if each driver consumes 1.0 cpu and it is desirable to run up to 5 {{ model.techShortName }} jobs concurrently, you should create a quota that specifies 5 CPUs.
+
+### Setting quota for the drivers
+
+1. SSH to the Mesos master and set the quota for a role (`dispatcher` in this example):
+
+    ```bash
+    cat dispatcher-quota.json
+    {
+    "role": "dispatcher",
+    "guarantee": [
+      {
+        "name": "cpus",
+        "type": "SCALAR",
+        "scalar": { "value": 5.0 }
+      },
+      {
+        "name": "mem",
+        "type": "SCALAR",
+        "scalar": { "value": 5120.0 }
+      }
+    ]
+    }
+    curl -d @dispatcher-quota.json -X POST http://<master>:5050/quota
+    ```
+
+1. Install the {{ model.techShortName }} service with the following options (at a minimum):
+
+    ```bash
+    cat options.json
+    {
+        "service": {
+            "role": "dispatcher"
+        }
+    }
+    dcos package install spark --options=options.json
+    ```
+
+## Best practices for the executors
+
+It is recommended to allocate a quota for {{ model.techShortName }} job executors.  Allocating quota for the {{ model.techShortName }} executors provides:
+* A guarantee that {{ model.techShortName }} jobs  receive the requested amount of resources.
+* Additional assurance that even if misconfigured (for example, with a driver with `spark.cores.max` unset), {{ model.techShortName }} jobs do not consume resources that impact other tenants on the cluster.
+
+The drawback to allocating quota to the executors is that quota resources cannot be used by other frameworks in the cluster.
+
+### Setting quota for the executors
+
+Quota can be allocated for {{ model.techShortName }} executors in the same way it is allocated for {{ model.techShortName }} dispatchers.  If you want to run 100 executors concurrently, each with 1.0 CPU and 4096 MB of memory, you would do the following:
+
+```bash
+cat executor-quota.json
+{
+  "role": "executor",
+  "guarantee": [
+    {
+      "name": "cpus",
+      "type": "SCALAR",
+      "scalar": { "value": 100.0 }
+    },
+    {
+      "name": "mem",
+      "type": "SCALAR",
+      "scalar": { "value": 409600.0 }
+    }
+  ]
+}
+curl -d @executor-quota.json -X POST http://<master>:5050/quota
+
+```
+
+When {{ model.techShortName }} jobs are submitted, they must indicate the role for which the quota has been set to consume resources from this quota. For example:
+
+```bash
+dcos spark run --verbose --name=spark --submit-args="\
+--driver-cores=1 \
+--driver-memory=1024M \
+--conf spark.cores.max=8 \
+--conf spark.mesos.role=executor \
+--class org.apache.spark.examples.SparkPi \
+http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 3000"
+```
+
+<p class="message--important"><strong>IMPORTANT: </strong>: To prevent a single long-running or streaming {{ model.techShortName }} job from consuming the entire quota, you should set the maximum CPUs for the {{ model.techShortName }} job to roughly one “job’s worth” of the quota’s resources. This setting ensures that the {{ model.techShortName }} job gets sufficient resources to make progress, and prevents the job from starving other {{ model.techShortName }} jobs of resources and provides predictable offer suppression semantics.
+
+## Permissions when using quota with strict mode
+
+Strict mode clusters (see [security modes](/1.12/security/ent/#security-modes)) require extra
+permissions to be set before you can use quota. Follow the instructions in [installing](https://github.com/mesosphere/spark-build/blob/master/docs/install.md) and add the additional permissions for the roles you intend to use, as detailed below.
+
+Using the example above, you would set permissions as follows:
+
+1. First set the quota for the Dispatcher's role (`dispatcher`):
+
+    ```bash
+    cat dispatcher-quota.json
+    {
+      "role": "dispatcher",
+      "guarantee": [
+        {
+          "name": "cpus",
+          "type": "SCALAR",
+          "scalar": { "value": 5.0 }
+        },
+        {
+          "name": "mem",
+          "type": "SCALAR",
+          "scalar": { "value": 5120.0 }
+        }
+      ]
+    }
+    ```
+
+    If you have downloaded the CA certificate,`dcos-ca.crt` to your local machine from the `https://<dcos_url>/ca/dcos-ca.crt` endpoint, set the quota **from your local machine**:
+
+    ```bash
+    curl -X POST --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/mesos/quota -d @dispatcher-quota.json -H 'Content-Type: application/json'
+    ```
+
+1. Optionally, set the quota for the executors using the same settings as above:
+
+    ```bash
+    cat executor-quota.json
+    {
+      "role": "executor",
+      "guarantee": [
+        {
+          "name": "cpus",
+          "type": "SCALAR",
+          "scalar": { "value": 100.0 }
+        },
+        {
+          "name": "mem",
+          "type": "SCALAR",
+          "scalar": { "value": 409600.0 }
+        }
+      ]
+    }
+    ```
+
+1. If you have not already done so, set the quota from your local machine. For example, assuming you have `dcos-ca.crt` locally:
+
+    ```bash
+    curl -X POST --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/mesos/quota -d @executor-quota.json -H 'Content-Type: application/json'
+    ```
+
+1. Install {{ model.techShortName }} with these minimal configuration settings:
+
+    ```bash
+    {
+        "service": {
+                "service_account": "spark-principal",
+                "role": "dispatcher",
+                "user": "root",
+                "service_account_secret": "spark/spark-secret"
+        }
+    }
+    ```
+1. Now you are ready to run a {{ model.techShortName }} job using the principal you set and the roles:
+
+    ```bash
+    dcos spark run --verbose --submit-args=" \
+    --conf spark.mesos.principal=spark-principal \
+    --conf spark.mesos.role=executor \
+    --conf spark.mesos.containerizer=mesos \
+    --class org.apache.spark.examples.SparkPi http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 100"
+    ```
+
+# Setting `spark.cores.max`
+
+To improve {{ model.techShortName }} job execution reliability, set the maximum number of cores consumed by any given job. This avoids any particular {{ model.techShortName }} job from consuming too many resources in a cluster. It is highly recommended that each {{ model.techShortName }} job be submitted with a limitation on the maximum number of cores (CPUs) it can consume. This is especially important for long-running and streaming {{ model.techShortName }} jobs.
+
+  ```bash
+  dcos spark run --verbose --name=spark --submit-args="\
+  --driver-cores=1 \
+  --driver-memory=1024M \
+  --conf spark.cores.max=8 \ #<< Very important!
+  --class org.apache.spark.examples.SparkPi \
+  http://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 3000"
+  ```
+
+When running multiple concurrent {{ model.techShortName }} jobs, consider setting `spark.cores.max` between `<total_executor_quota>/<max_concurrent_jobs>` and `<total_executor_quota>`, depending on your workload characteristics and goals.
+
+# Fine-grained mode (deprecated)
+
+<p class="message--note"><strong>NOTE: </strong>Fine-grained mode has been deprecated and does not have all of the features of coarse-grained mode.</p>
+
+In "fine-grained" mode, each {{ model.techShortName }} **task** is represented by a single Mesos task. When a {{ model.techShortName }} task finishes, the resources represented by its Mesos task are relinquished. Fine-grained mode enables finer-grained resource allocation at
+the cost of task startup latency.
+
+* **Executor memory**: `spark.executor.memory`
+* **Executor CPUs**: Increases and decreases as tasks start and terminate.
+* **Number of Executors**: Increases and decreases as tasks start and terminate.
+* **Executors per agent**: At most 1
+
+# Properties
+
+The following is a description of the most common {{ model.techShortName }} scheduling properties on Mesos. For a full list, see the [{{ model.techShortName }}
+configuration page][1] and the [{{ model.techShortName }} on Mesos configuration page][2].
+
+<table class="table">
+<tr>
+<th>property</th>
+<th>default</th>
+<th>description</th>
+</tr>
+
+<tr>
+<td>spark.mesos.coarse</td>
+<td>true</td>
+<td>Described above.</td>
+</tr>
+
+<tr>
+<td>spark.executor.memory</td>
+<td>1g</td>
+<td>Executor memory allocation.</td>
+</tr>
+
+<tr>
+<td>spark.executor.cores</td>
+<td>All available cores in the offer</td>
+<td>Coarse-grained mode only. DC/OS {{ model.techName }} >= 1.6.1. Executor CPU allocation.</td>
+</tr>
+
+<tr>
+<td>spark.cores.max</td>
+<td>unlimited</td>
+<td>Maximum total number of cores to allocate.</td>
+</tr>
+</table>
+
+[1]: http://spark.apache.org/docs/latest/configuration.html
+[2]: http://spark.apache.org/docs/latest/running-on-mesos.html

--- a/pages/services/spark/2.8.0-2.4.0/kerberos/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/kerberos/index.md
@@ -1,0 +1,206 @@
+---
+layout: layout.pug
+excerpt: Setting up Kerberos to run with DC/OS Apache Spark
+title: Kerberos
+navigationTitle: Kerberos
+menuWeight: 120
+render: mustache
+model: /services/spark/data.yml
+---
+
+
+# HDFS Kerberos
+
+Kerberos is an authentication system that allows {{ model.techShortName }} to retrieve and write data securely to a Kerberos-enabled HDFS cluster. As of Mesosphere {{ model.techShortName }} `2.2.0-2`, long-running jobs will renew their delegation tokens (authentication credentials). This section assumes you have previously set up a Kerberos-enabled HDFS cluster.
+
+<p class="message--note"><strong>NOTE: </strong>Depending on your OS, {{ model.techShortName }} may need to be run as <code>root</code> in order to authenticate with your Kerberos-enabled service. This can be done by setting <code>--conf .mesos.driverEnv.SPARK_USER=root</code> when submitting your job.</p>
+
+## {{ model.techShortName }} installation
+
+{{ model.techShortName }} (and all Kerberos-enabled) components need a valid `krb5.conf` configuration file. You can set up the {{ model.techShortName }} service to use a single `krb5.conf` file for all of its drivers. The `krb5.conf` file tells {{ model.techShortName }} how to connect to your Kerberos key distribution center (KDC).  
+
+To use Kerberos with {{ model.techShortName }}:
+
+1. Base64 encode the `krb5.conf` file:
+
+        cat krb5.conf | base64 -w 0
+
+1. Add the encoded file as a string value into your JSON configuration file:
+
+    ```json
+    {
+       "security": {
+         "kerberos": {
+          "enabled": "true",
+          "krb5conf": "<base64 encoding>"
+          }
+       }
+    }
+    ```
+
+     The JSON configuration will probably also have the `hdfs` parameters similar to the following:
+
+    ```json
+        {
+        "service": {
+            "name": "kerberized-",
+            "user": "nobody"
+        },
+        "hdfs": {
+            "config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+        },
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "krb5conf": "<base64_encoding>"
+            }
+        }
+        }
+    ```
+
+     Alternatively, you can specify properties for the `krb5.conf` file with more concise options:
+    ```json
+        {
+        "security": {
+            "kerberos": {
+            "enabled": true,
+            "kdc": {
+                "hostname": "<kdc_hostname>",
+                "port": <kdc_port>
+            },
+            "realm": "<kdc_realm>"
+            }
+        }
+        }
+    ```
+
+1. Install {{ model.techShortName }} with your custom configuration, here called `options.json`:
+
+        dcos package install --options=/path/to/options.json
+1. Make sure your `keytab` file is in the DC/OS secret store, under a path that is accessible
+    by the {{ model.techShortName }} service. 
+    
+    Since the `keytab` is a binary file, you must also base64 encode it on DC/OS 1.10 or earlier. See [Using the Secret Store](/1.12/security/) for details.
+
+1. If you are using the history server, you must also configure the `krb5.conf`, principal, and keytab for the history server. Add the Kerberos configurations to your `-history` JSON configuration file:
+
+    ```json
+        {
+        "service": {
+            "user": "nobody",
+            "hdfs-config-url": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+        },
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "krb5conf": "<base64_encoding>",
+                "principal": "<Kerberos principal>",  # e.g. @REALM
+                "keytab": "<keytab secret path>"      # e.g. -history/hdfs_keytab
+            }
+        }
+        }
+    ```
+   Alternatively, you can specify properties of the `krb5.conf`:
+
+    ```json
+        {
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "kdc": {
+                    "hostname": "<kdc_hostname>",
+                    "port": <kdc_port>
+            },
+                "realm": "<kdc_realm>"
+                "principal": "<Kerberos principal>",  # e.g. @REALM
+                "keytab": "<keytab secret path>"      # e.g. -history/hdfs_keytab
+            }
+        }
+        }
+    ```
+
+1. Make sure all users have write permission to the history HDFS directory. In an HDFS client:
+    ```bash
+    hdfs dfs -chmod 1777 <history directory>
+    ```
+
+## Job submission
+
+To authenticate to a Kerberos KDC, {{ model.techShortName }} on Mesos supports keytab files as well as ticket-granting tickets (TGTs). Keytabs are valid indefinitely, while tickets can expire. Keytabs are recommended, especially for long-running streaming jobs.
+
+### Controlling the `krb5.conf` with environment variables
+
+If you did not specify `service.security.kerberos.kdc.hostname`, `service.security.kerberos.kdc.port`, and `services.security.realm` at install time, but wish to use a templated `krb5.conf` on a job submission, you can do this with the following environment variables:
+
+    --conf .mesos.driverEnv.SPARK_SECURITY_KERBEROS_KDC_HOSTNAME=<kdc_hostname> \
+    --conf .mesos.driverEnv.SPARK_SECURITY_KERBEROS_KDC_PORT=<kdc_port> \
+    --conf .mesos.driverEnv.SPARK_SECURITY_KERBEROS_REALM=<kerberos_realm> \
+
+You can also set the base64 encoded `krb5.conf` after install time:
+
+    --conf .mesos.driverEnv.SPARK_MESOS_KRB5_CONF_BASE64=<krb5.conf_base64_encoding> \
+
+<p class="message--note"><strong>NOTE: </strong>This setting <code>SPARK_MESOS_KRB5_CONF_BASE64</code> overrides any settings set with <code>SPARK_SECURITY_KERBEROS_KDC_HOSTNAME</code>, <code>SPARK_SECURITY_KERBEROS_KDC_PORT</code>, and <code>SPARK_SECURITY_KERBEROS_REALM</code>.</p>
+
+### Setting the {{ model.techShortName }} user
+
+By default, when Kerberos is enabled, {{ model.techShortName }} runs as the OS user corresponding to the primary of the specified Kerberos principal. For example, the principal "alice@LOCAL" would map to the user name "alice". If it is known that "alice" is not available as an OS user, either in the Docker image or in the host, the {{ model.techShortName }} user should be specified as `root` or `nobody` instead:
+
+        --conf .mesos.driverEnv.SPARK_USER=<{{ model.techShortName }} user>
+
+### Keytab authentication
+
+Submit the job with the keytab:
+
+    dcos  run --submit-args="\
+    --kerberos-principal user@REALM \
+    --keytab-secret-path //hdfs-keytab \
+    --conf .mesos.driverEnv.SPARK_USER=< user> \
+    --conf ... --class My{{ model.techShortName }}Job <url> <args>"
+
+### TGT authentication
+
+Submit the job with the ticket:
+
+    dcos  run --submit-args="\
+    --kerberos-principal user@REALM \
+    --tgt-secret-path //tgt \
+    --conf .mesos.driverEnv.SPARK_USER=< user> \
+    --conf ... --class My{{ model.techShortName }}Job <url> <args>"
+
+<p class="message--note"><strong>NOTE: </strong>The examples on this page assume that you are using the default service name for {{ model.techShortName }}, "spark". If using a different service name, update the secret paths accordingly.</p>
+
+You can access external (non-DC/OS) Kerberos-secured HDFS clusters from {{ model.techShortName }} on Mesos.
+
+<p class="message--important"><strong>IMPORTANT: DC/OS 1.10 or earlier:</strong> These credentials are security-critical. The DC/OS secret store requires you to use base64 to encode binary secrets (such as the Kerberos keytab) before adding them. If they are uploaded with the <code>__dcos_base64__</code> prefix, they are automatically decoded when the secret is made available to your {{ model.techShortName }} job. If the secret name <strong>does not</strong> have this prefix, the keytab will be decoded and written to a file in the sandbox. This leaves the secret exposed and is not recommended. </p>
+
+# Using Kerberos-secured Kafka
+
+{{ model.techShortName }} can consume data from a Kerberos-enabled Kafka cluster. Connecting {{ model.techShortName }} to secure Kafka does not require special installation parameters. 
+
+However, the Kafka cluster does require the {{ model.techShortName }} driver **and** the {{ model.techShortName }} executors be able to access the following files:
+
+* Client Java Authentication and Authorization Service (JAAS) file. This file is provided using Mesos URIS with `--conf .mesos.uris=<location_of_jaas>`.
+* `krb5.conf` for your Kerberos setup. Like HDFS, this file is provided using a base64 encoding of the file:
+
+        cat krb5.conf | base64 -w 0
+
+    The encoded file is assigned to the environment variable `KRB5_CONFIG_BASE64` for the driver and the executors:
+
+        --conf .mesos.driverEnv.KRB5_CONFIG_BASE64=<base64_encoded_string>
+        --conf .executorEnv.KRB5_CONFIG_BASE64=<base64_encoded_string>
+
+* The `keytab` containing the credentials for accessing the Kafka cluster.
+
+        --conf .mesos.containerizer=mesos                            # required for secrets
+        --conf .mesos.driver.secret.names=<keytab>                   # e.g. /kafka_keytab
+        --conf .mesos.driver.secret.filenames=<keytab_file_name>     # e.g. kafka.keytab
+        --conf .mesos.executor.secret.names=<keytab>                 # e.g. /kafka_keytab
+        --conf .mesos.executor.secret.filenames=<keytab_file_name>   # e.g. kafka.keytab
+
+* Finally, you will need to tell {{ model.techShortName }} to use the JAAS file:
+
+        --conf park.driver.extraJavaOptions=-Djava.security.auth.login.config=/mnt/mesos/sandbox/<jaas_file>
+        --conf .executor.extraJavaOptions=-Djava.security.auth.login.config=/mnt/mesos/sandbox/<jaas_file>
+
+<p class="message--important"><strong>IMPORTANT: </strong>It is important that the file name is the same for the driver and executor keytab file (<code>keytab_file_name</code> above) and that this file is properly addressed in your JAAS file. </p>

--- a/pages/services/spark/2.8.0-2.4.0/limitations/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/limitations/index.md
@@ -1,0 +1,40 @@
+---
+layout: layout.pug
+navigationTitle:
+excerpt: Limitations of DC/OS Apache Spark
+title: Limitations
+menuWeight: 135
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+*   Mesosphere does not provide support for {{ model.techShortName }} app development, such as writing a Python app to process data from
+    Kafka or writing Scala code to process data from HDFS.
+
+*   {{ model.techShortName }} jobs run in Docker containers. The first time you run a {{ model.techShortName }} job on a node, it might take longer than you
+    expect because of the `docker pull`.
+
+*   DC/OS Apache {{ model.techShortName }} only supports running the {{ model.techShortName }} shell from within a DC/OS cluster. See the {{ model.techShortName }} Shell section
+    for more information. For interactive analytics, we recommend Zeppelin, which supports visualizations and dynamic
+    dependency management.
+
+*   With {{ model.techShortName }} SSL/TLS enabled, if you specify environment-based secrets with
+    `{{ model.serviceName }}.mesos.[driver|executor].secret.envkeys`, the keystore and truststore secrets will also show up as
+    environment-based secrets, due to the way secrets are implemented. You can ignore these extra environment variables.
+
+*   Anyone who has access to the {{ model.techShortName }} (Dispatcher) service instance has access to all secrets available to it. Do not
+    grant users access to the {{ model.techShortName }} Dispatcher instance unless they are also permitted to access all secrets available
+    to the {{ model.techShortName }} Dispatcher instance.
+
+*   When using Kerberos and HDFS, the {{ model.techShortName }} Driver generates delegation tokens and distributes them to it's Executors
+    via RPC.  Authentication of the Executors with the Driver is done with a [shared
+    secret](https://docs.mesosphere.com/services/{{ model.serviceName }}/latest/security/#using-the-secret-store). Without authentication, it is possible
+    for executor containers to register with the Driver and retrieve the delegation tokens. To secure delegation token
+    distribution, use the `--executor-auth-secret` option.
+
+*   CNI limitations:
+  * Configuration of network plugin labels from DC/OS UI supported only in JSON editing mode.
+  * Network plugin labels are not supported by Docker containerizer.
+  * Currently, DC/OS Admin Router doesn't support virtual networks so DC/OS {{ model.techShortName }} endpoints
+  will not be accessible from CLI and jobs need to be submitted from a routable network.

--- a/pages/services/spark/2.8.0-2.4.0/limits/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/limits/index.md
@@ -1,0 +1,33 @@
+---
+layout: layout.pug
+navigationTitle: Tested Limits
+excerpt: Mesosphere has scale-tested Spark on DC/OS
+title: Tested Limits
+menuWeight: 140
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+# DC/OS {{ model.techShortName }} limits
+Mesosphere has scale-tested {{ model.techShortName }} on DC/OS by running a CPU-bound Monte Carlo application on the following hardware:
+
+## Cluster characteristics
+- 2560 cores total
+- 40 m4.16xlarge EC2 instances
+
+### Single executor per node
+- 40 executors
+- Each executor: 64 cores, 2GB memory
+- CPU utilization was > 90%, with majority of time spent in task computation
+
+### Multiple executors per node
+On a smaller, 1024-core, 16 node (m4.16xlarge) cluster, the following variations were tested:
+
+ Executors | Time to launch all executors | Executors per node
+ --------- | --------------------------- | -----------------
+ 82 | 7 s. | 16
+ 400 | 17 s. | 64
+ 820 | 28 s. | 64
+
+In all tests, the application completed successfully.

--- a/pages/services/spark/2.8.0-2.4.0/quickstart/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/quickstart/index.md
@@ -1,0 +1,149 @@
+---
+layout: layout.pug
+navigationTitle: Quick Start
+excerpt: Introduction to DC/OS Apache Spark service
+title: Quick Start
+menuWeight: 11
+model: /services/spark/data.yml
+render: mustache
+featureMaturity:
+---
+
+This page explains how to install the DC/OS {{ model.techName }} service.
+
+**Prerequisites**
+
+* [DC/OS and DC/OS CLI installed](/1.12/installing/) with a minimum of {{ model.install.nodeDescription }}
+* Depending on your [security mode](/1.12/security/ent/), {{ model.techShortName }} requires service authentication for access to DC/OS. See [Provisioning a service account](/services/spark/2.8.0-2.4.0/security/#provision-a-service-account) for more information.
+
+    | Security mode  | Service account  |
+    |---------------|-----------------|
+    | Disabled      | Not available   |
+    | Permissive    | Optional   |
+    | Strict        | Required |
+
+1. Install the {{ model.techShortName }} package. This may take a few minutes. This step installs the {{ model.techShortName }} DC/OS service, {{ model.techShortName }} CLI, dispatcher, and, optionally, the history server. See the [History Server](/services/spark/2.8.0-2.4.0/history-server/#installing-hdfs) section for information about how to install the history server.
+
+    ```bash
+    dcos package install spark
+    ```
+
+    Expected output:
+
+    ```bash
+    Installing Marathon app for package [{{ model.packageName }}] version [2.8.0-2.4.0]
+    Installing CLI subcommand for package [{{ model.packageName }}] version [2.8.0-2.4.0]
+    New command available: dcos spark
+    DC/OS {{ model.techShortName }} is being installed!
+
+    	Documentation: https://docs.mesosphere.com/services/{{ model.packageName }}/
+    	Issues: https://docs.mesosphere.com/support/
+    ```
+
+   <p class="message--note"><strong>NOTE: </strong>Type <code>dcos spark</code> to view the {{ model.techShortName }} CLI options.</p>
+
+1. Run the sample SparkPi jar for DC/OS.
+
+    You can view the example source [here](https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.3.2.jar).
+
+    1. Use the following command to run a {{ model.techShortName }} job which calculates the value of Pi.
+
+        ```bash
+        dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.0.1.jar 30"
+        ```
+
+        Expected output:
+
+        ```bash
+        2017/08/24 15:42:07 Using docker image mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 for drivers
+        2017/08/24 15:42:07 Pulling image mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 for executors, by default. To bypass set spark.mesos.executor.docker.forcePullImage=false
+        2017/08/24 15:42:07 Setting DCOS_SPACE to /spark
+        Run job succeeded. Submission id: driver-20170824224209-0001
+        ```
+
+    2. View the standard output from your job:
+
+        ```bash
+        dcos spark log driver-20170824224209-0001
+        ```
+
+        Expected output:
+
+        ```bash
+        Pi is roughly 3.141853333333333
+        ```
+
+2. Run a Python SparkPi jar. You can view the example source [here](https://downloads.mesosphere.com/spark/examples/pi.py).
+
+    1. Use the following command to run a Python {{ model.techShortName }} job which calculates the value of Pi.
+
+        ```bash
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/pi.py 30"
+        ```
+
+        Expected output:
+
+        ```bash
+        2017/08/24 15:44:20 Parsing application as Python job
+        2017/08/24 15:44:23 Using docker image mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 for drivers
+        2017/08/24 15:44:23 Pulling image mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 for executors, by default. To bypass set spark.mesos.executor.docker.forcePullImage=false
+        2017/08/24 15:44:23 Setting DCOS_SPACE to /spark
+        Run job succeeded. Submission id: driver-20170824224423-0002
+        ```
+
+    2. View the standard output from your job:
+
+        ```bash
+        dcos task log --completed driver-20170616213917-0002
+        ```
+
+        Expected output:
+
+        ```bash
+        Pi is roughly 3.142715
+        ```
+
+3. Run an R job. You can view the example source [here](https://downloads.mesosphere.com/spark/examples/dataframe.R).
+
+    1. Use the following command to run an R job.
+
+        ```bash
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/dataframe.R"
+        ```
+
+        Expected output:
+
+        ```bash
+        2017/08/24 15:45:21 Parsing application as R job
+        2017/08/24 15:45:23 Using docker image mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 for drivers
+        2017/08/24 15:45:23 Pulling image mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 for executors, by default. To bypass set spark.mesos.executor.docker.forcePullImage=false
+        2017/08/24 15:45:23 Setting DCOS_SPACE to /spark
+        Run job succeeded. Submission id: driver-20170824224524-0003
+        ```
+
+    2. Use the following command to view the standard output from your job.
+
+        ```bash
+        dcos spark log --lines_count=10 driver-20170824224524-0003
+        ```
+
+        Expected output:
+
+        ```bash
+        In Filter(nzchar, unlist(strsplit(input, ",|\\s"))) :
+          bytecode version mismatch; using eval
+        root
+         |-- name: string (nullable = true)
+         |-- age: double (nullable = true)
+        root
+         |-- age: long (nullable = true)
+         |-- name: string (nullable = true)
+            name
+        1 Justin
+        ```
+
+## Next steps
+
+- To view the status of your job, run the `dcos spark webui` command then visit the {{ model.techShortName }} cluster dispatcher UI at `http://<dcos-url>/service/spark/` .
+- To view the logs, see the documentation for [Mesosphere DC/OS monitoring](https://docs.mesosphere.com/1.12/monitoring/logging/).
+- To view details about your {{ model.techShortName }} job, run the `dcos task log --completed <submissionId>` command.

--- a/pages/services/spark/2.8.0-2.4.0/release-notes/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/release-notes/index.md
@@ -1,0 +1,278 @@
+---
+layout: layout.pug
+navigationTitle: Release Notes
+title: Release Notes
+menuWeight: 10
+excerpt: Release notes for DC/OS Apache Spark 2.8.0-2.4.0
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+## Version Spark and Spark history 2.8.0-2.4.0
+
+### New features
+- Mesos checkpointing support for Spark Drivers submitted to Dispatcher. For more information check [fault tolerance][21] documentation
+
+### Updates
+- Upgraded Hadoop dependency to 2.9.2
+
+### Bug fixes
+- Fixed bug for Spark Executor ID being different from Mesos Task ID
+- Fixed a bug in Spark CLI causing incorrect parsing of `jars` argument when word "jars" is present in path
+
+### Breaking changes
+- The default Hadoop dependency is now 2.9 and not 2.7
+
+
+## Version Spark and Spark history 2.7.0-2.4.0
+
+### New features
+- Upgraded Spark and Spark History Server to 2.4.0
+
+### Updates
+- {{ model.techShortName }} Mesos Dispatcher uses the same user for running {{ model.techShortName }} jobs as itself and defaults to `nobody`
+- Switched to [dcos-commons](https://github.com/mesosphere/dcos-commons/) bootstrap script for IP address detection
+
+### Breaking changes
+- Removed configuration option `use_bootstrap_for_IP_detect` since we now use `bootstrap` by default for Spark container IP detection which works across all containerizers: `DOCKER` & `MESOS` (UCR) and networking modes: `HOST` & CNI Virtual Networks.
+
+## Version Spark and Spark history 2.6.0-2.3.2
+
+### New features
+- Upgraded Spark and Spark History Server to 2.3.2
+- Added DC/OS Spark CLI support for `--jars`
+- Added CNI Support for Dispatcher, Driver, and Executors for Docker and Mesos containerizers
+- Added CNI labels support for Mesos containerizer
+- Added package configuration for CNI:
+    - `virtual_network_enabled`
+    - `virtual_network_name`
+    - `virtual_network_plugin_labels`
+- Spark Dispatcher by default launches Spark Drivers and Executors in the same virtual network it was launched in itself
+
+<p class="message--note"><strong>NOTE: </strong>Limitations of current Spark CNI support:
+<ul>
+  <li>Configuration of network plugin labels from DC/OS UI supported only in JSON editing mode</li>
+  <li>Network plugin labels are not supported by Docker containerizer</li>
+  <li>Currently, DC/OS AdminRouter doesn't support virtual networks so DC/OS {{ model.techShortName }} endpoints will not be accessible from CLI, and jobs need to be submitted from a routable network</li>
+</ul>
+</p>
+
+### Updates
+- `SPARK_HOME` environment variable defaults to `/opt/spark` in Dockerfile and executable scripts
+- Switched to Spark's own StatsD Sink instead of 3rd-party dependency
+- Updated [dcos-commons](https://github.com/mesosphere/dcos-commons/) bootstrap version to 0.55.2
+
+### Bug fixes
+- Fixed bug for Dispatcher restarting duplicate Spark drivers after agent restart in `--supervised` mode
+- Fixed bug for CLI incorrect `--jars` parsing resulting in submit failure
+
+## Version Spark and Spark history 2.5.0-2.2.1
+
+### New features
+- Added unique Mesos Task IDs for Spark executors.
+- Added trusted Ubuntu 18.04 base Docker image.
+- Added `nobody` user support on RHEL/CentOS (through configuration).
+
+### Updates
+- Changed the default user for the Docker container from `root` to `nobody`.
+- Upgraded JRE to 1.8.192.
+- Upgraded to Ubuntu 18.04`
+- Updated Hadoop dependencies from 2.7.3 to 2.7.7 (fixes CVE-2016-6811, CVE-2017-3162, CVE-2017-3166, CVE-2018-8009).
+- Updated Jetty dependencies from 9.3.11.v20160721 to 9.3.24.v20180605 (fixes CVE-2017-7658).
+- Updated Jackson dependencies from 2.6.5 to 2.9.6 (fixes CVE-2017-15095, CVE-2017-17485, CVE-2017-7525, CVE-2018-7489, CVE-2016-3720).
+- Updated ZooKeeper dependencies from 3.4.6 to 3.4.13.
+
+### Bug fixes
+- `dcos task log` now works because of unique Mesos Tasks IDs of Spark executors.
+- Fixed unstable health checks for Spark dispatcher and history server.
+- Spark dispatcher task output now redirects to stdout and is available in logs.
+
+### Breaking changes
+- Added a new configuration option `docker_user` to override the user when running Spark using Docker containerizer.
+- The default Hadoop dependency is now 2.7 and not 2.6.
+
+## Version Spark and Spark history 2.4.0-2.2.1-3
+
+### New features
+- Added service name to dispatcher’s VIP endpoints.
+- Added shell-escape fix to spark-cli (SPARK-21014).
+- Added spark.mesos.executor.gpus (SPARK-21033).
+- Added dispatcher and driver metrics.
+- Added `statsd` sink for spark metrics.
+  <p class="message--note"><strong>NOTE: </strong>Metrics is a beta feature and requires enabling UCR. Production use is not advised.</p>
+
+### Updates
+- Updated tests, build tools, CLI, and vendor packages.
+- Updated bootstrap version to 0.50.0.
+- Updated JRE version to 8u172.
+
+### Bug fixes
+- Fixed duplicate docker image URLs, with use `resource.json` as the default.
+
+### Breaking changes
+- VIP endpoints for the dispatcher are no longer `spark-dispatcher:<port>` and are now `dispatcher.{{service.name}}:<port>`.
+
+## Version Spark and Spark history 2.4.0-2.2.1-3
+
+### New features
+- Added service name to dispatcher’s VIP endpoints.
+- Added shell-escape fix to spark-cli (SPARK-21014).
+- Added spark.mesos.executor.gpus (SPARK-21033).
+- Added dispatcher and driver metrics.
+- Added `statsd` sink for spark metrics.
+  <p class="message--note"><strong>NOTE: </strong>Metrics is a beta feature and requires enabling UCR. Production use is not advised.</p>
+
+### Updates
+- Updated tests, build tools, CLI, and vendor packages.
+- Updated bootstrap version to 0.50.0.
+- Updated JRE version to 8u172.
+
+### Bug fixes
+- Fixed duplicate docker image URLs, with use `resource.json` as the default.
+
+### Breaking changes
+- VIP endpoints for the dispatcher are no longer `spark-dispatcher:<port>` and are now `dispatcher.{{service.name}}:<port>`.
+
+## Version Spark and Spark history 2.3.1-2.2.1-2
+
+### Updates
+- Updated `libmesos`  version with a critical bug fix.
+
+### Documentation
+- Added a [page](https://docs.mesosphere.com/services/spark/2.3.1-2.2.1-2/limits/) documenting results from scale testing of Spark on DC/OS.
+
+## Version 2.3.0-2.2.1-2
+
+### New features
+- Added secrets support for drivers, so that a secret can be disseminated to the executors. (SPARK-22131).
+- Added Kerberos ticket renewal (SPARK-21842).
+- Added Mesos sandbox URI to the Dispatcher UI (SPARK-13041).
+- Added support for Driver <-> Executor TLS with file-based secrets.
+- Added support for Driver <-> Executor SASL (RPC endpoint authentication and encryption) using file-based secrets.
+- Added `--executor-auth-secret` as a shortcut for Driver <-> Executor Spark SASL (RPC endpoint authentication and encryption) configuration.
+- Added CLI command to generate a random secret.
+- Enabled native BLAS for MLLib.
+- Added configuration to deploy Dispatcher on UCR (default is Docker).
+- Instead of setting the `krb5.conf` as a base64-encoded blob, the user can now specify `service.security.kerberos.kdc.[port|hostname]` and `service.security.kerberos.realm` directly in the `options.json` file. The behavior with the base64-encoded blob remains the same, and will overwrite the new configuration.
+
+### History server
+- Added Kerberos support for integration with a Kerberized HDFS. See documentation for configuration instructions.
+- Made the user configurable, defaults to root.
+
+### Updates
+- Updated JRE version to 8u152 JCE.
+- Changed the default user to root (Breaking change).
+
+### Bug fixes
+- First delegation token renewal time is not 75% of renewal time (SPARK-22583).
+- Fixed supervise mode with checkpointing(SPARK-22145).
+- Added support for older SPARK_MESOS_KRB5_CONF_BASE64 environment variable.
+- The spark CLI has "shortcut" command-line arguments that are translated into `spark.config=setting` configurations downstream (such as `spark.executor.memory`) no longer overwrite the configuration a user sets directly with the default value for the shortcut argument.
+
+### Breaking changes
+- Changed the default user to root, in both the Dispatcher and history server.
+- To configure Kerberos in the `options.json` file, a new property `service.security.kerberos.enabled` must be set to `true`. This option applies to both the Dispatcher and history server.
+- Removed the `security.ssl` properties from the `options.json` file. These properties are no longer needed for the Go-based CLI.
+- Removed `--dcos-space` option from the CLI. Access to secrets is determined by the Spark Dispatcher service name. See [security](/security/) for more information about where to place secrets.
+
+## Version 2.1.0-2.2.0-1
+
+### Improvements
+- Changed the image to run as user `nobody` instead of `root` by default. (https://github.com/mesosphere/spark-build/pull/189)
+
+### Bug fixes
+- Configuration to allow custom Dispatcher docker image. (https://github.com/mesosphere/spark-build/pull/179)
+- CLI breaks with multiple spaces in submit args. (https://github.com/mesosphere/spark-build/pull/193)
+
+### Documentation
+- Updated the HDFS endpoint information in [hdfs]{/hdfs/}.
+- Added checkpointing instructions. (https://github.com/mesosphere/spark-build/pull/181)
+- Updated custom docker image support policy. (https://github.com/mesosphere/spark-build/pull/200)
+
+## Version 2.2.0-2.2.0-2-beta
+
+### Improvements
+* Added secrets support in driver (SPARK-22131).
+* Added Kerberos ticket renewal (SPARK-21842).
+* Added Mesos sandbox URI to dispatcher UI(SPARK-13041).
+* Updated JRE version to 8u152 JCE.
+* Added support for Driver <-> Executor TLS with file-based secrets.
+* Added support for Driver <-> Executor SASL (RPC endpoint authentication and encryption) with file-based secrets.
+* Added CLI command to generate a random secret.
+* Enabled native BLAS for MLLib.
+* Added configuration to deploy Dispatcher on UCR (default is Docker).
+
+### Bug fixes
+* First delegation token renewal time is not 75% of renewal time (SPARK-22583).
+* Fixed `supervise` mode with checkpointing(SPARK-22145).
+* Added support for older `SPARK_MESOS_KRB5_CONF_BASE64` environment variable.
+
+### Tests
+* Added integration test that reads / writes to a Kerberized HDFS.
+* Added integration test that reads / writes to a Kerberized Kafka.
+* Added integration test of checkpointing and supervise.
+
+### Documentation
+* Updated naming of DC/OS.
+* Updated docs links in package post-install notes.
+* Updated Kerberos docs.
+* Documented running Spark Streaming jobs with Kerberized Kafka.
+* Documented `nobody` limitation on certain OSes.
+
+## Version 2.1.0-2.2.0-1
+
+### Improvements
+- Changed the image to run as user `nobody` instead of `root` by default. (https://github.com/mesosphere/spark-build/pull/189)
+
+### Bug fixes
+- Configuration to allow a custom dispatcher Docker image. (https://github.com/mesosphere/spark-build/pull/179)
+- CLI breaks with multiple spaces in submit arguments. (https://github.com/mesosphere/spark-build/pull/193)
+
+### Documentation
+- Updated HDFS endpoint information in [hdfs](/hdfs/).
+- Added checkpointing instructions. (https://github.com/mesosphere/spark-build/pull/181)
+- Updated custom docker image support policy. (https://github.com/mesosphere/spark-build/pull/200)
+
+## Version 2.0.1-2.2.0-1
+
+### Improvements
+- Exposed isR and isPython spark run arguments.
+
+### Bug fixes
+- Allowed for application args to have arguments without equals sign.
+- Fixed docs link in Universe package description.
+
+## Version 2.0.0-2.2.0-1
+
+### Improvements
+- Kerberos support has changed to use common code from `spark-core` instead of custom implementation.
+- Added file and environment variable-based secret support.
+- Kerberos keytab/TGT login from the DC/OS Spark CLI in cluster mode (uses file-based secrets).
+- Added CNI network label support.
+- CLI doesn't require spark-submit to be present on client machine.
+
+### Bug fixes
+- Drivers are successfully re-launched when `--supervise` flag is set.
+- CLI works on 1.9 and 1.10 DC/OS clusters.
+
+### Breaking changes
+- Setting `spark.app_id` has been removed (for example, `dcos config set spark.app_id <dispatcher_app_id>`). To submit jobs with a given
+dispatcher, use `dcos spark --name <dispatcher_app_id>`.
+- `principal` is now `service_account` and `secret` is now `service_account_secret`.
+
+## Version 1.1.1-2.2.0
+
+### Improvements
+* Upgrade to Spark 2.2.0.
+* Spark driver now supports configurable failover_timeout. The default value is 0 when the configuration is not set [SPARK-21456](https://issues.apache.org/jira/browse/SPARK-21456).
+
+### Breaking change
+
+*  Spark CLI no longer supports `-Dspark` arguments.
+
+## Version 1.0.9-2.1.0-1
+
+- The history server has been removed from the "spark" package, and put into a dedicated "spark-history" package.
+
+[21] https://docs.mesosphere.com/services/{{ model.packageName }}/2.8.0-2.4.0/fault-tolerance/#mesos-checkpointing

--- a/pages/services/spark/2.8.0-2.4.0/run-job/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/run-job/index.md
@@ -1,0 +1,105 @@
+---
+layout: layout.pug
+navigationTitle: Run a Spark Job
+excerpt: Running a Spark job
+title: Run a Spark Job
+menuWeight: 80
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+1. Before submitting your job, upload the artifact (such as a `jar` file) to a location that is visible to the cluster (such as HTTP, S3, or HDFS). [Learn more][13].
+
+1. Run the job.
+    - Include all configuration flags for the job before the `jar` url.
+    - Provide the arguments for the {{ model.techShortName }} job after the `jar` url.
+
+    Follow the template `dcos spark run --submit-args="<flags> URL [args]`, where:
+    - `<flags>` are options like `--conf spark.cores.max=16` and `--class my.aprk.App`
+    - `URL` is the location of the application
+    -`[args]` are any arguments for the application
+
+    For example:
+
+        dcos spark run --submit-args=--class MySampleClass http://external.website/mysparkapp.jar"
+        dcos spark run --submit-args="--py-files mydependency.py http://external.website/mysparkapp.py"
+        dcos spark run --submit-args="http://external.website/mysparkapp.R"
+
+    If your job runs successfully, you will get a message with the job’s submission ID:
+
+        Run job succeeded. Submission id: driver-20160126183319-0001
+
+1. View the {{ model.techShortName }} scheduler progress by navigating to the {{ model.techShortName }} dispatcher at http://<dcos-url>/service/spark/`.
+
+1. View the job's logs through the Mesos UI at `http://<dcos-url>/mesos/` or by running `dcos task log --follow <submission_id>`.
+
+# Setting {{ model.techShortName }} properties
+
+{{ model.techShortName }} job settings are controlled by configuring [{{ model.techShortName }} properties][14].
+
+## Submission
+
+All properties are submitted through the `--submit-args` option to `dcos spark run`. There are a few options that are unique to DC/OS that are not in {{ model.techShortName }} Submit (for example `--keytab-secret-path`).  View `dcos spark run --help` for a list of all these options. All `--conf` properties supported by {{ model.techShortName }} can be passed through the command-line with within the `--submit-args` string.
+
+    dcos spark run --submit-args="--conf spark.executor.memory=4g --supervise --class MySampleClass http://external.website/mysparkapp.jar 30"
+
+## Setting automatic configuration defaults
+
+To set {{ model.techShortName }} properties with a configuration file, create a
+`spark-defaults.conf` file and set the environment variable
+`SPARK_CONF_DIR` to the containing directory. [Learn more][15].
+
+## Using a properties file
+
+To reuse {{ model.techShortName }} properties without cluttering the command line, the CLI supports passing a path to a local file containing {{ model.techShortName }} properties. Such a file consists of properties and values separated by whitespace. For example:
+```text
+spark.mesos.containerizer   mesos
+spark.executors.cores       4
+spark.eventLog.enabled      true
+spark.eventLog.dir          hdfs:///history
+```
+This sample property file sets the containerizer to `mesos`, the executor cores to `4` and enables the history server. This file is parsed locally, so it is not be available to your driver applications.
+
+## Secrets
+
+Enterprise DC/OS provides a secrets store to enable access to sensitive data such as database passwords, private keys, and API tokens. DC/OS manages secure transportation of secret data, access control and authorization, and secure storage of secret content. A secret can be exposed to drivers and executors as a file or as an environment variable.
+
+To configure a job to access a secret, see the sections on
+* [Using the Secret Store](../security/#using-the-secret-store) and
+* [Using Mesos Secrets](../security/#using-mesos-secrets)
+
+# DC/OS overlay network
+
+To submit a {{ model.techShortName }} job inside the [DC/OS Overlay Network](/1.12/overview/design/overlay/), run a command similar to the following:
+
+    dcos spark run --submit-args="--conf spark.mesos.containerizer=mesos --conf spark.mesos.network.name=dcos --class MySampleClass http://external.website/mysparkapp.jar"
+
+Note that DC/OS overlay support requires the [UCR](/1.12/deploying-services/containerizers/ucr/)   rather than the default Docker Containerizer, so you must set `--conf spark.mesos.containerizer=mesos`.
+
+# Driver failover timeout
+
+The `--conf spark.mesos.driver.failoverTimeout` option specifies the number of seconds that the master will wait for the driver to reconnect, after being temporarily disconnected, before it tears down the driver framework by killing
+all its executors. The default value is zero, meaning no timeout. If the
+driver disconnects and the value of this option is zero, the master immediately tears down the framework.
+
+To submit a job with a nonzero failover timeout, run a command similar to the following:
+
+    dcos spark run --submit-args="--conf spark.mesos.driver.failoverTimeout=60 --class MySampleClass http://external.website/mysparkapp.jar"
+
+<p class="message--important"><strong>IMPORTANT: </strong>If you kill a job before it finishes, the framework will persist as an <code>inactive</code> framework in Mesos for a period equal to the failover timeout. You can manually tear down the framework before that period is over by hitting
+the <a href="http://mesos.apache.org/documentation/latest/endpoints/master/teardown/">Mesos teardown endpoint</a>.</p>
+
+# Versioning
+
+The DC/OS {{ model.techName }} Docker image contains OpenJDK 8 and Python 2.7.6.
+
+DC/OS {{ model.techName }} distributions 1.X are compiled with Scala 2.10.  DC/OS {{ model.techName }} distributions 2.X are compiled with Scala 2.11.  Scala is not binary compatible across minor verions, so your {{ model.techShortName }} job must be compiled with the same Scala version as your version of DC/OS {{ model.techName }}.
+
+The default DC/OS {{ model.techName }} distribution is compiled against Hadoop 2.9 libraries.  However, you can choose a different version by following the instructions in [Customize {{ model.techShortName }} distribution](/services/spark/2.8.0-2.4.0/install/#custom-dist/).
+
+
+[13]: http://spark.apache.org/docs/latest/submitting-applications.html
+[14]: http://spark.apache.org/docs/latest/configuration.html#spark-properties
+[15]: http://spark.apache.org/docs/latest/configuration.html#overriding-configuration-directory
+[18]: http://mesos.apache.org/documentation/latest/endpoints/master/teardown/

--- a/pages/services/spark/2.8.0-2.4.0/runtime-config-change/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/runtime-config-change/index.md
@@ -1,0 +1,22 @@
+---
+layout: layout.pug
+navigationTitle: Runtime Configuration Changes
+excerpt: Customizing DC/OS Apache Spark while it is up and running
+title: Runtime Configuration Changes
+menuWeight: 70
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+You can customize DC/OS {{ model.techName }} in-place when it is up and running.
+
+1. Go to the DC/OS GUI.
+
+1. Click the **Services** tab, then the name of the {{ model.techShortName }} framework to be updated.
+
+1. Within the {{ model.techShortName }} instance details view, click the menu in the upper right, then choose **Edit**.
+
+1. In the dialog that appears, click the **Environment** tab and update any field(s) to their desired value(s).
+
+1. Click **REVIEW & RUN** to apply any changes and cleanly reload {{ model.techShortName }}.

--- a/pages/services/spark/2.8.0-2.4.0/security/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/security/index.md
@@ -1,0 +1,203 @@
+---
+layout: layout.pug
+navigationTitle: Security
+excerpt: Configuring DC/OS service accounts for Spark
+title: Security
+menuWeight: 40
+render: mustache
+model: /services/spark/data.yml
+---
+
+This section describes how to configure secure DC/OS service accounts for {{ model.techShortName }}.
+
+When running in [DC/OS strict security mode](https://docs.mesosphere.com/latest/security/ent/#security-modes), both the dispatcher and jobs must authenticate to Mesos using a [DC/OS service account](/services/spark/2.8.0-2.4.0/security/#provision-a-service-account).
+
+#include /services/include/service-account.tmpl
+
+<a name="give-perms"></a>
+
+# Create and assign permissions
+
+Use the following `curl` commands to rapidly provision the {{ model.techShortName }} service account with the required permissions. You can also provision the service account through the UI.
+
+When running in [DC/OS strict security mode](/1.12/security/ent/#security-modes/), both the dispatcher and jobs must authenticate to Mesos using a [DC/OS service account](/1.12/security/ent/#service/).
+
+Follow these instructions to [authenticate in strict mode](https://docs.mesosphere.com/services/spark/spark-auth/).
+
+# Using the secret store
+
+DC/OS Enterprise allows users to add privileged information in the form of a file to the DC/OS secret store. These files can be referenced in {{ model.techShortName }} jobs and used for authentication and authorization with various external services (for example, HDFS). For example, you can use this functionality to pass Kerberos `keytab` files. For details about how to use secrets, see [understanding secrets](/1.12/security/ent/secrets/).
+
+## Where to place secrets
+
+For a secret to be available to {{ model.techShortName }}, it must be placed in a path
+that can be accessed by the {{ model.techShortName }} service. If only {{ model.techShortName }} requires access to a secret, you can store the secret in a path that matches the name of the {{ model.techShortName }} service (for example, `spark/secret`).  See the [Secrets Documentation about Spaces][13] for details about how secret paths restrict service access to secrets.
+
+## Limitations
+
+Anyone who has access to the {{ model.techShortName }} (Dispatcher) service instance has access to all secrets available to it. Do not grant users access to the {{ model.techShortName }} Dispatchers instance unless they are also permitted to access all secrets available to the {{ model.techShortName }} Dispatcher instance.
+
+## Binary secrets
+
+You can store binary files, like a Kerberos keytab, in the DC/OS secrets store. In DC/OS 1.11 and later, you can create secrets from binary files directly. In DC/OS 1.10 or lower, files must be base64-encoded--as specified in RFC 4648--before being stored as secrets.
+
+### DC/OS 1.11 and later
+
+To create a secret called `mysecret` with the binary contents of `kerb5.keytab`, run the following command:
+
+```bash
+dcos security secrets create --file kerb5.keytab mysecret
+```
+
+### DC/OS 1.10 or earlier
+
+To create a secret called `mysecret` with the binary contents of `kerb5.keytab`, first encode it using the `base64` command line utility. The following example uses BSD `base64` (default on macOS).
+
+```bash
+base64 -i krb5.keytab -o kerb5.keytab.base64-encoded
+```
+
+Alternatively, GNU `base64` (the default on Linux) inserts line-feeds in the encoded data by default.
+Disable line-wrapping with the `-w 0` argument.
+
+```bash
+base64 -w 0 -i krb5.keytab > kerb5.keytab.base64-encoded
+```
+
+Now that the file is encoded, it can be stored as a secret.
+
+```bash
+dcos security secrets  create -f kerb5.keytab.base64-encoded  some/path/__dcos_base64__mysecret
+```
+
+<p class="message--note"><strong>NOTE: </strong>The secret name <strong>must</strong> be prefixed with <code>__dcos_base64__</code>.</p>
+
+When the `some/path/__dcos_base64__mysecret` secret is referenced in your `dcos spark run` command, its base64-decoded contents are made available as a [temporary file](http://mesos.apache.org/documentation/latest/secrets/#file-based-secrets) in your {{ model.techShortName }} application.
+
+<p class="message--note"><strong>NOTE: </strong>Make sure to only refer to binary secrets as files since holding binary content in environment variables is discouraged.</p>
+
+# Using Mesos secrets
+
+Once a secret has been added in the secret store, you can pass it to {{ model.techShortName }} with the `spark.mesos.<task-name>.secret.names` and `spark.mesos.<task-name>.secret.<filenames|envkeys>` configuration parameters, where `<task-name>` is either `driver` or `executor`. Specifying `filenames` or `envkeys` identifies the secret as either a file-based secret or an environment variable. These configuration parameters take comma-separated lists that are "zipped" together to make the final secret file or environment variable. In most cases, you should use file-based secrets whenever possible because they are more secure than environment variable secrets.
+
+<p class="message--note"><strong>NOTE: </strong>Secrets are only supported for the Mesos Universal containerizer and not for the Docker containerizer.</p>
+
+To use the Mesos containerizer, add this configuration:
+
+```
+--conf spark.mesos.containerizer=mesos
+```
+
+For example, to use a secret named `spark/my-secret-file` as a file in the driver **and** the executors, add these configuration parameters:
+```
+--conf spark.mesos.containerizer=mesos
+--conf spark.mesos.driver.secret.names=spark/my-secret-file
+--conf spark.mesos.driver.secret.filenames=target-secret-file
+--conf spark.mesos.executor.secret.names=spark/my-secret-file
+--conf spark.mesos.executor.secret.filenames=target-secret-file
+```
+These settings put the contents of the secret `spark/my-secret-file` in a secure RAM-FS mounted secret file named `target-secret-file` in the drivers' and executors' sandboxes. If you want to use a secret as an environment variable (for example, AWS credentials), you can change the configurations to be similar to the following:
+```
+--conf spark.mesos.containerizer=mesos
+--conf spark.mesos.driver.secret.names=/spark/my-aws-secret,/spark/my-aws-key
+--conf spark.mesos.driver.secret.envkeys=AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID
+```
+These example settings illustrate a secret access key stored in a secret named `spark/my-aws-secret` and a secret key ID in
+`spark/my-aws-key`.
+
+## Limitations
+
+When using a combination of environment and file-based secrets, there must be an equal number of sinks and secret sources (files and environment variables). For example:
+
+```
+--conf spark.mesos.containerizer=mesos
+--conf spark.mesos.driver.secret.names=/spark/my-secret-file,/spark/my-secret-envvar
+--conf spark.mesos.driver.secret.filenames=target-secret-file,placeholder-file
+--conf spark.mesos.driver.secret.envkeys=PLACEHOLDER,SECRET_ENVVAR
+```
+
+This code places the content of `spark/my-secret-file` into the `PLACEHOLDER` environment variable and the `target-secret-file` file as well as the content of `spark/my-secret-envvar` into the `SECRET_ENVVAR` and `placeholder-file`. In the case of binary secrets, the environment variable is empty because environment variables cannot be assigned binary values.
+
+# {{ model.techShortName }} SSL
+
+SSL support in DC/OS Apache {{ model.techShortName }} encrypts the following channels:
+
+* From the [DC/OS admin router][11] to the dispatcher.
+* Files served from the drivers to their executors.
+
+To enable SSL, a Java keystore (and, optionally, truststore) must be provided, along with their passwords. The first three settings below are **required** during job submission. If using a truststore, the last two are also **required**:
+
+| Variable                         | Description                                     |
+|----------------------------------|-------------------------------------------------|
+| `--keystore-secret-path`         | Path to keystore in secret store                |
+| `--keystore-password`            | The password used to access the keystore        |
+| `--private-key-password`         | The password for the private key                |
+| `--truststore-secret-path`       | Path to truststore in secret store              |
+| `--truststore-password`          | The password used to access the truststore      |
+
+In addition, there are a number of {{ model.techShortName }} configuration variables relevant to SSL setup.  These configuration settings
+are **optional**:
+
+| Variable                         | Description           | Default value |
+|----------------------------------|-----------------------|---------------|
+| `spark.ssl.enabledAlgorithms`    | Allowed cyphers       | JVM defaults  |
+| `spark.ssl.protocol`             | Protocol              | TLS           |
+
+The keystore and truststore are created using the [Java keytool][12]. The keystore must contain one private key and its signed public key. The truststore is optional and might contain a self-signed root-CA certificate that is explicitly
+trusted by Java.
+
+Add the stores to your secrets in the DC/OS secret store. For example, if your keystores and truststores are `server.jks` and `trust.jks`, respectively, then use the following commands to add them to the secret store:
+
+```bash
+dcos security secrets create /spark/keystore --value-file server.jks
+dcos security secrets create /spark/truststore --value-file trust.jks
+```
+
+You must add the following configurations to your `dcos spark run ` command.
+The ones in parentheses are optional:
+
+```bash
+
+dcos spark run --verbose --submit-args="\
+--keystore-secret-path=<path/to/keystore, e.g. spark/keystore> \
+--keystore-password=<password to keystore> \
+--private-key-password=<password to private key in keystore> \
+(—-truststore-secret-path=<path/to/truststore, for example, spark/truststore> \)
+(--truststore-password=<password to truststore> \)
+(—-conf spark.ssl.enabledAlgorithms=<cipher, for example, TLS_RSA_WITH_AES_128_CBC_SHA256> \)
+--class <{{ model.techShortName }} Main class> <{{ model.techShortName }} Application JAR> [application args]"
+```
+
+**DC/OS 1.10 or earlier:** Since both stores are binary files, they must be base64 encoded before being placed in the DC/OS secret store. Follow the instructions above on encoding binary secrets to encode the keystore and truststore.
+
+<p class="message--note"><strong>NOTE: </strong>If you specify environment-based secrets with <code>spark.mesos.[driver|executor].secret.envkeys</code>, the keystore and
+truststore secrets will also show up as environment variable-based secrets because of how secrets are implemented. You can ignore these extra environment variables.</p>
+
+# {{ model.techShortName }} SASL
+
+This section discusses executor authentication and BlockTransferService encryption.
+
+{{ model.techShortName }} uses Simple Authentication Security Layer (SASL) to authenticate executors with the driver and for encrypting messages sent between components. This functionality relies on a shared secret between all components you expect to communicate with each other. A secret can be generated with the DC/OS {{ model.techShortName }} CLI:
+
+```bash
+dcos spark secret <secret_path>
+```
+For example:
+
+```
+dcos spark secret /spark/sparkAuthSecret
+```
+This example generates a random secret and uploads it to the [DC/OS secrets store][14] at the designated path. To use this secret for RPC authentication, add the following configutations to your CLI command:
+
+```bash
+dcos spark run --submit-args="\
+...
+--executor-auth-secret=/spark/sparkAuthSecret
+...
+"
+```
+
+ [11]: https://docs.mesosphere.com/latest/overview/architecture/components/
+ [12]: http://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html
+ [13]: https://docs.mesosphere.com/latest/security/ent/#spaces-for-secrets
+ [14]: https://docs.mesosphere.com/latest/security/ent/secrets/

--- a/pages/services/spark/2.8.0-2.4.0/spark-shell/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/spark-shell/index.md
@@ -1,0 +1,54 @@
+---
+layout: layout.pug
+navigationTitle: Spark Shell
+excerpt: Running commands interactively in the Apache Spark shell
+title: Interactive Spark Shell
+menuWeight: 90
+render: mustache
+model: /services/spark/data.yml
+---
+
+# Interactive {{ model.techShortName }} shell
+
+You can run {{ model.techShortName }} commands interactively in the {{ model.techShortName }} shell. The {{ model.techShortName }} shell is available in Scala, Python, and R.
+
+1. Launch a long-running interactive `bash` session using [`dcos task exec`](/1.12/cli/command-reference/dcos-task/dcos-task-exec/).
+
+1. From your interactive `bash` session, pull and run a {{ model.techShortName }} Docker image.
+
+        docker pull mesosphere/spark:2.8.0-2.4.0-hadoop-2.9
+
+        docker run -it --net=host mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 /bin/bash
+
+1. Run the {{ model.techShortName }} shell from within the Docker image.
+
+    For the Scala {{ model.techShortName }} shell:
+
+        ./bin/spark-shell --master mesos://<internal-leader-ip>:5050 --conf spark.mesos.executor.docker.image=mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 --conf spark.mesos.executor.home=/opt/spark/dist
+
+    For the Python {{ model.techShortName }} shell:
+
+        ./bin/pyspark --master mesos://<internal-leader-ip>:5050 --conf spark.mesos.executor.docker.image=mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 --conf spark.mesos.executor.home=/opt/spark/dist
+
+    For the R {{ model.techShortName }} shell:
+
+        ./bin/sparkR --master mesos://<internal-leader-ip>:5050 --conf spark.mesos.executor.docker.image=mesosphere/spark:2.8.0-2.4.0-hadoop-2.9 --conf spark.mesos.executor.home=/opt/spark/dist
+
+    <p class="message--note"><strong>NOTE: </strong>Find your internal leader IP by going to <code>dcos-url/mesos</code>. The internal leader IP is listed in the upper left hand corner.</p>
+
+1. Run {{ model.techShortName }} commands interactively.
+
+    In the Scala shell:
+
+        val textFile = sc.textFile("/opt/spark/dist/README.md")
+        textFile.count()
+
+    In the Python shell:
+
+        textFile = sc.textFile("/opt/spark/dist/README.md")
+        textFile.count()
+
+    In the R shell:
+
+        df <- as.DataFrame(faithful)
+        head(df)

--- a/pages/services/spark/2.8.0-2.4.0/troubleshooting/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/troubleshooting/index.md
@@ -1,0 +1,31 @@
+---
+layout: layout.pug
+navigationTitle: Troubleshooting
+excerpt: Troubleshooting DC/OS Apache Spark
+title: Troubleshooting
+menuWeight: 125
+render: mustache
+model: /services/spark/data.yml
+---
+
+# Dispatcher
+
+* The Mesos cluster dispatcher is responsible for queuing, tracking, and supervising drivers. Potential problems can arise if the dispatcher does not receive the resources offers you expect from Mesos, or if driver submission is failing. To debug this class of issue, visit the Mesos UI at `http://<dcos-url>/mesos/` and navigate to the sandbox for the dispatcher.
+
+# Jobs
+
+*   DC/OS Apache Spark jobs are submitted through the dispatcher, which displays Spark properties and job state. Start here to verify that the job is configured as you expect.
+
+*   The dispatcher further provides a link to the job's entry in the history server, which displays the Spark Job UI. The UI shows scheduling and performance information for the job. Go here to debug issues with scheduling and performance.
+
+*   Jobs themselves log output to their sandbox, which you can access through the Mesos UI. The Spark logs are sent to standard error (`stderr`), while any output you write in your job is sent to standard output (`stdout`).
+
+# CLI
+
+The Spark CLI is integrated with the dispatcher so that they always use the same version of Spark, and so that certain defaults are honored. To debug issues with their communication, run your jobs with the `--verbose` flag.
+
+# HDFS Kerberos
+
+To debug authentication in a Spark job, enable Java security debug output:
+
+    dcos spark run --submit-args="--conf sun.security.krb5.debug=true..."

--- a/pages/services/spark/2.8.0-2.4.0/uninstall/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/uninstall/index.md
@@ -1,0 +1,19 @@
+---
+layout: layout.pug
+navigationTitle: Uninstall
+excerpt: Uninstalling DC/OS Apache Spark
+title: Uninstalling Spark
+menuWeight: 60
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+To  uninstall DC/OS {{ model.techName }}, run the following command:
+
+    dcos package uninstall --app-id=<app-id> spark
+
+The {{ model.techShortName }} dispatcher persists state in ZooKeeper, so to fully uninstall the DC/OS {{ model.techName }} package, you must:
+
+1. Navigate to `http://<dcos-url>/exhibitor`.
+1. Click on `Explorer`.
+1. Delete the znode corresponding to your instance of {{ model.techShortName }}. By default, this node is `spark_mesos_Dispatcher`.

--- a/pages/services/spark/2.8.0-2.4.0/upgrade/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/upgrade/index.md
@@ -1,0 +1,28 @@
+---
+layout: layout.pug
+navigationTitle: Upgrade
+excerpt: Upgrading DC/OS Apache Spark
+title: Upgrade
+menuWeight: 50
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+Because the {{ model.techShortName }} dispatcher persists its state in ZooKeeper, upgrading the DC/OS {{ model.techName }} package requires you to complete the following steps:
+- Remove the DC/OS {{ model.techName }} package from ZooKeeper.
+- Uninstall your current DC/OS {{ model.techName }} package.
+- Install the DC/OS {{ model.techName }} upgrade.
+
+To upgrade DC/OS {{ model.techName }}, do the following:
+1. Navigate to `http://<dcos-url>/exhibitor`.
+1. Click `Explorer`.
+1. Delete the znode corresponding to your instance of {{ model.techShortName }}.
+        By default, the znode instance is `spark_mesos_Dispatcher`.
+1. Select the {{ model.techShortName }} service from the list of Services in the DC/OS GUI and click **Delete** or run the following command from the DC/OS CLI:
+
+        dcos package uninstall --app-id=<app-id> spark
+1. Verify that you no longer see your {{ model.techShortName }} service on the **Services** page.
+1. Reinstall the new {{ model.techShortName }} package by running the following command:
+
+        dcos package install spark

--- a/pages/services/spark/2.8.0-2.4.0/usage-examples/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/usage-examples/index.md
@@ -1,0 +1,64 @@
+---
+layout: layout.pug
+navigationTitle: Usage Examples
+excerpt: Using DC/OS Apache Spark
+title: Usage Examples
+menuWeight: 15
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+This section describes a basic and advanced example of how to use DC/OS {{ model.techName }}.
+
+# Basic
+
+1. Perform a default installation by following the instructions in the [Install and Customize](/services/spark/2.8.0-2.4.0/install/) section.
+
+1. Run a {{ model.techShortName }} job:
+
+        dcos spark run --submit-args="--class org.apache.spark.examples.SparkPi https://downloads.mesosphere.com/spark/assets/spark-examples_2.11-2.4.0.jar 30"
+
+1. Run a Python {{ model.techShortName }} job:
+
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/pi.py 30"
+
+1. Run an R {{ model.techShortName }} job:
+
+        dcos spark run --submit-args="https://downloads.mesosphere.com/spark/examples/dataframe.R"
+
+1. View the status of your job using the Spark cluster dispatcher or use the Mesos UI to see job logs.
+
+# Advanced
+
+Run a {{ model.techShortName }} Streaming job with Kafka.
+
+Examples of {{ model.techShortName }} Streaming applications that connect to a secure Kafka cluster can be found at [spark-build](https://github.com/mesosphere/spark-build/blob/2.8.0-2.4.0/tests/jobs/scala/src/main/scala/KafkaJobs.scala). As mentioned in the [Kerberos](/services/spark/2.8.0-2.4.0/kerberos/) section, {{ model.techShortName }} requires a JAAS file, the `krb5.conf`, and the keytab.
+
+An example of a JAAS file is:
+
+        KafkaClient {
+            com.sun.security.auth.module.Krb5LoginModule required
+            useKeyTab=true
+            storeKey=true
+            keyTab="/mnt/mesos/sandbox/kafka-client.keytab"
+            useTicketCache=false
+            serviceName="kafka"
+            principal="client@LOCAL";
+        };
+
+The corresponding `dcos spark` command would be:
+
+        dcos spark run --submit-args="\
+        --conf spark.mesos.containerizer=mesos \  # required for secrets
+        --conf spark.mesos.uris=<URI_of_jaas.conf> \
+        --conf spark.mesos.driver.secret.names=spark/__dcos_base64___keytab \  # base64 encoding of binary secrets required in DC/OS 1.10 or lower
+        --conf spark.mesos.driver.secret.filenames=kafka-client.keytab \
+        --conf spark.mesos.executor.secret.names=spark/__dcos_base64___keytab \
+        --conf spark.mesos.executor.secret.filenames=kafka-client.keytab \
+        --conf spark.mesos.task.labels=DCOS_SPACE:/spark \
+        --conf spark.scheduler.minRegisteredResourcesRatio=1.0 \
+        --conf spark.executorEnv.KRB5_CONFIG_BASE64=W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKCltyZWFsbXNdCiAgTE9DQUwgPSB7CiAgICBrZGMgPSBrZGMubWFyYXRob24uYXV0b2lwLmRjb3MudGhpc2Rjb3MuZGlyZWN0b3J5OjI1MDAKICB9Cg== \
+        --conf spark.mesos.driverEnv.KRB5_CONFIG_BASE64=W2xpYmRlZmF1bHRzXQpkZWZhdWx0X3JlYWxtID0gTE9DQUwKCltyZWFsbXNdCiAgTE9DQUwgPSB7CiAgICBrZGMgPSBrZGMubWFyYXRob24uYXV0b2lwLmRjb3MudGhpc2Rjb3MuZGlyZWN0b3J5OjI1MDAKICB9Cg== \
+        --class MyAppClass <URL_of_jar> [application args]"
+
+<p class="message--note"><strong>NOTE: </strong>There are additional walkthroughs available in the <code>docs/walkthroughs/</code> directory of Mesosphere's <a href="https://github.com/mesosphere/spark-build/"><code>spark-build</code></a>.</p>

--- a/pages/services/spark/2.8.0-2.4.0/version-policy/index.md
+++ b/pages/services/spark/2.8.0-2.4.0/version-policy/index.md
@@ -1,0 +1,12 @@
+---
+layout: layout.pug
+navigationTitle: Version Policy
+excerpt: Understanding DC/OS Apache Spark version policy
+title: Version Policy
+menuWeight: 130
+featureMaturity:
+render: mustache
+model: /services/spark/data.yml
+---
+
+We have selected the latest version of the [Apache Spark](http://spark.apache.org) stable release train for new releases. We support HDFS version 2.7 by default and version 2.6.


### PR DESCRIPTION
## Description
Resolves [DCOS-51582: Release and site docs for Spark 2.4.0 Hadoop 2.9.2 release](https://jira.mesosphere.com/browse/DCOS-51582)

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
