### PR TITLE
Addresses issue DCOS_OSS-5183. Fixes typos in cli/update/ page for v1…

### DIFF
--- a/pages/1.10/cli/update/index.md
+++ b/pages/1.10/cli/update/index.md
@@ -42,7 +42,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.10.0         http://example.com
@@ -84,7 +84,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.10.0         http://example.com

--- a/pages/1.11/cli/update/index.md
+++ b/pages/1.11/cli/update/index.md
@@ -41,7 +41,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL           
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.12.0         http://example.com
@@ -83,7 +83,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL           
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.11.0         http://example.com

--- a/pages/1.12/cli/update/index.md
+++ b/pages/1.12/cli/update/index.md
@@ -41,7 +41,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL           
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.12.0         http://example.com
@@ -83,7 +83,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL           
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.12.0         http://example.com

--- a/pages/1.13/cli/update/index.md
+++ b/pages/1.13/cli/update/index.md
@@ -42,7 +42,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.13.0         http://example.com
@@ -84,7 +84,7 @@ The recommended method to install the DC/OS CLI is by getting a preformatted set
 1. Verify your cluster(s) by listing them:
 
     ```bash
-    docs cluster list
+    dcos cluster list
 
                 NAME                          ID                    STATUS    VERSION        URL
     *  kjdskjd-ds-derr-1     0e2f90b-ded3-458b-8157-0365c8bd1ca4  AVAILABLE  1.13.0         http://example.com


### PR DESCRIPTION
Updated typo in cli/update/ page for versions 1.10 through 1.13.

## Jira Ticket

https://jira.mesosphere.com/browse/DCOS_OSS-5183

## Description of changes being made
Updated misspelled "docs" (should be "dcos") in CLI verification steps.

## Checklist
- [ x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ x] Test all commands and procedures where applicable.
- [ x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
