### PR TITLE
Adjusted docs for TASK_GONE_BY_OPERATOR

### DIFF
--- a/pages/1.12/deploying-services/task-handling/index.md
+++ b/pages/1.12/deploying-services/task-handling/index.md
@@ -12,7 +12,7 @@ Marathon sorts tasks into three categories: initial, non-terminal, and terminal.
 
 You can also  [configure Marathon's behavior when a task is unreachable](/deploying-services/task-handling/configure-task-handling/).
 
-![Task Handling Flow](/img/task-handling-corrected.png)
+![Task Handling Flow](/1.12/img/task-handling-corrected.png)
 
 Figure 1. Task handling diagram
 

--- a/pages/1.12/deploying-services/task-handling/index.md
+++ b/pages/1.12/deploying-services/task-handling/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 Marathon sorts tasks into three categories: initial, non-terminal, and terminal. Tasks within these categories may be in one of several states, as summarized in the diagram below. To learn the state of a task, you can consult the DC/OS logs or query the [events stream](http://mesosphere.github.io/marathon/docs/event-bus.html) of the [Marathon API](http://mesosphere.github.io/marathon/api-console/index.html) (/v2/events).
 
-You can also  [configure Marathon's behavior when a task is unreachable](/deploying-services/task-handling/configure-task-handling/).
+You can also [configure Marathon's behavior when a task is unreachable](/1.12/deploying-services/task-handling/configure-task-handling/).
 
 ![Task Handling Flow](/1.12/img/task-handling-corrected.png)
 

--- a/pages/1.13/administering-clusters/delete-node/index.md
+++ b/pages/1.13/administering-clusters/delete-node/index.md
@@ -16,17 +16,17 @@ If your node has gone down in an unplanned way, you only have to [Decommission t
 
 When Mesos detects that a node has stopped, it puts the node in the `UNREACHABLE` state because Mesos does not know if the node is temporarily stopped and will come back online, or if it is permanently stopped. You can explicitly tell Mesos to put a node in the `GONE` state if you know a node will not come back.
 
-Once a node is decommissioned, the corresponding agent ID is marked as `GONE` internally and not allowed to come back and re-register with the master. Any tasks running on the node are transitioned to `TASK_GONE_BY_OPERATOR` state.
+Once a node is decommissioned, the corresponding agent ID is marked as `GONE` internally and not allowed to come back and re-register with the master. Any tasks running on the node are transitioned to `TASK_GONE_BY_OPERATOR` state. If these tasks were using [Local Persistent Volumes](../../storage/persistent-volume), the responsible framework will abandon these Local Persistent Volumes once they are notified of the agent being gone. They will automatically create new tasks with new reservations and volumes on other suitable agents.  
 
 You should decommission nodes in the following situations.
 
-- You are deleting a node, especially if you are deleting multiple nodes. DC/OS is configured to only allow one node to be marked `UNREACHABLE` every 20 minutes, so if you do not explicity decommission nodes, it can take a long time for Mesos to mark your nodes as `UNREACHABLE` and allow services to reschedule tasks on another node.
+- You are deleting a node, especially if you are deleting multiple nodes. DC/OS is configured to only allow one node to be marked `UNREACHABLE` every 20 minutes, so if you do not explicitly decommission nodes, it can take a long time for Mesos to mark your nodes as `UNREACHABLE` and allow services to reschedule tasks on another node.
 
 - If you are working with stateful services, like the [DC/OS data services](/services/). It is expensive for stateful services to reschedule tasks, so the services need to know that an agent is not going to come back online before they reschedule.
 
 - When a node has gone down in an unplanned way.
 
-Enter the following command from the DC/OS CLI to identify the node that is to be decomissioned.
+Enter the following command from the DC/OS CLI to identify the node that is to be decommissioned.
 
 ```
 dcos node 
@@ -61,5 +61,5 @@ If the DC/OS node is still running, the Mesos slave process will continue to try
   -  **Public agent**
 
   ```bash
-  ⁠⁠⁠⁠sudo sh -c 'systemctl stop dcos-mesos-slave-public'
+  sudo sh -c 'systemctl stop dcos-mesos-slave-public'
   ```

--- a/pages/1.13/administering-clusters/delete-node/index.md
+++ b/pages/1.13/administering-clusters/delete-node/index.md
@@ -16,7 +16,7 @@ If your node has gone down in an unplanned way, you only have to [Decommission t
 
 When Mesos detects that a node has stopped, it puts the node in the `UNREACHABLE` state because Mesos does not know if the node is temporarily stopped and will come back online, or if it is permanently stopped. You can explicitly tell Mesos to put a node in the `GONE` state if you know a node will not come back.
 
-Once a node is decommissioned, the corresponding agent ID is marked as `GONE` internally and not allowed to come back and re-register with the master. Any tasks running on the node are transitioned to `TASK_GONE_BY_OPERATOR` state. If these tasks were using [Local Persistent Volumes](../../storage/persistent-volume), the responsible framework will abandon these Local Persistent Volumes once they are notified of the agent being gone. They will automatically create new tasks with new reservations and volumes on other suitable agents.  
+Once a node is decommissioned, the corresponding agent ID is marked as `GONE` internally and not allowed to come back and re-register with the master. Any tasks running on the node are transitioned to `TASK_GONE_BY_OPERATOR` state. If these tasks were using [Local Persistent Volumes](/1.13/storage/persistent-volume), the responsible framework will abandon these Local Persistent Volumes once they are notified of the agent being gone. They will automatically create new tasks with new reservations and volumes on other suitable agents.  
 
 You should decommission nodes in the following situations.
 

--- a/pages/1.13/deploying-services/task-handling/index.md
+++ b/pages/1.13/deploying-services/task-handling/index.md
@@ -42,7 +42,9 @@ The task was running on an agent that has been shutdown (e.g., the agent become 
 ```
 case TASK_GONE_BY_OPERATOR => Gone
 ```
-The task was running on an agent that the master cannot contact; the operator has asserted that the agent has been shutdown, but this has not been directly confirmed by the master. If the operator is correct, the task is not running and this is a terminal state; if the operator is mistaken, the task might still be running, and might return to the RUNNING state in the future. After Marathon marks the task as failed, it expunges the task and starts a new one.    
+The task was running on an agent that the master cannot contact; the operator has asserted that the agent has been shutdown, but this has not been directly confirmed by the master. If the operator is correct, the task is not running and this is a terminal state; if the operator is mistaken, the task might still be running, and might return to the RUNNING state in the future. After Marathon marks the task as failed, it expunges the task and starts a new one.
+
+If the task was configured to use [Local Persistent Volumes](../../storage/persistent-volume), these will be abandoned given that the agent is considered to be gone and not able to offer those volumes. A new task will be created as a replacement, with new volumes for its use.
 
 ```
 case TASK_FINISHED => Finished
@@ -52,7 +54,7 @@ The task finished successfully.
 ```
 case TASK_UNKNOWN => Unknown
 ```
-The master has no knowledge of the task. This is typically because either (a) the master never had knowledge of the task, or (b) the master forgot about the task because it garbaged collected its metadata about the task. The task may or may not still be running. When Marathon receives the Unknown message, it expunges the task and starts a new one.
+The master has no knowledge of the task. This is typically because either (a) the master never had knowledge of the task, or (b) the master forgot about the task because it garbage collected its metadata about the task. The task may or may not still be running. When Marathon receives the Unknown message, it expunges the task and starts a new one.
 
 ```
 case TASK_KILLED => Killed

--- a/pages/1.13/deploying-services/task-handling/index.md
+++ b/pages/1.13/deploying-services/task-handling/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 Marathon sorts tasks into three categories: initial, non-terminal, and terminal. Tasks within these categories may be in one of several states, as summarized in the diagram below. To learn the state of a task, you can consult the DC/OS logs or query the [events stream](http://mesosphere.github.io/marathon/docs/event-bus.html) of the [Marathon API](http://mesosphere.github.io/marathon/api-console/index.html) (/v2/events).
 
-You can also  [configure Marathon's behavior when a task is unreachable](/deploying-services/task-handling/configure-task-handling/).
+You can also  [configure Marathon's behavior when a task is unreachable](/1.13/deploying-services/task-handling/configure-task-handling/).
 
 ![Task Handling Flow](/1.13/img/task-handling-corrected.png)
 
@@ -44,7 +44,7 @@ case TASK_GONE_BY_OPERATOR => Gone
 ```
 The task was running on an agent that the master cannot contact; the operator has asserted that the agent has been shutdown, but this has not been directly confirmed by the master. If the operator is correct, the task is not running and this is a terminal state; if the operator is mistaken, the task might still be running, and might return to the RUNNING state in the future. After Marathon marks the task as failed, it expunges the task and starts a new one.
 
-If the task was configured to use [Local Persistent Volumes](../../storage/persistent-volume), these will be abandoned given that the agent is considered to be gone and not able to offer those volumes. A new task will be created as a replacement, with new volumes for its use.
+If the task was configured to use [Local Persistent Volumes](/1.13/storage/persistent-volume), these will be abandoned given that the agent is considered to be gone and not able to offer those volumes. A new task will be created as a replacement, with new volumes for its use.
 
 ```
 case TASK_FINISHED => Finished

--- a/pages/1.13/deploying-services/task-handling/index.md
+++ b/pages/1.13/deploying-services/task-handling/index.md
@@ -12,7 +12,7 @@ Marathon sorts tasks into three categories: initial, non-terminal, and terminal.
 
 You can also  [configure Marathon's behavior when a task is unreachable](/deploying-services/task-handling/configure-task-handling/).
 
-![Task Handling Flow](/img/task-handling-corrected.png)
+![Task Handling Flow](/1.13/img/task-handling-corrected.png)
 
 Figure 1. Task handling diagram
 

--- a/pages/1.13/deploying-services/task-handling/index.md
+++ b/pages/1.13/deploying-services/task-handling/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 Marathon sorts tasks into three categories: initial, non-terminal, and terminal. Tasks within these categories may be in one of several states, as summarized in the diagram below. To learn the state of a task, you can consult the DC/OS logs or query the [events stream](http://mesosphere.github.io/marathon/docs/event-bus.html) of the [Marathon API](http://mesosphere.github.io/marathon/api-console/index.html) (/v2/events).
 
-You can also  [configure Marathon's behavior when a task is unreachable](/1.13/deploying-services/task-handling/configure-task-handling/).
+You can also [configure Marathon's behavior when a task is unreachable](/1.13/deploying-services/task-handling/configure-task-handling/).
 
 ![Task Handling Flow](/1.13/img/task-handling-corrected.png)
 


### PR DESCRIPTION
Adjusted docs to explain handling of persistent volumes in the event of TASK_GONE_BY_OPERATOR.

## Description
[DCOS-51225](https://jira.mesosphere.com/browse/DCOS-51225)

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
