### PR TITLE
Document Marathon-LB Release 1.13.0

### DIFF
--- a/pages/services/marathon-lb/1.12.x/index.md
+++ b/pages/services/marathon-lb/1.12.x/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Marathon-LB 1.12.x
 title: Marathon-LB 1.12.x
-menuWeight: 1
+menuWeight: 5
 excerpt: Marathon-LB is a load balancing service for TCP, HTTP, and HTTPS requests
 enterprise: false
 ---

--- a/pages/services/marathon-lb/1.13.x/index.md
+++ b/pages/services/marathon-lb/1.13.x/index.md
@@ -1,0 +1,22 @@
+---
+layout: layout.pug
+navigationTitle:  Marathon-LB 1.12.x
+title: Marathon-LB 1.12.x
+menuWeight: 1
+excerpt: Marathon-LB is a load balancing service for TCP, HTTP, and HTTPS requests
+enterprise: false
+---
+
+<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
+
+Marathon provides a meta-framework for scheduling, container orchestration, and load balancing as part of the Mesosphere DC/OS platform. Marathon load balancer (Marathon-LB) is a proxy server and load balancer for TCP, HTTP, and HTTPS requests based on `HAProxy` open-source software. 
+
+You can configure Marathon-LB with various topologies. Here are some examples of how you might use Marathon-LB:
+
+* Use Marathon-LB as your edge load balancer running on public-facing nodes to route inbound traffic. In this scenario, Marathon-LB uses the DNS service address (A) records of public-facing nodes to route internal or external acccess requests to application instances.
+
+* Use Marathon-LB as an internal load balancer with a separate load balancer for routing public traffic. For example, in this scenario, you might use an external F5 load balancer on-premise or an Elastic Load Balancer on Amazon Web Services to route public traffic.
+
+* Use Marathon-LB strictly as an internal load balancer without providing load balancing for any public-facing traffic.
+
+* Use Marathon-LB instances in a combination of internal and external load balancers, with different services exposed on different load balancers.

--- a/pages/services/marathon-lb/1.13.x/index.md
+++ b/pages/services/marathon-lb/1.13.x/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
-navigationTitle:  Marathon-LB 1.12.x
-title: Marathon-LB 1.12.x
+navigationTitle:  Marathon-LB 1.13.x
+title: Marathon-LB 1.13.x
 menuWeight: 1
 excerpt: Marathon-LB is a load balancing service for TCP, HTTP, and HTTPS requests
 enterprise: false

