### PR TITLE
kubernetes: Fix missing strict permissions for kubernetes package

### DIFF
--- a/pages/services/kubernetes/2.0.0-1.12.1/getting-started/install-basic/index.md
+++ b/pages/services/kubernetes/2.0.0-1.12.1/getting-started/install-basic/index.md
@@ -40,6 +40,7 @@ In order to run the `kubernetes` package on DC/OS Enterprise, a [service account
 
     ```shell
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create
     dcos security org users grant kubernetes dcos:mesos:master:task:user:nobody create
     ```

--- a/pages/services/kubernetes/2.0.1-1.12.2/getting-started/install-basic/index.md
+++ b/pages/services/kubernetes/2.0.1-1.12.2/getting-started/install-basic/index.md
@@ -40,6 +40,7 @@ In order to run the `kubernetes` package on DC/OS Enterprise, a [service account
 
     ```shell
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create
     dcos security org users grant kubernetes dcos:mesos:master:task:user:nobody create
     ```

--- a/pages/services/kubernetes/2.1.0-1.12.3/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.1.0-1.12.3/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create

--- a/pages/services/kubernetes/2.1.1-1.12.5/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.1.1-1.12.5/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create

--- a/pages/services/kubernetes/2.2.0-1.13.3/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.2.0-1.13.3/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create

--- a/pages/services/kubernetes/2.2.1-1.13.4/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.2.1-1.13.4/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create

--- a/pages/services/kubernetes/2.2.2-1.13.5/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.2.2-1.13.5/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create

--- a/pages/services/kubernetes/2.3.0-1.14.1/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.3.0-1.14.1/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create

--- a/pages/services/kubernetes/2.3.1-1.14.2/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.3.1-1.14.2/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create

--- a/pages/services/kubernetes/2.3.2-1.14.1/getting-started/installing-mke/index.md
+++ b/pages/services/kubernetes/2.3.2-1.14.1/getting-started/installing-mke/index.md
@@ -65,17 +65,18 @@ In order to run Mesosphere Kubernetes Engine - the `kubernetes` package - on DC/
 
 Now that a service account is provisioned for MKE, we need to grant certain permissions to the service account under a Mesos role, in this case `kubernetes-role`. To grant the permissions to MKE:
 
-1. <strong>First, grant</strong> `mesos master reservation role` <strong> permissions to the kubernetes service account under</strong>`kubernetes-role`</strong>:
+1. <strong>First, grant</strong> `mesos master reservation role` <strong>permissions to the kubernetes service account under</strong> `kubernetes-role` <strong> to create reservations, and to the</strong> `kubernetes` <strong>principal to delete reservations</strong>:
 
     In the CLI, enter:
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:reservation:role:kubernetes-role create
+    dcos security org users grant kubernetes dcos:mesos:master:reservation:principal:kubernetes delete
     ```
 
     Again, like in the procedure above, these `dcos-security` commands will not respond with output in the CLI. However, some conditions will cause corresponding errors to register, such as already having granted the permissions trying to be granted.
 
-1. <strong>Next, grant </strong> `mesos master framework` <strong> permission under the same role. </strong>
+1. <strong>Next, grant</strong> `mesos master framework` <strong>permission under the same role. </strong>
 
     ```bash
     dcos security org users grant kubernetes dcos:mesos:master:framework:role:kubernetes-role create


### PR DESCRIPTION
## Description of changes being made
Update documentation to add missing delete reservation permission for Kubernetes package.

## Checklist
- [X] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [X] Test all commands and procedures where applicable.
- [X] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.