### PR TITLE
LG/DCOS-51163: Fix broken links-version was stripped out causing the …

### DIFF
--- a/pages/1.12/deploying-services/service-groups/index.md
+++ b/pages/1.12/deploying-services/service-groups/index.md
@@ -8,16 +8,16 @@ excerpt: Implementing fine-grained user access to services using the web interfa
 enterprise: true
 ---
 
-You can implement fine-grained user access to services using either the DC/OS web interface or the [API](/security/ent/iam-api/), or the CLI.
+You can implement fine-grained user access to services using either the DC/OS web interface or the [API](/1.12/security/ent/iam-api/), or the CLI.
 
-The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) allow you to restrict a user's access to services on either a per service or a per service group basis. This section walks you through the steps to accomplish this.  
+The [Marathon permissions](/1.12/security/ent/perms-reference/#marathon-metronome) allow you to restrict a user's access to services on either a per service or a per service group basis. This section walks you through the steps to accomplish this.  
 
-[Marathon permissions](/security/ent/perms-reference/#marathon-metronome) and [Mesos permissions](/security/ent/perms-reference/#mesos) do not distinguish between service names, job names, service groups, or job groups. Therefore your naming must be unique.
+[Marathon permissions](/1.12/security/ent/perms-reference/#marathon-metronome) and [Mesos permissions](/1.12/security/ent/perms-reference/#mesos) do not distinguish between service names, job names, service groups, or job groups. Therefore your naming must be unique.
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
-- A [user account](/security/ent/users-groups/) to assign permissions to.
+- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser.
+- A [user account](/1.12/security/ent/users-groups/) to assign permissions to.
 
 # <a name="root-service"></a>Granting access to a service
 
@@ -41,7 +41,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 1.  Click **INSERT PERMISSION STRING** to toggle the dialog.
 
-1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/security/ent/#security-modes).
+1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.12/security/ent/#security-modes).
 
     ![Add permission](/1.12/img/GUI-Organization-Users-User_Alice_Add_Gen_Perms-1_12.png)
 
@@ -92,7 +92,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
+- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser.
 
 - To grant permissions to a group instead of a user, replace `users grant <uid>` with `groups grant <gid>`.
 
@@ -169,7 +169,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
     Figure 5. Add permission
 
-1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/security/ent/#security-modes).
+1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.12/security/ent/#security-modes).
 
     ### Permissive
 
@@ -220,7 +220,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
+- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser.
 
 **Tips:**
 
@@ -299,7 +299,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
     Figure 7. Add permissions
 
-1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/security/ent/#security-modes).
+1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.12/security/ent/#security-modes).
 
     ### Permissive
 
@@ -350,7 +350,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
+- You must have the [DC/OS CLI installed](/1.12/cli/install/) and be logged in as a superuser.
 
 **Tips:**
 

--- a/pages/1.13/deploying-services/service-groups/index.md
+++ b/pages/1.13/deploying-services/service-groups/index.md
@@ -4,24 +4,23 @@ navigationTitle:  Granting Access to Services and Groups
 title: Granting Access to Services and Groups
 menuWeight: 3
 excerpt: Implementing fine-grained user access to services using the web interface or the CLI
-
 enterprise: true
 ---
 
-You can implement fine-grained user access to services using either the DC/OS web interface or the [API](/security/ent/iam-api/), or the CLI.
+You can implement fine-grained user access to services using either the DC/OS web interface or the [API](/1.13/security/ent/iam-api/), or the CLI.
 
-The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) allow you to restrict a user's access to services on either a per service or a per service group basis. This section walks you through the steps to accomplish this.  
+The [Marathon permissions](/1.13/security/ent/perms-reference/#marathon-metronome) allow you to restrict a user's access to services on either a per service or a per service group basis. This section walks you through the steps to accomplish this.  
 
-[Marathon permissions](/security/ent/perms-reference/#marathon-metronome) and [Mesos permissions](/security/ent/perms-reference/#mesos) do not distinguish between service names, job names, service groups, or job groups. Therefore your naming must be unique.
+[Marathon permissions](/1.13/security/ent/perms-reference/#marathon-metronome) and [Mesos permissions](/1.13/security/ent/perms-reference/#mesos) do not distinguish between service names, job names, service groups, or job groups. Therefore your naming must be unique.
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
-- A [user account](/security/ent/users-groups/) to assign permissions to.
+- You must have the [DC/OS CLI installed](/1.13/cli/install/) and be logged in as a superuser.
+- A [user account](/1.13/security/ent/users-groups/) to assign permissions to.
 
 # <a name="root-service"></a>Granting access to a service
 
-## <a name="root-service-ui"></a>Via the DC/OS web interface
+## <a name="root-service-ui"></a>Using the DC/OS web interface
 
 1. Log into the DC/OS web interface as a user with the `superuser` permission.
 
@@ -41,7 +40,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 1.  Click **INSERT PERMISSION STRING** to toggle the dialog.
 
-1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/security/ent/#security-modes).
+1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.13/security/ent/#security-modes).
 
     ![Add permission](/1.13/img/GUI-Organization-Users-User_Alice_Add_Gen_Perms-1_12.png)
 
@@ -92,7 +91,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
+- You must have the [DC/OS CLI installed](/1.13/cli/install/) and be logged in as a superuser.
 
 - To grant permissions to a group instead of a user, replace `users grant <uid>` with `groups grant <gid>`.
 
@@ -169,7 +168,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
     Figure 5. Add permission
 
-1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/security/ent/#security-modes).
+1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.13/security/ent/#security-modes).
 
     ### Permissive
 
@@ -220,7 +219,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
+- You must have the [DC/OS CLI installed](/1.13/cli/install/) and be logged in as a superuser.
 
 **Tips:**
 
@@ -299,7 +298,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
     Figure 7. Add permissions
 
-1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/security/ent/#security-modes).
+1.  Copy and paste the permission in the **Permissions Strings** field. Choose the permission strings based on your [security mode](/1.13/security/ent/#security-modes).
 
     ### Permissive
 
@@ -350,7 +349,7 @@ The [Marathon permissions](/security/ent/perms-reference/#marathon-metronome) al
 
 **Prerequisites:**
 
-- You must have the [DC/OS CLI installed](/cli/install/) and be logged in as a superuser.
+- You must have the [DC/OS CLI installed](/1.13/cli/install/) and be logged in as a superuser.
 
 **Tips:**
 

--- a/pages/1.13/security/ent/perms-reference/index.md
+++ b/pages/1.13/security/ent/perms-reference/index.md
@@ -86,7 +86,8 @@ through Admin Router.
 | `dcos:adminrouter:service:marathon` <br>Controls access to the native Marathon instance.                                                                                                                                                                                                                | x      |     |     |     |     |
 | `dcos:adminrouter:service:metronome`<br>  Controls access to [DC/OS Jobs (Metronome)](/1.13/deploying-jobs/).                                                                                                                                                                                           | x      |     |     |     |     |
 
-## <a name="mesos"></a>Mesos permissions
+<a name="mesos"></a>
+## Mesos permissions
 
 Many Mesos operations require authorization.
 The necessary privileges must be assigned to the DC/OS user who issues the HTTP request to Mesos.
@@ -132,7 +133,9 @@ Applications launched with Root Marathon can only receive offers for resources r
 | `dcos:mesos:master:volume:role[:<role-name>]`<br> Controls access to create a volume for the given [Mesos role](/1.13/overview/concepts/#mesos-role).                                                                                                                               |        | x   |     |     |     |
 | `dcos:mesos:master:weight:role[:<role-name>]`<br> Control access to the [weight](https://mesos.apache.org/documentation/latest/weights/) for the given [Mesos role](/1.13/overview/concepts/#mesos-role).                                                                           |        |     | x   | x   |     |
 
-## <a name="marathon-metronome"></a>Marathon and Metronome permissions
+<a name="marathon-metronome"></a>
+
+## Marathon and Metronome permissions
 
 Marathon and Metronome require that HTTP requests made to certain protected resources must be authorized. For example, a DC/OS user must be granted the `create` action on the `dcos:service:marathon:marathon:services:/dev` resource in order to create a new Marathon app in the `/dev` service group.
 


### PR DESCRIPTION
…link paths to return Page not found errors-1.12, 1.13

## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DCOS-51163
https://jira.mesosphere.com/browse/DCOS-51164
## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
