### PR TITLE
CK Remove fault_domain info from 1.10 docs

### DIFF
--- a/pages/1.10/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.10/installing/production/advanced-configuration/configuration-reference/index.md
@@ -391,9 +391,6 @@ Indicates whether to enable GPU support in DC/OS.
 
 For more information, see the [GPU documentation](/1.10/deploying-services/gpu/).
 
-## fault_domain_enabled [enterprise type="inline" size="small" /]
-By default, DC/OS clusters have [fault domain awareness](/1.10/deploying-services/fault-domain-awareness/) enabled, so no changes to your config.yaml are required to use this feature.
-
 ## gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.
 

--- a/pages/1.10/installing/production/deploying-dcos/installation/index.md
+++ b/pages/1.10/installing/production/deploying-dcos/installation/index.md
@@ -143,36 +143,6 @@ In this step, an IP detection script is created. This script reports the IP addr
             echo $INTERFACE_IP
         ```
 
-[enterprise]
-# Create a fault domain detection script
-[/enterprise]
-
-By default, DC/OS clusters have [fault domain awareness](/1.10/deploying-services/fault-domain-awareness/) enabled, so no changes to your `config.yaml` are required to use this feature. However, you must include a fault domain detection script named `fault-domain-detect` in your `./genconf` directory. To opt out of fault domain awareness, set the `fault_domain_enabled` parameter of your `config.yaml` file to `false`.
-
-
-1. Create a fault domain detect script named `fault-domain-detect` to run on each node to detect the node's fault domain. During installation, the output of this script is passed to Mesos.
-
-   The format for the script output is:
-
-    ```json
-    {
-        "fault_domain": {
-            "region": {
-                "name": "<region-name>"
-            },
-            "zone": {
-                "name": "<zone-name>"
-            }
-        }
-    }
-    ```
-
-    We provide [fault domain detect scripts for AWS and Azure](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
-
-   <p class="message--warning"><strong>WARNING: </strong>This script will not work if you use proxies in your environment. If you use a proxy, modifications will be required.</p>
-
-
-2. Add your newly created `fault-domain-detect` script to the `/genconf` directory of your bootstrap node.
 
 
 # Create a configuration file
@@ -246,7 +216,6 @@ https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>
 no_proxy:
 - 'foo.bar.com'
 - '.baz.com'
-fault_domain_enabled: false
 #If IPv6 is disabled in your kernel, you must disable it in the config.yaml
 enable_ipv6: 'false'
 ```

