### PR TITLE
[DS] Remove older, unsupported frameworks out of sight

### DIFF
--- a/pages/services/confluent-kafka/2.3.0-4.0.0e/index.md
+++ b/pages/services/confluent-kafka/2.3.0-4.0.0e/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Confluent Kafka 2.3.0-4.0.0e
 excerpt:
 title: Confluent Kafka 2.3.0-4.0.0e
-menuWeight: 10
+menuWeight: -1
 model: /services/confluent-kafka/data.yml
 render: mustache
 featureMaturity:

--- a/pages/services/confluent-kafka/2.4.0-4.1.1/index.md
+++ b/pages/services/confluent-kafka/2.4.0-4.1.1/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Confluent Kafka 2.4.0-4.1.1
 excerpt: DC/OS Confluent Kafka is an automated service that makes it easy to deploy and manage Confluent Kafka on Mesosphere DC/OS.
 title: Confluent Kafka 2.4.0-4.1.1
-menuWeight: 3
+menuWeight: -1
 model: /services/confluent-kafka/data.yml
 render: mustache
 featureMaturity:

--- a/pages/services/confluent-zookeeper/2.3.0-4.0.0e/index.md
+++ b/pages/services/confluent-zookeeper/2.3.0-4.0.0e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.3.0-4.0.0e
 title: Confluent ZooKeeper 2.3.0-4.0.0e
-menuWeight: 5
+menuWeight: -1
 excerpt:
 
 model: /services/confluent-zookeeper/data.yml

--- a/pages/services/confluent-zookeeper/2.4.0-4.0.0e/index.md
+++ b/pages/services/confluent-zookeeper/2.4.0-4.0.0e/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent ZooKeeper 2.4.0-4.0.0e
 title: Confluent ZooKeeper 2.4.0-4.0.0e
-menuWeight: 4
+menuWeight: -1
 excerpt:
 
 model: /services/confluent-zookeeper/data.yml

--- a/pages/services/elastic/2.5.0-6.3.2/index.md
+++ b/pages/services/elastic/2.5.0-6.3.2/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Elastic 2.5.0-6.3.2
 excerpt: DC/OS Elastic lets you manage an Elasticsearch cluster
 title: Elastic 2.5.0-6.3.2
-menuWeight: 1
+menuWeight: -1
 model: /services/elastic/data.yml
 render: mustache
 ---

--- a/pages/services/kafka/2.3.0-1.0.0/index.md
+++ b/pages/services/kafka/2.3.0-1.0.0/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Kafka 2.3.0-1.0.0
 excerpt:
 title: Kafka 2.3.0-1.0.0
-menuWeight: 2
+menuWeight: -1
 model: /services/kafka/data.yml
 render: mustache
 ---

--- a/pages/services/kafka/2.3.0-1.1.0/index.md
+++ b/pages/services/kafka/2.3.0-1.1.0/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Kafka 2.3.0-1.1.0
 excerpt:
 title: Kafka 2.3.0-1.1.0
-menuWeight: 1
+menuWeight: -1
 model: /services/kafka/data.yml
 render: mustache
 ---

--- a/pages/services/kafka/2.4.0-1.1.1/index.md
+++ b/pages/services/kafka/2.4.0-1.1.1/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Kafka 2.4.0-1.1.1
 excerpt:
 title: Kafka 2.4.0-1.1.1
-menuWeight: 1
+menuWeight: 2
 model: /services/kafka/data.yml
 render: mustache
 ---

--- a/pages/services/spark/2.6.0-2.3.2/index.md
+++ b/pages/services/spark/2.6.0-2.3.2/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Spark 2.6.0-2.3.2
 navigationTitle: Spark 2.6.0-2.3.2
-menuWeight: 3
+menuWeight: 2
 excerpt: Documentation for DC/OS Apache Spark 2.6.0-2.3.2
 model: /services/spark/data.yml
 render: mustache

--- a/pages/services/spark/2.7.0-2.4.0/index.md
+++ b/pages/services/spark/2.7.0-2.4.0/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Spark 2.7.0-2.4.0
 navigationTitle: Spark 2.7.0-2.4.0
-menuWeight: 2
+menuWeight: -1
 excerpt: Documentation for DC/OS Apache Spark 2.7.0-2.4.0
 model: /services/spark/data.yml
 render: mustache


### PR DESCRIPTION
Our official policy is to support N-1 major versions of any given data service framework. This PR marks older versions invisible so they do not appear in our [service docs website](https://docs.mesosphere.com/services). 

At the end of the day, there should only be 2 versions displayed.
