### PR TITLE
Hide Spark 2.7.0 docs

### DIFF
--- a/pages/services/spark/2.7.0-2.4.0/index.md
+++ b/pages/services/spark/2.7.0-2.4.0/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 title: Spark 2.7.0-2.4.0
 navigationTitle: Spark 2.7.0-2.4.0
-menuWeight: 2
+menuWeight: -1
 excerpt: Documentation for DC/OS Apache Spark 2.7.0-2.4.0
 model: /services/spark/data.yml
 render: mustache


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS-51550


## Description of changes being made
Hiding obsolete service docs.

See https://docs.google.com/spreadsheets/d/1r4CrlTGKnmBp2frkQanhdVRWj6YHIT8nH0wUXR9fDCw/edit#gid=0