### PR TITLE
universal installer v0.2: provide working examples for multi-region / replaceable masters

### DIFF
--- a/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
@@ -13,7 +13,7 @@ The Terraform-based Universal Installer is designed to be flexible with configur
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/aws"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/pages/1.13/installing/evaluation/aws/aws-replaceable-masters/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-replaceable-masters/index.md
@@ -59,7 +59,7 @@ module "dcos" {
 
   dcos_variant              = "ee"
   dcos_version              = "1.12.3"
-  dcos_license_key_contents = "${file("~/license.txt")}"
+  dcos_license_key_contents = "${file("./license.txt")}"
 
   with_replaceable_masters = true
 }


### PR DESCRIPTION
This change requires the latest versions of the v0.2 to be available before this PR can be merged. The following changes below were also required to make this work:

* https://github.com/dcos-terraform/terraform-aws-lb/pull/3
* https://github.com/dcos-terraform/terraform-aws-vpc-peering/releases/tag/1.0.1


## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS-53149

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).