### PR TITLE
beta-storage/release-notes: backport spelling fix from 0.6.1

### DIFF
--- a/pages/services/beta-storage/0.6.0-beta/release-notes/index.md
+++ b/pages/services/beta-storage/0.6.0-beta/release-notes/index.md
@@ -27,7 +27,7 @@ beta: true
 
 * Narrowed the scope of Mesos disk permissions required by the storage service.
 * Devices provider is not removable if another provider (e.g. LVM provider) is consuming one or more of its devices.
-* Improved observability via additional metrics intrumented thoughout the storage service.
+* Improved observability via additional metrics instrumented throughout the storage service.
 * `journald+logrotate` logging enabled, by default, for the storage service.
 * Streamlined resource management via default storage service offer filters.
 * Tutorial for extending the default Universal Installer configuration in order to provide additional raw disks for the storage service to consume.


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DCOS-53723

This fix has already landed upstream in dcos-storage, both on the releases/v0.6.x branch and master branch. It's also already in this repo on the storage/0_6_1 branch. But we want this fixed for DSS v0.6.0 users, so ... here's the backport.

## Urgency
- [ ] Blocker <!-- Ping @pavisandhu for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, 1.10, 1.11, 1.12).
- See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing).