--- a/pages/1.11/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.11/installing/production/advanced-configuration/configuration-reference/index.md
@@ -30,6 +30,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [custom_checks](#custom-checks)                                       | Custom installation checks that are added to the default check configuration process. |
 | [exhibitor_storage_backend](#exhibitor-storage-backend)               | The type of storage backend to use for Exhibitor. |
 | [enable_gpu_isolation](#enable-gpu-isolation)                         | Indicates whether to enable GPU support in DC/OS.  |
+| [fault_domain_enabled](#fault-domain-enabled-enterprise)              | By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.11/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, set to `false`, and no fault domain information will be expected or used. [enterprise type="inline" size="small" /]  |
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
@@ -393,7 +394,7 @@ Indicates whether to enable GPU support in DC/OS.
 For more information, see the [GPU documentation](/1.11/deploying-services/gpu/).
 
 ### fault_domain_enabled [enterprise type="inline" size="small" /]
-By default, DC/OS clusters have [fault domain awareness](/1.11/deploying-services/fault-domain-awareness/) enabled, so no changes to your config.yaml are required to use this feature.
+By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.11/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, add this parameter set to `false`, and no fault domain information will be expected or used.
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/1.12/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.12/installing/production/advanced-configuration/configuration-reference/index.md
@@ -30,6 +30,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [custom_checks](#custom-checks)                                       | Custom installation checks that are added to the default check configuration process. |
 | [exhibitor_storage_backend](#exhibitor-storage-backend)               | The type of storage backend to use for Exhibitor. |
 | [enable_gpu_isolation](#enable-gpu-isolation)                         | Indicates whether to enable GPU support in DC/OS.  |
+| [fault_domain_enabled](#fault-domain-enabled-enterprise)              | By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.12/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, set to `false`, and no fault domain information will be expected or used. [enterprise type="inline" size="small" /]  |
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
@@ -406,7 +407,7 @@ Indicates whether to enable GPU support in DC/OS.
 For more information, see the [GPU documentation](/1.12/deploying-services/gpu/).
 
 ### fault_domain_enabled [enterprise type="inline" size="small" /]
-By default, DC/OS clusters have [fault domain awareness](/1.12/deploying-services/fault-domain-awareness/) enabled, so no changes to your config.yaml are required to use this feature.
+By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.12/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, add this parameter set to `false`, and no fault domain information will be expected or used.
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
@@ -30,6 +30,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [custom_checks](#custom-checks)                                       | Custom installation checks that are added to the default check configuration process. |
 | [exhibitor_storage_backend](#exhibitor-storage-backend)               | The type of storage backend to use for Exhibitor. |
 | [enable_gpu_isolation](#enable-gpu-isolation)                         | Indicates whether to enable GPU support in DC/OS.  |
+| [fault_domain_enabled](#fault-domain-enabled-enterprise)              | By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.13/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, set to `false`, and no fault domain information will be expected or used.   |
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
@@ -410,7 +411,7 @@ Indicates whether to enable GPU support in DC/OS.
 For more information, see the [GPU documentation](/1.13/deploying-services/gpu/).
 
 ### fault_domain_enabled [enterprise type="inline" size="small" /]
-By default, DC/OS clusters have [fault domain awareness](/1.13/deploying-services/fault-domain-awareness/) enabled, so no changes to your config.yaml are required to use this feature.
+By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.13/installing/production/deploying-dcos/installation/). To override this feature, add this parameter set to `false`, and no fault domain information will be expected or used.
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
@@ -30,7 +30,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [custom_checks](#custom-checks)                                       | Custom installation checks that are added to the default check configuration process. |
 | [exhibitor_storage_backend](#exhibitor-storage-backend)               | The type of storage backend to use for Exhibitor. |
 | [enable_gpu_isolation](#enable-gpu-isolation)                         | Indicates whether to enable GPU support in DC/OS.  |
-| [fault_domain_enabled](#fault-domain-enabled-enterprise)              | By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.13/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, set to `false`, and no fault domain information will be expected or used.   |
+| [fault_domain_enabled](#fault-domain-enabled-enterprise)              | By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.13/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, set to `false`, and no fault domain information will be expected or used. [enterprise type="inline" size="small" /]  |
 | [gpus_are_scarce](#gpus-are-scarce)                                   | Indicates whether to treat GPUs as a scarce resource in the cluster. |
 | [ip_detect_public_filename](#ip-detect-public-filename)               | The IP detect file to use in your cluster.  |
 | [master_discovery](#master-discovery)                                 | (Required) The Mesos master discovery method.         |
@@ -411,7 +411,7 @@ Indicates whether to enable GPU support in DC/OS.
 For more information, see the [GPU documentation](/1.13/deploying-services/gpu/).
 
 ### fault_domain_enabled [enterprise type="inline" size="small" /]
-By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.13/installing/production/deploying-dcos/installation/). To override this feature, add this parameter set to `false`, and no fault domain information will be expected or used.
+By default, fault domain awareness is enabled and the installer will expect input for zones and regions from a [fault detect script](/1.13/installing/production/deploying-dcos/installation/#create-a-fault-domain-detection-script-enterprise). To override this feature, add this parameter set to `false`, and no fault domain information will be expected or used.
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

https://jira.mesosphere.com/browse/DCOS_OSS-4323

## Description of changes being made

fault_domain_enabled is confusing and wrongly showing in 1.10 docs. This PR is to remove from 1.10 and clarify in docs as needed. 

## Checklist
- [ ] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
