### PR TITLE
beta-dcos-monitoring: Update docs for 0.5.0-beta

### DIFF
--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/configure-dcos-access/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/configure-dcos-access/index.md
@@ -1,0 +1,93 @@
+---
+layout: layout.pug
+navigationTitle: Configuring DC/OS access for Beta DC/OS Monitoring Service
+title: Configuring DC/OS access for Beta DC/OS Monitoring Service
+menuWeight: 20
+excerpt: Configuring DC/OS access for Beta DC/OS Monitoring Service
+render: mustache
+model: ../data.yml
+---
+
+The {{ model.techName }} service is run on DC/OS clusters in either `permissive` or `strict` mode. DC/OS access controls must be used to restrict access to the {{ model.techName }} service when running on [strict](/1.12/security/ent/#security-modes) mode clusters. Configure the {{ model.techName }} service to authenticate itself using a certificate and to only grant permissions required by the service.
+
+This page describes how to configure DC/OS access for {{ model.techName }} Service. Depending on your [security mode](/1.12/security/ent/#security-modes/), {{ model.techName }} Service requires [service authentication](/1.12/security/ent/service-auth/) for access to DC/OS.
+
+| Security mode | Service Account |
+|---------------|-----------------------|
+| Disabled      | Not available   |
+| Permissive    | Optional   |
+| Strict        | Required |
+
+If you install a service in `permissive` mode and do not specify a service account, Metronome and Marathon will act as if requests from this service is made by an account with the [superuser permission](/1.12/security/ent/perms-reference/#superuser).
+
+**Prerequisites:**
+
+- [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser.
+- [Enterprise DC/OS CLI 0.4.14 or later installed](/1.12/cli/enterprise-cli/#ent-cli-install).
+- If your [security mode](/1.12/security/ent/#security-modes/) is `permissive` or `strict`, you must [get the root cert](/1.12/security/ent/tls-ssl/get-cert/) before issuing the curl commands in this section.
+
+# Create a Key Pair
+
+In this step, a 2048-bit RSA public-private key pair is created using the Enterprise DC/OS CLI.
+
+Create a public-private key pair and save each value into a separate file within the current directory.
+
+```bash
+dcos security org service-accounts keypair <private-key>.pem <public-key>.pem
+```
+
+**Tip:** You can use the [DC/OS Secret Store](/1.12/security/ent/secrets/) to secure the key pair.
+
+# Create a Service Account
+
+From a terminal prompt, create a service account named `{{ model.packageName }}-principal` and store its private certificate in a secret named `{{ model.packageName }}/service-private-key` using the following CLI commands.
+
+```bash
+dcos security org service-accounts keypair {{ model.packageName }}-private-key.pem {{ model.packageName }}-public-key.pem
+dcos security org service-accounts create -p {{ model.packageName }}-public-key.pem -d "{{ model.packageName }} service account" {{ model.packageName }}-principal
+dcos security secrets create-sa-secret --strict {{ model.packageName }}-private-key.pem {{ model.packageName }}-principal {{ model.packageName }}/service-private-key
+```
+
+# Assign service permissions
+
+Grant `{{ model.packageName }}-principal` the permissions required to run the {{ model.techName }} service using the following commands.
+
+```bash
+dcos security org users grant {{ model.packageName }}-principal dcos:adminrouter:ops:ca:rw full
+dcos security org users grant {{ model.packageName }}-principal dcos:adminrouter:ops:ca:ro full
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:agent:framework:role:slave_public read
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:framework:role:{{ model.packageName }}-role create
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:framework:role:slave_public read
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:framework:role:slave_public/{{ model.packageName }}-role read
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:framework:role:slave_public/{{ model.packageName }}-role create
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:reservation:principal:{{ model.packageName }}-principal delete
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:reservation:role:{{ model.packageName }}-role create
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:reservation:role:slave_public/{{ model.packageName }}-role create
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:task:user:nobody create
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:volume:principal:{{ model.packageName }}-principal delete
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:volume:role:{{ model.packageName }}-role create
+dcos security org users grant {{ model.packageName }}-principal dcos:mesos:master:volume:role:slave_public/{{ model.packageName }}-role create
+dcos security org users grant {{ model.packageName }}-principal dcos:secrets:default:/{{ model.packageName }}/\* full
+dcos security org users grant {{ model.packageName }}-principal dcos:secrets:list:default:/{{ model.packageName }} read
+```
+
+# Create a Configuration file
+
+Create a custom options file that is used to install {{ model.techName }} service and save the file as (`options.json`).
+
+```json
+{
+  "service": {
+    "service_account": "{{ model.packageName }}-principal",
+    "service_account_secret": "{{ model.packageName }}/service-private-key"
+  }
+}
+```
+
+# Install {{ model.techName }} service
+
+Now, install {{ model.techName }} service using the following command.
+
+```bash
+dcos package install {{ model.packageName }} --options=options.json
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/data.yml
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/data.yml
@@ -1,0 +1,8 @@
+# Common values:
+
+packageName: beta-dcos-monitoring
+serviceName: beta-dcos-monitoring
+techName:  Beta DC/OS Monitoring
+techShortName: Beta DC/OS Monitoring
+
+# Values specific to certain templates:

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/data.yml.tmpl
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/data.yml.tmpl
@@ -1,0 +1,8 @@
+# Common values:
+
+packageName: ${ANNOTATED_PACKAGE_NAME}
+serviceName: ${ANNOTATED_PACKAGE_NAME}
+techName:  ${ANNOTATED_TECH_NAME}
+techShortName: ${ANNOTATED_TECH_NAME}
+
+# Values specific to certain templates:

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/getting-started/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/getting-started/index.md
@@ -1,0 +1,55 @@
+---
+layout: layout.pug
+navigationTitle: Getting Started
+title: Getting Started
+menuWeight: 10
+excerpt: Download and install Beta DC/OS Monitoring Service
+render: mustache
+model: ../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+In this section, you will download and install the {{ model.techName }} service.
+By default, Prometheus and Grafana are run with the default configuration options.
+Alert Manager is off by default and must be configured by the user in order to be run.
+
+# Prerequisites
+
+- DC/OS Enterprise 1.12 or later.
+- [DC/OS CLI](/latest/cli/install/) is installed.
+- You are logged in as a superuser.
+
+# Install {{ model.techName }} service
+
+## Download the package
+
+The {{ model.techName }} package is installable via the [catalog](https://docs.mesosphere.com/1.12/gui/catalog/).
+
+## Install the service
+
+Use the following command to install the service.
+
+```bash
+dcos package install {{ model.packageName }} --package-version=<VERSION>
+```
+
+<p class="message--note"><strong>NOTE: </strong>The command `dcos package install` will install the package CLI and the service.</p>
+
+## Verify service deployment
+
+After installing the package CLI, you can monitor the deployment of your service. Run the command:
+
+```bash
+dcos {{ model.packageName }} plan show deploy
+```
+
+# Access Grafana dashboards
+
+Assuming the service name is `{{ model.serviceName }}` (default), you should be able to access the Grafana dashboards using the following URL:
+
+```bash
+https://<CLUSTER_URL>/service/{{ model.serviceName }}/grafana/
+```
+
+See more details in [Accessing the Grafana UI](operations/grafana/ui/).

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/index.md
@@ -1,0 +1,16 @@
+---
+layout: layout.pug
+navigationTitle: Beta DC/OS Monitoring Service 0.5.0
+title: Beta DC/OS Monitoring Service 0.5.0
+menuWeight: 0
+excerpt:
+render: mustache
+model: data.yml
+---
+
+The {{ model.techName }} service makes it easy to monitor DC/OS components and your services on the DC/OS cluster.
+It can be configured to automatically load Grafana dashboard and alert configurations from Git repositories.
+It also ships with a set of default Grafana dashboards for monitoring DC/OS itself.
+The service can be configured to automatically load Alert Manager configuration from a Git repository.
+
+#include /services/include/beta-software-warning.tmpl

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/index.md.tmpl
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/index.md.tmpl
@@ -1,0 +1,16 @@
+---
+layout: layout.pug
+navigationTitle: ${ANNOTATED_TECH_NAME} Service ${DOCS_VERSION}
+title: ${ANNOTATED_TECH_NAME} Service ${DOCS_VERSION}
+menuWeight: 0
+excerpt:
+render: mustache
+model: data.yml
+---
+
+The {{ model.techName }} service makes it easy to monitor DC/OS components and your services on the DC/OS cluster.
+It can be configured to automatically load Grafana dashboard and alert configurations from Git repositories.
+It also ships with a set of default Grafana dashboards for monitoring DC/OS itself.
+The service can be configured to automatically load Alert Manager configuration from a Git repository.
+
+#include /services/include/beta-software-warning.tmpl

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/alertmanager/config/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/alertmanager/config/index.md
@@ -1,0 +1,159 @@
+---
+layout: layout.pug
+navigationTitle: Managing Alert Manager Configurations
+title: Managing Alert Manager Configurations
+menuWeight: 20
+excerpt: Enabling and configuring Alert Manager
+render: mustache
+model: ../../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Enabling Alert Manager
+
+Alert Manager is off by default.
+There is no default configuration that the Alert Manager is automatically run with.
+To enable Alert Manager, the {{ model.techName }} service must be configured to load the Alert Manager configurations from a Git repository.
+
+## Save Alert Manager configurations
+
+You should save your Alert Manager configuration file (YAML format), as well as all template files in a Git repository.
+Assume that the repository is `https://github.com/company/alertmanager-configs`.
+
+You can put the configuration file and template files in a subfolder in the repository.
+For instance, `https://github.com/company/alertmanager-configs/production`.
+
+```json
+{
+  "alertmanager": {
+    "config_repository": {
+      "url": "https://github.com/company/alertmanager-configs",
+      "path": "/production"
+    }
+  }
+}
+```
+
+The Git repository can be either public or private.
+You can omit the `credentials` section if the Git repository is public.
+If the Git repository is private, you will need to configure the credentials to access the Git repository.
+
+## Create secrets for Git repository credentials
+
+If the Git repository containing the Alert Manager configurations is private, you will need to configure the secrets first.
+Currently, the following Auth types are supported.
+
+### HTTP Auth
+
+```bash
+dcos security secrets create --value=<GITHUB_USERNAME> githubusername
+dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
+```
+
+For GitHub, the password can be the API token.
+
+Create a custom option file (`options.json`) like the following.
+
+```json
+{
+  "alertmanager": {
+    "config_repository": {
+      "url": "https://github.com/company/alertmanager-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+### SSH Auth
+
+```bash
+dcos security secrets create -f <PATH_TO_PRIVATE_KEY> gitsshkey
+```
+
+For Github, please make sure to add the [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (that is, the public key) to the repository.
+
+Create a custom option file (`options.json`) like the following.
+
+```json
+{
+  "alertmanager": {
+    "config_repository": {
+      "url": "git@github.com:company/alertmanager-configs",
+      "path": "/production",
+      "credentials": {
+        "deploy_key": "gitsshkey"
+      }
+    }
+  }
+}
+```
+
+Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
+
+## Secrets in Alert Manager configuration file
+
+Instead of putting plain text secrets in the configuration file, you can save the secrets in the secret store, and the service will automatically configure the global default value in the Alert Manager configuration file.
+
+The following secrets in the configuration file are supported:
+
+### Slack API URL
+
+The service will automatically add the following global default value for `slack_api_url` in the configuration file.
+
+```yaml
+global:
+- slack_api_url: '<SLACK_API_URL>'
+```
+
+Then, you need to save the secret in the secret store.
+
+```bash
+dcos security secrets create --value=<SLACK_API_URL> slackapiurl
+```
+
+When installing the service, you must configure the `secrets` section to point to the secret created.
+
+## Install {{ model.techName }} service
+
+Create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the Git repository is public.
+
+```json
+{
+  "alertmanager": {
+    "secrets": {
+      "slack_api_url": "slackapiurl"
+    },
+    "config_repository": {
+      "url": "https://github.com/company/alertmanager-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+Then, install the service:
+
+```bash
+dcos package install {{ model.serviceName }} --options=options.json
+```
+
+The Alert Manager configurations defined in the repository will be automatically loaded when the service finishes deploying.
+
+## Triggering a reload of Alert Manager configurations
+
+It is possible to trigger a reload of the Alert Manager configurations after the service is installed.
+
+```bash
+dcos {{ model.serviceName }} plan start reload-alertmanager-config
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/alertmanager/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/alertmanager/index.md
@@ -1,0 +1,15 @@
+---
+layout: layout.pug
+navigationTitle: Configuring Alert Manager
+title: Configuring Alert Manager
+menuWeight: 50
+excerpt: Configuring Alert Manager
+render: mustache
+model: ../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+The Alert Manager bundled with the {{ model.techName }} service is off by default.
+To run Alert Manager, you must configure it to pull the Alert Manager configurations from a Git repository.
+This section explains how to configure Alert Manager.

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/alertmanager/ui/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/alertmanager/ui/index.md
@@ -1,0 +1,23 @@
+---
+layout: layout.pug
+navigationTitle: Alert Manager UI
+title: Alert Manager UI
+menuWeight: 10
+excerpt: Alert Manager UI
+render: mustache
+model: ../../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Access Alert Manager UI
+
+## Access through Admin Router
+
+You can access the Alert Manager UI through Admin Router using "Services" routes by default.
+
+Assuming the service name is `{{ model.serviceName }}`, you can access the Alert Manager UI using the following URL:
+
+```bash
+https://<CLUSTER_URL>/service/{{ model.serviceName }}/alertmanager/
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/dashboard-configs/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/dashboard-configs/index.md
@@ -1,0 +1,151 @@
+---
+layout: layout.pug
+navigationTitle: Grafana Dashboard Configurations
+title: Grafana Dashboard Configurations
+menuWeight: 20
+excerpt: Automatically loading Grafana dashboard configurations
+render: mustache
+model: ../../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Automatically loading Grafana dashboard configurations
+
+The {{ model.techName }} service can be configured to automatically load Grafana dashboard configurations from a Git repository.
+
+## Save Grafana dashboard configurations
+
+You should save your Grafana dashboard configurations (JSON format) in a Git repository.
+Assume that the repository is `https://github.com/company/dashboard-configs`.
+
+You can put the Grafana dashboard configurations in a subfolder in the repository.
+For instance, `https://github.com/company/dashboard-configs/production`.
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "https://github.com/company/dashboard-configs",
+      "path": "/production"
+    }
+  }
+}
+```
+
+The Git repository can be either public or private.
+If the Git repository is private, you will need to configure the credentials to access the Git repository (see below).
+
+<p class="message--note"><strong>NOTE:</strong> If enabled, the set of default dashboards shipped with the service is from the Mesosphere-maintained Git repository `https://github.com/dcos/grafana-dashboards`.
+These dashboards are updated with {{ model.techName }} service releases.
+If you would like to use the most up-to-date version of these dashboards that has not yet been released, you can configure the repository url to point to `https://github.com/dcos/grafana-dashboards`.
+The `grafana.default_dashboards` option should be set to `false`.
+As it is a public repository, there is no need to set up the `credentials`.</p>
+
+```json
+{
+  "grafana": {
+    "default_dashboards": false,
+    "dashboard_config_repository": {
+      "url": "https://github.com/dcos/grafana-dashboards",
+      "path": "/dashboards"
+    }
+  }
+}
+```
+
+## Create secrets for Git repository credentials
+
+If the Git repository containing the Grafana dashboard configurations is private, you will need to configure the secrets first.
+Currently, the following Auth types are supported.
+
+### HTTP Auth
+
+```bash
+dcos security secrets create --value=<GITHUB_USERNAME> githubusername
+dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
+```
+
+For Github, the password can be the API token.
+
+Create a custom option file (`options.json`) like the following.
+You can omit the `credentials` section if the Git repository is public.
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "https://github.com/company/dashboard-configs",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+### SSH Auth
+
+```bash
+dcos security secrets create -f <PATH_TO_PRIVATE_KEY> gitsshkey
+```
+
+For Github, please make sure to add [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (i.e., the public key) to the repository.
+
+Create a custom option file (`options.json`) like the following.
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "git@github.com:company/dashboard-configs.git",
+      "path": "/production",
+      "credentials": {
+        "deploy_key": "gitsshkey"
+      }
+    }
+  }
+}
+```
+
+Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
+
+## Fetching from a branch in a Git repository
+
+By default, the service will fetch from the master branch (that is, `refs/heads/master`) of the Git repository.
+
+If you want to fetch the Grafana dashboard configurations from another branch in a Git repository, you can set the `reference_name` field:
+
+```json
+{
+  "grafana": {
+    "dashboard_config_repository": {
+      "url": "https://github.com/company/dashboard-configs",
+      "path": "/production",
+      "reference_name": "refs/heads/my_branch"
+    }
+  }
+}
+
+```
+
+## Install {{ model.techName }} service
+
+Then, install the service:
+
+```bash
+dcos package install {{ model.serviceName }} --options=options.json
+```
+
+The Grafana dashboards defined in the repository will be automatically loaded when the service finishes deploying.
+You can go to the Grafana UI to verify.
+
+## Triggering a reload of Grafana dashboard configurations
+
+It is possible to trigger a reload of the Grafana dashboard configurations after the service is installed.
+
+```bash
+dcos {{ model.serviceName }} plan start reload-grafana-dashboard-configs
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/default-dashboards/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/default-dashboards/index.md
@@ -1,0 +1,30 @@
+---
+layout: layout.pug
+navigationTitle: Default Grafana Dashboards for DC/OS
+title: Default Grafana Dashboards for DC/OS
+menuWeight: 30
+excerpt: Default Grafana dashboards for DC/OS.
+render: mustache
+model: ../../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Load default Grafana dashboards for DC/OS
+
+The {{ model.techName }} service ships with a set of default Grafana dashboards for DC/OS.
+Those dashboards will be automatically loaded if `grafana.default_dashboards` is set to `true`.
+
+Users can choose to disable this feature by setting `grafana.default_dashboards` to `false`.
+
+```json
+{
+  "grafana": {
+    "default_dashboards": true
+  }
+}
+```
+
+These default dashboards are pulled from the Mesosphere-maintained Git repository `https://github.com/dcos/grafana-dashboards`.
+Dashboards are updated with each {{ model.techName }} service release.
+To use the most up-to-date version of these dashboards instead of waiting for the next release, users should set `grafana.default_dashboards` to `false` and [configure](../dashboard-configs) the {{ model.techName }} service to load Grafana dashboard configurations from this Git repository.

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/index.md
@@ -1,0 +1,13 @@
+---
+layout: layout.pug
+navigationTitle: Configuring Grafana
+title: Configuring Grafana
+menuWeight: 40
+excerpt: Configuring Grafana
+render: mustache
+model: ../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+This section walks you through how to configure the Grafana bundled with the {{ model.techName }} service.

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/ui/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/grafana/ui/index.md
@@ -1,0 +1,67 @@
+---
+layout: layout.pug
+navigationTitle: Grafana UI
+title: Grafana UI
+menuWeight: 10
+excerpt: Grafana UI
+render: mustache
+model: ../../../data.yml
+---
+#include /services/include/beta-software-warning.tmpl
+
+# Access Grafana UI
+
+## Access through Admin Router
+
+You can access the Grafana UI through Admin Router using "Services" routes by default (unless `grafana.admin_router_proxy` is set to `false`).
+
+Assuming the service name is `{{ model.serviceName }}`, you can access the Grafana UI using the following URL:
+
+```bash
+https://<CLUSTER_URL>/service/{{ model.serviceName }}/grafana/
+```
+
+## Direct access
+
+Grafana will be installed on a public agent if `public` is set to `true` (default: `false`) in the package config.
+The port that Grafana uses can be configured by setting `ui_port` (default: `3000`).
+Find that agent's public IP address.
+Grafana will be present at `<public_ip>:<ui_port>`.
+
+By default, the username and password is `admin:admin`. See the [Admin Credentials section](#admin-credentials) for directions on configuring these credentials.
+
+Note that you need to set `grafana.admin_router_proxy` to `false`.
+
+```json
+{
+  "grafana": {
+    "public": true,
+    "ui_port": 3000,
+    "admin_router_proxy": false
+  }
+}
+```
+
+# Admin credentials
+
+By default, the Admin user credentials for Grafana are `admin:admin`.
+
+You can configure the Admin user credentials by setting `grafana.admin_credentials`.
+
+```bash
+dcos security secrets create --value=<ADMIN_USERNAME> adminusername
+dcos security secrets create --value=<ADMIN_PASSWORD> adminpassword
+```
+
+Create a custom option file (`options.json`) like the following.
+
+```json
+{
+  "grafana": {
+    "admin_credentials": {
+      "username": "adminusername",
+      "password": "adminpassword"
+    }
+  }
+}
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/index.md
@@ -1,0 +1,13 @@
+---
+layout: layout.pug
+navigationTitle: Operations
+title: Operations
+menuWeight: 30
+excerpt: Installing, configuring, and uninstalling the service
+render: mustache
+model: ../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+The following sections will take you through installing, configuring, and uninstalling the {{ model.techName }} service.

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/install/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/install/index.md
@@ -1,0 +1,13 @@
+---
+layout: layout.pug
+navigationTitle: Install
+title: Install
+menuWeight: 10
+excerpt: Installing the service on a DC/OS cluster
+render: mustache
+model: ../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+Please refer to the [Getting Started](../../getting-started/) page.

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/placement-constraint/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/placement-constraint/index.md
@@ -1,0 +1,48 @@
+---
+layout: layout.pug
+navigationTitle: Placement Constraints
+title: Placement Constraints
+menuWeight: 60
+excerpt: Placement constraints
+render: mustache
+model: ../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Placement constraints
+
+Placement constraints allow you to customize where a service is deployed in the DC/OS cluster.
+Placement constraints use the [Marathon operators](http://mesosphere.github.io/marathon/docs/constraints.html) syntax.
+For example, `[["hostname", "UNIQUE"]]` ensures that at most one pod instance is deployed per agent.
+
+A common task is to specify a list of whitelisted systems to deploy to.
+To achieve this, use the following syntax for the placement constraint:
+
+```json
+[["hostname", "LIKE", "10.0.0.159|10.0.1.202|10.0.3.3"]]
+```
+
+<p class="message--important"><strong>IMPORTANT: </strong> Be sure to include excess capacity in such a scenario so that if one of the whitelisted systems goes down, there is still enough capacity to repair your service.</p>
+
+## Updating placement constraints
+
+Clusters change, and so will your placement constraints.
+However, already-running service pods will **not** be affected by changes in placement constraints.
+This is because altering a placement constraint might invalidate the current placement of a running pod, and the pod will not be relocated automatically, as doing so is a destructive action.
+We recommend using the following procedure to update the placement constraints of a pod:
+
+1. Update the placement constraint definition in the service.
+1. For each affected pod, perform a `pod replace` procedure, one at a time. This will (destructively) move the pod to be in accordance with the new placement constraints.
+
+# Grafana server placement constraints
+
+To control where the Grafana server is placed, please specify the placement constraints, as in the following:
+
+```json
+{
+  "grafana": {
+    "placement_constraints": "[[\"hostname\", \"IS\", \"10.0.0.73\"]]"
+  }
+}
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/alert-rules/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/alert-rules/index.md
@@ -1,0 +1,156 @@
+---
+layout: layout.pug
+navigationTitle: Alert Rules
+title: Alert Rules
+menuWeight: 30
+excerpt: Alert Rules
+render: mustache
+model: ../../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Automatically loading Prometheus alert rules
+
+The {{ model.techName }} service can be configured to automatically load Prometheus alert rules from a Git repository.
+
+## Save Prometheus alert rules
+
+You should save your Prometheus alert rules (YAML format) in a Git repository.
+Assume that the repository is `https://github.com/company/alert-rules`.
+
+You can put the alert rules in a subfolder in the repository.
+For instance, `https://github.com/company/alert-rules/production`.
+
+```json
+{
+  "prometheus": {
+    "alert_rules_repository": {
+      "config_repository": {
+        "url": "https://github.com/company/alert-rules",
+        "path": "/production"
+      }
+    }
+  }
+}
+```
+
+<p class="message--important"><strong>IMPORTANT: </strong>Make sure that each of the alert rule files has suffix `.yml` and is a direct child of the subfolder (i.e., not nested under another subfolder).</p>
+
+The Git repository can be either public or private.
+If the Git repository is private, you will need to configure the credentials to access the Git repository (see below).
+
+<p class="message--note">
+<strong>NOTE:</strong> Mesosphere maintains a Git repository with Prometheus alerting rule configurations at `https://github.com/dcos/prometheus-alert-rules`.
+If you would like to use these preconfigured Prometheus alerting rules, you should set `prometheus.alert_rules_repository.config_repository.url` to `https://github.com/dcos/prometheus-alert-rules` and `prometheus.alert_rules_repository.config_repository.path` to `/rules`.
+As it is a public repository, there is no need to set up the `credentials`.
+</p>
+
+```json
+{
+  "prometheus": {
+    "alert_rules_repository": {
+      "config_repository": {
+        "url": "https://github.com/dcos/prometheus-alert-rules",
+        "path": "/rules"
+      }
+    }
+  }
+}
+```
+
+## Create secrets for Git repository credentials
+
+If the Git repository containing the alert rules is private, you will need to configure the secrets first.
+Currently, the following Auth types are supported.
+
+### HTTP Auth
+
+```bash
+dcos security secrets create --value=<GITHUB_USERNAME> githubusername
+dcos security secrets create --value=<GITHUB_PASSWORD> githubpassword
+```
+
+For Github, the password can be the API token.
+
+Create a custom option file (`options.json`) like the following.
+You may omit the `credentials` section if the Git repository is public.
+
+```json
+{
+  "prometheus": {
+    "alert_rules_repository": {
+      "url": "https://github.com/company/alert-rules",
+      "path": "/production",
+      "credentials": {
+        "username": "githubusername",
+        "password": "githubpassword"
+      }
+    }
+  }
+}
+```
+
+### SSH Auth
+
+```bash
+dcos security secrets create -f <PATH_TO_PRIVATE_KEY> gitsshkey
+```
+
+For Github, please make sure to add [Deployment Key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) (i.e., the public key) to the repository.
+
+Create a custom option file (`options.json`) like the following.
+
+```json
+{
+  "prometheus": {
+    "alert_rules_repository": {
+      "url": "git@github.com:company/alert-rules.git",
+      "path": "/production",
+      "credentials": {
+        "deploy_key": "gitsshkey"
+      }
+    }
+  }
+}
+```
+
+Note that you'll have to use `git@github.com:<USER>/<REPO>.git` instead of `https` as the scheme of the URL.
+
+## Fetching from a branch in a Git repository
+
+By default, the service will fetch from the master branch (that is, `refs/heads/master`) of the Git repository.
+
+If you want to fetch the alert rules from another branch in a Git repository, you can set the `reference_name` field:
+
+```json
+{
+  "prometheus": {
+    "alert_rules_repository": {
+      "url": "https://github.com/company/alert-rules",
+      "path": "/production",
+      "reference_name": "refs/heads/my_branch"
+    }
+  }
+}
+
+```
+
+## Install {{ model.techName }} service
+
+Then, install the service:
+
+```bash
+dcos package install {{ model.serviceName }} --options=options.json
+```
+
+The Prometheus alert rules defined in the repository will be automatically loaded when the service finishes deploying.
+You can go to the Prometheus UI to verify.
+
+## Triggering a reload of Prometheus alert rules
+
+It is possible to trigger a reload of the Prometheus alert rules after the service is installed.
+
+```bash
+dcos {{ model.serviceName }} plan start reload-prometheus-alert-rules
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/index.md
@@ -1,0 +1,13 @@
+---
+layout: layout.pug
+navigationTitle: Configuring Prometheus
+title: Configuring Prometheus
+menuWeight: 30
+excerpt: Configuring Prometheus
+render: mustache
+model: ../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+This section walks you through how to configure the Prometheus bundled with the {{ model.techName }} service.

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/storage/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/storage/index.md
@@ -1,0 +1,28 @@
+---
+layout: layout.pug
+navigationTitle: Prometheus Storage
+title: Prometheus Storage
+menuWeight: 20
+excerpt: Prometheus Storage
+render: mustache
+model: ../../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Configuring Prometheus Storage
+
+## Storage Retention
+
+You can configure the storage retention (default: 15d) of Prometheus by setting the package options like the following during package install.
+
+```json
+{
+  "prometheus": {
+    "storage_tsdb_retention": "30d"
+  }
+}
+```
+
+The above configuration will tell Prometheus to remove old data after 30 days.
+Refer to this [document](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects) for more details about storage retention.

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/ui/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/prometheus/ui/index.md
@@ -1,0 +1,61 @@
+---
+layout: layout.pug
+navigationTitle: Prometheus UI
+title: Prometheus UI
+menuWeight: 10
+excerpt: Prometheus UI
+render: mustache
+model: ../../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Access Prometheus UI
+
+## Access through Admin Router
+
+You can access the Prometheus UI through Admin Router using "Services" routes by default (unless `prometheus.admin_router_proxy.enabled` is set to `false`).
+
+Assuming the service name is `{{ model.serviceName }}`, you can access the Prometheus UI using the following URL:
+
+```bash
+https://<CLUSTER_URL>/service/{{ model.serviceName }}/prometheus/
+```
+
+The Admin Router URL can be configured to adapt to the FQDN of your DC/OS cluster.
+This step is not required if the users are not using the [`generatorURL`](https://prometheus.io/docs/alerting/clients/) field from an alert.
+
+```json
+{
+  "prometheus": {
+    "admin_router_proxy": {
+      "url": "https://dcos.example.com"
+    }
+  }
+}
+```
+
+## Access through Marathon LB
+
+You can also choose to access the Prometheus UI through [Marathon LB](https://docs.mesosphere.com/services/marathon-lb/1.12.x/) by configuring the service.
+
+Please configure `prometheus.marathon_lb_proxy.vhost` field to be the Fully Qualified Domain Name (FQDN) for the service.
+This is typically your cloud load balancer FQDN (e.g., ELB).
+You must turn off the admin router proxy support to enable the Marathon LB support.
+
+```json
+{
+  "prometheus": {
+    "admin_router_proxy": {
+      "enabled": false
+    },
+    "marathon_lb_proxy": {
+      "enabled": true,
+      "vhost": "prometheus.example.com"
+    }
+  }
+}
+```
+
+<p class="message--note"><strong>NOTE:</strong> There is one limitation currently that the service name cannot contain any character that is not allowed in a DNS name (e.g., /).
+That means the service cannot be installed in a Marathon folder. </p>

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/uninstall/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/operations/uninstall/index.md
@@ -1,0 +1,19 @@
+---
+layout: layout.pug
+navigationTitle: Uninstall
+title: Uninstall
+menuWeight: 20
+excerpt: Removing the service from a DC/OS cluster
+render: mustache
+model: ../../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Uninstall the {{ model.techName }} service
+
+You can uninstall the service using the following command:
+
+```bash
+dcos package uninstall {{ model.packageName }}
+```

--- a/pages/services/beta-dcos-monitoring/0.5.0-beta/release-notes/index.md
+++ b/pages/services/beta-dcos-monitoring/0.5.0-beta/release-notes/index.md
@@ -1,0 +1,135 @@
+---
+layout: layout.pug
+navigationTitle: Release Notes
+title: Release Notes
+menuWeight: 40
+excerpt: New features, updates, and known limitations
+render: mustache
+model: ../data.yml
+---
+
+#include /services/include/beta-software-warning.tmpl
+
+# Version v0.5.0
+
+## New features
+
+* Added Marathon LB integration.
+* Enabled gzip compression for Grafana's HTTP server.
+* Added a link to the Grafana UI on the Services page.
+* Set the Home dashboard in Grafana to the DC/OS Overview dashboard.
+
+## Updates
+
+* Grafana dashboard titles are no longer overwritten by the file path of the dashboard json.
+
+## Known limitations
+
+* Service name cannot contain characters that are not allowed in a DNS name (e.g., /) if using Marathon LB integration.
+
+# Version v0.4.3
+
+## Updates
+
+* Fixed the issues when the service is installed in a folder.
+* Fixed a regression related to deploy key support.
+
+# Version v0.4.2
+
+## Updates
+
+* Workaround the UI bug for package install.
+
+# Version v0.4.1
+
+## Updates
+
+* Bug fixes (DSS profile support is missing).
+
+# Version v0.4.0
+
+## New features
+
+* Allow accessing Alert Manager UI through Admin Router.
+* Allow accessing Prometheus UI through Admin Router.
+* Support loading Prometheus alert rules from a git repository.
+* Support reloading Alert Manager configurations after install.
+* Support DC/OS Storage Service (DSS) volume profiles.
+
+## Updates
+
+* Support for configuring Prometheus storage retention.
+* Support for configuring Alert Manager resource footprint (i.e., CPU and memory).
+* Installable from the Universe.
+* Updated SDK to 0.55.2.
+* New logo.
+
+## Known limitations
+
+* Upgrading from v0.3.0 is not supported at this time.
+* Does not support loading Prometheus alert rules recursively from a directory.
+
+# Version v0.3.0
+
+## New features
+
+* Allow accessing Grafana UI through Admin Router.
+* Support configuring Grafana admin user credentials.
+* Support Open DC/OS.
+* Support [Package Registry](https://docs.mesosphere.com/latest/administering-clusters/repo/package-registry/).
+
+## Updates
+
+* Remove support for Prometheus Mesos Exporter, which is no longer used to collect Mesos metrics.
+
+# Version v0.2.1
+
+## Updates
+
+* Correct permissions required to run the package.
+
+# Version v0.2.0
+
+## New features
+
+* Grafana v5.3.4.
+* Support `SSH auth` when fetching from Git repository.
+* Add default Grafana dashboards which can be automatically loaded.
+* Support Grafana server placement constraints.
+* Support fetching from a branch in a Git repository.
+
+## Updates
+
+* Use local persistent volume for Grafana server.
+* Used Docker image for Grafana server.
+* Recursively clone git sub-modules from a git repository.
+
+# Version v0.1.1
+
+Bug fix release.
+
+## Updates
+
+* Add missing release notes.
+
+# Version v0.1.0
+
+Initial release.
+
+## New features
+
+* Prometheus v2.2.1.
+* Grafana v5.0.1.
+* Alert Manager v0.15.2.
+* Push Gateway v0.5.2.
+* Automatically scrape dcos-metrics service endpoints in Prometheus.
+* Automatically load Grafana dashboard configurations from a git repository.
+* Automatically load Alert Manager configurations from a git repository.
+* Support strict mode DC/OS cluster.
+* Support launching Grafana server on public agents.
+
+## Known limitations
+
+* No persistent storage for Grafana dashboard configurations.
+* No external storage for Prometheus data.
+* No backup for Prometheus data.


### PR DESCRIPTION
## Description
This is a beta v0.5.0 release we're doing for dcos-monitoring since we are pushing v1.0 (GA) back to the next RI. These docs have technically already been reviewed in the dcos-monitoring repo. There have also been subsequent docs changes done that will be included in 1.0, so I would prefer not to make too many changes here since it was already done in a later version and beta will soon be removed altogether.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
