### PR TITLE
[DCOS_OSS-5127] Add note about noexec requirement on 1.13

### DIFF
--- a/pages/1.11/installing/production/system-requirements/index.md
+++ b/pages/1.11/installing/production/system-requirements/index.md
@@ -62,7 +62,7 @@ There are many mixed workloads on the masters. Examples of mixed workloads on th
   | _/var/lib/dcos/cockroach_ | CockroachDB [enterprise type="inline" size="small" /] |
   | _/var/lib/dcos/navstar_ | for Mnesia database |
   | _/var/lib/dcos/secrets_ | secrets vault [enterprise type="inline" size="small" /] |
-  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. _/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`. |
+  | _/var/lib/dcos/exec_ | Temporary files required by various DC/OS services. The _/var/lib/dcos/exec_ directory must not be on a volume which is mounted with the `noexec` option. |
   | _/var/lib/dcos/exhibitor_ | Zookeeper database |
   | _/var/lib/dcos/exhibitor/zookeeper/transactions_ | The ZooKeeper transaction logs are very sensitive to delays in disk writes. If you can only provide limited SSD space, this is the directory to place there. A minimum of 2 GB must be available for these logs. |
 

--- a/pages/1.11/installing/production/system-requirements/index.md
+++ b/pages/1.11/installing/production/system-requirements/index.md
@@ -62,6 +62,7 @@ There are many mixed workloads on the masters. Examples of mixed workloads on th
   | _/var/lib/dcos/cockroach_ | CockroachDB [enterprise type="inline" size="small" /] |
   | _/var/lib/dcos/navstar_ | for Mnesia database |
   | _/var/lib/dcos/secrets_ | secrets vault [enterprise type="inline" size="small" /] |
+  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. _/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`. |
   | _/var/lib/dcos/exhibitor_ | Zookeeper database |
   | _/var/lib/dcos/exhibitor/zookeeper/transactions_ | The ZooKeeper transaction logs are very sensitive to delays in disk writes. If you can only provide limited SSD space, this is the directory to place there. A minimum of 2 GB must be available for these logs. |
 

--- a/pages/1.12/installing/production/system-requirements/index.md
+++ b/pages/1.12/installing/production/system-requirements/index.md
@@ -62,7 +62,7 @@ There are many mixed workloads on the masters. Examples of mixed workloads on th
   | _/var/lib/dcos/cockroach_ | CockroachDB [enterprise type="inline" size="small" /] |
   | _/var/lib/dcos/navstar_ | for Mnesia database |
   | _/var/lib/dcos/secrets_ | secrets vault [enterprise type="inline" size="small" /] |
-  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. _/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`. |
+  | _/var/lib/dcos/exec_ | Temporary files required by various DC/OS services. The _/var/lib/dcos/exec_ directory must not be on a volume which is mounted with the `noexec` option. |
   | _/var/lib/dcos/exhibitor_ | ZooKeeper snapshot database |
   | _/var/lib/dcos/exhibitor/zookeeper/transactions_ | The ZooKeeper transaction logs are very sensitive to delays in disk writes. If you can only provide limited SSD space, this is the directory to place there. A minimum of 2 GB must be available for these logs. |
 

--- a/pages/1.12/installing/production/system-requirements/index.md
+++ b/pages/1.12/installing/production/system-requirements/index.md
@@ -62,6 +62,7 @@ There are many mixed workloads on the masters. Examples of mixed workloads on th
   | _/var/lib/dcos/cockroach_ | CockroachDB [enterprise type="inline" size="small" /] |
   | _/var/lib/dcos/navstar_ | for Mnesia database |
   | _/var/lib/dcos/secrets_ | secrets vault [enterprise type="inline" size="small" /] |
+  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. _/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`. |
   | _/var/lib/dcos/exhibitor_ | ZooKeeper snapshot database |
   | _/var/lib/dcos/exhibitor/zookeeper/transactions_ | The ZooKeeper transaction logs are very sensitive to delays in disk writes. If you can only provide limited SSD space, this is the directory to place there. A minimum of 2 GB must be available for these logs. |
 

