### PR TITLE
ss/DCOS-51550 Updates to version-policy support page.

### DIFF
--- a/pages/services/confluent-kafka/2.3.0-4.0.0e/index.md
+++ b/pages/services/confluent-kafka/2.3.0-4.0.0e/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Confluent Kafka 2.3.0-4.0.0e
 excerpt:
 title: Confluent Kafka 2.3.0-4.0.0e
-menuWeight: 10
+menuWeight: -1
 model: /services/confluent-kafka/data.yml
 render: mustache
 featureMaturity:

--- a/pages/services/confluent-kafka/2.4.0-4.1.1/index.md
+++ b/pages/services/confluent-kafka/2.4.0-4.1.1/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Confluent Kafka 2.4.0-4.1.1
 excerpt: DC/OS Confluent Kafka is an automated service that makes it easy to deploy and manage Confluent Kafka on Mesosphere DC/OS.
 title: Confluent Kafka 2.4.0-4.1.1
-menuWeight: 3
+menuWeight: -1
 model: /services/confluent-kafka/data.yml
 render: mustache
 featureMaturity:

--- a/pages/services/confluent-zookeeper/2.3.0-4.0.0e/index.md
+++ b/pages/services/confluent-zookeeper/2.3.0-4.0.0e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.3.0-4.0.0e
 title: Confluent ZooKeeper 2.3.0-4.0.0e
-menuWeight: 5
+menuWeight: -1
 excerpt:
 
 model: /services/confluent-zookeeper/data.yml

--- a/pages/services/confluent-zookeeper/2.4.0-4.0.0e/index.md
+++ b/pages/services/confluent-zookeeper/2.4.0-4.0.0e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.4.0-4.0.0e
 title: Confluent ZooKeeper 2.4.0-4.0.0e
-menuWeight: 4
+menuWeight: -1
 excerpt:
 
 model: /services/confluent-zookeeper/data.yml

--- a/pages/services/elastic/2.4.0-5.6.9/index.md
+++ b/pages/services/elastic/2.4.0-5.6.9/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Elastic 2.4.0-5.6.9
 excerpt: DC/OS Elastic lets you manage an Elasticsearch cluster
 title: Elastic 2.4.0-5.6.9
-menuWeight: 2
+menuWeight: -1
 model: /services/elastic/data.yml
 render: mustache
 ---

--- a/pages/services/kafka/2.3.0-1.0.0/index.md
+++ b/pages/services/kafka/2.3.0-1.0.0/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Kafka 2.3.0-1.0.0
 excerpt:
 title: Kafka 2.3.0-1.0.0
-menuWeight: 2
+menuWeight: -1
 model: /services/kafka/data.yml
 render: mustache
 ---

--- a/pages/services/kafka/2.3.0-1.1.0/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Kafka 2.3.0-1.1.0
 excerpt:
 title: Kafka 2.3.0-1.1.0
-menuWeight: 1
+menuWeight: -1
 model: /services/kafka/data.yml
 render: mustache
 ---

--- a/pages/version-policy/index.md
+++ b/pages/version-policy/index.md
@@ -221,12 +221,12 @@ Use the following legend table to see the supported/not supported service for th
     </tr>
 </table>
 
-<p class="message--note"><strong>NOTE: </strong>CoreOS 1800.7.0 requires DC/OS 1.11.6 or later releases.</p>
+<p class="message--note"><strong>NOTE: </strong>CoreOS 1800.7.0 requires DC/OS version 1.11.6 or later.</p>
 
 ## Customer Advisory for CentOS/RHEL 7.X
-<p class="message--important"><strong>IMPORTANT: </strong>Docker recently enabled `kmem` accounting in version `17.06+`. Customers may notice instability for the entire system when running under RHEL or CentOS 7.x. The symptoms include tasks getting stuck indefinitely and kernel-related error messages in the system logs. The `kmem` accounting feature in Redhat’s forked Linux Kernel is incomplete and can cause kernel deadlocks or kernel memory leaks. Details on the bug and mitigation instructions are located <a href="https://mesosphere-community.force.com/s/article/Critical-Issue-KMEM-MSPH-2018-0006">here</a>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Docker recently enabled <code>kmem</code> accounting in version 17.06+. Customers may notice instability for the entire system when running under RHEL or CentOS 7.x. The symptoms include tasks getting stuck indefinitely and kernel-related error messages in the system logs. The <code>kmem</code> accounting feature in Redhat’s forked Linux Kernel is incomplete and can cause kernel deadlocks or kernel memory leaks. Details on the bug and mitigation instructions are located <a href="https://mesosphere-community.force.com/s/article/Critical-Issue-KMEM-MSPH-2018-0006">here</a>.</p>
 