--- a/pages/services/marathon-lb/1.13.x/mlb-advanced-tutorial/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-advanced-tutorial/index.md
@@ -1,0 +1,310 @@
+---
+layout: layout.pug
+navigationTitle: Tutorial - Internal and external load balancing
+title: Tutorial - Advanced internal and external load balancing
+menuWeight: 30
+excerpt: How to use Marathon-LB for both internal and external load balancing
+enterprise: false
+---
+
+This tutorial guides you through the steps for configuring Marathon-LB to be used as an internal and external load balancer.
+- The **external load balancer** is used to route external HTTP traffic into the cluster.
+- The **internal load balancer** is used for internal service discovery and load balancing within the cluster. 
+
+This tutorial illustrates a DC/OS cluster running on an AWS instance, with external traffic routed directly to an external load balancer first. The external load balancer is configured to expose the “public” agent nodes in the DC/OS cluster. The public agent nodes route inbound requests that then run as containerized DC/OS services for a website.
+
+After completing this tutorial, you will have hands-on practice configuring Marathon-LB for a cluster running on an AWS instance with Marathon-LB providing internal and external load balancing using a sample application.
+
+# Before you begin
+* You must have a DC/OS cluster installed by using [AWS cloud templates](/1.12/installing/evaluation/aws/) and credentials.
+* The DC/OS cluster must have at least one master node, at least three private agent nodes, and at least one public agent node.
+* You must have an account with access to the DC/OS web-based administrative console or DC/OS command-line interface.
+* You must have Marathon-LB installed.
+
+# Verify Marathon-LB is installed and running
+Before you configure load balancing for external or internal applications, you should verify that you have Marathon-LB installed and working properly. 
+
+To verify you have Marathon-LB installed and running:
+
+1. Find the public IP address for your [public node](/1.12/administering-clusters/locate-public-agent/).
+
+1. Navigate to the `http://<public-agent-IP>:9090/haproxy?stats` endpoint.
+
+1. Review the statistics report page.
+
+    <p>
+    <img src="/1.12/img/lb2.jpg" alt="Marathon-LB HAProxy statistics">
+    </p>
+  
+# Deploy internal load balancing
+To set up Marathon-LB for internal load balancing, you must first specify some configuration options for the Marathon-LB package. The following steps illustrate how to modify a sample configuration file for **internal load balancing**.
+
+1. Create a file called `marathon-lb-internal.json` with the following contents:
+
+    ```
+    {
+      "marathon-lb":{
+        "name":"marathon-lb-internal",
+        "haproxy-group":"internal",
+        "bind-http-https":false,
+        "role":""
+      }
+    }
+    ```
+
+    The sample configuration file:
+    * Changes the name of the app instance to `marathon-lb-internal`.
+    * Sets the name of the `HAProxy` group for load balancing to `internal`.
+    * Disables HTTP and HTTPS forwarding on ports 80 and 443 because it is not needed.
+
+1. Install the internal Marathon-LB instance to use the custom options specified by running the following command:
+
+    ``` bash
+    dcos package install marathon-lb --options=marathon-lb-internal.json --yes
+    ```
+
+    There are now two Marathon-LB load balancer instances:
+    * Internal (`marathon-lb-internal`)
+    * External (`marathon-lb`)
+
+# Deploy an external-facing NGINX app
+The following steps illustrate how to modify a sample configuration file to use Marathon-LB to handle load balancing for an external-facing application.
+
+1. Copy the JSON below into a file and name it `nginx-external.json`.
+
+    ``` json
+    {
+      "id": "nginx-external",
+      "container": {
+        "type": "DOCKER",
+        "portMappings": [
+          { "hostPort": 0, "containerPort": 80, "servicePort": 10000 }
+        ],
+        "docker": {
+          "image": "nginx:latest",
+          "forcePullImage":true
+        }
+      },
+      "instances": 1,
+      "cpus": 0.1,
+      "mem": 65,
+      "networks": [ { "mode": "container/bridge" } ],
+      "healthChecks": [{
+          "protocol": "HTTP",
+          "path": "/",
+          "portIndex": 0,
+          "timeoutSeconds": 10,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 2,
+          "maxConsecutiveFailures": 10
+      }],
+      "labels":{
+        "HAPROXY_GROUP":"external"
+      }
+    }
+    ```
+
+    The sample application definition includes the `"HAPROXY_GROUP":"external"` label. The `HAPROXY_GROUP` label instructs the external Marathon-LB (`marathon-lb`) instance to expose the application because `marathon-lb` was deployed with the `--group` parameter set to the default `external` value.
+
+1. Deploy the external NGINX app on DC/OS using this command:
+
+    ``` bash 
+    dcos marathon app add nginx-external.json
+    ```
+
+# Deploy an internal-facing NGINX app
+The following steps illustrate how to modify a sample configuration file to use Marathon-LB to handle load balancing for an internal-facing application.
+
+1. Copy the JSON below into a file and name it `nginx-internal.json`.
+
+    ``` json
+    {
+      "id": "nginx-internal",
+      "networks": [
+        { "mode": "container/bridge" }
+      ],
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "image": "nginx:latest",
+          "forcePullImage": true
+        },
+        "portMappings": [
+          {
+            "hostPort": 0,
+            "containerPort": 80,
+            "servicePort": 10001
+          }
+        ]
+      },
+      "instances": 1,
+      "cpus": 0.1,
+      "mem": 65,
+      "healthChecks": [
+        {
+          "protocol": "HTTP",
+          "path": "/",
+          "portIndex": 0,
+          "timeoutSeconds": 10,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 2,
+          "maxConsecutiveFailures": 10
+        }
+      ],
+      "labels": {
+        "HAPROXY_GROUP": "internal"
+      }
+    }
+    ```
+
+    This sample app definition specifies the `servicePort` parameter to expose the internal NGINX app service to Marathon-LB on port 10001. By default, ports 10000 through to 10100 are reserved for Marathon-LB services. Unless you modify the reserved port range, you should begin numbering your service ports from 10000.
+
+1. Deploy the internal NGINX app on DC/OS using this command:
+
+    ``` bash
+    dcos marathon app add nginx-internal.json
+    ```
+
+# Deploy an external and internal facing NGINX app
+The following steps illustrate how to modify a sample configuration file to do load balancing for an application that is accessible both externally from a public agent IP address and internally from within the cluster.
+
+1. Copy the JSON below into a file and name it `nginx-everywhere.json`. 
+
+    ``` json
+    {
+      "id": "nginx-everywhere",
+      "networks": [
+        { "mode": "container/bridge" }
+      ],
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "image": "nginx:latest",
+          "forcePullImage":true
+        },
+        "portMappings": [
+          { "hostPort": 0, "containerPort": 80, "servicePort": 10002 }
+        ]
+      },
+      "instances": 1,
+      "cpus": 0.1,
+      "mem": 65,
+      "healthChecks": [{
+          "protocol": "HTTP",
+          "path": "/",
+          "portIndex": 0,
+          "timeoutSeconds": 10,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 2,
+          "maxConsecutiveFailures": 10
+      }],
+      "labels":{
+        "HAPROXY_GROUP":"external,internal"
+      }
+    }
+    ```
+
+    This sample configuration file exposes the app both internally and externally with a unique `servicePort` setting that does not overlap with the other NGINX instances. Service ports can be defined either by using `portMappings` like the examples in this tutorial, or with the `ports` parameter in the Marathon app definition.
+
+1. Deploy the NGINX everywhere app on DC/OS using this command:
+
+    ``` bash
+    dcos marathon app add nginx-everywhere.json
+    ```
+
+# Confirm apps are deployed and accessible
+You can test your load balancing configurations by opening a [secure shell (SSH)](/1.12/administering-clusters/sshcluster/) into one of the instances in the cluster (such as a master), and running `curl` for the endpoints. For example, run the following commands.
+
+* To test access to the external load balancer, run:
+  `curl http://marathon-lb.marathon.mesos:10000`
+
+* To test access to the internal load balancer, run:
+  `curl http://marathon-lb-internal.marathon.mesos:10001`
+
+* To test access to the `nginx` app from the external load balancer, run:
+  `curl http://marathon-lb.marathon.mesos:10002/`
+
+* To test access to the `nginx` app from the internal load balancer, run:
+  `curl http://marathon-lb-internal.marathon.mesos:10002/`
+
+Each of these commands should return the NGINX ‘Welcome’ page similar to the following:
+
+<p>
+<img src="/1.12/img/lb3.jpg" alt="NGINX Welcome">
+</p>
+
+# Using virtual hosts
+An important feature of Marathon-LB is support for virtual hosts (vhost). Virtual hosts enable you to route HTTP traffic for multiple hosts (FQDNs) to the correct endpoint. For example, you could have two distinct web properties, `ilovesteak.com` and `steaknow.com`, with DNS for both pointing to the same load balancer on the same port. You can use virtual host information to ensure `HAProxy` routes traffic to the correct endpoint based on the domain name.
+
+To demonstrate how to use virtual hosts:
+1. Find your public agent IP address.
+
+1. Modify the app definition to point to the public agent DNS name. 
+
+    You can modify your app by using the [DC/OS command-line interface](#virtual-host-cli) or [web-based console](#virtual-host-web).
+
+1. Deploy the modified app definition to use the new configuration.
+
+<a name="virtual-host-cli"></a>
+
+## Modifying with app definition with the CLI
+If you are working with the external NGINX app and the `nginx-external.json` app definition file, you can modify and deploy the virtual host settings for the the NGINX application using the DC/OS CLI.
+
+1. Add the HAPROXY_0_VHOST label to your local `nginx-external.json` file. 
+
+    In this example, the public DNS name is `brenden-j-publicsl-1ltlkzeh6b2g6-1145355943.us-west-2.elb.amazonaws.com` so you would modify the app definition to contain settings similar to this code segment:
+
+    ```
+      "labels":{
+        "HAPROXY_GROUP":"external",
+        "HAPROXY_0_VHOST":"brenden-j-publicsl-1ltlkzeh6b2g6-1145355943.us-west-2.elb.amazonaws.com"
+      }
+    }
+    ```
+    The app definition should not include the leading `http://` or the trailing slash (`/`) in the public DNS name.
+
+1. Replace the contents of the deployed `nginx-external.json` with your modified local copy and deploy the modified configuration in a single step by running the following command:
+
+    ```bash
+    cat nginx-external.json | dcos marathon app update nginx-external
+    ```
+
+    You should see output similar to this:
+    <pre>
+    Created deployment 5f3e06ff-e077-48ee-afc0-745f167bc105
+    </pre>
+
+    Alternatively, you could deploy the modified NGINX external app definition as a separate step by running this command:<br>
+    <code>dcos marathon app add nginx-external.json</code>
+
+<a name="virtual-host-web"></a>
+
+## Modifying with app definition with the web-based console
+If you are working with the external NGINX application and the `nginx-external.json` app definition file, you can modify and deploy the virtual host settings for the the NGINX application using the DC/OS web-based console. 
+
+1. Open a web browser and navigate to the URL for the DC/OS web-based console.
+
+1. Click **Services**, then select the `nginx-external` service.
+
+1. Click the vertical ellipsis menu at the far right, then select **Edit**.
+
+1. Click **Environment**, then select **Add Label**.
+
+1. Type `HAPROXY_0_VHOST` for the **Key** and the public agent DNS name for the **Value**.
+    <p>
+    <img src="/1.12/img/nginx-external-gui.png" alt="Update app">
+    </p>
+
+    * The `HAPROXY_0_VHOST` label instructs Marathon-LB to expose NGINX on the external load balancer with a virtual host.
+
+    * The 0 in the label key corresponds to the `servicePort` index, beginning from 0. 
+    
+    If you have multiple `servicePort` definitions, you would iterate them as 0, 1, 2, and so on. Specifying the `servicePort` is not required, however, because Marathon assigns one by default.
+
+1. Click **Review & Run**, then click **Run Service**.
+
+1. Navigate to the public agent in your browser to verify that you see the NGINX welcome page.
+
+    <p>
+    <img src="/1.12/img/nginx-external-gui.png" alt="Update app">
+    </p>

--- a/pages/services/marathon-lb/1.13.x/mlb-basic-tutorial/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-basic-tutorial/index.md
@@ -1,0 +1,135 @@
+---
+layout: layout.pug
+navigationTitle:  Tutorial - Basic external load balancing
+title: Tutorial - External load balancing for a sample app  
+menuWeight: 25
+excerpt: How to use an external group for accessing a containerized service through Marathon-LB
+enterprise: false
+---
+This tutorial guides you through the steps for configuring Marathon-LB to run a containerized DC/OS service with external load balancing for a website. After completing this tutorial, you will have hands-on practice configuring load balancing for a sample application.
+
+In this tutorial, you will:
+* Download a Docker image that contains NGINX as a sample app.
+* Prepare load balancing for the NGINX application on the `dcos.io` website.
+* Install Marathon-LB as the edge load balancer for the service.
+* Run Marathon-LB on a public-facing node to route inbound network traffic.
+
+# Before you begin
+* You must have a DC/OS cluster with a bootstrap node, at least one master node, at least one private agent node, and at least one public agent node.
+* You must have an account with access to the DC/OS web-based administrative console or DC/OS command-line interface.
+* You must have Marathon-LB installed.
+
+# Download the app definition and container
+This tutorial uses a sample app definition file that you can download from the `dcos-website` GitHub repository.
+
+1. Copy [`dcos-website/dcos-website.json`](https://github.com/dcos/dcos-website/blob/develop/dcos-website.json) from the `dcos-website` GitHub repository.
+
+1. Go to the [`mesosphere/dcos-website`](https://hub.docker.com/r/mesosphere/dcos-website/tags) Docker repository and copy the latest `image` tag.
+
+  <p>
+  <img src="/1.12/img/dockerhub.png" alt="Mesosphere Docker Hub">
+  </p>
+
+  For example, after clicking **Tags**, you might see an identifier similar to this:
+  <code>cff383e4f5a51bf04e2d0177c5023e7cebcab3cc</code> 
+
+  <p>
+  <img src="/services/img/docker-repo-tag.png" alt="Sample image tag">
+  </p>
+
+# Modify the app image tag and public IP address
+
+1. Open the `dcos-website.json` app definition file you downloaded from the repository.
+
+1. Add the `image-tag` in the `docker:image` field with the Docker image tag.
+
+    For example:
+
+    ```json
+    {
+      "id": "dcos-website",
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "image": "mesosphere/dcos-website:cff383e4f5a51bf04e2d0177c5023e7cebcab3cc",
+          "network": "BRIDGE",
+          "portMappings": [
+            { "hostPort": 0, "containerPort": 80, "servicePort": 10004 }
+          ]
+        }
+      },
+    ```
+
+1. Identify the public-facing IP address for your public agent node. 
+
+    For information about how to find your public agent IP address, see [Finding a public agent IP](https://docs.mesosphere.com/1.12/administering-clusters/locate-public-agent/).
+
+1. In the `labels` field, add an entry for `HAPROXY_0_VHOST` and assign it the value of your public agent IP. 
+
+    For example, if the public agent node IP address is 64.172.103.2, you might add lines similar to the following:
+
+    ```
+    "labels":{
+            "HAPROXY_DEPLOYMENT_GROUP":"dcos-website",
+            "HAPROXY_DEPLOYMENT_ALT_PORT":"10005",
+            "HAPROXY_GROUP":"external",
+            "HAPROXY_0_REDIRECT_TO_HTTPS":"true",
+            "HAPROXY_0_VHOST": "64.172.103.2"
+          }
+    ```
+
+    Be sure to remove the leading `http://` and the trailing slash () from the IP address, and to add a comma after the preceding field.
+
+    The complete JSON app definition file should resemble the following:
+
+    ```json
+      {
+        "id": "dcos-website",
+        "container": {
+          "type": "DOCKER",
+          "portMappings": [
+            { "hostPort": 0, "containerPort": 80, "servicePort": 10004 }
+          ],
+          "docker": {
+            "image": "mesosphere/dcos-website:cff383e4f5a51bf04e2d0177c5023e7cebcab3cc"
+          }
+        },
+        "instances": 3,
+        "cpus": 0.25,
+        "mem": 100,
+        "network": "BRIDGE",
+        "healthChecks": [{
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,
+            "timeoutSeconds": 2,
+            "gracePeriodSeconds": 15,
+            "intervalSeconds": 3,
+            "maxConsecutiveFailures": 2
+        }],
+        "labels":{
+          "HAPROXY_DEPLOYMENT_GROUP":"dcos-website",
+          "HAPROXY_DEPLOYMENT_ALT_PORT":"10005",
+          "HAPROXY_GROUP":"external",
+          "HAPROXY_0_REDIRECT_TO_HTTPS":"true",
+          "HAPROXY_0_VHOST": "64.172.103.2"
+        }
+      }
+    ```
+
+  Only apps with the label `HAPROXY_GROUP=external` will be exposed using this Marathon-LB configuration.
+
+# Add the load-balanced application and check its status 
+1. Run the service from the DC/OS CLI using the following command:
+
+    ``` bash
+    dcos marathon app add dcos-website.json
+    ```
+
+1. Open the DC/OS web-based console URL in a browser, then click **Services** to verify that your application is deployed and running.
+
+    <p>
+    <img src="/1.12/img/healthy-dcos-website.png" alt="Healthy service">
+    </p>
+
+1. In the web browser, navigate to the IP address for your public agent node to verify the site you have deployed is running.

--- a/pages/services/marathon-lb/1.13.x/mlb-configuration/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-configuration/index.md
@@ -1,0 +1,556 @@
+---
+layout: layout.pug
+excerpt: Working with templates and app labels for Marathon-LB
+title: Working with templates and app labels
+menuWeight: 15
+---
+
+Marathon-LB provides load balancing tool for Marathon-orchestrated applications.  Marathon-LB leverages the core features of the `HAProxy` program. For DC/OS clusters, Marathon-LB reads the Marathon task information and dynamically generates the required `HAProxy` configuration details. To gather this task information, you must specify the location of one or more Marathon instances. Marathon-LB  can then use the service configuration details stored globally in **templates** or defined in app definition **labels** to route traffic to the appropriate nodes and service ports.
+
+# Using Marathon-LB templates and app labels
+Marathon-LB provides templates and application labels that enable you to use default or set custom `HAProxy` configuration parameters. Configuration parameters provide details such as the algorithm you want to use for how workload is distributed. For example, you can set a configuration parameter to distribute processing for app access requests by using a "round-robin" model or to the server with the fewest current connections. The configuration templates can be set either globally for all apps, or overridden on a service-port or per-app basis.
+
+# Overriding template and app label values
+You can override the values set in Marathon-LB global templates by: 
+- Creating an environment variable in the Marathon-LB container.
+- Placing configuration files in the `templates` directory where the path is relative to the location from which the Marathon-LB script runs.
+- Specifying labels in the app definition file. 
+
+## Overriding settings using environment variables
+One way you can override global settings is by modifying the definition for a default template setting. For example, you might modify the `HAPROXY_HTTPS_FRONTEND_HEAD` template to specify the following content:
+
+<code>
+frontend new_frontend_label
+  bind *:443 ssl crt /etc/ssl/cert.pem
+  mode http
+</code>
+
+You could then add this setting as an environment variable for the Marathon-LB configuration by specifying the following:
+
+<code> "HAPROXY_HTTPS_FRONTEND_HEAD": "\\nfrontend new_frontend_label\\n  bind *:443 ssl {sslCerts}\\n  mode http"</code>
+
+## Overriding settings using files in the templates directory
+Alternatively, you could place a file called `HAPROXY_HTTPS_FRONTEND_HEAD ` in the `templates` directory through the use of an artifact URI. At periodic intervals, Marathon-LB checks the `templates` directory for new or changed configuration settings.
+
+You can add your own custom templates to the Docker image directly, or provide them in the `templates` directory that Marathon-LB reads at startup.
+
+## Overriding settings using app labels
+Most of the Marathon-LB template settings can be overridden using app labels. By using app labels, you can override template settings per service port. App labels are specified in the Marathon app definition. For example, the following app definition excerpt uses app labels to specify the `external` load balancing group for an application with a virtual host named `service.mesosphere.com`:
+
+```json
+{
+  "id": "http-service",
+  "labels": {
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_VHOST":"service.mesosphere.com"
+  }
+}
+```
+
+The following example illustrates settings for a service called `http-service` that requires `http-keep-alive` to be disabled:
+
+```json
+{
+  "id": "http-service",
+  "labels":{
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_BACKEND_HTTP_OPTIONS":"  option forwardfor\n  no option http-keep-alive\n  http-request set-header X-Forwarded-Port %[dst_port]\n  http-request add-header X-Forwarded-Proto https if { ssl_fc }\n"
+  }
+}
+```
+
+### Specifying strings in app labels
+In specifying labels for load balancing, keep in mind that strings are interpreted as literal `HAProxy` configuration parameters, with substitutions respected. The `HAProxy` configuration file settings are validated before reloading the `HAProxy` program after you make changes. Because the configuration is checked before reloading, problems with `HAProxy` labels can prevent the `HAProxy` service from restarting with the updated configuration.
+
+### Specifying an index identifier in app labels
+Settings that you can specify per service port include the port index identifier {n} in the label name, where {n} corresponds to the service port index, beginning at zero (0).
+
+# Setting global default options
+As a shortcut for adding global default options without overriding the global template, you can specify a comma-separated list of options using the `HAPROXY_GLOBAL_DEFAULT_OPTIONS` environment variable. The default value for the `HAPROXY_GLOBAL_DEFAULT_OPTIONS` environment variable is:
+<code>Redispatch,http-server-close,dontlognull</code>
+
+To add the `httplog` option and keep the existing defaults, you could specify:
+
+<code>
+HAPROXY_GLOBAL_DEFAULT_OPTIONS=redispatch,http-server-close,dontlognull,httplog.
+</code>
+
+The setting takes effect the next time Marathon-LB checks for configuration changes. The setting does not take effect if the `HAPROXY_HEAD` template has been overridden.
+
+# Creating a sample global template
+Templates and app definition labels enable you to set custom `HAProxy` configuration parameters. Templates can be set either globally for all apps, or defined on a per-app basis using labels. The following steps summarize how to create a sample global template, add it as an archive file to the `templates` directory, and restart load balancing to use the new global template. 
+
+To create a custom global template:
+
+1. On your local computer, create a file called `HAPROXY_HEAD` in a directory called `templates` using commands similar to the following: 
+
+    ```bash
+    mkdir -p templates
+    cat > templates/HAPROXY_HEAD
+    ```
+
+1. Open the `HAPROXY_HEAD` file and add content similar to the following:
+
+    ```
+    global
+      log /dev/log local0
+      log /dev/log local1 notice
+      spread-checks 5
+      max-spread-checks 15000
+      maxconn 4096
+      tune.ssl.default-dh-param 2048
+      ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:!aNULL:!MD5:!DSS
+      ssl-default-bind-options no-sslv3 no-tlsv10 no-tls-tickets
+      ssl-default-server-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:!aNULL:!MD5:!DSS
+      ssl-default-server-options no-sslv3 no-tlsv10 no-tls-tickets
+      stats socket /var/run/haproxy/socket expose-fd listeners
+      server-state-file global
+      server-state-base /var/state/haproxy/
+      lua-load /marathon-lb/getpids.lua
+      lua-load /marathon-lb/getconfig.lua
+      lua-load /marathon-lb/getmaps.lua
+      lua-load /marathon-lb/signalmlb.lua
+    defaults
+      load-server-state-from-file global
+      log               global
+      retries                   3
+      backlog               10000
+      maxconn                3000
+      timeout connect          5s
+      timeout client          20s
+      timeout server          40s
+      timeout tunnel        3600s
+      timeout http-keep-alive  1s
+      timeout http-request    15s
+      timeout queue           30s
+      timeout tarpit          60s
+      option            dontlognull
+      option            http-server-close
+      option            redispatch
+    listen stats
+      bind 0.0.0.0:9090
+      balance
+      mode http
+      stats enable
+      monitor-uri /_haproxy_health_check
+      acl getpid path /_haproxy_getpids
+      http-request use-service lua.getpids if getpid
+      acl getvhostmap path /_haproxy_getvhostmap
+      http-request use-service lua.getvhostmap if getvhostmap
+      acl getappmap path /_haproxy_getappmap
+      http-request use-service lua.getappmap if getappmap
+      acl getconfig path /_haproxy_getconfig
+      http-request use-service lua.getconfig if getconfig
+
+      acl signalmlbhup path /_mlb_signal/hup
+      http-request use-service lua.signalmlbhup if signalmlbhup
+      acl signalmlbusr1 path /_mlb_signal/usr1
+      http-request use-service lua.signalmlbusr1 if signalmlbusr1
+    ```
+
+      In this example, the `maxconn`, `timeout client`, and `timeout server` property values have changed from the default.
+
+1. Create a compressed archive of the `HAPROXY_HEAD` file using a `tar` or `zip` command. 
+
+    For example, type the following to add the `HAPROXY_HEAD` file.
+
+    ``` #!/bin/bash
+    mkdir -p templates
+    cat > templates/HAPROXY_HEAD <<EOL
+    tar czf templates.tgz templates/
+    ```
+
+1. Make the `templates.tgz` file available by uploading the file to an HTTP server. For example, you can use FTP or another file transfer program to copy the file to a static web server URL such as Amazon S3.
+
+    You can download the sample template file using this URI: https://downloads.mesosphere.com/marathon/marathon-lb/templates.tgz
+
+1. Add the Marathon-LB template configuration to the Marathon-LB service definition by including the path to the template file, `templates` directory, or URI in a custom JSON file.
+
+    For example, you might create a new file called `marathon-lb-template-options.json` with the following lines:
+
+    ```json
+    {
+      "marathon-lb": {
+        "template-url":"https://downloads.mesosphere.com/marathon/marathon-lb/templates.tgz"
+      }
+    }
+    ```
+
+1. Restart Marathon-LB with the new configuration settings:
+
+    ```bash
+    dcos package install marathon-lb --options=marathon-lb-template-options.json --yes
+    ```
+
+  Your customized Marathon-LB instance now runs using the new template.
+
+# Creating a sample per-app template
+To create a template for an individual app, modify the application definition. In the example below, the default template for the external NGINX application definition (`nginx-external.json`) has been modified to disable the HTTP keep-alive setting. While this is not a common scenario, there may be cases where you need to override certain default values on a per-application basis.
+
+1. Copy the following lines into the `nginx-external.json` app definition file:
+
+    ```json
+    {
+        "id": "nginx-external",
+        "container": {
+          "type": "DOCKER",
+          "portMappings": [
+            { "hostPort": 0, "containerPort": 80, "servicePort": 10000 }
+          ],
+          "docker": {
+            "image": "nginx:1.7.7",
+            "forcePullImage":true
+          }
+        },
+        "instances": 1,
+        "cpus": 0.1,
+        "mem": 65,
+        "network": "BRIDGE",
+        "healthChecks": [{
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,
+            "timeoutSeconds": 10,
+            "gracePeriodSeconds": 10,
+            "intervalSeconds": 2,
+            "maxConsecutiveFailures": 10
+        }],
+        "labels":{
+          "HAPROXY_GROUP":"external",
+          "HAPROXY_0_BACKEND_HTTP_OPTIONS":"  option forwardfor\n  no option http-keep-alive\n      http-request set-header X-Forwarded-Port %[dst_port]\n  http-request add-header X-Forwarded-Proto https if { ssl_fc }\n"
+        }
+      }
+    ```
+
+1. Deploy the external NGINX app on DC/OS using the following command:
+
+    ```bash
+    dcos marathon app add nginx-external.json
+    ```
+
+Other options you might want to specify using customized app definition labels include:
+* enabling the sticky session option
+* redirecting to HTTPS
+* specifying a virtual host
+
+For example:
+
+```json
+   "labels":{
+      "HAPROXY_0_STICKY":"true",
+      "HAPROXY_0_BACKEND_STICKY_OPTIONS": " cookie JSESSIONID prefix nocache "
+      "HAPROXY_0_REDIRECT_TO_HTTPS":"true",
+      "HAPROXY_0_VHOST":"nginx.mesosphere.com"
+    }
+```
+
+For more information about specifying a virtual host, see [Resolving virtual hosts](/services/marathon-lb/mlb-configuration/#virtual-hosts). For information about other configuration templates and app labels, see [Marathon-LB reference](/services/marathon-lb/mlb-reference/).
+
+# Working with SSL certificates
+Marathon-LB supports secure socket layer (SSL) encryption and certificates. You can provide the path to your SSL certificate as a command line argument or in the frontend section of the load balancer configuration file using the `--ssl-certs` option. For example, if you are running the script directly, you might provide a command line similar to the following:
+
+```
+./marathon_lb.py --marathon http://localhost:8080 --group external --ssl-certs /etc/ssl/site1.co,/etc/ssl/site2.co --health-check --strict-mode
+```
+
+## Options for specifying the SSL certificate
+To use SSL certificates, you can:
+- Use the default certificate path and file name specified in the `HAProxy` configuration file. In this case, you would either save the certificate as `/etc/ssl/cert.pem` using the default certificate path or edit the configuration file to specify the correct path.
+- Provide the certificate path using the `--ssl-certs` command line option and have the `HAProxy` configuration file use that path.
+- Provide the full SSL certificate text in the `HAPROXY_SSL_CERT` environment variable. The environment variable contents are then written to the  `/etc/ssl/cert.pem` file and used if you don’t specify any additional certificate paths.
+
+If you don’t specify the SSL certificate when you run Marathon-LB (`marathon_lb.py`) on the command line, by using the Docker run script, or from the Docker image, `HAProxy` automatically creates a self-signed certificate in the default `/etc/ssl/cert.pem` location and the configuration file then uses the self-signed certificate.
+
+## Specifying multiple SSL certificates
+You can specify multiple SSL certificates per frontend. You can include the additional SSL certificates by passing a list of paths with the `--ssl-certs` command line option. You can also add multiple SSL certificates by specifying the `HAPROXY_SSL_CERT` environment variable in your application definition.
+
+If you do not specify at least one SSL certificate, Marathon-LB generates a self-signed certificate at startup. If you are using multiple SSL certificates, you can select the SSL certificate per app service port by specifying the `HAPROXY_{n}_SSL_CERT` app label that corresponds to the file path for the SSL certificates you want to use. For example, you might have:
+
+```json
+   "labels": {
+      "HAPROXY_0_VHOST":"nginx.mesosphere.com",
+      "HAPROXY_0_SSL_CERT":"/etc/ssl/certs/nginx.mesosphere.com"
+    }
+```
+
+The SSL certificates must be pre-loaded into the container for Marathon-LB to load them. You can do this by building your own image of Marathon-LB, rather than using the Mesosphere-provided image.
+
+# Applying sample configuration settings
+The following examples illustrate some common load balancer operational behavior and corresponding configuration settings. For simplicity, the examples only provide relevant segments of JSON configuration settings rather than complete JSON application defintions.
+
+## Adding HTTP headers to the health check
+The following example adds the Host header to the health check executed by HAProxy:
+
+```json
+{
+  "id":"app",
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_BACKEND_HTTP_HEALTHCHECK_OPTIONS": "  option  httpchk GET {healthCheckPath} HTTP/1.1\\r\\nHost:\\ www\n  timeout check {healthCheckTimeoutSeconds}s\n"
+  }
+}
+```
+
+## Setting timeout for long-lived socket connections
+If you're trying to run a TCP service that uses long-lived sockets through HAProxy, such as a MySQL instance, you should set longer timeouts for the backend. The following example sets the client and server timeout to 30 minutes for the specified backend.
+
+```json
+{
+  "id":"app",
+  "labels":{
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_BACKEND_HEAD":"backend {backend}\n  balance {balance}\n  mode {mode}\n  timeout server 30m\n  timeout client 30m\n"
+  }
+}
+```
+
+## Terminating SSL requests at an Elastic Load Balancer
+In some cases, you might want to allow an Elastic Load Balancer (ELB) to terminate a secure socket connection for you, but want Marathon-LB to continue to redirect non-HTTPS requests. In this scenario, the Elastic Load Balancer uses HTTP headers to communicate that the request it received came over a secure channel and has been decrypted. Specifically, the `X-Forwarded-Proto` header is set to `https`, indicating that the request was decrypted by the Elastic Load Balancer. If HAProxy isn’t configured to look for the `X-Forwarded-Proto` header, the request is processed as if it is unencrypted and is redirected using the standard redirection rules.
+
+The following configuration setting illustrates how to have Marathon-LB generate a backend rule that looks for the X-Forwarded-Proto header or a regular TLS connection and redirects the request if neither are specified.
+
+```json
+"labels": {
+  "HAPROXY_0_BACKEND_HTTP_OPTIONS": "  acl is_proxy_https hdr(X-Forwarded-Proto) https\n  redirect scheme https unless { ssl_fc } or is_proxy_https\n"
+}
+```
+
+## Disabling service port binding
+If you do not want Marathon-LB to listen on service ports, the following example illustrates how you can disable the frontend definitions:
+
+```json
+ {
+    "labels": {
+      "HAPROXY_GROUP": "external",
+      "HAPROXY_0_FRONTEND_HEAD": "",
+      "HAPROXY_0_FRONTEND_BACKEND_GLUE": ""
+    }
+  }
+  ```
+<a name="virtual-hosts">
+
+## Resolving virtual hosts
+To create a virtual host or hosts the `HAPROXY_{n}_VHOST` label needs to be set on the given application. Applications that have a virtual host set are exposed on ports 80 and 443, in addition to their service port. You can specify multiple virtual hosts with the `HAPROXY_{n}_VHOST` template using a comma as a delimiter between host names.
+
+All applications are also exposed on port 9091, using the X-Marathon-App-Id HTTP header. For more information, see `HAPROXY_HTTP_FRONTEND_APPID_HEAD` in the templates section.
+
+You can access the HAProxy statistics using the `haproxy_sta
+ts` endpoint, and you can retrieve the current HAProxy configuration settings from the `haproxy_getconfig` endpoint.
+
+If you want all subdomains for a given domain to resolve to a particular backend (for example, HTTP and HTTPS), use the following labels. Note that there is a period (.) required before the {hostname} in the `HAPROXY_0_HTTPS_FRONTEND_ACL` label. Note that you should disable virtual host mapping by removing the `--haproxy-map` argument, if you have not previously removed it.
+
+```json
+{
+  "labels": {
+    "HAPROXY_0_BACKEND_WEIGHT": "-1",
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_HTTP_FRONTEND_ACL": "  acl host_{cleanedUpHostname} hdr_end(host) -i {hostname}\n  use_backend {backend} if host_{cleanedUpHostname}\n",
+    "HAPROXY_0_HTTPS_FRONTEND_ACL": "  use_backend {backend} if {{ ssl_fc_sni -m end .{hostname} }}\n",
+    "HAPROXY_0_VHOST": "example.com"
+  }
+}
+```
+
+## Enabling HAProxy logging
+HAProxy uses socket-based logging. It is configured by default to log information to the `/dev/log` directory. To begin logging HAProxy messages, you must first mount the `/dev/log` volume in the container, then enable logging for any backends or frontends for which you want to log information. 
+
+After you enable logging, you can examine the log file results with the `journalctl` facility.
+
+1. Mount the volume into your `/marathon-lb` app:
+
+    ```json
+    {
+      "id": "/marathon-lb",
+      "container": {
+        "type": "DOCKER",
+        "volumes": [
+          {
+            "containerPath": "/dev/log",
+            "hostPath": "/dev/log",
+            "mode": "RW"
+          }
+        ],
+        "docker": {
+          "image": "mesosphere/marathon-lb:latest",
+          "network": "HOST",
+          "privileged": true,
+          "parameters": [],
+          "forcePullImage": true
+        }
+      }
+    }
+    ```
+
+1. Set option `httplog` on one backend to enable logging. In this example, the backend is `my_crappy_website`:
+
+    ```json
+    {
+      "id": "/my-crappy-website",
+      "cmd": null,
+      "cpus": 0.5,
+      "mem": 64,
+      "disk": 0,
+      "instances": 2,
+      "container": {
+        "type": "DOCKER",
+        "volumes": [],
+        "docker": {
+          "image": "brndnmtthws/my-crappy-website",
+          "network": "BRIDGE",
+          "portMappings": [
+            {
+              "containerPort": 80,
+              "hostPort": 0,
+              "servicePort": 10012,
+              "protocol": "tcp",
+              "labels": {}
+            }
+          ],
+          "privileged": false,
+          "parameters": [],
+          "forcePullImage": true
+        }
+      },
+      "healthChecks": [
+        {
+          "path": "/",
+          "protocol": "HTTP",
+          "portIndex": 0,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 15,
+          "timeoutSeconds": 2,
+          "maxConsecutiveFailures": 3,
+          "ignoreHttp1xx": false
+        }
+      ],
+      "labels": {
+        "HAPROXY_0_USE_HSTS": "true",
+        "HAPROXY_0_REDIRECT_TO_HTTPS": "true",
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_BACKEND_HTTP_OPTIONS": "  option httplog\n  option forwardfor\n  http-request set-header X-Forwarded-Port %[dst_port]\n  http-request add-header X-Forwarded-Proto https if { ssl_fc }\n",
+        "HAPROXY_0_VHOST": "diddyinc.com,www.diddyinc.com"
+      },
+      "portDefinitions": [
+        {
+          "port": 10012,
+          "protocol": "tcp",
+          "labels": {}
+        }
+      ]
+    }
+    ```
+
+    Enabling the `httplog` option only affects the backend for the service port. To enable logging for ports 80 and 443, you must modify the global HAProxy template.
+
+1. Open a secure shell (SSH) on any public agent node.
+
+1. View the logs using `journalctl`:
+
+  ```bash
+  journalctl -f -l SYSLOG_IDENTIFIER=haproxy
+  ```
+
+## Adding a custom HAProxy error response
+You can specify a custom HAProxy error response by overriding the default `errorfile` directive in a template or an app definition label. For example, you could customize the template to return a redirect to a different backend if no backends are available. 
+
+To illustrate using a custom error response:
+1. Open the application definition file for the application.
+
+1. Add a template URI to your Marathon-LB app definition like this:
+
+  ```json
+  {
+      "id":"/marathon-lb",
+      "fetch":["https://downloads.mesosphere.com/marathon/marathon-lb/templates-custom-500-response.tar.gz"]
+    }
+  ```
+
+  This example returns a custom 503 page by updating the `templates/500.http` file within the `templates-custom-500-response.tar.gz` archive file.  Alternatively, you could return a redirect to a URI by updating the `templates-custom-500-response.tar.gz` archive file like this:
+
+  ```
+  HTTP/1.1 302 Found
+  Location: http://my-redirect-handler.computers.com/
+  ```
+
+## Using HAProxy maps for backend lookup
+You can use HAProxy maps to speed up virtual hosts to backend lookup requests.
+
+This configuration setting is very useful for large installations where the traditional virtual-host-to-backend rules comparison takes considerable time because each rule is evaluated sequentially. HAProxy map creates a hash-based lookup table so that it is faster than the traditional rules-based approach. 
+
+You can add HAProxy maps for Marathon-LB by using the `--haproxy-map` flag. For example:
+
+```
+./marathon_lb.py --marathon http://localhost:8080 --group external --haproxy-map
+```
+This command creates a lookup dictionary for the host header (both HTTP and HTTPS) and X-Marathon-App-Id header. For path-based routing and authentication, Marathon-LB continues to use the backend rules comparison.
+
+## Using internal and external groups for load balancing
+You should consider using a dedicated load balancer in front of Marathon-LB to simplify upgrades and changes. Common choices for a dedicated load balancer to work with Marathon-LB include an Elastic Load Balancer (on AWS) or a hardware load balancer for on-premise installations.
+
+Use separate Marathon-LB groups (specified with the `–group` option) for internal and external load balancing. On DC/OS, the default group is `external`. The basic configuration setting for an internal load balancer would be:
+
+```json
+ {
+    "marathon-lb": {
+      "name": "marathon-lb-internal",
+      "haproxy-group": "internal",
+      "bind-http-https": false,
+      "role": ""
+    }
+  }
+```
+
+## Specifying reserved ports for load-balanced applications
+You should use service ports within the reserved range (which is 10000 to 10100 by default). Using the reserved port identifiers:
+* prevents port conflicts
+* ensures that reloads don't result in connection errors
+
+In general, you should define service ports and avoid using the `HAPROXY_{n}_PORT` label.
+
+For HTTP services, you should consider setting the virtual host and, optionally, a path to access services on ports 80 and 443. Alternatively, you can access the service on port 9091 using the `X-Marathon-App-Id header`. 
+
+For example, if you want to configure access to an app with the ID tweeter:
+
+1. Open a terminal then run the following command to switch to a master node.
+
+    ```bash
+    dcos node ssh --master-proxy --leader
+    ```
+
+1. From the master node, run the following command:
+
+    ``` bash
+    curl -vH “X-Marathon-App-Id: /tweeter” marathon-lb.marathon.mesos:9091/
+    ```
+
+1. Review the connection result.
+
+    ```
+    $ curl -vH "X-Marathon-App-Id: /tweeter" marathon-lb.marathon.mesos:9091/
+    *   Trying 10.0.5.190...
+    * TCP_NODELAY set
+    * Connected to marathon-lb.marathon.mesos (10.0.5.190) port 9091 (#0)
+    > GET / HTTP/1.1
+    > Host: marathon-lb.marathon.mesos:9091
+    > User-Agent: curl/7.50.3
+    > Accept: */*
+    > X-Marathon-App-Id: /tweeter
+    >    
+    * HTTP 1.0, assume close after body
+    < HTTP/1.0 503 Service Unavailable
+    < Cache-Control: no-cache
+    < Connection: close
+    < Content-Type: text/html
+    <
+    <html><body><h1>503 Service Unavailable</h1>
+    No server is available to handle this request.
+    </body></html>
+    * Curl_http_done: called premature == 0
+    * Closing connection 0
+
+## Assigning ports for IP-per-task apps
+Marathon-LB supports load balancing for applications that are assigned an IP address and port on a per-task basis. If each task is assigned its own unique IP address, access to the task is routed directly through the application’s service discovery port. If the service ports are not defined, Marathon-LB automatically assigns port values from a configurable range.
+
+You can configure the range for port assignment values using the `--min-serv-port-ip-per-task` and `--max-serv-port-ip-per-task` options. 
+
+You should note that the port assignment is not guaranteed if you change the set of deployed apps. For example, if you deploy a new app with a per-task IP address, the port assignments might change.

--- a/pages/services/marathon-lb/1.13.x/mlb-install/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-install/index.md
@@ -1,0 +1,463 @@
+---
+layout: layout.pug
+excerpt: Installing Marathon-LB using default or custom options for a DC/OS cluster
+title: Installing Marathon-LB
+# model: /services/marathon-lb/data.yml
+# render: mustache
+menuWeight: 10
+---
+# Installing Marathon-LB on DC/OS
+You can install Marathon-LB on a DC/OS open source or DC/OS enterprise cluster. You can install the Marathon-LB package and customize its configuration settings using the DC/OS web-based administrative console or by running DC/OS commands in a shell terminal.
+
+## Before you begin
+* You must have a DC/OS open source or enterprise cluster with a bootstrap node, at least one master node, and at least one agent node.
+* You must have access to the DC/OS web-based administrative console or DC/OS command-line interface.
+* You must have an account with administrative privileges to provision a service account and to store a secret to secure the cluster.
+
+If you are installing on DC/OS Enterprise, you must log in as a user with the appropriate permissions for the security mode--disabled, permissive, or strict--associated with the cluster. For more information about the permissions required when using different security modes, see [Permissions reference](/1.12/security/ent/perms-reference/).
+
+## Install with the default configuration options
+You can install Marathon-LB with its default configuration settings on a DC/OS open source cluster or on a DC/OS enterprise cluster by using either the DC/OS web-based administrative console or by running DC/OS commands in a shell terminal. 
+
+### To install with the default settings using the web-based DC/OS console:
+1. Log in to your DC/OS cluster using a web browser.
+1. Click **Catalog** and search for the Marathon-LB package.
+1. Select the package, then click **Review & Run** to display the **Edit Configuration** page.
+1. Configure the package settings, as needed, using the DC/OS UI or by clicking **JSON Editor** and modifying the app definition manually. 
+
+    For example, you might customize configuration settings to specify a load balancing group name or the specific number of instances to run.
+
+    For more information about customizing the configuration and the configuration settings available, see [Install with custom configuration options](#custom-config-options).
+
+1. Click **Review & Run**.
+1. Review the installation notes, then click **Run Service** to deploy the Marathon-LB package.
+
+### To install with the default settings using the DC/OS CLI:
+1. Open a terminal and connect to the DC/OS enterprise cluster from a computer where the DC/OS CLI is available.
+1. Run the following command to install Marathon-LB with its default configuration settings:
+
+  ```bash
+  dcos package install marathon-lb
+  ```
+
+Installing with the default configuration options is most appropriate if you are setting up a test environment, preparing a cluster for development, or establishing a basic pilot program before moving components to production.
+
+In most cases, you would instead deploy load balancing with at least a few custom configuration settings, such as virtual host information or SSL certificates. If you are installing load balancing on DC/OS Enterprise using `strict` security, you must also provision a service account with valid credentials to run Marathon-LB. Provisioning a service account with SSL credentials is optional if security for DC/OS Enterprise is `disabled` or in `permissive` mode.
+
+<a name=custom-config-options>
+
+## Install with custom configuration options
+You can install Marathon-LB with custom configuration settings on a DC/OS open source cluster or on a DC/OS enterprise cluster. You can specify the custom configuration options by using either the DC/OS web-based administrative console or by running DC/OS commands in a shell terminal. 
+
+Regardless of whether you install using the web-based console or the CLI, the steps are essentially the same as installing with the default configuration options. However, Marathon-LB offers many basic and advanced load balancing settings that you can customize. At a minimum, most organizations customize the load balancing group, virtual network information, secure socket layer certificates and keys, and service account information. For more information about configuration settings and using templates and app definition label, see [High availability template reference]().
+
+### To install with custom configuration settings using the DC/OS CLI:
+1. Open a terminal and connect to the DC/OS cluster from a computer where the DC/OS CLI is available.
+1. Run the following command to view all of the available Marathon-LB configuration options:
+
+    ``` bash
+    dcos package describe --config marathon-lb
+    ```
+  
+      You can redirect the output from this command to a file to save the configuration properties for editing. The default app definition for Marathon-LB looks like this:
+
+    ``` json
+    {
+      "properties": {
+        "marathon-lb": {
+          "properties": {
+            "auto-assign-service-ports": {
+              "default": false,
+              "description": "Auto assign service ports for tasks which use IP-per-task. See https://github.com/mesosphere/marathon-lb#mesos-with-ip-per-task-support for details.",
+              "type": "boolean"
+            },
+            "bind-http-https": {
+              "default": true,
+              "description": "Reserve ports 80 and 443 for the LB. Use this if you intend to use virtual hosts.",
+              "type": "boolean"
+            },
+            "container-syslogd": {
+              "default": false,
+              "description": "Enable verbose syslogd logging to container stdout. This will also capture all HAProxy http connection and other logs.",
+              "type": "boolean"
+            },
+            "cpus": {
+              "default": 2,
+              "description": "CPU shares to allocate to each marathon-lb instance.",
+              "minimum": 1,
+              "type": "number"
+            },
+            "haproxy-group": {
+              "default": "external",
+              "description": "HAProxy group parameter. Matches with HAPROXY_GROUP in the app labels.",
+              "type": "string"
+            },
+            "haproxy-map": {
+              "default": true,
+              "description": "Enable HAProxy VHost maps for fast VHost routing.",
+              "type": "boolean"
+            },
+            "haproxy_global_default_options": {
+              "default": "redispatch,http-server-close,dontlognull",
+              "description": "Default global options for HAProxy.",
+              "type": "string"
+            },
+            "instances": {
+              "default": 1,
+              "description": "Number of instances to run.",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "marathon-uri": {
+              "default": "http://marathon.mesos:8080",
+              "description": "URI of Marathon instance",
+              "type": "string"
+            },
+            "max-reload-retries": {
+              "default": 10,
+              "description": "Max reload retries before failure. Reloads happen every --reload-interval seconds. Set to 0 to disable or -1 for infinite retries.",
+              "type": "integer"
+            },
+            "maximumOverCapacity": {
+              "default": 0.2,
+              "description": "Maximum over capacity.",
+              "minimum": 0,
+              "type": "number"
+            },
+            "mem": {
+              "default": 1024.0,
+              "description": "Memory (MB) to allocate to each marathon-lb task.",
+              "minimum": 256.0,
+              "type": "number"
+            },
+            "minimumHealthCapacity": {
+              "default": 0.5,
+              "description": "Minimum health capacity.",
+              "minimum": 0,
+              "type": "number"
+            },
+            "name": {
+              "default": "marathon-lb",
+              "description": "Name for this LB instance",
+              "type": "string"
+            },
+            "parameters": {
+              "default": [],
+              "description": "Docker parameters",
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "reload-interval": {
+              "default": 10,
+              "description": "When retry-reload enabled, wait this long before attempting another reload.",
+              "type": "integer"
+            },
+            "role": {
+              "default": "slave_public",
+              "description": "Deploy marathon-lb only on nodes with this role.",
+              "type": "string"
+            },
+            "secret_name": {
+              "default": "",
+              "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+              "type": "string"
+            },
+            "ssl-cert": {
+              "description": "TLS Cert and private key for HTTPS.",
+              "type": "string"
+            },
+            "strict-mode": {
+              "default": false,
+              "description": "Enable strict mode. This requires that you explicitly enable each backend with `HAPROXY_{n}_ENABLED=true`.",
+              "type": "boolean"
+            },
+            "sysctl-params": {
+              "default": "net.ipv4.tcp_tw_reuse=1 net.ipv4.tcp_fin_timeout=30 net.ipv4.tcp_max_syn_backlog=10240 net.ipv4.tcp_max_tw_buckets=400000 net.ipv4.tcp_max_orphans=60000 net.core.somaxconn=10000",
+              "description": "sysctl params to set at startup for HAProxy.",
+              "type": "string"
+            },
+            "template-url": {
+              "default": "",
+              "description": "URL to tarball containing a directory templates/ to customize haproxy config.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "cpus",
+            "mem",
+            "haproxy-group",
+            "instances",
+            "name"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+    ```
+
+1. Edit the JSON configuration file with your customizations. 
+
+    You can choose an any file name, However, you might want to choose a file name that includes a package identifier, such as `marathon-lb-options.json`, in the name. 
+
+    For example:
+    * Change the CPU shares allocated to each Marathon-LB instance to `3`:
+
+        ```
+          "cpus": {
+            "default": 3,
+            "description": "CPU shares to allocate to each marathon-lb instance.",
+            "minimum": 3,
+            "type": "number"
+          },
+        ```
+
+    * Set the load balancing group to `na-external`:
+
+        ```
+          "haproxy-group": {
+            "default": "na-external",
+            "description": "HAProxy group parameter. Matches with HAPROXY_GROUP in the app labels.",
+            "type": "string"
+          },
+        ```
+
+    * Set the memory allocation to `2048`:
+        ```
+          "mem": {
+            "default": 2048.0,
+            "description": "Memory (MB) to allocate to each marathon-lb task.",
+            "minimum": 2048.0,
+            "type": "number"
+          },
+        ```
+
+1. Run the following command to install Marathon-LB using the settings in the customized `marathon-lb-options.json` file:
+
+  ``` bash
+  dcos package install marathon-lb --options=marathon-lb-options.json --yes
+  ```
+
+## Install on a cluster with a provisioned service account
+If you are installing Marathon-LB on a DC/OS Enterprise cluster, creating a service account is **optional** when the security mode is disabled or permissive. The service account is **required** if the security mode is strict. If the DC/OS cluster uses strict security, you must create a service account and a certificate that authorizes the service account to access Marathon-LB.
+
+To increase the security of your cluster and conform to the principle of least privilege, Mesosphere recommends that you provision a service account even if the cluster runs in disabled or permissive security mode. Note that you must have superuser permission for the cluster to create the service account. 
+
+The following steps summarize how to prepare a service account for running Marathon-LB and how set provision the service account to run a Marathon-LB instance that distributes application instances to agent nodes. If you set up multiple Marathon-LB instances that interact with the same Marathon instance, you can use the same service account for each Marathon-LB instance.
+* Create a public-private key pair.
+* Create a service account.
+* Create a service account secret (optional)
+* Provision the service account with the necessary permissions.
+* Create a customized configuration file.
+* Install Marathon-LB.
+
+If you currently running the cluster in permissive mode and plan to upgrade to strict security in the future, provisioning a service account for Marathon-LB makes upgrading easier.
+
+<a name="create-key-pair">
+
+### Create a public-private key pair
+You must generate a 2048-bit RSA public-private key pair to use to encrypt and decrypt certificates for secure socket layer (SSL) connections. One convenient way to generate the key pair is by using the DC/OS Enterprise CLI. The DC/OS command-line interface returns the keys in the `.pem` format required by DC/OS.
+
+1. Open a terminal and connect to the DC/OS enterprise cluster from a computer where the DC/OS CLI is available.
+
+1. Install the DC/OS Enterprise command-line interface (CLI), if necessary.
+
+    ``` bash
+    dcos package install dcos-enterprise-cli --yes
+    ```
+
+1. Run the following command to create a public-private key pair and save each value into a separate file within the current directory.
+
+    ``` bash
+    dcos security org service-accounts keypair mlb-private-key.pem mlb-public-key.pem
+    ```
+
+    In this example, `mlb-private-key.pem` is the name of the file containing the private key and `mlb-public-key.pem` is the name of the file containing the public key. Use the modified names to specify the private and public key files. 
+ 
+1. Verify the contents of each file.
+
+### Create a service account
+You can create a service account to use with Marathon-LB by running DC/OS Enterprise commands or by using the DC/OS web-based administrative console.
+
+#### To create a service account using the DC/OS Enterprise CLI:
+1. Open a terminal and connect to the DC/OS enterprise cluster from a computer where the DC/OS CLI is available.
+1. Run the following command to set your login authentication level to superuser.
+
+    ``` bash
+    dcos auth login
+    ```
+
+1.	Run the following command to create a new service account called `marathon-lb-sa` containing the public key you just generated.
+
+    ``` bash
+    dcos security org service-accounts create -p mlb-public-key.pem -d "Marathon-LB service account" marathon-lb-sa
+    ```
+
+1. 	Verify your new service account using the following command.
+
+    ``` bash
+    dcos security org service-accounts show marathon-lb-sa
+    ```
+
+#### To create a service account using the DC/OS Enterprise web-based console:
+1. In the DC/OS web interface, navigate to the Organization > Service Accounts tab.
+1. Click **New Service Account**.
+1. Enter a description and the service account ID. 
+1. Copy the contents of the relevant public key file, for example, `mlb-public-key.pem` into the **Public Key** field.
+
+### Create a secret for the service account
+For additional security, you can create a secret associated with the service account that contains the private key. You can create the secret by running DC/OS Enterprise commands or by using the DC/OS web-based administrative console.
+
+#### To create a secret for a service account using the DC/OS Enterprise CLI:
+1. Open a terminal and connect to the DC/OS enterprise cluster from a computer where the DC/OS CLI is available.
+1. Run the following command to set your login authentication level to superuser.
+
+    ``` bash
+    dcos auth login
+    ```
+
+1. Run one of the following commands to create a new secret called `service-account-secret` in the marathon-lb path. 
+
+    * For **strict** or **permissive** security:
+
+      ``` bash
+      dcos security secrets create-sa-secret --strict mlb-private-key.pem marathon-lb-sa marathon-lb/service-account-secret
+      ```
+
+    * For **disabled** security:
+
+      ``` bash
+      dcos security secrets create-sa-secret mlb-private-key.pem marathon-lb-sa marathon-lb/service-account-secret
+      ```
+
+    The full path to the secret for this example is `marathon-lb/service-account-secret`. Locating the secret inside the marathon-lb path ensures that only the Marathon-LB service can access it. The secret will contain the private key, the name of the service account, and other data.
+
+1. Ensure the secret was created successfully:
+
+    ``` bash
+    dcos security secrets list /
+    ```
+
+    If you have jq 1.5 or later installed, you can also use the following command to retrieve the secret and ensure that it contains the correct service account ID and private key.
+
+      ``` bash
+      dcos security secrets get /marathon-lb/service-account-secret --json | jq -r .value | jq
+      ```
+
+      If the cluster uses strict or permissive security, verify that the `login_endpoint` URL uses HTTPS protocol. If security is disabled for the cluster, the `login_endpoint` should use HTTP. If the URL begins with `https` and the cluster is in disabled mode, try upgrading the DC/OS Enterprise CLI, deleting the secret, and recreating it.
+
+1. Delete the private key file from your file system.
+
+    After you have stored the private key in the DC/OS secret store, you should delete your copy of the private key to prevent unauthorized users from using it to authenticate to DC/OS.
+
+    ``` bash
+    rm -rf mlb-private-key.pem
+    ```
+
+#### To create a secret for a service account using the DC/OS web-based console:
+
+1. Log in to the DC/OS web-based administrative console as a user with the superuser permission.
+1. Click **System**, then click **Security**.
+1. Click **New Secret**.
+1. Type `marathon-lb/service-account-secret` into the ID field to create a new secret called `service-account-secret` in the `marathon-lb` path. Locating the secret inside the `marathon-lb` path ensures that only the Marathon-LB service can access it.
+
+    If you have a **strict** or **permissive** cluster, paste the following JSON into the Value field.
+
+    ``` bash
+    {
+      "scheme": "RS256",
+      "uid": "marathon-lb-sa",
+      "private_key": "<private-key-value>",
+      "login_endpoint": "https://master.mesos/acs/api/v1/auth/login"
+    }
+    ```
+
+    If you have a **disabled** cluster, paste the following JSON into the Value field.
+
+    ```  bash
+    {
+      "scheme": "RS256",
+      "uid": "marathon-lb-sa",
+      "private_key": "<private-key-value>",
+      "login_endpoint": "http://master.mesos/acs/api/v1/auth/login"
+    }
+    ```
+
+1. Replace <private-key-value> with the value of the private key created in [Create a public-private key pair](#create-key-pair).
+1. Click **Create** to store the secret.
+1. Copy the path to your secret into a text editor. You will need this later.
+
+#### Changing the service name or location
+If you are not using `marathon-lb` as the marathon service name or if you are installing Marathon-LB in a custom location, keep in mind that you must change the secret location accordingly. The sample commands also use `marathon-lb/service-account-secret` as the full path for the secret used to store the credentials for the Marathon-LB service account. If you change the `marathon-lb` service name, you must also change this path.
+
+#### Modifying the command strings for storing a secret
+If you use the names included in the examples, you can copy and paste the commands directly into a terminal. If you decide to change any names, make sure to modify the commands before issuing them. You should note that storing the secret in the `marathon-lb/service-account-secret` path protects the secret from other services, so Mesosphere recommends you leave the path unchanged.
+
+### Provision the service account with permissions
+You can run the following commands to provision the Marathon-LB service account with the required permissions. You can execute these commands from outside of the cluster.
+
+1. Open a terminal and connect to the DC/OS enterprise cluster from a computer where the DC/OS CLI is available.
+1. Run the following command to set your login authentication level to superuser.
+
+    ``` bash
+    dcos auth login
+    ```
+
+1. Grant permissions and allowed actions to the service account using the following commands.
+
+    ``` bash
+      dcos security org users grant marathon-lb-sa dcos:service:marathon:marathon:services:/ read
+      dcos security org users grant marathon-lb-sa dcos:service:marathon:marathon:admin:events read --description "Allows access to Marathon events"
+    ```
+    You can optionally specify a description for the permissions granted. However, the `--description` argument is ignored if an access control list (ACL) already exists for the service account you are modifying.
+
+1. Add the service account secret to the configuration file by modifying the `marathon-lb-options.json` file to include the secret name.
+    * For **strict** or **permissive** security, copy and paste the following JSON into the `marathon-lb-options.json` file. Replace `marathon-lb/service-account-secret` with the secret name you used, if necessary:
+
+      ``` bash
+      {
+          "marathon-lb": {
+              "secret_name": "marathon-lb/service-account-secret",
+              "marathon-uri": "https://marathon.mesos:8443"
+          }
+      }
+      ```
+
+      This example illustrates changing the port used to communicate with Marathon to 8443. Changing the port is not required for clusters configured for `permissive` security. However, changing this setting is recommended because it ensures that communication between Marathon-LB and Marathon is encrypted.
+
+    * For **disabled** security, copy and paste the following JSON into the `marathon-lb-options.json` file. Replace `marathon-lb/service-account-secret` with the secret name you used, if necessary:
+
+      ``` bash
+      {
+          "marathon-lb": {
+              "secret_name": "marathon-lb/service-account-secret"
+          }
+      }
+      ```
+
+### Install Marathon-LB
+You can modify other default values before installing the service. To view the configuration options and default values for Marathon-LB, type the following command:
+
+``` bash
+dcos package describe --config marathon-lb
+```
+
+After you have reviewed the default `config.json` file and modified it to include the appropriate required and optional parameters, use a command similar to the following to install the package with the modified `marathon-lb-options.json` configuration file:
+
+``` bash
+dcos package install marathon-lb --options=marathon-lb-options.json --yes
+```

--- a/pages/services/marathon-lb/1.13.x/mlb-overview/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-overview/index.md
@@ -1,0 +1,99 @@
+---
+layout: layout.pug
+navigationTitle:  Marathon-LB overview
+title: Marathon-LB overview
+excerpt: Marathon-LB provides proxy and load balancing services for Marathon-orchestrated apps running on DC/OS
+menuWeight: 5
+--- 
+Marathon and Marathon load balancer (Marathon-LB) work together to provide a meta-framework for scheduling, container orchestration, and load balancing as part of the Mesosphere DC/OS platform.
+
+# Marathon orchestrates apps and frameworks
+Without load balancing, Marathon runs on the DC/OS cluster to act as the orchestrator for scheduling other applications and services to run. When you use Marathon, it is the first framework launched and its scheduler processes are started directly at startup with other initialization processes. The following diagram illustrates Marathon managing two instances of the MyApp scheduler that were started from a Docker image and other application containers for JBoss, Jetty, Sinatra, and Rails service instances.
+
+<p>
+<img src="/services/img/marathon-basic-overview.png" alt="Simplified view of Marathon orchestration">
+</p>
+
+If one of its scheduler instances fails, Marathon can restart it on another node that has available capacity to ensure that two MyApp scheduler instances are always running. In this example, the MyApp scheduler represents a supported framework that receives resource offers and can start its own tasks on the cluster. In the diagram, the MyApp scheduler runs two tasks. One task is a job that dumps a production MySQL database to S3. The other task sends an email newsletter job to an application that forwards the newsletter to all customers. 
+
+As this example illustrates, Marathon can start and manage individual application instances, manage the availability of other framework instances, help clustered applications maintain 100% uptime within any resource constraints you  specify, and can coexist with other frameworks that create their own workloads in the cluster.
+
+# Basic Marathon scaling and fault recovery
+To illustrate scaling, assume you have a cluster where Marathon running three applications: Search, Jetty, and Rails. Each application is scaled to a different number of containers: one for Search, three for Jetty, and five for Rails.
+
+If you decide to scale out the Search service and Rails-based application, you might use the Marathon REST API to add more instances. Marathon then takes care of placing the new containers on agent nodes with spare capacity, honoring any constraints you have previously set. After adding the new Search and Rails instances, your cluster of agent nodes might look like this: 
+
+<p>
+<img src="/services/img/marathon-add-instances.png" alt="Adding app instances using Marathon">
+</p>
+
+If one of the servers where an application instance runs becomes unavailable, Marathon simply moves the affected containers to another node in the cluster that has spare capacity as illustrated in the following diagram.
+
+<p>
+<img src="/services/img/marathon-failover-instances.png" alt="Failover for app instances from a disconnected node">
+</p>
+
+In this example, a datacenter worker unplugs an agent node where Search and Rails instances were previously running. In response, Marathon moves the Search and Rails instances from the agent that is no longer available to other agent nodes, maintaining  the application’s effective uptime even when there’s been a physical machine failure.
+
+# How Marathon-LB works 
+Marathon load balancer (Marathon-LB) is based on `HAProxy`, which is open-source software that acts as a proxy server and load balancer for TCP, HTTP, and HTTPS requests. `HAProxy` provides high-availability failover support, load balancing, server health checks, and throughput metrics for TCP and HTTP based applications. `HAProxy` load balancing helps to ensure that application workload does not negatively affect application performance while routing traffic efficiently and preventing service interruptions.
+
+`HAProxy` supports secure socket layer (SSL) authentication and authorization for connecting to applications, HTTP compression, endpoints for checking server health and activity, and customizable templates for modifying the `HAProxy` configuration settings. 
+
+You can also customize operations for `HAProxy` and Marathon-LB through Lua scripting or Marathon REST API calls.
+
+## Locating services and ports for load balancing
+When your app is up and running, you need a way to send traffic to it from other applications on the same cluster and from external clients. The most common way network traffic is routed to the appropriate application instances running on the appropriate agent nodes is through the domain name services ([DNS](http://en.wikipedia.org/wiki/Domain_Name_System)) you deploy. 
+
+For example, [Mesos-DNS](https://github.com/mesosphere/mesos-dns) provides service discovery through a cluster-aware domain name service that identifies IP addresses for master and agent nodes. For more information about service discovery and the default Mesosphere DNS configuration, see [DNS](/1.12/networking/DNS/mesos-dns/) and [DNS API](http://docs.mesosphere.com/1.12/networking/DNS/mesos-dns/mesos-dns-api).
+
+Marathon-LB locates applications through the Marathon framework port-based service discovery using a virtual or DNS-defined IP address and the frontend and backend configuration settings specified for the HAProxy program. For a detailed description of how ports work in Marathon, see [Networking](https://mesosphere.github.io/marathon/docs/networking.html).
+
+If you install and configure Marathon-LB, the load balancer runs the `HAProxy` TCP/HTTP proxy service on each host in the cluster. The `HAProxy` service listens for inbound connection requests on a service port on a public agent node. If clients connect to the service port to request access to an app, the `HAProxy` service transparently forwards the requests to a host name and port number associated with the individual application instances orchestrated by the Marathon service.
+
+## What Marathon-LB provides
+Marathon-LB is a Dockerized application that includes a script for running the `HAProxy` program, a default configuration file, endpoints and support for the Marathon REST API. You can secure communication through the `HAProxy` program by enabling secure socket layer (SSL) connections and creating and storing encrypted certificates. The `HAProxy` program also supports sticky sessions to send all requests in a session to the same instance, and virtual host (vhost) load balancing, allowing you to specify virtual hosts for your Marathon applications.
+
+With Marathon-LB, you can use the virtual IP address routing you configure for the network to allocate dedicated, virtual addresses to your applications. The virtual IP address enables the app to be available to any node in the cluster, regardless of where it might be scheduled to run.
+
+You can also configure Marathon-LB on DC/OS enterprise clusters to define authorization rules to support multi-tenancy, with each user or group granted access to its own applications and groups.
+
+For more information about Marathon features and benefits, see [Marathon features](https://mesosphere.github.io/marathon/docs/networking.html).  For more information about features that are specific to Marathon-LB or using Marathon with DC/OS, see [Marathon-LB features](https://mesosphere.github.io/marathon/docs/networking.html).
+
+# Marathon-LB as a cluster-edge load balancer
+An **edge load balancer** is used to accept traffic from outside networks and proxy that traffic to the application containers inside the DC/OS cluster. The edge load balancer is located outside of the firewall with a port that accepts inbound requests through a publicly-exposed IP address or virtual IP address and routes the requests to the appropriate nodes responsible for servicing specific applications requests inside of the cluster network.
+
+The following diagram illustrates using Marathon-LB as the edge load balancer that accepts TCP and HTTP-based traffic from the internet that is then routed into applications inside the cluster. In this scenario, the load balancer doesn’t route internal requests.
+
+<p>
+<img src="/services/img/marathon-edge-external-facing.png" alt="Marathon-LB as an external-facing edge load balancer">
+</p>
+
+# Marathon-LB for internal and external requests
+You can also use Marathon-LB to perform load balancing and routing for both internal and external requests.
+
+The following diagram illustrates using Marathon-LB as both an external load balancer and internal load balancer routing TCP and HTTP-based traffic. In this scenario, a separate edge load balancer receives traffic from the internet outside of the cluster and routes the external traffic to the Marathon-LB external load balancer instance separate from the traffic routed to the Marathon-LB internal balancer instance.
+
+<p>
+<img src="/services/img/marathon-internal-external.png" alt="Marathon-LB distributing internal and external traffic">
+</p>
+
+# Common load balancing scenarios
+You can configure Marathon-LB to work with different load balancing strategies and network topologies. As part of your planning process, you might want to consider how best to use Marathon-LB to suit the specific details of your environment. 
+
+The following scenarios represent the most common load balancing strategies and the network configuration used in each case:
+
+* One simple strategy is to use Marathon-LB strictly as an internal load balancer for application instances running on the cluster and to route internal client requested to discovered services.
+
+* A slightly more complex alternative would be to use Marathon-LB as the edge load balancer and for service discovery. In this scenario, you could run Marathon-LB on public-facing nodes to route inbound traffic, using the IP addresses of the public-facing nodes in the A-records for the internal or external DNS records to route traffic to its intended destination.
+
+* Another potential strategy would involve using Marathon-LB as an internal and external load balancer for cluster inbound requests with a separate high-availability load balancer for routing public-facing traffic. For example, you might use an external F5 load balancer for an on-premise cluster, or an Elastic Load Balancer (ELB) for a cluster deployed on Amazon Web Services.
+
+If none of these common load balancing strategies suits your organization, you might want to use a combination of internal and external load balancers, with different services exposed on different load balancers.
+
+# Running multiple load balancer instances
+For practical purposes, you should consider running three or more instances of Marathon-LB to provide high availability for production workloads. You should never run a single load balancing instance because a single instance cannot provide high-availability or fault tolerance for applications. Except in the case of extreme processing load, running five or more load-balancing instances does not typically add significant value in term of application availability or performance.
+
+The specific number of Marathon-LB instances you should run to best suit your environment depends on the workload you expect, characteristics of the application itself, and the level of failure tolerance required. 
+
+You should not run Marathon-LB on every node in your cluster. Running too many instances of Marathon-LB can affect processing, efficiency, and overall performance because of additional calls to the Marathon API and excess health checking.

--- a/pages/services/marathon-lb/1.13.x/mlb-reference/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-reference/index.md
@@ -1,0 +1,1150 @@
+---
+layout: layout.pug
+navigationTitle:  Reference information
+title: Reference information
+menuWeight: 50
+excerpt: Marathon-LB endpoints, command-line reference, and configuration templates and labels
+enterprise: false
+---
+
+<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
+
+# Marathon-LB HAProxy endpoints
+Marathon-LB automatically generates configuration information for the HAProxy program, then reloads and restarts HAProxy, as needed. Marathon-LB generates the HAProxy configuration based on application data available from the Marathon API. It can also subscribe to the [Marathon Event Bus](https://mesosphere.github.io/marathon/docs/event-bus.html) for real-time updates. 
+
+When an application starts, stops, relocates, or has any change in health status, Marathon-LB automatically regenerates the HAProxy configuration and reloads HAProxy.
+
+Marathon-LB exposes the following endpoints on port `9090` by default.
+
+| <b>Endpoint</b> | <b>Description</b> |
+| :--- | :-------- |
+|<code>public-node:9090/haproxy?stats</code> | The **Statistics** endpoint produces an HTML page that provides statistical information about the current HAProxy instance and its load balancing activity. You can view the statistics from this endpoint in your browser. |
+<code>public-node:9090/haproxy?stats;csv</code> | The **Statistics CSV** endpoint provides statistical information about the current HAProxy instance and load balancing activity as comma-separated values (CSV). In CSV format, the information can be consumed by other tools. For example, this endpoint produces the results used in the `zdd.py` script. |
+<code>public-node:9090/_haproxy_health_check</code> | The **Health check** endpoint returns 200 OK if HAProxy is healthy. |
+<code>public-node:9090/_haproxy_getconfig</code> | The **Configuration** endpoint returns the HAProxy configuration file as it was when HAProxy was started. Implemented in `getconfig.lua`. |
+<code>public-node:9090/_haproxy_getvhostmap</code> | The **Virtual-host-to-backend** endpoint returns the HAProxy virtual host to backend map if the `--haproxy-map` flag is enabled. If you are not using the `--haproxy-map` option, the endpoint returns an empty string. Implemented in `getmaps.lua`. |
+<code>public-node:9090/_haproxy_getappmap</code> | The **App-ID-to-backend** endpoint returns the HAProxy application identifier to backend map. Like `_haproxy_getvhostmap`, this endpoint requires you to enable the `--haproxy-map` option and returns an empty string otherwise. Also implemented in `getmaps.lua`. |
+<code>public-node:9090/_haproxy_getpids</code> | The **Process identifiers** endpoint returns the PIDs for all HAProxy instances within the current process namespace. The endpoint literally returns the output of $(`pidof haproxy`). Implemented in `getpids.lua`. This endpoint is also used by the `zdd.py` script to determine if connections have finished draining during a deployment. |
+<code>public-node:9090/_mlb_signal/hup</code> | The **Reload configuration** endpoint sends a SIGHUP signal to the `marathon-lb` process, causing it to fetch the running apps from Marathon and reload the `HAProxy` configuration as though an event was received from Marathon. |
+<code>public-node:9090/_mlb_signal/usr1</code> | The **Restart configuration** endpoint sends a `SIGUSR1` signal to the `marathon-lb` process, causing it to restart the `HAProxy` load balancer with the existing configuration, without checking Marathon for changes. |
+
+<p class="message--note"><strong>NOTE: </strong>The <code>/_mlb_signal/hup</code> and <code>/_mlb_signal/usr1</code> endpoints do not function if Marathon-LB is running in <code>poll</code> mode. With the <code>poll</code> argument, Marathon-LB exits after each poll, so there is no running <code>marathon_lb.py</code> process to be signaled.</p>
+
+# Marathon-LB command reference
+Marathon-LB manages operations for the `HAProxy` program to provide high availability for applications running on high-volume websites. Marathon-LB relies on the `marathon_lb.py` script to perform the following key tasks:
+* Connects to the Marathon API to retrieve information about all running apps.
+* Generates and validates the Marathon-LB `HAProxy` configuration file settings.
+* Reloads the `HAProxy` program.
+
+    <p>
+    <img src="/services/img/simple-mlb-haproxy.png" alt="Marathon-LB works with HAProxy configuration settings to provide load balancing">
+    </p>
+
+By default, Marathon-LB binds to the service port of every application and sends incoming requests to the application instances. Services are exposed on their service port as defined in their Marathon app definition. Furthermore, apps are only exposed on the load balancers that have the same load balancer `group` setting. The `group` setting is defined globally or in the app definition file by specifying the `HAPROXY_GROUP` label for individual applications. 
+
+## Invoking marathon-lb directly
+In most cases, the `marathon_lb.py` script runs in the background. However, you can also run the script directly from the command-line. For example, you can generate the `HAProxy` configuration information from Marathon by running the `marathon_lb.py` script for `localhost:8080` with the following command:
+
+```
+./marathon_lb.py --marathon http://localhost:8080 --group external --strict-mode --health-check
+```
+
+## Specifying credentials when running marathon-lb
+If Marathon requires authentication, you can include a user name and password using the `--auth-credentials` configuration option. For example:
+
+```
+./marathon_lb.py --marathon http://localhost:8080 --auth-credentials=admin:password
+```
+
+You can also provide credentials from the VAULT if you define the following environment variables before running Marathon-LB:
+* `VAULT_TOKEN`
+* `VAULT_HOST`
+* `VAULT_PORT`
+* `VAULT_PATH`
+
+If you set these environment variables, you should set the `VAULT_PATH` to the root path where your user account and password are located.
+
+## Skipping configuration validation
+Running the `marathon-lb.py` script refreshes the `haproxy.cfg` configuration file. If there are any changes to the configuration file, the script automatically reloads the `HAProxy` program with the changes. You can skip the configuration file validation process if you don't have `HAProxy` installed or if you are running `HAProxy` on Docker containers.
+
+To skip validation of configuration settings, run the following command:
+```
+./marathon_lb.py --marathon http://localhost:8080 --group external --skip-validation
+```
+
+## Viewing complete usage information
+If you run the `marathon-lb.py` script directly from the command line, you can specify additional functionality such as sticky sessions, HTTP to HTTPS redirection, SSL offloading, virtual host support, and the configuration templates to use.
+
+To get the full command reference, run the following command:
+
+```
+./marathon_lb.py --help
+```
+
+## Running Docker commands for Marathon-LB
+Marathon supports both Universal Container Runtime (using `cgroups`) and Docker containers and images. You can run Marathon-LB using a command similar to the following for Docker images:
+
+```
+docker run -e PORTS=$portnumber --net=host mesosphere/marathon-lb ...
+```
+
+This command uses the `-e` option to set the `PORTS` environment variable. The port number is required to allow the `HAProxy` program bind to this port. The `-net` option enables the command to connect a container to a specified network.
+
+For example, to expose load-balanced applications from a Docker image on port 9090, you might run the following command:
+
+```
+docker run -e PORTS=9090 mesosphere/marathon-lb sse [other arguments]
+```
+
+### Using server-sent events (sse)
+If you specify the `sse` option, the Marathon-LB script connects to the Marathon events endpoint to get notified about state changes.
+You can use a command similar to the following to capture server-sent events (`sse`).
+
+```
+docker run mesosphere/marathon-lb sse [other arguments]
+```
+
+### Determining the current status for Marathon-LB instances
+If you can't use the HTTP callbacks, you can run a command similar to the following to poll the scheduler state periodically:
+
+```
+docker run mesosphere/marathon-lb poll [other args]
+```
+
+You can also use environment variables to set other configuration options for Marathon-LB. For example, you can set the `POLL_INTERVAL` environment variable to change the poll interval from its default of 60 seconds.
+
+## Usage and command arguments
+You can run the Marathon load balancer script (`marathon_lb.py`) directly from the command-line in a shell terminal or programmatically. The script accepts the following command-line options and arguments.
+
+### Usage 
+<pre>
+marathon_lb.py [-h] [--longhelp] [--marathon MARATHON [MARATHON ...]]
+                      [--haproxy-config HAPROXY_CONFIG] [--group GROUP]
+                      [--command COMMAND]
+                      [--max-reload-retries MAX_RELOAD_RETRIES]
+                      [--reload-interval RELOAD_INTERVAL] [--strict-mode]
+                      [--sse] [--archive-versions ARCHIVE_VERSIONS]
+                      [--health-check]
+                      [--lru-cache-capacity LRU_CACHE_CAPACITY]
+                      [--haproxy-map] [--dont-bind-http-https]
+                      [--group-https-by-vhost] [--ssl-certs SSL_CERTS]
+                      [--skip-validation] [--dry]
+                      [--min-serv-port-ip-per-task MIN_SERV_PORT_IP_PER_TASK]
+                      [--max-serv-port-ip-per-task MAX_SERV_PORT_IP_PER_TASK]
+                      [--syslog-socket SYSLOG_SOCKET]
+                      [--log-format LOG_FORMAT] [--log-level LOG_LEVEL]
+                      [--marathon-auth-credential-file MARATHON_AUTH_CREDENTIAL_FILE]
+                      [--auth-credentials AUTH_CREDENTIALS]
+                      [--dcos-auth-credentials DCOS_AUTH_CREDENTIALS]
+                      [--marathon-ca-cert MARATHON_CA_CERT]
+</pre>
+
+### Required arguments
+<table class="table">
+  <tr>
+    <th style="font-weight:bold">Argument</th>
+    <th style="font-weight:bold">Description</th>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">-m, --marathon MARATHON [MARATHON ...]</span></td>
+    <td>Specifies one or more Marathon endpoints. This argument specifies the location of the Marathon containers for Marathon-LB to use. The default endpoint is <span style="background-color: #f2f2f2">http://master.mesos:8080</span>. For example, you can use this argument to specify two Marathon instances like this: <span style="background-color: #f2f2f2">-m http://marathon1:8080 http://marathon2:8080</span>.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--group GROUP</span></td>
+    <td>Generates configuration information only for the apps with the specified group names. Use `*` to match all groups, including groups without a group name specified. The default is an empty string.</td>
+  </tr>
+</table>
+
+### Optional arguments
+<table class="table">
+  <tr>
+    <th style="font-weight:bold">Argument</th>
+    <th style="font-weight:bold">Description</th>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">-h, --help</span></td>
+    <td>Show this help message and exit.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--longhelp</span></td>
+    <td>Print out configuration details. The default is false.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--haproxy-config HAPROXY_CONFIG</span></td>
+    <td>Specifies the location of the `haproxy` configuration file. The default is <span style="background-color: #f2f2f2">/etc/haproxy/haproxy.cfg</span></td>.
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--command COMMAND, -c COMMAND</span></td>
+    <td>If set, run this command to reload haproxy. The default is none.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--max-reload-retries MAX_RELOAD_RETRIES</span></td>
+    <td>Specifies the maximum number if reload retries before failure. Reloads happen every <span style="background-color: #f2f2f2">--reload-interval</span> seconds. Set to 0 to disable reloading attempts or -1 for infinite retries. The default is 10.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--reload-interval RELOAD_INTERVAL</span></td>
+    <td>Waits the specified number of seconds between reload retries. The default is 10.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--strict-mode</span></td>
+    <td>Enables backends to be advertised only if <span style="background-color: #f2f2f2">HAPROXY_{n}_ENABLED=true</span>. Strict mode might be enabled by default in a future release. The default is false.</td>
+  </tr>
+   <tr>
+    <td><span style="background-color: #f2f2f2">--sse, -s</span></td>
+    <td>Uses server-sent events. The default is false.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--archive-versions ARCHIVE_VERSIONS</span></td>
+    <td>Specifies the number of configuration versions to archive. The default is 5.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--health-check, -H</span></td>
+    <td>Determines Marathon's health check status before adding the app instance into the backend pool. The default is false.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--lru-cache-capacity LRU_CACHE_CAPACITY</span></td>
+    <td>Specifies the LRU cache size (in number of items). This argument should be at least as large as the number of tasks exposed to marathon-lb. The default is 1000.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--haproxy-map</span></td>
+    <td>Uses HAProxy maps for domain name to backend mapping. The default is false.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--dont-bind-http-https</span></td>
+    <td>Prevents binding to HTTP and HTTPS frontends. The default is false.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--group-https-by-vhost</span></td>
+    <td>Groups https frontends by virtual host. The default is false.</td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--ssl-certs SSL_CERTS</span></td>
+    <td>Lists SSL certificates separated by commas for frontend <span style="background-color: #f2f2f2">marathon_https_in</span>. The default is <span style="background-color: #f2f2f2">/etc/ssl/cert.pem</span>. For example: <span style="background-color: #f2f2f2">/etc/ssl/site1.co.pem,/etc/ssl/site2.co.pem</span></td>
+  </tr>
+  <tr>
+    <td><span style="background-color: #f2f2f2">--skip-validation</span></td>
+    <td>Skips haproxy configuration file validation. The default is false.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--dry, -d</span></td>
+    <td>Only prints configuration information to the console. The default is false.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--min-serv-port-ip-per-task MIN_SERV_PORT_IP_PER_TASK</span></td>
+    <td>Specifies the minimum port number to use when auto-assigning service ports for IP-per-task applications. The default is 10050.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--max-serv-port-ip-per-task MAX_SERV_PORT_IP_PER_TASK</span></td>
+    <td>Specifies the maximum port number to use when auto-assigning service ports for IP-per-task applications. The default is 10100.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--syslog-socket SYSLOG_SOCKET</span></td>
+    <td>Specifies the socket to write syslog messages to. Use <span style="background-color: #f2f2f2">/dev/null</span> to disable logging to <span style="background-color: #f2f2f2">syslog</span>. The default is <span style="background-color: #f2f2f2">/dev/log</span>.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">-log-format LOG_FORMAT</span></td>
+    <td>Sets the log message format. The default is <span style="background-color: #f2f2f2">%(asctime)-15s %(name)s: %(message)s</span>.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--log-level LOG_LEVEL</span></td>
+    <td>Sets the log level, The default is DEBUG.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--marathon-auth-credential-file MARATHON_AUTH_CREDENTIAL_FILE</span></td>
+    <td>Specifies the path to file containing a user name and password for the Marathon HTTP API in the format of <span style="background-color: #f2f2f2">user:pass</span>. The default is none.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--auth-credentials AUTH_CREDENTIALS</span></td>
+    <td>Specifies the user name and password for the Marathon HTTP API in the format of <span style="background-color: #f2f2f2">user:pass</span>. The default is none.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--dcos-auth-credentials DCOS_AUTH_CREDENTIALS</span></td>
+    <td>Specifies the DC/OS service account credentials. The default is none.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--dcos-auth-credentials DCOS_AUTH_CREDENTIALS</span></td>
+    <td>Specifies the DC/OS service account credentials. The default is none.</td>
+  </tr> 
+  <tr>
+    <td><span style="background-color: #f2f2f2">--marathon-ca-cert MARATHON_CA_CERT</span></td>
+    <td>Specifies the CA certificate for Marathon HTTPS connections. The default is none.</td>
+  </tr> 
+</table>
+
+# Template and label reference
+The following is a list of the available `HAProxy` configuration **templates**. Some templates are global-only (such as `HAPROXY_HEAD`), but most can be specified on a per service port basis as **app labels** to override the global settings.
+
+The templates and app labels that can be set per-service-port include an index identifier {n} in the template or label name. The index identifier corresponds to the service port index, beginning at 0, to which the app label applies. For example, you could specify `HAPROXY_0_BACKEND_HEAD` to override the global template `HAPROXY_BACKUP_HEAD` for the first port of a given application.
+
+## Backend template settings
+Use the following template and app labels to configure backend settings for the load balancer.
+
+<table class="table" style="table-layout: fixed">
+<colgroup>
+    <col span="1" width="45px">
+    <col span="1" width="80px">
+</colgroup>
+<tr>
+<th style="font-weight:bold">Template name</th>
+<th style="font-weight:bold">Description and examples</th>
+</tr>
+<tbody valign="top">
+<tr>
+<td><code>HAPROXY_BACKEND_HEAD</code></td><td>Defines the type of load balancing and the connection mode for a backend. The default load balancing type (algorithm) is <code>roundrobin</code>. The default connection mode is <code>tcp</code>.
+
+The valid values for the load balancing type include:
+
+* <code>roundrobin</code> - Each server is used in turns, according to their weights. 
+  This algorithm is dynamic and ensures processing time remains equally distributed. 
+* <code>static-rr</code> - Each server is used in turns, according to their weights. 
+  This algorithm is as similar to roundrobin except that it is static.
+* <code>leastconn</code> - The server with the least number of connections receives the next connection request. 
+  Round-robin selection is performed within groups of servers that have the same load to ensure that all servers are used. This algorithm is recommended when long sessions, such as LDAP or SQL sessions are expected, is not appropriate for protocols using short sessions such as HTTP.
+* <code>source</code> - The source IP address is hashed and divided by the total weight of the running servers to designate which server should receive the request. 
+  This algorithm ensures that the same client IP address always reaches the same server as long as no server goes down or up. If the hash result changes because the number of running servers has changed, clients  are directed to a different server. This algorithm is generally used with TCP mode or for clients that refuse session cookies.
+* <code>uri</code> - This algorithm hashes either the left part of the URI (before the question mark) or the whole URI (if the "whole" parameter is present) and divides the hash value by the total weight of the running servers. 
+  The result designates which server receives the request.
+  
+You can set the connection mode to `tcp`, `http`, or `health`. 
+
+The default template for `HAPROXY_BACKEND_HEAD` is:
+<code>backend {backend}
+  balance {balance}
+  mode {mode}
+</code>
+
+You can override this template using the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_HEAD": "\nbackend {backend}\n  balance {balance}\n  mode {mode}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_HSTS<br>_OPTIONS</code></td><td>Specifies the backend options to use where the <code>HAPROXY_{n}_USE_HSTS</code> app label that enables the HSTS response header for HTTP clients is set to true. 
+
+The default template for `HAPROXY_BACKEND_HSTS_OPTIONS` is:
+<code>rspadd Strict-Transport-Security:\ max-age=15768000</code>
+
+You can override this template using the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_HSTS_OPTIONS": " rspadd Strict-Transport-Security:\\ max-age=15768000\n"</code>
+</td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_HTTP<br>_HEALTHCHECK_OPTIONS</code></td><td>Sets HTTP health check options, such as the health check timeout interval and consecutive failures allowed. 
+
+The valid options for the first health check or the first health check for a given service are exposed as follows:
+- healthCheckPortIndex
+- healthCheckPort
+- healthCheckProtocol
+- healthCheckPath
+- healthCheckTimeoutSeconds
+- healthCheckIntervalSeconds
+- healthCheckGracePeriodSeconds
+- healthCheckMaxConsecutiveFailures
+- healthCheckFalls (healthCheckMaxConsecutiveFailures + 1)
+- healthCheckPortOptions (port {healthCheckPort})
+
+The default template for `HAPROXY_BACKEND_HTTP_HEALTHCHECK_OPTIONS` is:
+<code>option  httpchk GET {healthCheckPath
+  timeout check {healthCheckTimeoutSeconds}s</code>
+
+You can override this template using the following app label for the first port (`0`) of a given app:
+<code style="word-break: break-word;">"HAPROXY_0_BACKEND_HTTP_HEALTHCHECK_OPTIONS": "  option  httpchk GET {healthCheckPath}\n  timeout check {healthCheckTimeoutSeconds}s\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_HTTP<br>_OPTIONS</code></td><td>Sets HTTP headers, for example, X-Forwarded-For and X-Forwarded-Proto. 
+
+The default template for `HAPROXY_BACKEND_HTTP_OPTIONS` is:
+<code>option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }</code>
+
+You can override this template using the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_HTTP_OPTIONS": "  option forwardfor\n  http-request set-header X-Forwarded-Port %[dst_port]\n  http-request add-header X-Forwarded-Proto https if { ssl_fc }\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_REDIRECT<br>_HTTP_TO_HTTPS</code></td><td>Redirects backends if the HAPROXY_{n}_REDIRECT_TO_HTTPS label is set to true. 
+
+The default template for `HAPROXY_BACKEND_REDIRECT_HTTP_TO_HTTPS` is:
+<code>redirect scheme https code 301 if !{{ ssl_fc }} host_{cleanedUpHostname}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>HAPROXY_0_BACKEND_REDIRECT_HTTP_TO_HTTPS": " redirect scheme https code 301 if !{{ ssl_fc }} host_{cleanedUpHostname}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_REDIRECT<br>_HTTP_TO_HTTPS_WITH_PATH</code></td><td>Redirects backends if the `HAPROXY_{n}_REDIRECT_TO_HTTPS_WITH_PATH` label is set to true, but includes a path. 
+
+The default template for <code style="word-break: break-word;">HAPROXY_BACKEND_REDIRECT_HTTP_TO_HTTPS_WITH_PATH</code> is:
+<code>redirect scheme https code 301 if !{{ ssl_fc }} host_{cleanedUpHostname} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code style="word-break: break-word;">"HAPROXY_0_BACKEND_REDIRECT_HTTP_TO_HTTPS_WITH_PATH": " redirect scheme https code 301 if !{{ ssl_fc }} host_{cleanedUpHostname} path_{backend}\n"</code>
+</td></tr>
+<tr><td><code>HAPROXY_BACKEND_SERVER<br>_HTTP_HEALTHCHECK_OPTIONS </code></td><td>Sets HTTP health check options, such as the health check timeout interval, for a single server. 
+
+The valid options for the first health check or the first health check for a given service are exposed as follows:
+- healthCheckPortIndex
+- healthCheckPort
+- healthCheckProtocol
+- healthCheckPath
+- healthCheckTimeoutSeconds
+- healthCheckIntervalSeconds
+- healthCheckGracePeriodSeconds
+- healthCheckMaxConsecutiveFailures
+- healthCheckFalls (healthCheckMaxConsecutiveFailures + 1)
+- healthCheckPortOptions (port {healthCheckPort})
+
+The default template for `HAPROXY_BACKEND_SERVER_HTTP_HEALTHCHECK_OPTIONS` is:
+<code> check inter {healthCheckIntervalSeconds}s fall {healthCheckFalls}{healthCheckPortOptions}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_SERVER_HTTP_HEALTHCHECK_OPTIONS": "  check inter {healthCheckIntervalSeconds}s fall {healthCheckFalls}{healthCheckPortOptions}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_SERVER<br>_OPTIONS </code></td><td>Specifies the options for each server added to a backend. 
+
+The default template for HAPROXY_BACKEND_SERVER_OPTIONS is:
+<code> server {serverName} {host_ipv4}:{port}{cookieOptions}{healthCheckOptions}{otherOptions}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_SERVER_OPTIONS": "  server {serverName} {host_ipv4}:{port}{cookieOptions}{healthCheckOptions}{otherOptions}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_SERVER<br>_TCP_HEALTHCHECK<br>_OPTIONS </code></td><td>Sets TCP health check options, such as the health check timeout interval, for a single server.
+
+The valid options for the first health check or the first health check for a given service are exposed as follows:
+- healthCheckPortIndex
+- healthCheckPort
+- healthCheckProtocol
+- healthCheckTimeoutSeconds
+- healthCheckIntervalSeconds
+- healthCheckGracePeriodSeconds
+- healthCheckMaxConsecutiveFailures
+- healthCheckFalls (healthCheckMaxConsecutiveFailures + 1)
+- healthCheckPortOptions (port {healthCheckPort})
+
+The default template for `HAPROXY_BACKEND_SERVER_TCP_HEALTHCHECK_OPTIONS` is:
+<code>check inter {healthCheckIntervalSeconds}s fall {healthCheckFalls}{healthCheckPortOptions}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_SERVER_TCP_HEALTHCHECK_OPTIONS": "  check inter {healthCheckIntervalSeconds}s fall {healthCheckFalls}{healthCheckPortOptions}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_STICKY_OPTIONS </code></td><td>Sets a cookie for services where HAPROXY_{n}_STICKY is true.
+
+The default template for `HAPROXY_BACKEND_STICKY_OPTIONS` is:
+<code> cookie mesosphere_server_id insert indirect nocache</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_STICKY_OPTIONS": "  cookie mesosphere_server_id insert indirect nocache\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_BACKEND_TCP<br>_HEALTHCHECK_OPTIONS </code></td><td>Sets TCP health check options,such as the timeout check. 
+
+The valid options for the first health check or the first health check for a given service are exposed as follows:
+- healthCheckPortIndex
+- healthCheckPort
+- healthCheckProtocol
+- healthCheckTimeoutSeconds
+- healthCheckIntervalSeconds
+- healthCheckGracePeriodSeconds
+- healthCheckMaxConsecutiveFailures
+- healthCheckFalls (healthCheckMaxConsecutiveFailures + 1)
+- healthCheckPortOptions (port {healthCheckPort})
+
+The default template for `HAPROXY_BACKEND_TCP_HEALTHCHECK_OPTIONS` is an empty string. 
+
+The following example sets a timeout check:
+<code> timeout check {healthCheckTimeoutSeconds}s</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_BACKEND_TCP_HEALTHCHECK_OPTIONS": ""</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_GROUPED<br>_VHOST_BACKEND_HEAD </code></td><td>Defines the HTTPS backend for vhost. 
+
+You must enable the `group-https-by-vhost` option to use this setting. This template is a global template that cannot be modified by service port or per application.
+
+The default template for `HAPROXY_HTTPS_GROUPED_VHOST_BACKEND_HEAD` is:
+<code>backend {name}
+  server loopback-for-tls abns@{name} send-proxy-v2</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_BACKEND<br>_ACL_ALLOW_DENY </code></td><td>Denies access for all IP addresses (or IP ranges) that are not explicitly allowed to access the HTTP backend. Use this template with HAPROXY_HTTP_BACKEND_NETWORK_ALLOWED_ACL. This template is a global template that cannot be modified by service port or per application. 
+
+The default template for `HAPROXY_HTTP_BACKEND_ACL_ALLOW_DENY` is:
+<code> http-request allow if network_allowed
+  http-request deny</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_BACKEND<br>_NETWORK_ALLOWED_ACL </code></td><td>Specifies the IP addresses (or IP  ranges) that have access to the HTTP backend. This template is a global template that cannot be modified by service port or per application. 
+
+The default template for `HAPROXY_HTTP_BACKEND_NETWORK_ALLOWED_ACL` is:
+<code>acl network_allowed src {network_allowed}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_BACKEND_NETWORK_ALLOWED_ACL": "  acl network_allowed src {network_allowed}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_BACKEND<br>_PROXYPASS_GLUE</code></td><td>Specifies the backend glue for HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_PATH. 
+
+The default template for `HAPROXY_HTTP_BACKEND_PROXYPASS_GLUE` is:
+<code>http-request set-header Host {hostname}
+  reqirep  "^([^ :]*)\ {proxypath}/?(.*)" "\1\ /\2" </code>
+
+You can override this template with the following app label for the first port (`0`)of a given app:
+<code>"HAPROXY_0_HTTP_BACKEND_PROXYPASS_GLUE": "  http-request set-header Host {hostname}\n  reqirep  \"^([^ :]*)\\ {proxypath}/?(.*)\" \"\\1\\ /\\2\"\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_BACKEND_REDIR </code></td><td>Sets the path to which you want to redirect the root of the domain. 
+
+The default template for `HAPROXY_HTTP_BACKEND_REDIR` is:
+<code>acl is_root path -i /
+  acl is_domain hdr(host) -i {hostname}
+  redirect code 301 location {redirpath} if is_domain is_root</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_BACKEND_REDIR": "  acl is_root path -i /\n  acl is_domain hdr(host) -i {hostname}\n  redirect code 301 location {redirpath} if is_domain is_root\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_BACKEND<br>_REVPROXY_GLUE </code></td><td>Specifies the backend glue for HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH. 
+
+The default template for `HAPROXY_HTTP_BACKEND_REVPROXY_GLUE` is:
+<code>acl hdr_location res.hdr(Location) -m found
+  rspirep "^Location: (https?://{hostname}(:[0-9]+)?)?(/.*)" "Location:   {rootpath} if hdr_location"</code>
+
+You can override this template with the following app label for the first port (`0`)of a given app:
+<code>"HAPROXY_0_HTTP_BACKEND_REVPROXY_GLUE": "  acl hdr_location res.hdr(Location) -m found\n  rspirep \"^Location: (https?://{hostname}(:[0-9]+)?)?(/.*)\" \"Location:   {rootpath} if hdr_location\"\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_TCP_BACKEND<br>_ACL_ALLOW_DENY </code></td><td>Denies access for all IP addresses (or IP address ranges) that are not explicitly allowed to access the TCP backend. This global template cannot be overridden by service port or application. 
+
+The default template for `HAPROXY_TCP_BACKEND_ACL_ALLOW_DENY` is:
+<code>tcp-request content accept if network_allowed
+  tcp-request content reject</code></td></tr>
+
+<tr><td><code>HAPROXY_TCP_BACKEND<br>_NETWORK_ALLOWED_ACL </code></td><td>Specifies the IP addresses (or IP address ranges) that have been granted access to the TCP backend. 
+
+The default template for `HAPROXY_TCP_BACKEND_NETWORK_ALLOWED_ACL` is:
+<code>acl network_allowed src {network_allowed}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app: 
+<code>"HAPROXY_0_TCP_BACKEND_NETWORK_ALLOWED_ACL": "  acl network_allowed src {network_allowed}\n"</code></td></tr>
+</tbody>
+</table>
+
+## Frontend template settings
+Use the following template and app labels to configure frontend settings for the load balancer.
+
+<table class="table" style="table-layout: fixed">
+<colgroup>
+    <col span="1" width="45px">
+    <col span="1" width="80px">
+</colgroup>
+<tr>
+<th style="font-weight:bold">Template name</th>
+<th style="font-weight:bold">Description and examples</th>
+</tr>
+<tbody valign="top">
+<tr><td><code>HAPROXY_FRONTEND_BACKEND_GLUE </code></td><td>Glues the backend to the frontend. 
+
+The default template for `HAPROXY_FRONTEND_BACKEND_GLUE` is:
+<code> use_backend {backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_FRONTEND_BACKEND_GLUE": "  use_backend {backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_FRONTEND_HEAD </code></td><td>Defines the address and port to bind to for this frontend. 
+
+The default template for `HAPROXY_FRONTEND_HEAD` is:
+<code>frontend {backend}
+  bind {bindAddr}:{servicePort}{sslCert}{bindOptions}
+  mode {mode}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_FRONTEND_HEAD": "\nfrontend {backend}\n  bind {bindAddr}:{servicePort}{sslCert}{bindOptions}\n  mode {mode}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_ACL </code></td><td>Specifies the ACL that performs the SNI based hostname matching for the HAPROXY_HTTPS_FRONTEND_HEAD template. 
+
+The default template for `HAPROXY_HTTPS_FRONTEND_ACL` is:
+<code>use_backend {backend} if {{ ssl_fc_sni {hostname} }}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_ACL": "  use_backend {backend} if {{ ssl_fc_sni {hostname} }}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_ACL_ONLY_WITH_PATH </code></td><td>Defines the access control list (ACL) frontend that matches a particular host name with a path. This template is similar to HTTP_FRONTEND_ACL_ONLY_WITH_PATH, but is only applicable for HTTPS requests.
+
+The default template for `HAPROXY_HTTPS_FRONTEND_ACL_ONLY_WITH_PATH` is:
+<code>acl path_{backend} path_beg {path}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_ACL_ONLY_WITH_PATH": "  acl path_{backend} path_beg {path}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_ACL_WITH_AUTH </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding virtual host of the HAPROXY_HTTPS_FRONTEND_HEAD through HTTP Basic authentication. 
+
+The default template for `HAPROXY_HTTPS_FRONTEND_ACL_WITH_AUTH` is:
+<code> acl auth_{cleanedUpHostname} http_auth(user_{backend})
+  http-request auth realm "{realm}" if {{ ssl_fc_sni {hostname} }} !auth_{cleanedUpHostname}
+  use_backend {backend} if {{ ssl_fc_sni {hostname} }}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_ACL_WITH_AUTH": "  acl auth_{cleanedUpHostname} http_auth(user_{backend})\n  http-request auth realm \"{realm}\" if {{ ssl_fc_sni {hostname} }} !auth_{cleanedUpHostname}\n  use_backend {backend} if {{ ssl_fc_sni {hostname} }}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_ACL_WITH_AUTH<br>_AND_PATH</td><td>Specifies the ACL that glues a backend to the corresponding virtual host with path of the HAPROXY_HTTPS_FRONTEND_HEAD through HTTP Basic authentication. 
+
+The default template for `HAPROXY_HTTPS_FRONTEND_ACL_WITH_AUTH_AND_PATH` is:
+<code> acl auth_{cleanedUpHostname} http_auth(user_{backend})
+  http-request auth realm "{realm}" if {{ ssl_fc_sni {hostname} }} path_{backend} !auth_{cleanedUpHostname}
+  use_backend {backend} if {{ ssl_fc_sni {hostname} }} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_ACL_WITH_AUTH_AND_PATH": "  acl auth_{cleanedUpHostname} http_auth(user_{backend})\n  http-request auth realm \"{realm}\" if {{ ssl_fc_sni {hostname} }} path_{backend} !auth_{cleanedUpHostname}\n  use_backend {backend} if {{ ssl_fc_sni {hostname} }} path_{backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_ACL_WITH_PATH </code></td><td>Specifies the ACL that performs the SNI based hostname matching with path for the HAPROXY_HTTPS_FRONTEND_HEAD template. 
+
+The default template for `HAPROXY_HTTPS_FRONTEND_ACL_WITH_PATH` is:
+<code> use_backend {backend} if {{ ssl_fc_sni {hostname} }} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_ACL_WITH_PATH": "  use_backend {backend} if {{ ssl_fc_sni {hostname} }} path_{backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_AUTH_ACL_ONLY </code></td><td>Specifies the HTTP authentication ACL for the corresponding virtual host. 
+
+The default template for `HAPROXY_HTTPS_FRONTEND_AUTH_ACL_ONLY` is:
+<code> acl auth_{cleanedUpHostname} http_auth(user_{backend})<code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_AUTH_ACL_ONLY": "  acl auth_{cleanedUpHostname} http_auth(user_{backend})\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_AUTH_REQUEST_ONLY </code></td><td>Specifies the HTTP authentication request forthe corresponding virtual host. 
+
+The default template for `HAPROXY_HTTPS_FRONTEND_AUTH_REQUEST_ONLY` is:
+<code> http-request auth realm "{realm}" if {{ ssl_fc_sni {hostname} }} !auth_{cleanedUpHostname}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_AUTH_REQUEST_ONLY": "  http-request auth realm \"{realm}\" if {{ ssl_fc_sni {hostname} }} !auth_{cleanedUpHostname}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND_HEAD </code></td><td>Specifies an HTTPS frontend for encrypted connections that binds to port *:443 by default and gathers all virtual hosts as defined by the HAPROXY_{n}_VHOST label. This template is a global template that cannot be modified by service port or per application.
+
+You must modify this template setting if you want to include your SSL certificate. The default template for `HAPROXY_HTTPS_FRONTEND_HEAD` is:
+<code>frontend marathon_https_in
+  bind *:443 ssl {sslCerts}
+  mode http</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_FRONTEND<br>_ROUTING_ONLY_WITH<br>_PATH_AND_AUTH </code></td><td>Works in combination with HAPROXY_HTTP_FRONTEND_ACL_ONLY_WITH_PATH to glue ACL names to the appropriate backend. 
+The default template for `HAPROXY_HTTPS_FRONTEND_ROUTING_ONLY_WITH_PATH_AND_AUTH` is:
+<code> http-request auth realm "{realm}" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}
+  use_backend {backend} if host_{cleanedUpHostname} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTPS_FRONTEND_ROUTING_ONLY_WITH_PATH_AND_AUTH": "  http-request auth realm \"{realm}\" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}\n  use_backend {backend} if host_{cleanedUpHostname} path_{backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_GROUPED<br>_FRONTEND_HEAD </code></td><td>Defines the HTTPS frontend for encrypted connections that binds to port *:443 by default and gathers all virtual hosts as defined by the HAPROXY_{n}_VHOST label. This template is useful for adding client certificates per domain. 
+
+You must enable the `group-https-by-vhost` option to use this setting. This template is a global template that cannot be modified by service port or per application.
+
+The default template for `HAPROXY_HTTPS_GROUPED_FRONTEND_HEAD` is:
+<code>frontend marathon_https_in
+  bind *:443
+  mode tcp
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_GROUPED<br>_VHOST_FRONTEND_ACL </code></td><td>Specifies a route rule HTTPS entrypoint. 
+
+You must enable the `group-https-by-vhost` option to use this setting. This template is a global template that cannot be modified by service port or per application.
+
+The default template for `HAPROXY_HTTPS_GROUPED_VHOST_FRONTEND_ACL` is:
+<code> use_backend {backend} if {{ req_ssl_sni -i {host} }}</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTPS_GROUPED<br>_VHOST_FRONTEND_HEAD </code></td><td>Specifies the HTTPS frontend for the virtual host. 
+
+You must enable the `group-https-by-vhost` option to use this setting. This template is a global template that cannot be modified by service port or per application. The default template for `HAPROXY_HTTPS_GROUPED_VHOST_FRONTEND_HEAD` is:
+<code>frontend {name}
+  mode http
+  bind abns@{name} accept-proxy ssl {sslCerts}{bindOpts}</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND_ACL </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding virtual host of the HAPROXY_HTTP_FRONTEND_HEAD. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_AC`L` is:
+<code> acl host_{cleanedUpHostname} hdr(host) -i {hostname}
+  use_backend {backend} if host_{cleanedUpHostname}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ACL": "  acl host_{cleanedUpHostname} hdr(host) -i {hostname}\n  use_backend {backend} if host_{cleanedUpHostname}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ACL_ONLY </code></td><td>Defines the access control list (ACL) that matches a particular host name. Unlike HAPROXY_HTTP_FRONTEND_ACL, this template only includes the ACL portion. It does not glue the access control list (ACL) to the backend. You should only use this template if you have multiple virtual hosts routing to the same backend. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ACL_ONLY` is:
+<code> acl host_{cleanedUpHostname} hdr(host) -i {hostname}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ACL_ONLY": "  acl host_{cleanedUpHostname} hdr(host) -i {hostname}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ACL_ONLY_WITH_PATH </code></td><td>Defines the access control list (ACL) that matches a particular host name with a path. Unlike HAPROXY_HTTP_FRONTEND_ACL_WITH_PATH, this template only includes the ACL portion. It does not glue the access control list (ACL) to the backend. You should only use this template if you have multiple virtual hosts routing to the same backend. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ACL_ONLY_WITH_PATH` is:
+<code> acl path_{backend} path_beg {path} </code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ACL_ONLY_WITH_PATH": " acl path_{backend} path_beg {path}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ACL_ONLY_WITH<br>_PATH_AND_AUTH </code></td><td>Defines the access control list (ACL) that matches a particular host name with a path and authentication method. Unlike HAPROXY_HTTP_FRONTEND_ACL_WITH_PATH, this template only includes the ACL portion. It does not glue the access control list (ACL) to the backend. You should only use this template if you have multiple virtual hosts routing to the same backend. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ACL_ONLY_WITH_PATH_AND_AUTH` is:
+<code>acl path_{backend} path_beg {path}
+  acl auth_{cleanedUpHostname} http_auth(user_{backend})</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ACL_ONLY_WITH_PATH_AND_AUTH": "  acl path_{backend} path_beg {path}\n  acl auth_{cleanedUpHostname} http_auth(user_{backend})\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ACL_WITH_AUTH </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding virtual host specified by the HAPROXY_HTTP_FRONTEND_HEAD setting through HTTP Basic authentication. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ACL_WITH_AUTH` is:
+<code>
+ acl host_{cleanedUpHostname} hdr(host) -i {hostname}
+  acl auth_{cleanedUpHostname} http_auth(user_{backend})
+  http-request auth realm "{realm}" if host_{cleanedUpHostname} !auth_{cleanedUpHostname}
+  use_backend {backend} if host_{cleanedUpHostname}<code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ACL_WITH_AUTH": "  acl host_{cleanedUpHostname} hdr(host) -i {hostname}\n  acl auth_{cleanedUpHostname} http_auth(user_{backend})\n  http-request auth realm \"{realm}\" if host_{cleanedUpHostname} !auth_{cleanedUpHostname}\n  use_backend {backend} if host_{cleanedUpHostname}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ACL_WITH_AUTH<br>_AND_PATH </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding virtual host with the path specified by the HAPROXY_HTTP_FRONTEND_HEAD setting through HTTP Basic authentication. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ACL_WITH_AUTH_AND_PATH` is:
+<code>
+ acl host_{cleanedUpHostname} hdr(host) -i {hostname}
+  acl auth_{cleanedUpHostname} http_auth(user_{backend})
+  acl path_{backend} path_beg {path}
+  http-request auth realm "{realm}" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}
+  use_backend {backend} if host_{cleanedUpHostname} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ACL_WITH_AUTH_AND_PATH": "  acl host_{cleanedUpHostname} hdr(host) -i {hostname}\n  acl auth_{cleanedUpHostname} http_auth(user_{backend})\n  acl path_{backend} path_beg {path}\n  http-request auth realm \"{realm}\" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}\n  use_backend {backend} if host_{cleanedUpHostname} path_{backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ACL_WITH_PATH </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding virtual host with the path specified by the HAPROXY_HTTP_FRONTEND_HEAD setting. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ACL_WITH_PATH` is:
+<code>acl host_{cleanedUpHostname} hdr(host) -i {hostname}
+  acl path_{backend} path_beg {path}
+  use_backend {backend} if host_{cleanedUpHostname} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ACL_WITH_PATH": "  acl host_{cleanedUpHostname} hdr(host) -i {hostname}\n  acl path_{backend} path_beg {path}\n  use_backend {backend} if host_{cleanedUpHostname} path_{backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_APPID_ACL </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding app specified by the HAPROXY_HTTP_FRONTEND_APPID_HEAD setting. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_APPID_ACL` is:
+<code>acl app_{cleanedUpAppId} hdr(x-marathon-app-id) -i {appId}
+  use_backend {backend} if app_{cleanedUpAppId}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_APPID_ACL": "  acl app_{cleanedUpAppId} hdr(x-marathon-app-id) -i {appId}\n  use_backend {backend} if app_{cleanedUpAppId}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_APPID_HEAD </code></td><td>Specifies the HTTP frontend that binds to port *:9091 by default and gathers all apps in HTTP mode. To use this frontend to forward to your app, configure the app with HAPROXY_0_MODE=http then you can access it via a call to the :9091 with the header "X-Marathon-App-Id" set to the Marathon AppId. Note multiple HTTP ports being exposed by the same marathon app are not supported. Only the first HTTP port is available using this frontend. 
+
+This template is a global template that cannot be modified by service port or per application. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_APPID_HEAD` is:
+<code>frontend marathon_http_appid_in
+  bind *:9091
+  mode http</code></td></tr>
+<tr><td><code>HAPROXY_HTTP_FRONTEND_HEAD </code></td><td>Specifies the HTTP frontend that binds to port *:80 by default and gathers all virtual hosts as defined by the HAPROXY_{n}_VHOST label. This template is a global template that cannot be modified by service port or per application. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_HEAD` is:
+<code>frontend marathon_http_in
+  bind *:80
+  mode http</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ROUTING_ONLY </code></td><td>Works in combination with the HAPROXY_HTTP_FRONTEND_ACL_ONLY setting to map access control list (ACL) names to their appropriate backends. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ROUTING_ONLY` is:
+<code> use_backend {backend} if host_{cleanedUpHostname}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ROUTING_ONLY": "  use_backend {backend} if host_{cleanedUpHostname}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ROUTING_ONLY_WITH_AUT </code></td><td>Works in combination with the HAPROXY_HTTP_FRONTEND_ACL_ONLY setting to map the access control list name to the appropriate backend and to add HTTP Basic authentication. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ROUTING_ONLY_WITH_AUTH` is:
+<code>acl auth_{cleanedUpHostname} http_auth(user_{backend})
+  http-request auth realm "{realm}" if host_{cleanedUpHostname} !auth_{cleanedUpHostname}
+  use_backend {backend} if host_{cleanedUpHostname}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ROUTING_ONLY_WITH_AUTH": "  acl auth_{cleanedUpHostname} http_auth(user_{backend})\n  http-request auth realm \"{realm}\" if host_{cleanedUpHostname} !auth_{cleanedUpHostname}\n  use_backend {backend} if host_{cleanedUpHostname}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ROUTING_ONLY_WITH_PATH</code></td><td>Works in combination with the HAPROXY_HTTP_FRONTEND_ACL_ONLY_WITH_PATH setting to map access control list (ACL) names to the appropriate backend. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ROUTING_ONLY_WITH_PATH` is:
+<code>use_backend {backend} if host_{cleanedUpHostname} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ROUTING_ONLY_WITH_PATH": "  use_backend {backend} if host_{cleanedUpHostname} path_{backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_HTTP_FRONTEND<br>_ROUTING_ONLY_WITH<br>_PATH_AND_AUTH </code></td><td>Works in combination with the HAPROXY_HTTP_FRONTEND_ACL_ONLY_WITH_PATH setting to map access control list names to the appropriate backend. 
+
+The default template for `HAPROXY_HTTP_FRONTEND_ROUTING_ONLY_WITH_PATH_AND_AUTH` is:
+<code>http-request auth realm "{realm}" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}
+  use_backend {backend} if host_{cleanedUpHostname} path_{backend}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_HTTP_FRONTEND_ROUTING_ONLY_WITH_PATH_AND_AUTH": "  http-request auth realm \"{realm}\" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}\n  use_backend {backend} if host_{cleanedUpHostname} path_{backend}\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_MAP_HTTPS<br>_FRONTEND_ACL </code></td><td>Specifies the access control list (ACL) that performs the SNI-based host name matching for the HAPROXY_HTTPS_FRONTEND_HEAD template using HAProxy maps. 
+
+The default template for `HAPROXY_MAP_HTTPS_FRONTEND_ACL` is:
+<code>use_backend %[ssl_fc_sni,lower,map({haproxy_dir}/domain2backend.map)</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_MAP_HTTPS_FRONTEND_ACL": "  use_backend %[ssl_fc_sni,lower,map({haproxy_dir}/domain2backend.map)]\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_MAP_HTTP<br>_FRONTEND_ACL </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding virtual host specified by the HAPROXY_HTTP_FRONTEND_HEAD setting using HAProxy maps. 
+
+The default template for `HAPROXY_MAP_HTTP_FRONTEND_ACL` is:
+<code style="word-break: break-word;">use_backend %[req.hdr(host),lower,regsub(:.*$,,),map({haproxy_dir}/domain2backend.map)</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code style="word-break: break-word;">"HAPROXY_0_MAP_HTTP_FRONTEND_ACL": "  use_backend %[req.hdr(host),lower,regsub(:.*$,,),map({haproxy_dir}/domain2backend.map)]\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_MAP_HTTP<br>_FRONTEND_ACL_ONLY </code></td><td> Defines the access control list (ACL) that matches a particular host name, You should only use this template if you have multiple virtual hosts routing to the same backend in the HAProxy map. 
+
+The default template for `HAPROXY_MAP_HTTP_FRONTEND_ACL_ONLY` is:
+<code style="word-break: break-word;">use_backend %[req.hdr(host),lower,regsub(:.*$,,),map({haproxy_dir}/domain2backend.map)</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code style="word-break: break-word;">"HAPROXY_0_MAP_HTTP_FRONTEND_ACL_ONLY": "  use_backend %[req.hdr(host),lower,regsub(:.*$,,),map({haproxy_dir}/domain2backend.map)]\n"</code></td></tr>
+
+<tr><td><code>HAPROXY_MAP_HTTP<br>_FRONTEND_APPID_ACL </code></td><td>Specifies the access control list (ACL) that glues a backend to the corresponding app specified by the HAPROXY_HTTP_FRONTEND_APPID_HEAD setting using HAProxy maps. 
+
+The default template for `HAPROXY_MAP_HTTP_FRONTEND_APPID_ACL` is:
+<code>use_backend %[req.hdr(x-marathon-app-id),lower,map({haproxy_dir}/app2backend.map)</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_MAP_HTTP_FRONTEND_APPID_ACL": "  use_backend %[req.hdr(x-marathon-app-id),lower,map({haproxy_dir}/app2backend.map)]\n"</code>
+</td></tr>
+</tbody>
+</table>
+
+## User authentication list setting
+Use the following template and app label to configure basic user name and password settings for the load balancer.
+
+<table class="table" style="table-layout: fixed">
+<colgroup>
+    <col span="1" width="45px">
+    <col span="1" width="80px">
+</colgroup>
+<tr>
+<th style="font-weight:bold">Template name</th>
+<th style="font-weight:bold">Description and examples</th>
+</tr>
+<tbody valign="top">
+<tr><td><code>HAPROXY_USERLIST_HEAD </code></td><td>Specifies the user list for HTTP Basic authentication. 
+
+The default template for `HAPROXY_USERLIST_HEAD` is:
+<code>userlist user_{backend}
+  user {user} password {passwd}</code>
+
+You can override this template with the following app label for the first port (`0`) of a given app:
+<code>"HAPROXY_0_USERLIST_HEAD": "\nuserlist user_{backend}\n  user {user} password {passwd}\n"</code></td></tr>
+</tbody>
+</table>
+
+## Global header settings
+Use the following template to configure default header settings for the load balancer.
+
+<table class="table" style="table-layout: fixed">
+<colgroup>
+    <col span="1" width="45px">
+    <col span="1" width="80px">
+</colgroup>
+<tr>
+<th style="font-weight:bold">Template name</th>
+<th style="font-weight:bold">Description and examples</th>
+</tr>
+<tbody valign="top">
+<tr><td><code>HAPROXY_HEAD </code></td><td>Specifies header information for the HAProxy configuration file. This template contains global settings and defaults. This template cannot be overridden by service port or application-based settings.
+
+The default template for `HAPROXY_HEAD` is:
+<pre>
+global
+  log /dev/log local0
+  log /dev/log local1 notice
+  spread-checks 5
+  max-spread-checks 15000
+  maxconn 50000
+  tune.ssl.default-dh-param 2048
+  ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:!aNULL:!MD5:!DSS
+  ssl-default-bind-options no-sslv3 no-tlsv10 no-tls-tickets
+  ssl-default-server-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:!aNULL:!MD5:!DSS
+  ssl-default-server-options no-sslv3 no-tlsv10 no-tls-tickets
+  stats socket /var/run/haproxy/socket expose-fd listeners
+  server-state-file global
+  server-state-base /var/state/haproxy/
+  lua-load /marathon-lb/getpids.lua
+  lua-load /marathon-lb/getconfig.lua
+  lua-load /marathon-lb/getmaps.lua
+  lua-load /marathon-lb/signalmlb.lua
+defaults
+  load-server-state-from-file global
+  log               global
+  retries                   3
+  backlog               10000
+  maxconn               10000
+  timeout connect          3s
+  timeout client          30s
+  timeout server          30s
+  timeout tunnel        3600s
+  timeout http-keep-alive  1s
+  timeout http-request    15s
+  timeout queue           30s
+  timeout tarpit          60s
+  option            dontlognull
+  option            http-server-close
+  option            redispatch
+listen stats
+  bind 0.0.0.0:9090
+  balance
+  mode http
+  stats enable
+  monitor-uri /_haproxy_health_check
+  acl getpid path /_haproxy_getpids
+  http-request use-service lua.getpids if getpid
+  acl getvhostmap path /_haproxy_getvhostmap
+  http-request use-service lua.getvhostmap if getvhostmap
+  acl getappmap path /_haproxy_getappmap
+  http-request use-service lua.getappmap if getappmap
+  acl getconfig path /_haproxy_getconfig
+  http-request use-service lua.getconfig if getconfig
+
+  acl signalmlbhup path /_mlb_signal/hup
+  http-request use-service lua.signalmlbhup if signalmlbhup
+  acl signalmlbusr1 path /_mlb_signal/usr1
+  http-request use-service lua.signalmlbusr1 if signalmlbusr1
+  </pre>
+  </td></tr>
+</tbody>
+</table>
+
+## Additional application labels
+You can use the following labels to configure additional application settings.
+
+<table>
+  <colgroup>
+    <col span="1" width="20px">
+    <col span="1" width="60px">
+  </colgroup>
+  <tr>
+    <th style="font-weight:bold">Label name</th>
+    <th style="font-weight:bold">Description and examples</th>
+  </tr>
+  <tbody valign="top">
+    <tr>
+    <td><code>HAPROXY_{n}_AUTH</code></td>
+    <td>Specifies the HTTP authentication method to use for the application on the given service port index. 
+    
+  For example, you can use this label to specify the realm name for Basic authentication:
+  
+  <code>
+    HAPROXY_0_AUTH = realm:username:encryptedpassword
+  </code>
+
+  For details on configuring authentication methods, see [HTTP Basic authentication]( https://github.com/mesosphere/marathon-lb/wiki/HTTP-Basic-Auth)</td>
+  </tr>
+
+  <tr><td><code>HAPROXY_{n}_BACKEND_<br>HEALTHCHECK_PORT_<br>INDEX</code></td>
+  <td>Sets the index of the port to use as the dedicated port for the backend health checks associated with a given service port. By default, the index for the backend health check is the same as the index used for the service port.
+
+  For example, if an app exposes two ports--`9000` and `9001`--you can specify one port for application activity, and one port for for receiving health check information:
+
+  <code>portMappings": [ 
+    { "containerPort": 9000, "hostPort": 0, "servicePort": 0, "protocol": "tcp" },
+    { "containerPort": 9001, "hostPort": 0, "servicePort": 0, "protocol": "tcp" }
+  </code>
+
+  You can then specify that you want to use port 9001 to perform the backend health checks:
+
+  <code>
+  HAPROXY_0_BACKEND_HEALTHCHECK_PORT_INDEX=1
+  </code> </td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_BACKEND<br>_NETWORK_ALLOWED_ACL</code></td> 
+<td>Sets the IP addresses (or IP address ranges) that have been granted access to the backend.  
+
+For example, you could set the following app label to restrict access to the specified IP addresses `10.1.40.0/24` and `10.1.55.43`:
+
+<code>
+HAPROXY_0_BACKEND_NETWORK_ALLOWED_ACL = '10.1.40.0/24 10.1.55.43'
+</code>
+
+By default, every IP address is allowed.
+</td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_BACKEND_<br>WEIGHT</code></td>
+<td>Specifies the order in which to enforce permissions if there are multiple backends sharing the access control lists for virtual hosts and paths. For example, if you are using a virtual host and have path access control lists that are shared by multiple backends, the order of the ACLs affects how permissions are granted for the application. 
+
+With `HAPROXY_{n}_BACKEND_WEIGHT`, you can change the order used to evaluated the ACLs by specifying a weight. The ACLs for the backends are then applied from largest to smallest weight. 
+
+If you don’t specify a value, the default weight of zero (0) is used. By default, any backends that use `HAPROXY_{n}_PATH` will have a weight of 1.
+
+<code>HAPROXY_0_BACKEND_WEIGHT = 1</code>
+</td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_BALANCE</code></td>
+<td>Sets the load balancing algorithm to be used in a backend. The default is `roundrobin`. 
+
+For example: 
+
+<code>
+HAPROXY_0_BALANCE = 'leastconn'
+</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_BIND_ADDR</code></td>
+<td>Binds the load balancer to the specific address for the service. 
+
+For example:
+
+<code>
+HAPROXY _0_BIND_ADDR = '10.0.0.42'
+</code>
+</td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_BIND_<br>OPTIONS</code></td><td>Sets additional bind options.
+
+For example: 
+
+<code>
+HAPROXY_0_BIND_OPTIONS = 'ciphers AES128+EECDH:AES128+EDH force-tlsv12 no-sslv3 no-tlsv10'
+</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_DEPLOYMENT<br>_ALT_PORT</code></td>
+<td>Specifies an alternate service port to be used during a blue/green deployment.</td>
+</tr>
+
+<tr><td><code>HAPROXY_DEPLOYMENT<br>_COLOUR</code></td>
+<td>Specifies the color to use for blue/green deployment. This label is used if you run the `bluegreen_deploy.py` script to determine the state of a deployment. You generally do not need to modify this label setting unless you implement your own deployment orchestrator.</td>
+</tr>
+
+<tr><td><code>HAPROXY_DEPLOYMENT<br>_GROUP</code></td>
+<td>Specifies the deployment group to which this app belongs.</td>
+</tr>
+
+<tr><td><code>HAPROXY_DEPLOYMENT<br>_STARTED_AT</code></td>
+<td>Specifies the time at which a deployment started. You generally do not need to modify this unless you implement your own deployment orchestrator.</td></tr>
+<tr><td><code>HAPROXY_DEPLOYMENT_<br>TARGET_INSTANCES</code></td>
+<td>Specifies the target number of app instances to seek during deployment. You generally do not need to modify this unless you implement your own deployment orchestrator.</td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_ENABLED</code></td>
+<td>Enables this backend. By default, all backends are enabled. To disable backends by default, specify the `--strict-mode` option. 
+
+For example:
+
+<code>HAPROXY_0_ENABLED = true</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_GROUP</code></td>
+<td>Specifies the HAProxy group per service. This app label enables you to use a different HAProxy group per service port. This label setting overrides `HAPROXY_GROUP` for the particular service. If you have both external and internal services running on same set of instances on different ports, you can use this setting to add them to different HAProxy configurations. 
+
+For example:
+
+<code> 
+HAPROXY_0_GROUP = 'external'
+HAPROXY_1_GROUP = 'internal'
+</code>
+
+If you run `marathon_lb` with the `--group` external option, the command adds the service on `HAPROXY_0_PORT` (or the first service port if `HAPROXY_0_HOST` is not configured) to the HAProxy configuration. 
+
+Similarly, if you run `marathon-lb` with the `--group` internal, the command adds the service on `HAPROXY_1_PORT` to the HAProxy configuration. If the HAProxy configuration includes a combination of `HAPROXY_GROUP` and `HAPROXY_{n}_GROUP` settings, the more specific definition takes precedence.
+
+For example, you might have a load balancing configuration where a service running on `HAPROXY_0_PORT` is associated with just the 'external' HAProxy group and not the 'internal' HAProxy group.
+
+<code>
+HAPROXY_0_GROUP = 'external' 
+HAPROXY_GROUP = 'internal'
+</code>
+
+In this example, there is no group setting defined for the second service. With this configuration, `marathon-lb` falls back to using the default `HAPROXY_GROUP`, which is then associated with the `internal` HAPorxy group. Load balancers with the group set to '*' collect all groups.</td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_HTTP_<br>BACKEND_PROXYPASS_<br>PATH</code></td>
+<td>Sets the location to use for mapping local server URLs to remote servers + URL.
+
+For example:
+
+<code>HAPROXY_0_HTTP_BACKEND_PROXYPASS_PATH = '/path/to/redirect'</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_HTTP_<br>BACKEND_REVPROXY_PATH</code></td>
+<td>Sets the URL in HTTP response headers sent from a reverse proxied server. This label only updates the Location, Content-Location, and URL fields. 
+
+For example:
+
+<code>HAPROXY_0_HTTP_BACKEND_REVPROXY_PATH = '/my/content'</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_MODE</code></td>
+<td>Sets the connection mode to either TCP or HTTP. The default is TCP. 
+
+The following exceptions apply:
+If you don’t specify the `HAPROXY_{n}_VHOST` label and have not set `HAPROXY_{n}_MODE`, the mode is set to `http`.
+
+If you have configured a health check for the given port and the protocol field is set to one of 'HTTP', 'HTTPS', 'MESOS_HTTP', 'MESOS_HTTPS', the mode is overridden to 'http', regardless of the value of the `HAPROXY_{n}_MODE` label. For example: 
+
+<code>
+HAPROXY_0_MODE = 'http'
+</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_PATH</code></td>
+<td>Specifies the HTTP path to match, starting at the beginning. You can specify multiple paths separated by spaces. The syntax matches that of the `path_beg` configuration option used in other templates and labels. 
+
+To use the path routing, you must also define a virtual host. 
+
+If you have multiple backends which share virtual hosts or paths, you can manually specify the order of the backend ACLs with the `HAPROXY_{n}_BACKEND_WEIGHT` setting. For HAProxy, the use_backend directive is evaluated in the order it appears in the configuration. 
+
+For example:<br>
+<code> 
+HAPROXY_0_PATH = '/v2/api/derp'
+HAPROXY_0_PATH = '-i /multiple /paths'
+</code></td>
+</tr>
+<tr><td><code>HAPROXY_{n}_PORT</code></td>
+<td>Binds to the specified port number for the service. This setting overrides the servicePort which has to be unique. For example:
+
+<code>
+HAPROXY_0_PORT = 80
+</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_REDIRECT_<br>TO_HTTPS</code></td>
+<td>Redirects HTTP traffic to HTTPS. Requires at least one virtual host be set. For example:
+
+<code> 
+HAPROXY_0_REDIRECT_TO_HTTPS = true
+</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_SSL_CERT</code></td>
+<td>Enables the given SSL certificate for TLS/SSL traffic. 
+For example:
+
+<code> 
+HAPROXY_0_SSL_CERT = '/etc/ssl/cert.pem'
+</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_STICKY</code></td>
+<td>Enables sticky request routing for the service. For example:
+
+<code>HAPROXY_0_STICKY = true
+</code></td>
+</tr>
+
+<tr><td><code>HAPROXY_{n}_USE_HSTS</code></td>
+<td>Enables the HSTS response header for the HTTP clients that support it. For example:
+
+<code>HAPROXY_0_USE_HSTS = true</code></td>
+</tr>
+<tr><td><code>HAPROXY_{n}_VHOST</code></td>
+<td>Specifies the Marathon HTTP virtual host proxy host name(s) to gather. 
+
+If you have multiple backends that share the same virtual host names or paths, you might need to manually specify the appropriate order to use for the backend access control lists using the <code>HAPROXY_{n}_BACKEND_WEIGHT</code> setting. The HAProxy `use_backend` directive is evaluated in the order it appears in the configuration.
+
+For example:
+
+<code>
+HAPROXY_0_VHOST = 'marathon.mesosphere.com'<br>
+HAPROXY_0_VHOST = 'marathon.mesosphere.com,marathon'
+</code>
+</td></tr>
+</tbody>
+</table>

--- a/pages/services/marathon-lb/1.13.x/mlb-scaling-tutorial/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-scaling-tutorial/index.md
@@ -1,0 +1,204 @@
+---
+layout: layout.pug
+navigationTitle:  Tutorial - Scaling apps using Marathon-LB statistics
+title: Tutorial - Automated scaling using Marathon-LB statistics  
+menuWeight: 35
+excerpt: How to automate application scaling using Marathon-LB statistics
+enterprise: false
+---
+
+You can use the Marathon-LB HAProxy statistics endpoint report to monitor application health and performance, and as input for application scheduling and scaling. The `HAProxy` program collects data points using performance counters and 1-second rates for various metrics.
+
+One way you can use the metrics that Marathon-LB generates through HAProxy is to implement automatic scaling for Marathon apps.
+
+# What this tutorial demonstrates
+
+This tutorial guides you through the steps for configuring Marathon-LB if you want to use the load balancing statistics to automate application scaling.
+
+After completing this tutorial, you will have hands-on practice configuring a sample application that uses load balancing statistics to automate the deployment of instances to address increasing demand.
+
+# Measuring application requests-per-second
+
+For a given application, you can measure performance in terms of **requests-per-second** for a given set of resources. If the application is stateless and scales horizontally, you can then scale the number of app instances proportionally to the average number of requests-per-second over a certain number of intervals.
+
+As part of this tutorial, the `marathon-lb-autoscale` script polls the HAProxy `stats` endpoint and automatically scales application instances based on the incoming number of requests.
+
+<p>
+<img src="/services/img/marathon-lb-autoscale.png" alt="Using Marathon-LB statistics for automatic scaling">
+</p>
+
+The autoscale script takes the current requests-per-second and divides that number by the target number of requests-per-second for the app instance. The result of this fraction is the number of app instances required (or rather, the ceiling of that fraction is the number of instances required).
+
+<p>
+<img src="/1.12/img/image00.png" alt="Current requests-per-second divided by target requests-per-second">
+
+# Before you begin
+
+* You must have a DC/OS cluster installed.
+* The DC/OS cluster must have at least one master node, at least three private agent nodes, and at least one public agent node.
+* You must have an account with access to the DC/OS web-based administrative console or DC/OS command-line interface.
+* You must have Marathon-LB installed.
+
+# Identify the apps for demonstration purposes
+To demonstrate autoscaling, assume you have the following Marathon apps:
+* `marathon-lb-autoscale` is a script that monitors `HAProxy` and scales the sample app using the Marathon API.
+* `nginx` is the demonstration application.
+* `siege` is a tool for generating HTTP requests.
+
+# Configure app definitions for automatic scaling
+To illustrate automatic scaling, you need to configure and deploy the app definitions for the Marathon apps.
+
+1. Open a shell terminal.
+
+1. Create a text file and copy the following [sample app definition](https://gist.github.com/brndnmtthws/2ca7e10b985b2ce9f8ee) file to prepare the `marathon-lb-autoscale` application.
+
+    ```json
+    {
+    "id": "marathon-lb-autoscale",
+    "args":[
+        "--marathon", "http://leader.mesos:8080",
+        "--haproxy", "http://marathon-lb.marathon.mesos:9090",
+        "--target-rps", "100",
+        "--apps", "nginx_10000"
+    ],
+    "cpus": 0.1,
+    "mem": 16.0,
+    "instances": 1,
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+        "image": "brndnmtthws/marathon-lb-autoscale",
+        "network": "HOST",
+        "forcePullImage": true
+        }
+    }
+    }
+    ```
+
+    The [sample app definition](https://gist.github.com/brndnmtthws/2ca7e10b985b2ce9f8ee) passes the following arguments that are important for load balancing: 
+
+    * `--target-rps` specifies the requests-per-second you want the `marathon-lb-autoscale` load balancing instance to use for scaling purposes.
+
+    * `--apps` specifies a comma-separated list of the Marathon apps and service ports to monitor, concatenated with an underscore (_). 
+
+    Each app could expose multiple service ports to the load balancer, if configured to do so. The `marathon-lb-autoscale` instance scales the app to meet the greatest common denominator for the number of required instances.
+
+1. Save the app definition for the `marathon-lb-autoscale` load balancing instance.
+
+1. Run the `marathon-lb-autoscale` application using Marathon. For example:
+
+    ```
+    dcos marathon app add https://gist.githubusercontent.com/brndnmtthws/2ca7e10b985b2ce9f8ee/raw/66cbcbe171afc95f8ef49b70034f2842bfdb0aca/marathon-lb-autoscale.json
+    ```
+
+1. Start an external Marathon-LB instance if it is not already running:
+
+    ```bash
+    dcos package install marathon-lb
+    ```
+
+1. Create a text file and copy the following [sample app definition](https://gist.github.com/brndnmtthws/84d0ab8ac057aaacba05) to prepare the NGINX test application instance:
+
+    ```json
+    {
+    "id": "nginx",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+        "image": "nginx:1.7.7",
+        "network": "BRIDGE",
+        "portMappings": [
+            { "hostPort": 0, "containerPort": 80, "servicePort": 10000 }
+        ],
+        "forcePullImage":true
+        }
+    },
+    "instances": 1,
+    "cpus": 0.1,
+    "mem": 65,
+    "healthChecks": [{
+        "protocol": "HTTP",
+        "path": "/",
+        "portIndex": 0,
+        "timeoutSeconds": 10,
+        "gracePeriodSeconds": 10,
+        "intervalSeconds": 2,
+        "maxConsecutiveFailures": 10
+    }],
+    "labels":{
+        "HAPROXY_GROUP":"external"
+    }
+    }
+    ```
+
+1. Save the app definition for the `nginx` test application.
+
+1. Start the NGINX test application instance using Marathon: 
+
+    ```bash
+    dcos marathon app add https://gist.githubusercontent.com/brndnmtthws/84d0ab8ac057aaacba05/raw/d028fa9477d30b723b140065748e43f8fd974a84/nginx.json
+    ```
+
+1. Create a text file and copy the following [sample app definition](https://gist.github.com/brndnmtthws/fe3fb0c13c19a96c362e) for the `siege` application.
+
+    ```json
+    {
+    "id": "siege",
+    "args":[
+        "-d1",
+        "-r1000",
+        "-c100",
+        "http://marathon-lb.marathon.mesos:10000/"
+    ],
+    "cpus": 0.5,
+    "mem": 16.0,
+    "instances": 1,
+    "container": {
+        "type": "DOCKER",
+        "volumes": [],
+        "docker": {
+        "image": "yokogawa/siege",
+        "network": "HOST",
+        "privileged": false,
+        "parameters": [],
+        "forcePullImage": false
+        }
+    }
+    }
+    ```
+1. Save the app definition for the `siege` application.
+
+1. Start the `siege` application using Marathon:
+
+    ```bash
+    dcos marathon app add https://gist.githubusercontent.com/brndnmtthws/fe3fb0c13c19a96c362e/raw/32280a39e1a8a6fe2286d746b0c07329fedcb722/siege.json
+    ```
+
+1. In your web browser, navigate to the HAProxy statistics endpoint to display the HAProxy status page where you can see requests hitting the NGINX instance. 
+
+    For example, if the agent IP address is `52.35.15.50` and you are using the default endpoint:<br>
+
+    <code>52.35.15.50:9090/haproxy?stats</code>
+
+    <p>
+    <img src="/1.12/img/image02-800x508.png" alt="HAProxy statistics">
+    </p>
+
+    Check the “Session rate” to see the number requests-per-second generated on the NGINX application frontend.
+
+1. Scale the `siege` app to generate a large number of HTTP requests.
+
+    For example:
+
+    ```bash
+    dcos marathon app update /siege instances=15
+    ```
+
+    After a few minutes, you should see that the NGINX app has been automatically scaled up to serve the increased traffic.
+
+# Exploring scaling on your own
+You can experiment further with automated application scaling using the additional parameters for the `marathon-lb-autoscale` sample script. For example, you might want to try changing the interval, number of samples, or other values until you achieve the desired effect. 
+
+The default values are fairly conservative. In experiementing with these values, you might want to include a 50 percent safety factor in the target RPS. For example, if you want your application to meet service-level agreement (SLA) at 1500 requests-per-second with 1 CPU and 1 GiB of memory, you might want to set the target RPS to 1000.
+
+For more information about the parameters you can set to work with the `marathon-lb-autoscale` script, see the [autoscale usage information](https://github.com/mesosphere/marathon-lb-autoscale). 

--- a/pages/services/marathon-lb/1.13.x/mlb-troubleshooting/index.md
+++ b/pages/services/marathon-lb/1.13.x/mlb-troubleshooting/index.md
@@ -1,0 +1,45 @@
+---
+layout: layout.pug
+navigationTitle:  Troubleshooting Marathon-LB
+title: Troubleshooting Marathon-LB  
+menuWeight: 45
+excerpt: Common issues and troubleshooting tips for Marathon-LB
+enterprise: false
+---
+This section covers potential issues and troubleshooting techniques for Marathon-LB load balancer running on DC/OS clusters.
+
+# Collecting container and HAProxy information
+You can collect detailed information about containers and HAProxy activity to analyze and troubleshoot operations, identify potential problems, and view connections for frontends and backends. You collect this information by setting the `HAPROXY_SYSLOGD` environment variable or the `container-syslogd` value in a custom `options.json` file like this:
+
+```json
+  {
+    "marathon-lb": {
+      "container-syslogd": true
+    }
+  }
+```
+
+# Removing orphaned processes
+`HAProxy` typically produces orphan processes because of its two-step reloading process. In most cases, Marathon-LB removes the orphan processes it generates using the tini program. The Tini program runs transparently on a container as a single child process. It is responsible for removing orphan processes and performing signal forwarding.
+
+Over time, orphan processes consume resources and affect the process identifier namespace where they run, making the environment unstable or unusable. Therefore, you should be sure to remove any orphaned child processes either manually or programmatically.
+
+By default, Tini needs to run using the process identifier (PID) 1 to remove orphaned processes. If you cannot run Tini as PID 1 or if you are running containers without PID namespace isolation, you should register the Tini program as a process subreaper by  setting the TINI_SUBREAPER environment variable.  Setting the TINI_SUBREAPER environment variable ensures that the orphaned processes get re-parented as children of the Tini program which can then remove them to complete its execution.
+
+# Using a single PID namespace
+Some features, such as `/_mlb_signal endpoints`, `/_haproxy_getpids endpoints`, and `zero-downtime deployments`, require that only one Marathon-LB instance is running and that it runs in its own processing namespace as a container. If more than one instance of Marathon-LB is running in the same PID namespace, you might see unexpected results or errors that interfere with normal operations.
+
+# Enabling support for TLS v1.0
+Transport Layer Security (TLS), version 1.0, has been deprecated, and is no longer supported by the default Marathon-LB configuration. If you are using Marathon-LB based on `debian:stretch`, or earlier, and you require TLS v1.0 support, you must supply a custom template for `HAPROXY_HEAD` in your `marathon-lb` app definition that includes a configuration setting similar to this:
+
+```
+ {
+    "id":"/marathon-lb",   "uris":["https://downloads.mesosphere.com/marathon/marathon-lb/templates-with-tls-10.tgz"]
+  }
+```
+
+The following versions of Marathon-LB do not support TLS v1.0 or TLS v1.1:
+* 1.8.1
+* 1.11.1
+
+If possible, you should discontinue using Transport Layer Security (TLS), version 1.0 or 1.1.

--- a/pages/services/marathon-lb/1.13.x/release-notes/index.md
+++ b/pages/services/marathon-lb/1.13.x/release-notes/index.md
@@ -1,0 +1,40 @@
+---
+layout: layout.pug
+navigationTitle: Release notes
+title: Release notes
+menuWeight: 80
+excerpt: Discover the new features, updates, and known limitations in this release of the Marathon-LB Service
+---
+
+# Release Notes for Marathon-LB Service version 1.12.0
+
+## Noteworthy changes:
+
+- Update to HAProxy 1.8.4
+- Change reload mechanism away from iptables hack, use HAProxy 1.8 features instead
+
+Shortlist:
+
+```
+$ git shortlog v1.11.3..HEAD
+      Check for MESOS_TCP (#509)
+      Add long backend proxypass path test (#499)
+      Fix bug in config validation and reduce marathon calls (#563)
+      Add missing parameter to regenerate_config call (#573)
+      Merge beta features into master (bump to HAProxy 1.8.4) (#569)
+      Fixed broken links (#568)
+      Fix build status link (#548)
+      Use multiple keyservers for gpg verify of tini during Docker build (#549)
+      Work around python3 > dh-python > dkpg-dev > make dependency (#564)
+      Https frontend grouping by vhost (#524)
+      Fix ordering of acls that include paths when using haproxy map with https (#447)
+      Adding MLB Integration Tests to CI (#570)
+```
+
+## Known Issues
+
+* Existing custom `HAPROXY_HEAD` templates will cause v1.12.0 to not start up properly. Please remove `daemon` and add `stats socket /var/run/haproxy/socket expose-fd listeners` in the global section of your custom `HAPROXY_HEAD` to resolve the issue. More can info be found here: [https://docs.mesosphere.com/services/marathon-lb/advanced/#global-template](https://docs.mesosphere.com/services/marathon-lb/advanced/#global-template)
+
+# Previous Versions
+
+Click [here](https://github.com/mesosphere/marathon-lb/releases) to view the release notes prior to Marathon-LB Service version 1.12.0.

--- a/pages/services/marathon-lb/1.13.x/release-notes/index.md
+++ b/pages/services/marathon-lb/1.13.x/release-notes/index.md
@@ -6,35 +6,45 @@ menuWeight: 80
 excerpt: Discover the new features, updates, and known limitations in this release of the Marathon-LB Service
 ---
 
-# Release Notes for Marathon-LB Service version 1.12.0
+# Release Notes for Marathon-LB Service version 1.13.0
 
 ## Noteworthy changes:
 
-- Update to HAProxy 1.8.4
-- Change reload mechanism away from iptables hack, use HAProxy 1.8 features instead
+- Update to HAProxy 1.9.6
+- Fixes HAPROXY_HTTP_BACKEND_REVPROXY_GLUE default template syntax
 
 Shortlist:
 
 ```
-$ git shortlog v1.11.3..HEAD
-      Check for MESOS_TCP (#509)
-      Add long backend proxypass path test (#499)
-      Fix bug in config validation and reduce marathon calls (#563)
-      Add missing parameter to regenerate_config call (#573)
-      Merge beta features into master (bump to HAProxy 1.8.4) (#569)
-      Fixed broken links (#568)
-      Fix build status link (#548)
-      Use multiple keyservers for gpg verify of tini during Docker build (#549)
-      Work around python3 > dh-python > dkpg-dev > make dependency (#564)
-      Https frontend grouping by vhost (#524)
-      Fix ordering of acls that include paths when using haproxy map with https (#447)
-      Adding MLB Integration Tests to CI (#570)
+$ git shortlog v1.12.3..v1.13.0
+      add password authentication (#493)
+      Update README.md (#617)
+      Increase ZDD pids from 1 to 2 (#598)
+      Fixed typo on HAPROXY_HTTP_BACKEND_REVPROXY_GLUE template. (#501)
+      Fixes #613 - correctly validate global daemon flag. (#615)
+      Make sure we remove temp map files only after checking for map config. (#582)
+      Introduce "linear-increase" parameter to zdd.py. (#556)
+      tests: use raw strings instead of escaping
+      config: use raw strings instead of escaping
+      make: introduce makefile for testing/building
+      Fix tests (#619)
+      readme: point to github wiki (#627)
+      tests/dockerfile: update base image (#629)
+      utils: send auth to any host redirected to (#633)
+      use consistent line endings when comparing config (#622)
+      disable configuration cleanup on failed validation (#554) (#625)
+      Rebase and Flake8 fixes of #584 (#624)
+      print marathon master (#626)
+      Fallback on next Marathon instance on exception (#630)
+      updated to 1.9.6 (#631)
+      Bind the backend to the frontend when redirectHttpToHttps is used (#498)
+      Add backoff limitation option (#479)
+      fix: undefined HAPROXY_DEPLOYMENT_TARGET_INSTANCES (#537)
+      bump tini to version 0.18.0 and haproxy to version 1.8.16 (#608)
 ```
 
 ## Known Issues
 
-* Existing custom `HAPROXY_HEAD` templates will cause v1.12.0 to not start up properly. Please remove `daemon` and add `stats socket /var/run/haproxy/socket expose-fd listeners` in the global section of your custom `HAPROXY_HEAD` to resolve the issue. More can info be found here: [https://docs.mesosphere.com/services/marathon-lb/advanced/#global-template](https://docs.mesosphere.com/services/marathon-lb/advanced/#global-template)
-
 # Previous Versions
 
-Click [here](https://github.com/mesosphere/marathon-lb/releases) to view the release notes prior to Marathon-LB Service version 1.12.0.
+Click [here](https://github.com/mesosphere/marathon-lb/releases) to view the release notes prior to Marathon-LB Service version 1.13.0.


### PR DESCRIPTION
## Description

- Copies the 1.12.x structure over to 1.13.x
- Sets 1.13.x as the default
- Adds release notes for 1.13.0

https://jira.mesosphere.com/browse/DCOS_OSS-5111

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