--- a/pages/1.13/installing/production/system-requirements/index.md
+++ b/pages/1.13/installing/production/system-requirements/index.md
@@ -65,8 +65,11 @@ There are many mixed workloads on the masters. Examples of mixed workloads on th
   | _/var/lib/dcos/cockroach_ | CockroachDB [enterprise type="inline" size="small" /] |
   | _/var/lib/dcos/navstar_ | for Mnesia database |
   | _/var/lib/dcos/secrets_ | secrets vault [enterprise type="inline" size="small" /] |
+  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. |
   | _/var/lib/dcos/exhibitor_ | Zookeeper database |
   | _/var/lib/dcos/exhibitor/zookeeper/transactions_ | The ZooKeeper transaction logs are very sensitive to delays in disk writes. If you can only provide limited SSD space, this is the directory to place there. A minimum of 2 GB must be available for these logs. |
+
+_/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`.
 
 ### Agent nodes
 

--- a/pages/1.13/installing/production/system-requirements/index.md
+++ b/pages/1.13/installing/production/system-requirements/index.md
@@ -65,7 +65,7 @@ There are many mixed workloads on the masters. Examples of mixed workloads on th
   | _/var/lib/dcos/cockroach_ | CockroachDB [enterprise type="inline" size="small" /] |
   | _/var/lib/dcos/navstar_ | for Mnesia database |
   | _/var/lib/dcos/secrets_ | secrets vault [enterprise type="inline" size="small" /] |
-  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. _/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`. |
+  | _/var/lib/dcos/exec_ | Temporary files required by various DC/OS services. The _/var/lib/dcos/exec_ directory must not be on a volume which is mounted with the `noexec` option. |
   | _/var/lib/dcos/exhibitor_ | Zookeeper database |
   | _/var/lib/dcos/exhibitor/zookeeper/transactions_ | The ZooKeeper transaction logs are very sensitive to delays in disk writes. If you can only provide limited SSD space, this is the directory to place there. A minimum of 2 GB must be available for these logs. |
 

--- a/pages/1.13/installing/production/system-requirements/index.md
+++ b/pages/1.13/installing/production/system-requirements/index.md
@@ -65,11 +65,9 @@ There are many mixed workloads on the masters. Examples of mixed workloads on th
   | _/var/lib/dcos/cockroach_ | CockroachDB [enterprise type="inline" size="small" /] |
   | _/var/lib/dcos/navstar_ | for Mnesia database |
   | _/var/lib/dcos/secrets_ | secrets vault [enterprise type="inline" size="small" /] |
-  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. |
+  | _/var/lib/dcos/exec_ | Temporarily needed files from various DC/OS services. _/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`. |
   | _/var/lib/dcos/exhibitor_ | Zookeeper database |
   | _/var/lib/dcos/exhibitor/zookeeper/transactions_ | The ZooKeeper transaction logs are very sensitive to delays in disk writes. If you can only provide limited SSD space, this is the directory to place there. A minimum of 2 GB must be available for these logs. |
-
-_/var/lib/dcos/exec_ must not be on a volume which is mounted `noexec`.
 
 ### Agent nodes
 


### PR DESCRIPTION
## Jira Ticket

This aims to fulfil part of [DCOS_OSS-5127 - "Document that `/var/lib/dcos/exec` is a custom temporary directory and what to do about that"](https://jira.mesosphere.com/browse/DCOS_OSS-5127). Later we can follow-up with documentation about how and when to clean up this directory, when we have more information.

I will create the following once the Security Team is happy with this:

```
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.
```

See [DCOS_OSS-5174](https://jira.mesosphere.com/browse/DCOS_OSS-5174) for the Doc Team to review.

## Description of changes being made

Document that `/var/lib/dcos/exec` is a custom temporary directory and cannot be mounted on a volume which is mounted `noexec`.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [X] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.