### PR TITLE
ss/DCOS_OSS-5227 Correcting HTML exposure in GUI doc.

### DIFF
--- a/pages/1.13/gui/settings/index.md
+++ b/pages/1.13/gui/settings/index.md
@@ -12,9 +12,4 @@ In the Settings menu you can manage package repositories, change the UI settings
 
 ![Package repositories](/1.13/img/GUI-Settings-EE-Package_Repositories-1_12.png)
 
-<<<<<<< HEAD
 Figure 1 - **Settings > Package Repositories** tab
-=======
-Figure 1 - Settings > Package Repositories tab
-
->>>>>>> a2d18d6a6cb5def325af0993142700d54b705af5


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS_OSS-5227

## Description of changes being made
Corrected exposed HTML code in https://docs.mesosphere.com/1.13/gui/settings/. Issue does not appear in earlier versions of the page.