-<p class="message--note"><strong>NOTE: </strong>Because of the kmem bug, <strong>Mesosphere only supports Kubernetes on DC/OS with CentOS/RHEL 7.X when using DC/OS 1.12 or greater and CentOS/RHEL 7.5</strong>.</a></p>
+<p class="message--note"><strong>NOTE: </strong>Because of the kmem bug, <strong>Mesosphere only supports Kubernetes on DC/OS with CentOS/RHEL 7.X when using DC/OS 1.12 or later and CentOS/RHEL 7.5</strong>.</a></p>
 
 ## Version Compatibility Matrix
 
@@ -234,24 +234,24 @@ Mesosphere maintains and certifies several packages for DC/OS.
 
 ### Base Technology
 
-Mesosphere does not offer support services for the base technology (e.g. Jenkins). The base technology version is denoted as the second version in the package number (e.g. 1.2.3-4.5.6).
+Mesosphere does not offer support services for the base technology (for example, Jenkins). The base technology version is denoted as the second version in the package number (for example, 1.2.3-**4.5.6**).
 
 
 ### Certified Package Designations
 
-Services that are labeled as “Certified” have been tested by Mesosphere for interoperability with DC/OS, but Mesosphere disclaims all warranties, and makes no promises, including with respect to the services’ operation or production readiness. Support for the integration may be available from Mesosphere or the creator of the service. The matrix below lists certified packages and the current state of what packages are tested on what version of DC/OS, and what is within the best effort scope of our technical support organization.
+Services that are labeled as “Certified” have been tested by Mesosphere for interoperability with DC/OS, but Mesosphere disclaims all warranties, and makes no promises, including with respect to the services’ operation or production readiness. Support for the integration may be available from Mesosphere or the creator of the service. The matrix below lists certified packages and the current state of which packages are tested on what version of DC/OS, and what is within the best effort scope of our technical support organization.
 
 The designations are as follows:
 
-⚫- This combination is tested and compatible with the specified version of DC/OS.
+⚫ This combination is tested and compatible with the specified version of DC/OS.
 - This package is within the scope of our technical support organization.
 - This is package is eligible for bug fixes.
 
-◒ - This combination has been tested previously and should be compatible with the specified version of DC/OS.
+◒ This combination has been tested previously and should be compatible with the specified version of DC/OS.
 - This combination is not within the scope of our technical support organization.
 - This combination is not eligible for bug fixes.
 
-◯ - This package combination has not been tested.
+◯ This package combination has not been tested.
 - This combination is not within the scope of our technical support organization.
 - This combination is not eligible for bug fixes.
 
@@ -310,9 +310,7 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <!-- <tr>
         <td>²DataStax-Ops 2.4.x-6.1.9</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -323,10 +321,8 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-    </tr> -->
      <tr>
         <td>Edge-LB 1.2</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -336,11 +332,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Elastic 2.5.x-6.3.2</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -350,18 +344,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-    </tr>
-    <tr>
-        <td>HDFS 2.3.x-2.6.0-cdh5.11.0</td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>HDFS 2.4.x-2.6.0-cdh5.11.0 </td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -371,11 +356,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Jenkins 3.5.x-2.107.2</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -385,11 +368,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Kafka 2.4.x-1.1.1</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -399,11 +380,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Kafka-Zookeeper 2.3.x-3.4.12</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -414,10 +393,8 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <!-- Kibana is not on the Services page. -->
-    <!-- <tr>
+    <tr>
         <td>Kibana 2.5.x-6.3.2</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -428,60 +405,51 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-    </tr> -->
-    <tr>
-        <td>Kubernetes 1.3.x-1.10.y</td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-    </tr>
+    </tr> 
     <tr>
         <td>Kubernetes 2.1.x-1.12.y</td>
+        <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+    </tr>
+    <tr>
+        <td>Kubernetes 2.2.x-1.13.y </td>
+        <td><p style="text-align: center;">◯</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+    </tr>
+    <tr>
+        <td>Kubernetes 2.2.x-1.14.y (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
     <tr>
-        <td>Kubernetes 2.2.x-1.13.y (Recommended)</td>
+        <td>Kubernetes Cluster 2.2.x-1.13.y </td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
-     <tr>
-        <td>Kubernetes Cluster 2.1.x-1.12.y</td>
-        <td><p style="text-align: center;">⚫</p></td>
+    <tr>
+        <td>Kubernetes Cluster 2.3.x-1.14.y (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
     <tr>
-        <td>Kubernetes Cluster 2.2.x-1.13.y (Recommended)</td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-    </tr>
-    <tr>
-        <td>Marathon-LB 1.11.x</td>
-        <td><p style="text-align: center;">⚫</p></td>
+        <td>Marathon-LB 1.12.x</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
-        <td>Marathon-LB 1.12.x (Recommended)</td>
-        <td><p style="text-align: center;">⚫</p></td>
+        <td>Marathon-LB 1.13.x (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <!-- Marathon on Marathon is not listed on services page. -->
-    <!-- <tr>
+    <tr>
         <td>MoM (Marathon on Marathon) 1.6.x</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -491,39 +459,27 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>MoM (Marathon on Marathon) 1.8.x (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-    </tr> -->
-    <!-- Where is Minio? -->
-    <!-- Where is NiFi? -->
-    <!-- Where is Percona-Server-MongoDB? -->
-    <!-- Where is Percona XtraDB Cluster?  -->
-    <!-- Where is Prometheus? -->
+    </tr>
     <tr>
         <td>Spark 2.6.x-2.3.2</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <!-- Where is Spark 2.7.x? -->
     <tr>
         <td>Spark 2.8.x-2.4.0 (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <!-- Spark History is not listed in Services page. -->
     <tr>
         <td>Spark History 2.6.x-2.3.2</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -533,9 +489,7 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <!-- Where is Spinnaker? -->
 </table>
 
 ### Beta Package Designations
@@ -558,47 +512,34 @@ B - This package combination is *beta*.
         <th><p style="text-align: center;"><strong>DC/OS 1.13</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.12</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.11</strong></p></th>
-        <th><p style="text-align: center;"><strong>DC/OS 1.10</strong></p></th>
     </tr>
     <tr>
         <td>Beta DC/OS Storage Services 0.4.0</td>
+        <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+    </tr>
+    <tr>
+        <td>¹Beta DC/OS Storage Services 0.5.3 </td>
+        <td><p style="text-align: center;">◯</p></td>
+        <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+    </tr>
+    <tr>
+        <td>Beta DC/OS Storage Services 0.6.0 (Recommended)</td>
         <td><p style="text-align: center;">B</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
     <tr>
-        <td>¹Beta DC/OS Storage Services 0.5.x </td>
+        <td>Beta Mesosphere Jupyter Service 1.3.x - 0.35.4 (Recommended)</td>
         <td><p style="text-align: center;">B</p></td>
         <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-        <td><p style="text-align: center;">◯</p></td>
+        <td><p style="text-align: center;">B</p></td>
     </tr>
-    <tr>
-        <td>¹Beta DC/OS Storage Services 0.6.x (Recommended)</td>
-        <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-    </tr>
-    <tr>
-        <td>Beta DC/OS Monitoring Service 0.5.x-beta (Recommended)</td>
-        <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-    </tr>
-    <!-- There is no version 1.3.x for the Beta Jupyter service.
-    <tr>
-        <td>Beta Mesosphere Jupyter Service 1.3.x-0.35.4 (Recommended)</td>
-        <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-    </tr> -->
 </table>
 
 ### Footnotes
 
-- ¹ - *Beta DC/OS Storage Services 0.5.1 requires DC/OS 1.12.1*
-- ² - *Package maintained and supported solely by DataStax Corporation*
+- ¹ Beta DC/OS Storage Services 0.5.1 requires DC/OS 1.12.1 or later.
+- ² Package maintained and supported solely by DataStax Corporation.

--- a/pages/version-policy/index.md
+++ b/pages/version-policy/index.md
@@ -488,8 +488,7 @@ The designations are as follows:
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
-    <!-- What is Kubernetes Cluster? -->
-     <!-- <tr>
+     <tr>
         <td>Kubernetes Cluster 2.1.x-1.12.y</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -502,7 +501,7 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
-    </tr> -->
+    </tr>
     <tr>
         <td>Marathon-LB 1.11.x</td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -540,7 +539,7 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
     </tr> -->
     <!-- Where is Minio? -->
-    <!-- Where is Nifi? -->
+    <!-- Where is NiFi? -->
     <!-- Where is Percona-Server-MongoDB? -->
     <!-- Where is Percona XtraDB Cluster?  -->
     <!-- Where is Prometheus? -->

--- a/pages/version-policy/index.md
+++ b/pages/version-policy/index.md
@@ -56,11 +56,9 @@ Customers running DC/OS on non-supported platform components should upgrade to a
     <th><strong>DC/OS 1.13 Latest Stable</strong></th>
     <th><strong>DC/OS 1.12 Latest Stable</strong></th>
     <th><strong>DC/OS 1.11 Latest Stable</strong></th>
-    <th><strong>DC/OS 1.10 Latest Stable</strong></th>
     </tr>
     <tr>
         <td>CoreOS 2079.3.0</td>
-        <td><p style="text-align: center;">Docker CE 18.06.3</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.3</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.3</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.3</p></td>
@@ -70,11 +68,9 @@ Customers running DC/OS on non-supported platform components should upgrade to a
         <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
-        <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
     </tr>
     <tr>
         <td>CoreOS 2023.4.0</td>
-        <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
         <td><p style="text-align: center;">Docker CE 18.06.1</p></td>
@@ -88,11 +84,9 @@ Customers running DC/OS on non-supported platform components should upgrade to a
     <th><strong>DC/OS 1.13 Latest Stable</strong></th>
     <th><strong>DC/OS 1.12 Latest Stable</strong></th>
     <th><strong>DC/OS 1.11 Latest Stable</strong></th>
-    <th><strong>DC/OS 1.10 Latest Stable</strong></th>
     </tr>
     <tr>
         <td>CentOS 7.6</td>
-        <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
@@ -102,14 +96,12 @@ Customers running DC/OS on non-supported platform components should upgrade to a
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
-        <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
     </tr>
     <tr>
         <td>CentOS 7.4</td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker CE 18.09.2</p></td>
-        <td><p style="text-align: center;">RH Fork of Docker CE 1.13.1<sup>*</sup></p></td>
     </tr>
 </table>
 
@@ -120,11 +112,9 @@ Customers running DC/OS on non-supported platform components should upgrade to a
     <th><strong>DC/OS 1.13 Latest Stable</strong></th>
     <th><strong>DC/OS 1.12 Latest Stable</strong></th>
     <th><strong>DC/OS 1.11 Latest Stable</strong></th>
-    <th><strong>DC/OS 1.10 Latest Stable</strong></th>
     </tr>
     <tr>
         <td>RHEL 7.6</td>
-        <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
@@ -134,11 +124,9 @@ Customers running DC/OS on non-supported platform components should upgrade to a
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
-        <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
     </tr>
     <tr>
         <td>RHEL 7.4</td>
-        <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
@@ -152,11 +140,9 @@ Customers running DC/OS on non-supported platform components should upgrade to a
     <th><strong>DC/OS 1.13 Latest Stable</strong></th>
     <th><strong>DC/OS 1.12 Latest Stable</strong></th>
     <th><strong>DC/OS 1.11 Latest Stable</strong></th>
-    <th><strong>DC/OS 1.10 Latest Stable</strong></th>
     </tr>
     <tr>
         <td>Oracle Linux 7.6 (RHCK)</td>
-        <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
@@ -166,11 +152,9 @@ Customers running DC/OS on non-supported platform components should upgrade to a
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
-        <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
     </tr>
     <tr>
         <td>Oracle Linux 7.4 (RHCK)</td>
-        <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
         <td><p style="text-align: center;">Docker EE 18.09.2<br>Docker CE 18.09.2</p></td>
@@ -191,9 +175,9 @@ Use the following legend table to see the supported/not supported service for th
 <table class="table">
     <tr>
     <th><strong>Web Browser</strong></th>
+    <th><strong>DC/OS 1.13 Latest Stable</strong></th>
     <th><strong>DC/OS 1.12 Latest Stable</strong></th>
     <th><strong>DC/OS 1.11 Latest Stable</strong></th>
-    <th><strong>DC/OS 1.10 Latest Stable</strong></th>
     </tr>
     <tr>
         <td>Chrome</td>
@@ -213,9 +197,9 @@ Use the following legend table to see the supported/not supported service for th
 <table class="table">
     <tr>
     <th><strong>CLI</strong></th>
+    <th><strong>DC/OS 1.13 Latest Stable</strong></th>
     <th><strong>DC/OS 1.12 Latest Stable</strong></th>
     <th><strong>DC/OS 1.11 Latest Stable</strong></th>
-    <th><strong>DC/OS 1.10 Latest Stable</strong></th>
     </tr>    
     <tr>
         <td>DC/OS CLI 0.4.x</td>
@@ -278,11 +262,9 @@ The designations are as follows:
         <th><p style="text-align: center;"><strong>DC/OS 1.13</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.12</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.11</strong></p></th>
-        <th><p style="text-align: center;"><strong>DC/OS 1.10</strong></p></th>
     </tr>
     <tr>
         <td>Cassandra 2.4.x-3.0.16</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -292,11 +274,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Confluent-Kafka 2.5.x-4.1.2</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -306,11 +286,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Confluent-ZooKeeper 2.5.x-4.1.3e</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -320,25 +298,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <tr>
-        <td>Couchbase 0.2.0-5.5.0 </td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-    </tr>
-    <tr>
-        <td>Couchbase 0.3.0-5.5.3 (Recommended) </td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-    </tr>
-    <tr>
+        <tr>
         <td>²DataStax-DSE 2.4.x-5.1.10</td>
-        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>

--- a/pages/version-policy/index.md
+++ b/pages/version-policy/index.md
@@ -275,6 +275,7 @@ The designations are as follows:
 <table class="table">
     <tr>
         <th><strong>DC/OS Package for</strong></th>
+        <th><p style="text-align: center;"><strong>DC/OS 1.13</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.12</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.11</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.10</strong></p></th>
@@ -284,9 +285,11 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Cassandra 2.5.x-3.11.3 (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -296,9 +299,11 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Confluent-Kafka 2.6.x-5.1.2 (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -308,9 +313,25 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Confluent-ZooKeeper 2.6.x-5.1.2e (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+    </tr>
+    <tr>
+        <td>Couchbase 0.2.0-5.5.0 </td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+    </tr>
+    <tr>
+        <td>Couchbase 0.3.0-5.5.3 (Recommended) </td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -320,14 +341,16 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>²DataStax-DSE 3.0.x-6.7.2 (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <tr>
+    <!-- <tr>
         <td>²DataStax-Ops 2.4.x-6.1.9</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -338,21 +361,17 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-    </tr>
+    </tr> -->
      <tr>
-        <td>Edge-LB 1.2.2</td>
+        <td>Edge-LB 1.2</td>
         <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-        <td><p style="text-align: center;">⚫</p></td>
-    </tr>
-    <tr>
-        <td>Edge-LB 1.2.3</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
-        <td>Edge-LB 1.3.0 (Recommended)</td>
+        <td>Edge-LB 1.3 (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -362,9 +381,11 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Elastic 2.6.x-6.6.1 (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -374,9 +395,18 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
-        <td>HDFS 2.4.x-2.6.0-cdh5.11.0 (Recommended)</td>
+        <td>HDFS 2.4.x-2.6.0-cdh5.11.0 </td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
+    </tr>
+    <tr>
+        <td>HDFS 2.5.x-2.6.0-cdh5.11.0 (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -386,9 +416,11 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
-        <td>Jenkins 3.5.4-2.150.1 (Recommended)</td>
+        <td>Jenkins 3.5.x-2.150.1 (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -398,9 +430,11 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>Kafka 2.5.x-2.1.0 (Recommended)</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -410,14 +444,18 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
+    <!-- Where is Kafka-ZooKeeper 2.4.x? -->
     <tr>
         <td>Kafka-Zookeeper 2.5.x-3.4.13 (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <tr>
+    <!-- Kibana is not on the Services page. -->
+    <!-- <tr>
         <td>Kibana 2.5.x-6.3.2</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -428,9 +466,10 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-    </tr>
+    </tr> -->
     <tr>
         <td>Kubernetes 1.3.x-1.10.y</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
@@ -438,17 +477,21 @@ The designations are as follows:
     <tr>
         <td>Kubernetes 2.1.x-1.12.y</td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
     <tr>
         <td>Kubernetes 2.2.x-1.13.y (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
-     <tr>
+    <!-- What is Kubernetes Cluster? -->
+     <!-- <tr>
         <td>Kubernetes Cluster 2.1.x-1.12.y</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
@@ -456,11 +499,13 @@ The designations are as follows:
     <tr>
         <td>Kubernetes Cluster 2.2.x-1.13.y (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
-    </tr>
+    </tr> -->
     <tr>
         <td>Marathon-LB 1.11.x</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -470,9 +515,12 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-    <tr>
+    <!-- Marathon on Marathon is not listed on services page. -->
+    <!-- <tr>
         <td>MoM (Marathon on Marathon) 1.6.x</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -482,27 +530,39 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
         <td>MoM (Marathon on Marathon) 1.8.x (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
-    </tr>
+        <td><p style="text-align: center;">⚫</p></td>
+    </tr> -->
+    <!-- Where is Minio? -->
+    <!-- Where is Nifi? -->
+    <!-- Where is Percona-Server-MongoDB? -->
+    <!-- Where is Percona XtraDB Cluster?  -->
+    <!-- Where is Prometheus? -->
     <tr>
         <td>Spark 2.6.x-2.3.2</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
+    <!-- Where is Spark 2.7.x? -->
     <tr>
         <td>Spark 2.8.x-2.4.0 (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
-     <tr>
+    <!-- Spark History is not listed in Services page. -->
+    <tr>
         <td>Spark History 2.6.x-2.3.2</td>
+        <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
@@ -512,7 +572,9 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
+        <td><p style="text-align: center;">⚫</p></td>
     </tr>
+    <!-- Where is Spinnaker? -->
 </table>
 
 ### Beta Package Designations
@@ -532,6 +594,7 @@ B - This package combination is *beta*.
 <table class="table">
     <tr>
         <th><strong>DC/OS Package for</strong></th>
+        <th><p style="text-align: center;"><strong>DC/OS 1.13</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.12</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.11</strong></p></th>
         <th><p style="text-align: center;"><strong>DC/OS 1.10</strong></p></th>
@@ -539,21 +602,39 @@ B - This package combination is *beta*.
     <tr>
         <td>Beta DC/OS Storage Services 0.4.0</td>
         <td><p style="text-align: center;">B</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-        <td><p style="text-align: center;">◯</p></td>
-    </tr>
-    <tr>
-        <td>¹Beta DC/OS Storage Services 0.5.1 (Recommended)</td>
         <td><p style="text-align: center;">B</p></td>
         <td><p style="text-align: center;">◯</p></td>
         <td><p style="text-align: center;">◯</p></td>
     </tr>
+    <tr>
+        <td>¹Beta DC/OS Storage Services 0.5.x </td>
+        <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+    </tr>
+    <tr>
+        <td>¹Beta DC/OS Storage Services 0.6.x (Recommended)</td>
+        <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+    </tr>
+    <tr>
+        <td>Beta DC/OS Monitoring Service 0.5.x-beta (Recommended)</td>
+        <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+        <td><p style="text-align: center;">◯</p></td>
+    </tr>
+    <!-- There is no version 1.3.x for the Beta Jupyter service.
     <tr>
         <td>Beta Mesosphere Jupyter Service 1.3.x-0.35.4 (Recommended)</td>
         <td><p style="text-align: center;">B</p></td>
         <td><p style="text-align: center;">B</p></td>
+        <td><p style="text-align: center;">B</p></td>
         <td><p style="text-align: center;">◯</p></td>
-    </tr>
+    </tr> -->
 </table>
 
 ### Footnotes


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-51550

## Description of changes being made
Updates to version support page https://docs.mesosphere.com/version-policy/. I checked the listed version on the service docs page against the listed supported versions on the version-policy page.

- Chronos: listed in UI Catalog, not mentioned in version support page and not on Service docs page.
- Confluent-Kafka: hid versions 2.3.0 and 2.4.0 on Services page, as they are not listed as supported verisons.
- Confluent-ZooKeeper: hid versions 2.3.0e and 2.4.0e on Services page, as they are not listed as supported versions.
- Couchbase: added v. 0.2.0 and 0.3.0 to Versions page because they are listed on Service docs page.
- Elastic: hid version 2.4.0 because it is not listed as supported
- DataStax-Ops: hid entry on versions page because there is no Service docs for it
- Kafka: hid version 2.3.0x because it is not listed as supported.
- Kafka-ZoKeeper: v. 2.4.x is not listed on version support page. Why?
- Kibana: hid entry in versions page because it is not listed on Services page
- Kubernetes: Kubernetes-Cluster is listed on version support and Catalog but is not in Services docs
- Marathon-on-Marathon: listed as supported on version page, but there is no Catalog entry for it and no entry on Services Docs page.

**Missing from Version Support page but listed on Services Docs:**

- Kafka-ZooKeeper 2.4.x
- Kibana
- Marathon-on-Marathon
- Minio
- NiFi
- Percona-Server-MongoDB
- Percona XtraDB Cluster
- Prometheus
- Spark 2.7.x
- Spinnaker

**Beta Packages**

- Beta DC/OS Monitoring: Not listed on Version Support page
- Beta Jupyter Service: There is no version 1.3.x version of the docs on Service Docs page. Latest docs version available is 1.2.x.


