### PR TITLE
Replace all references to "Universe" with "Catalog"

### DIFF
--- a/pages/1.13/administering-clusters/add-a-node/index.md
+++ b/pages/1.13/administering-clusters/add-a-node/index.md
@@ -5,6 +5,8 @@ title: Adding Agent Nodes
 menuWeight: 800
 excerpt: Adding agent nodes to an existing DC/OS cluster
 enterprise: false
+render: mustache
+model: /1.13/data.yml
 ---
 
 Agent nodes are designated as [public](/latest/overview/concepts/#public-agent-node) or [private](/latest/overview/concepts/#private-agent-node) during installation. By default, they are designated as private during the GUI or CLI [installation](/latest/installing/evaluation/).

--- a/pages/1.13/administering-clusters/backup-and-restore/backup-restore-api/index.md
+++ b/pages/1.13/administering-clusters/backup-and-restore/backup-restore-api/index.md
@@ -5,6 +5,8 @@ title: Backup and Restore API
 menuWeight: 10
 excerpt: Backing up and restoring your cluster using the API
 enterprise: true
+render: mustache
+model: ../../../data.yml
 ---
 
 You can use the Backup and Restore API to create and restore backups of your cluster.

--- a/pages/1.13/administering-clusters/backup-and-restore/backup-restore-cli/index.md
+++ b/pages/1.13/administering-clusters/backup-and-restore/backup-restore-cli/index.md
@@ -5,6 +5,8 @@ title: Backup and Restore CLI
 menuWeight: 0
 excerpt: Backing up and restoring your cluster using the CLI
 enterprise: true
+render: mustache
+model: ../../../data.yml
 ---
 You can use the CLI to create and restore backups of your cluster.
 

--- a/pages/1.13/administering-clusters/backup-and-restore/index.md
+++ b/pages/1.13/administering-clusters/backup-and-restore/index.md
@@ -5,11 +5,13 @@ title: Backup and Restore
 menuWeight: 7
 excerpt: Backing up and restoring the native Marathon instance of your clusters
 enterprise: true
----
+render: mustache
+model: ../../data.yml
+--- 
 
 You can back up the state of the native Marathon instance of your cluster, and later restore from that backup.
 
-You may wish to back up your cluster before performing an upgrade or downgrade. You may need to restore your cluster to a known good state if something goes wrong during an upgrade or if you install a Universe package that does not perform as expected.
+You may wish to back up your cluster before performing an upgrade or downgrade. You may need to restore your cluster to a known good state if something goes wrong during an upgrade or if you install a {{ model.packageRepo }} package that does not perform as expected.
 
 # Limitations
 

--- a/pages/1.13/administering-clusters/component-management/index.md
+++ b/pages/1.13/administering-clusters/component-management/index.md
@@ -5,6 +5,8 @@ title: Component Management
 menuWeight: 5
 excerpt: Installing and managing DC/OS component services
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
 The component management API controls installation and management of DC/OS component services.

--- a/pages/1.13/administering-clusters/convert-agent-type/index.md
+++ b/pages/1.13/administering-clusters/convert-agent-type/index.md
@@ -5,6 +5,8 @@ title: Converting Agent Node Types
 menuWeight: 700
 excerpt: Converting agent nodes to public or private agent nodes.
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
 You can convert agent nodes to public or private for an existing DC/OS cluster.

--- a/pages/1.13/administering-clusters/delete-node/index.md
+++ b/pages/1.13/administering-clusters/delete-node/index.md
@@ -5,6 +5,8 @@ title: Shut Down and Decommission Nodes
 menuWeight: 810
 excerpt: Shutting down and decommissioning agent nodes
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
 In DC/OS 1.12 and later, deleting a node involves two steps: 

--- a/pages/1.13/administering-clusters/deploying-a-local-dcos-universe/index.md
+++ b/pages/1.13/administering-clusters/deploying-a-local-dcos-universe/index.md
@@ -1,30 +1,30 @@
 ---
 layout: layout.pug
-navigationTitle:  Deploying a Local Universe
-title: Deploying a Local Universe
+navigationTitle:  Deploying a Local Catalog
+title: Deploying a Local Catalog
 menuWeight: 1000
-excerpt: Installing and running DC/OS services on a local Universe datacenter
+excerpt: Installing and running DC/OS services on a local Catalog datacenter
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
-<tr>
-  <td align=justify style=color:black><strong>NOTE:</strong> If you are using dcos-enterprise, use <code>package-registry</code> for a seamless management of packages in air-gapped environments. Local universe support is deprecated.</td>
-</tr>
+<p class="message--note"><strong>NOTE: </strong> If you are using DC/OS Enterprise, use <tt>package-registry</tt> for seamless management of packages in air-gapped environments. Local {{ model.packageRepo }} support is deprecated.</p>
 
-You can install and run DC/OS services on a datacenter without internet access with a local [Universe](https://github.com/mesosphere/universe). You can deploy a local Universe that includes all Certified packages (basic), or a local Universe that includes selected packages (advanced).
+You can install and run DC/OS services on a datacenter without Internet access by using a local [{{ model.packageRepo }}](https://github.com/mesosphere/universe). You can deploy a local {{ model.packageRepo }} that includes all Certified packages (basic), or a local {{ model.packageRepo }} that includes selected packages (advanced).
 
 **Prerequisites:**
 
 - [DC/OS CLI installed](/1.13/cli/install/).
 
 - Logged into the DC/OS CLI. On DC/OS Enterprise, you must be logged in as a user with the `dcos:superuser` permission.
-<p class="message--note"><strong>NOTE: </strong>As the Universe tarball is over two gigabytes in size it may take some time to download it to your local drive and upload it to each master.</p>
+<p class="message--note"><strong>NOTE: </strong>As the {{ model.packageRepo }} tarball is over two gigabytes in size it may take some time to download it to your local drive and upload it to each master.</p>
 
-# <a name="certified"></a>Certified Universe packages
+# <a name="certified"></a>Certified {{ model.packageRepo }} packages
 
-This section explains how to deploy a local Universe containing certified Universe packages.
+This section explains how to deploy a local {{ model.packageRepo }} containing certified {{ model.packageRepo }} packages.
 
-1.  From a terminal prompt, use the following commands to download the local Universe and its service definitions onto your local drive.
+1.  From a terminal prompt, use the following commands to download the local {{ model.packageRepo }} and its service definitions onto your local drive.
 
     ```bash
     curl -v https://downloads.mesosphere.com/universe/public/local-universe.tar.gz -o local-universe.tar.gz
@@ -32,7 +32,7 @@ This section explains how to deploy a local Universe containing certified Univer
     curl -v https://raw.githubusercontent.com/mesosphere/universe/version-3.x/docker/local-universe/dcos-local-universe-registry.service -o dcos-local-universe-registry.service
     ```
 
-1.  Use [secure copy](https://linux.die.net/man/1/scp) (scp) to transfer the Universe and registry files to a master node, replacing `<master-IP>` with the public IP address of a master before issuing the following commands. (You can find the public IP address of a master in the top left corner of the DC/OS UI.)
+1.  Use [secure copy](https://linux.die.net/man/1/scp) (scp) to transfer the {{ model.packageRepo }} and registry files to a master node, replacing `<master-IP>` with the public IP address of a master before issuing the following commands. (You can find the public IP address of a master in the top left corner of the DC/OS UI.)
 
     ```bash
     scp local-universe.tar.gz core@<master-IP>:~
@@ -73,7 +73,7 @@ This section explains how to deploy a local Universe containing certified Univer
     ls -la /etc/systemd/system/dcos-local-universe-*
     ```
 
-1.  Load the Universe into the local Docker instance. This may take some time to complete.
+1.  Load the {{ model.packageRepo }} into the local Docker instance. This may take some time to complete.
 
     ```bash
     docker load < local-universe.tar.gz
@@ -104,7 +104,7 @@ This section explains how to deploy a local Universe containing certified Univer
 
 ## Configuring multiple masters
 
-If you only have one master, skip to [Linking local Universe to master](#linking) below. If you have multiple masters, continue with the following procedure.
+If you only have one master, skip to [Linking local {{ model.packageRepo }} to master](#linking) below. If you have multiple masters, continue with the following procedure.
 
 1.  Use the following command to discover the private IP addresses of all of your masters. Identify the private IP address of the master you are SSHed into right now from the list. It will match the path shown after `core@ip-` in your prompt, where the hyphens become periods.
 
@@ -112,7 +112,7 @@ If you only have one master, skip to [Linking local Universe to master](#linking
     host master.mesos
     ```
 
-1.  Use [secure copy](https://linux.die.net/man/1/scp) to transfer the Universe and registry files to one of the other masters. Replace `<master-IP>` with the IP address of the other master.
+1.  Use [secure copy](https://linux.die.net/man/1/scp) to transfer the {{ model.packageRepo }} and registry files to one of the other masters. Replace `<master-IP>` with the IP address of the other master.
 
     ```bash
     scp local-universe.tar.gz core@<master-IP>:~
@@ -151,7 +151,7 @@ If you only have one master, skip to [Linking local Universe to master](#linking
     ls -la /etc/systemd/system/dcos-local-universe-*
     ```
 
-1.  Load the Universe into the local Docker instance. This may take some time to complete.
+1.  Load the {{ model.packageRepo }} into the local Docker instance. This may take some time to complete.
 
     ```
     docker load < local-universe.tar.gz
@@ -177,25 +177,25 @@ If you only have one master, skip to [Linking local Universe to master](#linking
     sudo systemctl status dcos-local-universe-registry
     ```
 
-Repeat this section until you have completed this procedure for all of your masters. Then continue to the Linking local Universe to master section below.
+Repeat this section until you have completed this procedure for all of your masters. Then continue to the Linking local {{ model.packageRepo }} to master section below.
 
 <a name="linking"></a>
 
-## Linking local Universe to master
+## Linking local {{ model.packageRepo }} to master
 
 1.  Close the SSH session by typing `exit`, or open a new terminal prompt. You may have to exit more than one SSH session if you have multiple masters.
 
-1.  (Optional) Use the following command to remove the references to the default Universe from your cluster. If you want to leave the default Universe in place and just add the local Universe as an additional repository, skip to the next step. You can also remove the references to the default Universe repository from **Settings** > **Package Repositories** in the DC/OS web interface.
+1.  (Optional) Use the following command to remove the references to the default {{ model.packageRepo }} from your cluster. If you want to leave the default {{ model.packageRepo }} in place and just add the local {{ model.packageRepo }} as an additional repository, skip to the next step. You can also remove the references to the default {{ model.packageRepo }} repository from **Settings** > **Package Repositories** in the DC/OS web interface.
 
     ```bash
-    dcos package repo remove Universe
+    dcos package repo remove {{ model.packageRepo }}
     ```
 
 
-1.  Use the following command to add a reference to the local Universes that you added to each master.
+1.  Use the following command to add a reference to the local {{ model.packageRepo }}s that you added to each master.
 
     ```bash
-    dcos package repo add local-universe http://master.mesos:8082/repo
+    dcos package repo add local-{{ model.packageRepo }} http://master.mesos:8082/repo
     ```
     
 1.  [SSH into one of your agent nodes.](/1.13/administering-clusters/sshcluster/)
@@ -229,7 +229,7 @@ Repeat this section until you have completed this procedure for all of your mast
    ```
   
 1.  Close the SSH session by typing `exit`, or open a new terminal prompt. Repeat these steps on each agent node.
-1.  To verify your success, log into the DC/OS web interface and click the **Catalog** tab. You should see a list of Certified packages. Install one of the packages.
+1.  To verify your success, log into the DC/OS web interface and click the **{{ model.packageRepo }}** tab. You should see a list of Certified packages. Install one of the packages.
 
 ### FAQ
 
@@ -239,7 +239,7 @@ Repeat this section until you have completed this procedure for all of your mast
 
 *   **The images are broken**
 
-    All Universe components are hosted inside of your cluster, including the images. The components are served up by `master.mesos:8082`. If you have connectivity to that IP, you can add it to `/etc/hosts` and get the images working.
+    All {{ model.packageRepo }} components are hosted inside of your cluster, including the images. The components are served up by `master.mesos:8082`. If you have connectivity to that IP, you can add it to `/etc/hosts` and get the images working.
 
 *   **I don't see the package I was looking for**
 
@@ -249,9 +249,9 @@ Repeat this section until you have completed this procedure for all of your mast
 
 **Prerequisite:** [Git](https://git-scm.com/). On Unix/Linux, see these <a href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git" target="_blank">installation instructions</a>.
 
-To deploy a local Universe containing your own set of packages you must build a customized local Universe Docker image.
+To deploy a local {{ model.packageRepo }} containing your own set of packages you must build a customized local {{ model.packageRepo }} Docker image.
 
-1.  Clone the Universe repository:
+1.  Clone the {{ model.packageRepo }} repository:
 
     ```bash
     git clone https://github.com/mesosphere/universe.git --branch version-3.x
@@ -266,7 +266,7 @@ To deploy a local Universe containing your own set of packages you must build a 
 
 1.  Build the `mesosphere/universe` Docker image and compress it to the `local-universe.tar.gz`
 file. Specify a comma-separated list of package names and versions using the `DCOS_PACKAGE_INCLUDE`
-variable. To minimize the container size and download time, you can select only what you need. If you do not use the `DCOS_PACKAGE_INCLUDE` variable, all Certified Universe packages are
+variable. To minimize the container size and download time, you can select only what you need. If you do not use the `DCOS_PACKAGE_INCLUDE` variable, all Certified {{ model.packageRepo }} packages are
 included. To view which packages are Certified, click the **Catalog** tab in the DC/OS web
 interface.
 
@@ -274,5 +274,5 @@ interface.
     sudo make DCOS_VERSION=1.13 DCOS_PACKAGE_INCLUDE="cassandra:1.0.25-3.0.10,marathon:1.4.2" local-universe
     ```
 
-1.  Perform all of the steps as described in [Certified Universe packages](#certified).
+1.  Perform all of the steps as described in [Certified {{ model.packageRepo }} packages](#certified).
 

--- a/pages/1.13/administering-clusters/index.md
+++ b/pages/1.13/administering-clusters/index.md
@@ -5,7 +5,9 @@ title: Administering Clusters
 menuWeight: 60
 excerpt: Administering your DC/OS clusters
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 
-DC/OS makes it easy to set up and manage clusters.
+DC/OS makes it easy to set up and manage clusters. This section describes how to add and delete nodes, recover disk space, secure your cluster, and perform several other maintenance operations on your cluster.

--- a/pages/1.13/administering-clusters/licenses/index.md
+++ b/pages/1.13/administering-clusters/licenses/index.md
@@ -5,6 +5,8 @@ title: Licenses
 menuWeight: 1100
 enterprise: true
 excerpt: Administering your cluster in conformance with your license requirements
+render: mustache
+model: ../../data.yml
 ---
 
 The DC/OS licensing component allows you to administer your cluster in conformance with your license requirements. DC/OS licensing tracks the state of a cluster license, collects information to check if any licensing terms have been breached, and supports operations for updating the license when a contract is extended or changed.

--- a/pages/1.13/administering-clusters/licenses/license-api/index.md
+++ b/pages/1.13/administering-clusters/licenses/license-api/index.md
@@ -5,6 +5,8 @@ title: License API
 menuWeight: 3
 enterprise: true
 excerpt: Using the License API to manage your DC/OS license
+render: mustache
+model: ../../../data.yml
 ---
 # Routes
 
@@ -53,7 +55,6 @@ The License API also requires authorization via the following permissions:
 All routes can also be reached by users with the `dcos:superuser` permission.
 
 To assign permissions to your account, see the [permissions reference](/1.13/security/ent/perms-reference/).
-
 
 # API reference
 

--- a/pages/1.13/administering-clusters/licenses/license-cli/index.md
+++ b/pages/1.13/administering-clusters/licenses/license-cli/index.md
@@ -5,6 +5,8 @@ title: License CLI
 menuWeight: 0
 enterprise: true
 excerpt: Using the command line interface to manage your DC/OS license
+render: mustache
+model: ../../../data.yml
 ---
 
 The `dcos license` commands are also documented in the [CLI Command Reference](/1.13/cli/command-reference/dcos-license/) documentation.

--- a/pages/1.13/administering-clusters/locate-public-agent/index.md
+++ b/pages/1.13/administering-clusters/locate-public-agent/index.md
@@ -5,6 +5,8 @@ title: Finding a Public Agent IP
 menuWeight: 3
 excerpt: Finding a public agent IP address
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 After you have installed DC/OS with a public agent node declared, you can navigate to the public IP address of your public agent node. You can expose the public-facing IP address for an agent as a gateway for access to services that are running inside the DC/OS cluster. For example, if you are configuring load balancing to distribute inbound requests to the services in a cluster, the requests are typically routed through the public IP address frontend to an appropriate service instance backend isolated behind a firewall. 
 

--- a/pages/1.13/administering-clusters/managing-aws/index.md
+++ b/pages/1.13/administering-clusters/managing-aws/index.md
@@ -5,6 +5,8 @@ title: Managing AWS
 menuWeight: 9
 excerpt: Scaling your AWS cluster
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
 You can scale your AWS cluster or change the number of agent nodes.

--- a/pages/1.13/administering-clusters/multiple-clusters/cluster-connections/index.md
+++ b/pages/1.13/administering-clusters/multiple-clusters/cluster-connections/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Cluster Connections
 title: Cluster Connections
 menuWeight: 3
 excerpt: Connecting to multiple DC/OS clusters 
+render: mustache
+model: /data.yml
 ---
 
 You connect to multiple DC/OS clusters using [dcos cluster](/1.13/cli/command-reference/dcos-cluster/) commands.

--- a/pages/1.13/administering-clusters/multiple-clusters/cluster-link-api/index.md
+++ b/pages/1.13/administering-clusters/multiple-clusters/cluster-link-api/index.md
@@ -5,6 +5,8 @@ title: Cluster Link API
 menuWeight: 3
 excerpt: Managing cluster links with the Cluster Link API
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 You can use the Cluster Link API to manage cluster links.

--- a/pages/1.13/administering-clusters/multiple-clusters/cluster-links/index.md
+++ b/pages/1.13/administering-clusters/multiple-clusters/cluster-links/index.md
@@ -5,6 +5,8 @@ title: Cluster Links
 menuWeight: 3
 excerpt: Managing links between clusters
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 A cluster link is a **unidirectional** relationship between a cluster and another cluster.

--- a/pages/1.13/administering-clusters/multiple-clusters/index.md
+++ b/pages/1.13/administering-clusters/multiple-clusters/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Multiple Clusters
 title: Multiple Clusters
 menuWeight: 3
 excerpt: Using DC/OS to manage multiple clusters
+render: mustache
+model: ../../data.yml
 ---
 
 Organizations typically deploy and manage multiple DC/OS clusters. Multiple clusters are used for isolation (for example, testing versus production), accommodating geographic distribution, and so on. DC/OS multiple cluster operations make management and access of multiple DC/OS clusters easy for both operators and users.

--- a/pages/1.13/administering-clusters/package-registry/index.md
+++ b/pages/1.13/administering-clusters/package-registry/index.md
@@ -5,15 +5,17 @@ title: Package Registry
 menuWeight: 50
 excerpt: Using the web interface or CLI to manage your package repositories
 enterprise: true
+render: mustache
+model: ../../data.yml
 ---
 
 <!-- The source repo for this topic is https://github.com/dcos/dcos-docs-site -->
 
-DC/OS comes pre-configured with the [Mesosphere Universe](https://github.com/mesosphere/universe) package repository as the provider of DC/OS packages. However this assumes internet access which is not always possible. For air-gapped environments, DC/OS Enterprise offers the solution of package registry for a flexible and seamless management of your packages.
+DC/OS comes pre-configured with the [Mesosphere {{ model.packageRepo }}](https://github.com/mesosphere/universe) package repository as the provider of DC/OS packages. However this assumes Internet access, which is not always possible. For air-gapped environments, DC/OS Enterprise offers a package registry for a flexible and seamless management of your packages.
 
-For a full list of the configuration options available for the DC/OS Package Registry use the command `dcos package describe package-registry --config`. You can find more information about the `dcos package` commands in the [CLI documentation](/1.13/cli/command-reference/dcos-package/).
+For a full list of the configuration options available for the DC/OS Package Registry, use the command `dcos package describe package-registry --config`. You can find more information about the `dcos package` commands in the [CLI documentation](/1.13/cli/command-reference/dcos-package/).
 
-For a detailed description of how to configure and deploy DC/OS Services, see [Configuring Universe Services](/1.13/deploying-services/config-universe-service/).
+For a detailed description of how to configure and deploy DC/OS Services, see [Configuring {{ model.packageRepo }} Services](/1.13/deploying-services/config-universe-service/).
 
 # Default installation
 
@@ -27,33 +29,32 @@ dcos package install package-registry --cli --yes
 dcos registry activate
 ```
 
-The `registry activate` command uses the default options which is **NOT recommended** if you are installing in prod environments. Please read through the rest of the sections to creation an options file and then you can activate the package registry by executing:
+The `registry activate` command uses the default options, which are **NOT recommended** if you are installing in a production environment. Read through the rest of the sections to creation an options file, and then activate the package registry by executing the following command:
 
 ```bash
 dcos registry activate --options=<custom-options-file>
 ```
 
 # Configuration
+If you have a configuration file from one of the previous installations, you can skip this section and continue to the next section of installing the package-registry.
 
-Package registry can be configured with following options during deployment:
+Package registry can be configured with the following options during deployment:
 
-1. Storage Options (Local storage OR Mount Volumes OR S3 Compatible Storage)
-2. Serivice namespacing and secrets
+1. Storage Options (Local storage OR Mount Volumes OR S3-compatible Storage)
+2. Service namespacing and secrets
 
-If you have a config file from one of the previous installations, you can skip this section and continue to the next section of instalating the package-registry.
-
-## Storage Options
+## Storage options
 
 Package registry can be configured to use one of:
- 1. Local Storage
- 2. Mount Volumes OR
- 3. S3 Compatible storage
+- Local storage
+- Mount Volumes OR
+- S3-compatible storage
 
-Package registry would use local storage by default which is NOT recommended for production usage. Please configure a persistent volume or S3 compatible storage for production usage. If you are using this for developement purposes and wish to use local storage, skip to the next section.
+Package registry would use local storage by default, which is **NOT recommended** for production usage. Configure a persistent volume or S3-compatible storage for production usage. If you are using this for developement purposes and wish to use local storage, skip to the next section.
 
-### Mount volume Option
+### Mount volume option
 
-Refer to [Mount Volume Docs](/1.13/storage/mount-disk-resources/) to create mount volumes on DC/OS which includes an example that creates a loopback device. The rest of this guide assumes you have a mount volume created at `/dcos/package-registry`. You need to specify the `container-path` and a `pinned-hostname` which refers to the hostname of the agent the mount volume is mounted. Following options can be used to configure `package-registry` to use a mount volume :
+To create mount volumes on DC/OS, refer to the [Mount Volume](/1.13/storage/mount-disk-resources/) documentation, which includes an example that creates a loopback device. The rest of this guide assumes you have a mount volume created at `/dcos/package-registry`. You must specify the `container-path` and a `pinned-hostname`, which refers to the hostname of the agent on which the volume is mounted. The following options can be used to configure `package-registry` to use a mount volume :
 
 ```json
 {
@@ -68,32 +69,32 @@ Refer to [Mount Volume Docs](/1.13/storage/mount-disk-resources/) to create moun
 
 ### S3 Storage Option
 
-Given the default configuration of the DC/OS Package Registry, DC/OS Packages are stored in a local persistent volume in the host filesystem. When using this default storage configuration, you are limited to one instance of the registry. Package Registry also supports a highly available configuration by storing DC/OS Packages on a S3 compatible storage which supports deploying more than one instance of the registry.
+Given the default configuration of the DC/OS Package Registry, DC/OS Packages are stored in a local persistent volume in the host file system. When using this default storage configuration, you are limited to one instance of the registry. Package Registry also supports a highly available configuration by storing DC/OS Packages on S3-compatible storage, which supports deploying more than one instance of the registry.
 
-To configure a DC/OS Package Registry to store DC/OS Packages using S3 storage, you must provide following details :
+To configure a DC/OS Package Registry to store DC/OS Packages using S3 storage, you must provide the following details:
   1. Specific S3 endpoint.
   2. S3 bucket name and path.
   3. S3 access key and secret key.
 
 #### S3 Endpoint details
 
-When using Amazon S3, please refer to [Amazon S3 Regions & Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for more details on possible endpoints. Package registry has been tested and known to work with Amazon S3 and minio storage. It can work with any other S3 compatible storage. Please reach out if you face problems connecting with other S3 compatible storage.
+When using Amazon S3, refer to [Amazon S3 Regions & Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for more details on possible endpoints. Package registry has been tested and known to work with Amazon S3 and Minio storage. It can work with any other S3 compatible storage. Contact Mesosphere support if you face problems connecting with other S3 compatible storage.
 
 #### S3 bucket name and path
 
-The combiniation of S3 bucket name and path inside the bucket should be unique to each deployment of package registry. Multiple instances from each deployment would however ensure synchronized access to this bucket.
+The combiniation of an S3 bucket name and path inside the bucket should be unique to each deployment of Package registry. Multiple instances from each deployment will ensure synchronized access to this bucket.
 
 #### Upload the S3 credential to the DC/OS Secret store
 
-Create (or you an existing file) an s3 credential file and use it to create a file based secret in DC/OS.
+Create (or use an existing file) an S3 credential file and use it to create a file based secret in DC/OS.
 
 ```bash
 dcos security secrets create -f ~/.aws/credentials dcos-registry-s3-credential-file
 ```
 
-For information on how to create an AWS Credential file, please see the [AWS CLI User Guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html).
+For information on how to create an AWS Credential file, see the [AWS CLI User Guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html).
 
-The final `s3` config should something like this:
+The final `s3` config should look something like this:
 
 ```json
 {
@@ -111,16 +112,16 @@ The final `s3` config should something like this:
 
 <p class="message--note"><strong>NOTE: </strong>You must override the value for the properties <code>bucket</code>, <code>path</code> and <code>endpoint</code> to match the S3 configuration.</p>
 
-## Serivice namespacing and secrets
+## Service namespacing and secrets
 
-By default, package registry is installed as a marathon app with `dcos-registry` as its id. This name has somewhat unique significance because the `dockerd` on agents are configured to trust the package registry instance at `dcos-registry.marathon.l4lb.thisdcos.directory:443`. If you decide to change this name, you need to configure the `dockerd` to trust the custom name your registry is deployed at `<your-custom-name>.marathon.l4lb.thisdcos.directory:443`. For e.g. if you install registry under `/my/custom/dcos-registry` namespace, then ensure registry is accessible at `https://mycustomdcos-registry.marathon.l4lb.thisdcos.directory` (internal to cluster):
+By default, package registry is installed as a marathon app with `dcos-registry` as its ID. This name has unique significance because the `dockerd` on agents are configured to trust the package registry instance at `dcos-registry.marathon.l4lb.thisdcos.directory:443`. If you decide to change this name, you need to configure the `dockerd` to trust the custom name your registry is deployed at `<your-custom-name>.marathon.l4lb.thisdcos.directory:443`. For example, if you install package registry under `/my/custom/dcos-registry` namespace, then ensure that the registry is accessible at `https://mycustomdcos-registry.marathon.l4lb.thisdcos.directory` (internal to cluster):
 
 ```bash
 curl -k https://mycustomdcos-registry.marathon.l4lb.thisdcos.directory
 {"checks":{"/repo":{"Healthy":{"message":"Able to find 0 package(s)."}}}}
 ```
 
-You would also require your `dockerd` to trust the above domain name. To configure `dockerd` to trust package registry at `mycustomdcos-registry.marathon.l4lb.thisdcos.directory`, you can execute:
+You must also require your `dockerd` to trust the above domain name. To configure `dockerd` to trust package registry at `mycustomdcos-registry.marathon.l4lb.thisdcos.directory`, execute the following command:
 
 ```bash
 sudo mkdir -p /etc/docker/certs.d/mycustomdcos-registry.marathon.l4lb.thisdcos.directory
@@ -130,45 +131,45 @@ sudo systemctl restart docker
 
 <!-- TODO : Add more details on verification -->
 
-### Setup Service Account and Secret
+### Set Up Service Account and Secret
 
 DC/OS Package Registry needs a service account to be able to run in DC/OS Enterprise. Use the following procedure to create a service account with minimum permissions.
 
 1. Install the DC/OS Enterprise CLI:
 
-```bash
-dcos package install dcos-enterprise-cli --yes
-```
+    ```bash
+    dcos package install dcos-enterprise-cli --yes
+    ```
 
-2. Create a private/public key pair for the service account:
+1. Create a private/public key pair for the service account:
 
-```bash
-dcos security org service-accounts keypair private-key.pem public-key.pem
-```
+    ```bash
+    dcos security org service-accounts keypair private-key.pem public-key.pem
+    ```
 
-3. Create the service account:
+1. Create the service account:
 
-```bash
-dcos security org service-accounts create -p public-key.pem -d "dcos_registry service account" registry-account
-```
+    ```bash
+    dcos security org service-accounts create -p public-key.pem -d "dcos_registry service account" registry-account
+    ```
 
-4. Store private key in the Secret Store:
+1. Store private key in the Secret Store:
 
-```bash
-dcos security secrets create-sa-secret --strict private-key.pem registry-account registry-private-key
-```
+    ```bash
+    dcos security secrets create-sa-secret --strict private-key.pem registry-account registry-private-key
+    ```
 
-5. Give full permission to the service account:
+1. Give full permission to the service account:
 
-```bash
-dcos security org users grant registry-account dcos:adminrouter:ops:ca:rw full
-```
+    ```bash
+    dcos security org users grant registry-account dcos:adminrouter:ops:ca:rw full
+    ```
 
-<p class="message--important"><strong>IMPORTANT: </strong>The secret information associated with the service account is stored in a path called  <code>registry-private-key</code>  in the DC/OS Secret store. If using a different filename, substitute that for  <code>registry-private-key</code>  here. </p>
+<p class="message--important"><strong>IMPORTANT: </strong>The secret information associated with the service account is stored in a path called  <code>registry-private-key</code>  in the DC/OS Secret store. If using a different filename, substitute that for  <code>registry-private-key</code>. </p>
 
-<p class="message--warning"><strong>WARNING: </strong>These instructions create two sensitive files on the local file system: <code>private-key.pem</code> and <code>public-key.pem</code>. Please make sure to save these files in a secure place or delete them. They are not needed after being stored in the DC/OS Secret Store. </p>
+<p class="message--warning"><strong>WARNING: </strong>These instructions create two sensitive files on the local file system: <code>private-key.pem</code> and <code>public-key.pem</code>. Make sure to save these files in a secure place or delete them. They are not needed after being stored in the DC/OS Secret Store. </p>
 
-The service `instances`, `cpus`, `mem`, and `disk` can also be configured as needed. Execute the following command for getting an exhaustive list of all configuration options:
+The service `instances`, `cpus`, `mem`, and `disk` can also be configured as needed. Execute the following command to view an exhaustive list of all configuration options:
 
 ```bash
 dcos package describe package-registry --config
@@ -199,38 +200,38 @@ Here is a sample configuration file for the service:
 
 # Installation
 
-Now that you successfully created the config file (reffered to as `package-registry-options.json` from here on), you are ready to install the package registry. This can accomplished by following :
+Now that you have successfully created the config file (referred to as `package-registry-options.json` from here on), you are ready to install the package registry. This can accomplished by following :
 
 ```bash
 dcos package install package-registry --options=package-registry-options.json
 ```
 
-This would launch the marathon app for package-registry. This usually takes a couple of minutes. As soon as package-registry is healthy, you can add it as one of the package repositories in DC/OS. This can be done by:
+This would launch the Marathon app for `package-registry`. This usually takes a couple of minutes. As soon as `package-registry` is healthy, you can add it as one of the package repositories in DC/OS. This can be done by:
 
 ```bash
 # Change the repo name and URL if you need to customize
 dcos package repo add --index=0 "Registry" https://dcos-registry.marathon.l4lb.thisdcos.directory
 ```
 
-If you get errors in executing above command, wait for couple minutes (to account for the latency in package registry being healthy and its DNS entry being propogated to all master nodes) and try again.
+If you get errors in executing above command, wait for a couple of minutes (to account for the latency in `package-registry` being healthy and its DNS entry being propagated to all master nodes) and try again.
 
 # Using package registry
 
-After package registry is installed, you can start adding packages to it. There are two parts to this :
+After `package-registry` is installed, you can start adding packages to it. The two step process to use the package registry is as follows:
 
 1. Building the package files (`.dcos` files)
-2. Uploading the packages to package-registry.
+2. Uploading the packages to `package-registry`.
 
 
 ## Building the packages
 
-Mesosphere hosts all its certified packages at https://downloads.mesosphere.com/universe/packages/packages.html If the packages you need are available there, you can download them and skip to the next section of uploading these .dcos files to your cluster. When a universe catalog package is under development and you want to test it before creating a pull request OR if you want to build a non certified (community) package, this section is useful.
+Mesosphere hosts all its certified packages at https://downloads.mesosphere.com/universe/packages/packages.html. If the packages you need are available there, you can download them and skip to the next section of uploading these `.dcos` files to your cluster. When a {{ model.packageRepo }} package is under development and you want to test it before creating a pull request, or if you want to build a non certified (community) package, this section is useful.
 
 ### Requirements
 
-1.  Make sure you have the valid universe package defintion files([Schema here](https://github.com/mesosphere/universe/tree/version-3.x/repo/meta/schema)). Note that `package-registry` only support packages that are packaged with v4 or higher schema of universe packaging system. See [Creating a package](https://github.com/mesosphere/universe#creating-a-package) for more details.
-2. `docker` is installed in your system (**if** your package uses docker images).
-3. Package registry CLI needs to be installed as well. There are two ways to accomplish this.
+1.  Make sure you have the valid {{ model.packageRepo }} package definition files ([Schema](https://github.com/mesosphere/universe/tree/version-3.x/repo/meta/schema)). Note that `package-registry` only supports packages that are packaged with v4 or higher schemas of the {{ model.packageRepo }} packaging system. See [Creating a package](https://github.com/mesosphere/universe#creating-a-package) for more details.
+1. `docker` is installed in your system (**if** your package uses Docker images).
+1. The package registry CLI needs to be installed as well. There are two ways to accomplish this.
    1. Install `package-registry` CLI from a DC/OS cluster.
       ```bash
       # Install CLI subcommand "registry"
@@ -239,7 +240,8 @@ Mesosphere hosts all its certified packages at https://downloads.mesosphere.com/
       dcos registry --help
       ```
 
-   2. If you don't have access to a DC/OS Cluster (such as in CI/CD), download `package-registry` cli for [Linux](https://downloads.mesosphere.io/package-registry/binaries/cli/linux/x86-64/latest/dcos-registry-linux), [macOS](https://downloads.mesosphere.io/package-registry/binaries/cli/darwin/x86-64/latest/dcos-registry-darwin) or [Windows](https://downloads.mesosphere.io/package-registry/binaries/cli/windows/x86-64/latest/dcos-registry-windows.exe)
+   1. If you do not have access to a DC/OS Cluster (such as in CI/CD), download the `package-registry` CLI for [Linux](https://downloads.mesosphere.io/package-registry/binaries/cli/linux/x86-64/latest/dcos-registry-linux), [macOS](https://downloads.mesosphere.io/package-registry/binaries/cli/darwin/x86-64/latest/dcos-registry-darwin) or [Windows](https://downloads.mesosphere.io/package-registry/binaries/cli/windows/x86-64/latest/dcos-registry-windows.exe)
+
       ```bash
       # Change the URL based on macOS, linux or windows accordingly.
       curl -o dcos-registry https://downloads.mesosphere.io/package-registry/binaries/cli/darwin/x86-64/latest/dcos-registry-darwin
@@ -248,11 +250,11 @@ Mesosphere hosts all its certified packages at https://downloads.mesosphere.com/
       # Make sure the executable works
       ./dcos-registry registry --help
       ```
-      In the rest of the instructions in this page, we assume you have downloaded the subcommand from an attached DC/OS Cluster. If that is not your case, just replace `dcos` with `./dcos-registry` in your instructions.
+      In the rest of the instructions in this page, we assume you have downloaded the subcommand from an attached DC/OS Cluster. If that is not the case, replace `dcos` with `./dcos-registry` in your instructions.
 
 ### Instructions to generate `.dcos` bundle
 
-The `package-registry` cli can be used to bundle your package in to a `.dcos` file that can be used by the `package-registry`. Let us assume that the universe package files are in a directory called `/path/to/package/`. If you list the contents of the this folder, it should have the package definition files:
+The `package-registry` CLI can be used to bundle your package into a `.dcos` file that can be used by the `package-registry`. Assume that the {{ model.packageRepo }} package files are in a directory called `/path/to/package/`. It should contain the following package definition files:
 
 ```
 ➜ tree
@@ -262,7 +264,7 @@ The `package-registry` cli can be used to bundle your package in to a `.dcos` fi
 ├── package.json
 └── resource.json
 ```
-**Note**: All the assets URIs in the resource.json must be accessible to download from your environment. Relative file paths are accepted as well.
+<p class="message--note"><strong>NOTE: </strong>All the assets URIs in the <code>resource.json</code> must be accessible to download from your environment. Relative file paths are also accepted.</p>
 
 ```bash
 # Create a temporary work directory to store the build definition and other files necessary to create the bundle.
@@ -275,7 +277,7 @@ dcos registry migrate --package-directory=/path/to/package --output-directory=/p
 dcos registry build --build-definition-file=/path/to/output/<json-build-defintion-generated-above> --output-directory=/path/to/output
 ```
 
-If all the above steps are completed successfully your `/path/to/output` directory should look similar to:
+If all these steps are completed successfully, your `/path/to/output` directory should look similar to the following:
 
 ```
 ➜ tree
@@ -284,7 +286,7 @@ If all the above steps are completed successfully your `/path/to/output` directo
 └── <package-name>-<package-version>.json
 ```
 
-You can clean up the build defintion json file as it is no longer needed. Both the `build` and `migrate` subcommands accepts optional `--json` flag to support automation.
+You can clean up the build definition .json file, as it is no longer needed. Both the `build` and `migrate` subcommands accept an optional `--json` flag to support automation.
 
 After executing all the above steps, you should have a brand new `.dcos` file.
 
@@ -296,16 +298,16 @@ Now that you have all the `.dcos` files you need, you can continue to execute :
 dcos registry add --dcos-file <your-file>.dcos
 ```
 
-This is asynchronous and takes couple of minutes for the package to be visible in your catalog. Even if above command errors out (which can happen even on a successfull upload in slow network connections), you can track the status of upload by executing:
+This is asynchronous and takes couple of minutes for the package to be visible in your {{ model.packageRepo }}. Even if the above command errors out (which can happen even on a successful upload in slow network connections), you can track the status of the upload by executing:
 
 ```bash
 dcos registry describe --package-name=<package-name> --package-version=<package-version>
 ```
 
-Please be patient and wait for couple minutes for the package to be uploaded, processed and made visible in the catalog.
+Be patient and wait for couple minutes for the package to be uploaded, processed and made visible in the {{ model.packageRepo }}.
 
-See `dcos registry --help` for an exhaustive list of operations that you can use to manage the packages in package registry. The `registry` subcommand allows you to `add`, `remove` and `describe` a package.
+See `dcos registry --help` for an exhaustive list of operations that you can use to manage the packages in Package registry. The `registry` subcommand allows you to `add`, `remove` and `describe` a package.
 
 <p class="message--warning"><strong>WARNING: </strong>Removing a package while a service is still deployed may cause the service to stop working.</p>
 
-After doing the above, the rest of the flow is identical to packages fetched from Universe. Only difference is you don't need internet access (for customers with air-gapped environments) to install packages from `package-registry`.
+After executing the above instructions, the rest of the flow is identical to packages fetched from {{ model.packageRepo }}. The only difference is that you do not need Internet access (for customers with air-gapped environments) to install packages from `package-registry`.

--- a/pages/1.13/administering-clusters/recovering-agent-disk-space/index.md
+++ b/pages/1.13/administering-clusters/recovering-agent-disk-space/index.md
@@ -5,6 +5,8 @@ title: Recovering Agent Disk Space
 menuWeight: 900
 excerpt: Recovering space on an agent node volume
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
 If tasks fill up the reserved volume of an agent node, there are a few options to recover space:

--- a/pages/1.13/administering-clusters/replacing-a-master-node/index.md
+++ b/pages/1.13/administering-clusters/replacing-a-master-node/index.md
@@ -5,6 +5,8 @@ title: Replace a master node
 menuWeight: 800
 excerpt: Replacing a master node in an existing DC/OS cluster
 enterprise: true
+render: mustache
+model: ../../data.yml
 ---
 You can replace a master node in an existing DC/OS cluster. You should keep in mind, however, that you should only ever replace one master at a time. The following steps summarize how to replace a master node for a DC/OS cluster.
 

--- a/pages/1.13/administering-clusters/securing-your-cluster/index.md
+++ b/pages/1.13/administering-clusters/securing-your-cluster/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Securing a cluster
 title: Securing a cluster
 excerpt: Understanding the security features in DC/OS
 menuWeight: 7
+render: mustache
+model: ../../data.yml
 ---
 
 # General security concepts

--- a/pages/1.13/administering-clusters/sshcluster/index.md
+++ b/pages/1.13/administering-clusters/sshcluster/index.md
@@ -5,6 +5,8 @@ title: SSHing into Nodes
 menuWeight: 0
 excerpt: Setting up an SSH connection into your DC/OS cluster 
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
 

--- a/pages/1.13/administering-clusters/update-a-node/index.md
+++ b/pages/1.13/administering-clusters/update-a-node/index.md
@@ -5,6 +5,8 @@ title: Updating Nodes
 menuWeight: 801
 excerpt: Updating agent nodes in an active DC/OS cluster
 enterprise: false
+render: mustache
+model: ../../data.yml
 ---
 
 You can update agent nodes in an active DC/OS cluster by using maintenance windows or by manually killing agents. Maintenance windows are the preferred method since this is generally more stable and less error prone.

--- a/pages/1.13/api/access/index.md
+++ b/pages/1.13/api/access/index.md
@@ -5,6 +5,8 @@ title: Cluster Access
 menuWeight: 1
 excerpt: Gaining access to a cluster URL
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Gaining access to a cluster URL

--- a/pages/1.13/api/agent-routes/index.md
+++ b/pages/1.13/api/agent-routes/index.md
@@ -4,6 +4,8 @@ navigationTitle: Agent Routes
 title: Agent Routes
 menuWeight: 11
 excerpt: Admin Router running on DC/OS agent nodes.
+render: mustache
+model: /data.yml
 ---
 Admin Router Agent runs on DC/OS agent nodes. It exposes the following API routes.
 

--- a/pages/1.13/api/endpoints.yaml
+++ b/pages/1.13/api/endpoints.yaml
@@ -101,7 +101,7 @@ definitions:
         example: false
       packageVersion:
         type: string
-        description: The DC/OS GUI package version as found in Universe. This is usually a semantic version, or 'Default' if the current DC/OS GUI is the default.
+        description: The DC/OS GUI package version as found in {{ model.packageRepo }}. This is usually a semantic version, or 'Default' if the current DC/OS GUI is the default.
         example: 1.0.0
       buildVersion:
         type: string

--- a/pages/1.13/api/index.md
+++ b/pages/1.13/api/index.md
@@ -5,6 +5,8 @@ title: API Reference
 menuWeight: 150
 excerpt: DC/OS API reference manual
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 The DC/OS API is a collection of routes backed by [DC/OS components](/1.13/overview/architecture/components/) that are made available through an API gateway called [Admin Router](/1.13/overview/architecture/components/#admin-router).

--- a/pages/1.13/api/master-routes/index.md
+++ b/pages/1.13/api/master-routes/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Master Routes
 title: Master Routes
 menuWeight: 10
 excerpt: Admin Router running on DC/OS master nodes
+render: mustache
+model: /data.yml
 ---
 The Admin Router runs on DC/OS master nodes. It exposes the API routes shown below. Admin Router listens on port `80` (HTTP) and `443` (HTTPS).
 

--- a/pages/1.13/api/package-manager.yaml
+++ b/pages/1.13/api/package-manager.yaml
@@ -753,7 +753,7 @@ paths:
     post:
       consumes:
         - application/vnd.dcos.package.install-request+json;charset=utf-8;version=v1
-      description: Runs a service from a Universe package.
+      description: Runs a service from a Catalog package.
       operationId: POST-package-install
       parameters:
         - in: body
@@ -849,7 +849,7 @@ paths:
     post:
       consumes:
         - application/vnd.dcos.package.repository.add-request+json;charset=utf-8;version=v1
-      description: Adds a package repository (for example Universe) for use by DC/OS. To add a package repository to the beginning of the list set the index to zero (0). To add a package repository to the end of the list do not specify an index.
+      description: Adds a package repository (for example Catalog) for use by DC/OS. To add a package repository to the beginning of the list set the index to zero (0). To add a package repository to the end of the list do not specify an index.
       operationId: POST-package-repository-add
       parameters:
         - in: body
@@ -873,7 +873,7 @@ paths:
     post:
       consumes:
         - application/vnd.dcos.package.repository.delete-request+json;charset=utf-8;version=v1
-      description: Deletes a package repository (for example Universe) from DC/OS.
+      description: Deletes a package repository (for example Catalog) from DC/OS.
       operationId: POST-package-repository-delete
       parameters:
         - in: body
@@ -897,7 +897,7 @@ paths:
     post:
       consumes:
         - application/vnd.dcos.package.repository.list-request+json;charset=utf-8;version=v1
-      description: ' List all of the package repositories (for example Universe) used by DC/OS. The list is ordered by priority; if multiple repositories contain the same package, the package closest to the start of the list will be used.'
+      description: ' List all of the package repositories (for example Catalog) used by DC/OS. The list is ordered by priority; if multiple repositories contain the same package, the package closest to the start of the list will be used.'
       operationId: POST-package-repository-list
       parameters:
         - in: body

--- a/pages/1.13/api/versioning/index.md
+++ b/pages/1.13/api/versioning/index.md
@@ -5,6 +5,8 @@ title: API Versioning
 menuWeight: 2
 excerpt: Understanding component, resource, and route versioning
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 The DC/OS API is backed by many loosely coupled components; some are standalone projects and others are designed exclusively for DC/OS. Because of this, a variety of versioning mechanisms are supported: component, route, and resource versioning.

--- a/pages/1.13/cli/autocompletion/index.md
+++ b/pages/1.13/cli/autocompletion/index.md
@@ -5,6 +5,8 @@ title: CLI Autocompletion
 menuWeight: 7
 excerpt: Enabling autocompletion for the CLI
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 Autocompletion for the CLI is supported for `bash` and `zsh`. This allows you to press TAB to get access to subcommands and autocomplete the ones you are writing.

--- a/pages/1.13/cli/command-reference/dcos-auth/dcos-auth-list-providers/index.md
+++ b/pages/1.13/cli/command-reference/dcos-auth/dcos-auth-list-providers/index.md
@@ -5,6 +5,8 @@ title: dcos auth list-providers
 menuWeight: 1
 excerpt: Listing login providers for a cluster
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-auth/dcos-auth-login/index.md
+++ b/pages/1.13/cli/command-reference/dcos-auth/dcos-auth-login/index.md
@@ -5,6 +5,8 @@ title: dcos auth login
 menuWeight: 2
 excerpt: Log-in to your DC/OS cluster
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-auth/dcos-auth-logout/index.md
+++ b/pages/1.13/cli/command-reference/dcos-auth/dcos-auth-logout/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos auth logout
 title: dcos auth logout
 menuWeight: 3
 excerpt: Logging out of a DC/OS cluster
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-auth/index.md
+++ b/pages/1.13/cli/command-reference/dcos-auth/index.md
@@ -5,6 +5,8 @@ title: dcos auth
 menuWeight: 1
 excerpt: Managing DC/OS identity and access
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-create/index.md
+++ b/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-create/index.md
@@ -5,6 +5,8 @@ title: dcos backup create
 menuWeight: 10
 excerpt: Creating backups
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-delete/index.md
@@ -5,6 +5,8 @@ title: dcos backup delete
 menuWeight: 20
 excerpt: Deleting backups
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-list/index.md
@@ -5,6 +5,8 @@ title: dcos backup list
 menuWeight: 30
 excerpt: Listing backups
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-restore/index.md
+++ b/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-restore/index.md
@@ -5,6 +5,8 @@ title: dcos backup restore
 menuWeight: 30
 excerpt: Restoring from a backup
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-backup/dcos-backup-show/index.md
@@ -5,6 +5,8 @@ title: dcos backup show
 menuWeight: 50
 excerpt: Viewing details of a backup
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-backup/index.md
+++ b/pages/1.13/cli/command-reference/dcos-backup/index.md
@@ -5,6 +5,8 @@ title: dcos backup
 menuWeight: 2
 excerpt: Creating backups and restoring from them
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-attach/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-attach/index.md
@@ -5,6 +5,8 @@ title: dcos cluster attach
 menuWeight: 2
 excerpt: Attaching the CLI to a connected or linked cluster
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-link/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-link/index.md
@@ -5,6 +5,8 @@ title: dcos cluster link
 menuWeight: 3
 excerpt: Linking a connected cluster to another cluster
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-list/index.md
@@ -5,6 +5,8 @@ title: dcos cluster list
 menuWeight: 3
 excerpt: Listing connected clusters
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-remove/index.md
@@ -5,6 +5,8 @@ title: dcos cluster remove
 menuWeight: 4
 excerpt: Removing a connected cluster from the DC/OS CLI
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-rename/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-rename/index.md
@@ -5,6 +5,8 @@ title: dcos cluster rename
 menuWeight: 5
 excerpt: Renaming a cluster
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-setup/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-setup/index.md
@@ -5,6 +5,8 @@ title: dcos cluster setup
 menuWeight: 6
 excerpt: Configuring the CLI to communicate with a cluster
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-unlink/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/dcos-cluster-unlink/index.md
@@ -5,6 +5,8 @@ title: dcos cluster unlink
 menuWeight: 3
 excerpt: Unlinking a cluster from another cluster
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-cluster/index.md
+++ b/pages/1.13/cli/command-reference/dcos-cluster/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos cluster
 title: dcos cluster
 menuWeight: 3
 excerpt: Managing connections to DC/OS clusters
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-config/dcos-config-set/index.md
+++ b/pages/1.13/cli/command-reference/dcos-config/dcos-config-set/index.md
@@ -5,6 +5,8 @@ title: dcos config set
 menuWeight: 1
 excerpt: Adding or setting DC/OS configuration properties
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-config/dcos-config-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-config/dcos-config-show/index.md
@@ -5,6 +5,8 @@ title: dcos config show
 menuWeight: 2
 excerpt: Showing the cluster configuration file
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-config/dcos-config-unset/index.md
+++ b/pages/1.13/cli/command-reference/dcos-config/dcos-config-unset/index.md
@@ -5,6 +5,8 @@ title: dcos config unset
 menuWeight: 3
 excerpt: Removing a property from the configuration file
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-config/index.md
+++ b/pages/1.13/cli/command-reference/dcos-config/index.md
@@ -5,6 +5,8 @@ title: dcos config
 menuWeight: 4
 excerpt: Managing the DC/OS configuration file
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-help/index.md
+++ b/pages/1.13/cli/command-reference/dcos-help/index.md
@@ -1,10 +1,12 @@
 ---
 layout: layout.pug
-navigationTitle:  dcos help
+navigationTitle: dcos help
 title: dcos help
 menuWeight: 7
 excerpt: Displaying DC/OS CLI help information
-dcos helpenterprise: false
+enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-add/index.md
@@ -5,6 +5,8 @@ title: dcos job add
 menuWeight: 0
 excerpt: Adding a job
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-history/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-history/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos job history
 title: dcos job history
 menuWeight: 1
 excerpt: Displaying the job run history
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-kill/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-kill/index.md
@@ -5,6 +5,8 @@ title: dcos job kill
 menuWeight: 2
 excerpt: Ending DC/OS jobs
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-list/index.md
@@ -5,6 +5,8 @@ title: dcos job list
 menuWeight: 3
 excerpt: Displaying all job definitions
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-remove/index.md
@@ -5,6 +5,8 @@ title: dcos job remove
 menuWeight: 4
 excerpt: Removing jobs
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-run/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-run/index.md
@@ -5,6 +5,8 @@ title: dcos job run
 menuWeight: 5
 excerpt: Running a DC/OS job
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-add/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos job schedule add
 title: dcos job schedule add
 menuWeight: 6
 excerpt: Adding a schedule to a job
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-remove/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos job schedule remove
 title: dcos job schedule remove
 menuWeight: 7
 excerpt: Removing a job schedule
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-show/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos job schedule show
 title: dcos job schedule show
 menuWeight: 8
 excerpt: Viewing a job schedule
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-update/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-schedule-update/index.md
@@ -5,6 +5,8 @@ title: dcos job schedule update
 menuWeight: 9
 excerpt: Updating a job schedule
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-show-runs/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-show-runs/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos job show runs
 title: dcos job show runs
 menuWeight: 11
 excerpt: Displaying the status of job runs
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-show/index.md
@@ -5,6 +5,8 @@ title: dcos job show
 menuWeight: 10
 excerpt: Displaying job definitions
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-job/dcos-job-update/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/dcos-job-update/index.md
@@ -5,6 +5,8 @@ title: dcos job update
 menuWeight: 12
 excerpt: Updating a job
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-job/index.md
+++ b/pages/1.13/cli/command-reference/dcos-job/index.md
@@ -5,6 +5,8 @@ title: dcos job
 menuWeight: 8
 excerpt: Deploying and managing jobs in DC/OS
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-license/dcos-license-audit/index.md
+++ b/pages/1.13/cli/command-reference/dcos-license/dcos-license-audit/index.md
@@ -5,6 +5,8 @@ title: dcos license audit
 menuWeight: 1
 excerpt: Getting the cluster license audit records
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-license/dcos-license-get/index.md
+++ b/pages/1.13/cli/command-reference/dcos-license/dcos-license-get/index.md
@@ -5,6 +5,8 @@ title: dcos license get
 menuWeight: 2
 excerpt: Displaying the cluster licenses
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-license/dcos-license-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-license/dcos-license-list/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos license list
 title: dcos license list
 menuWeight: 3
 excerpt: Displaying the cluster licenses
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-license/dcos-license-renew/index.md
+++ b/pages/1.13/cli/command-reference/dcos-license/dcos-license-renew/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos license renew
 title: dcos license renew
 menuWeight: 3
 excerpt: Renewing a cluster license
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-license/dcos-license-status/index.md
+++ b/pages/1.13/cli/command-reference/dcos-license/dcos-license-status/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos license status
 title: dcos license status
 menuWeight: 4
 excerpt: Reviewing the cluster license status
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-license/index.md
+++ b/pages/1.13/cli/command-reference/dcos-license/index.md
@@ -5,6 +5,8 @@ title: dcos license
 excerpt: Managing your DC/OS licenses
 menuWeight: 9
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 The `dcos license` commands allow you to review the status of your license, audit your license, and get or renew a license.
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-about/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-about/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon about
 title: dcos marathon about
 menuWeight: 0
 excerpt: Displays the info.json file for DC/OS Marathon
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon app add
 title: dcos marathon app add
 menuWeight: 1
 excerpt: Adding an application
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-kill/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-kill/index.md
@@ -5,6 +5,8 @@ title: dcos marathon app kill
 menuWeight: 2
 excerpt: Killing an active application instance
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-list/index.md
@@ -5,6 +5,8 @@ title: dcos marathon app list
 menuWeight: 3
 excerpt: Displaying all installed applications
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-remove/index.md
@@ -5,6 +5,8 @@ title: dcos marathon app remove
 menuWeight: 4
 excerpt: Removing an application
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-restart/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-restart/index.md
@@ -5,6 +5,8 @@ title: dcos marathon app restart
 menuWeight: 5
 excerpt: Restarting an application
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-show/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon app show
 title: dcos marathon app show
 menuWeight: 6
 excerpt: Viewing the json file for an app
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-start/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-start/index.md
@@ -5,6 +5,8 @@ title: dcos marathon app start
 menuWeight: 7
 excerpt: Starting an application
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-stop/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-stop/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon app stop
 title: dcos marathon app stop
 menuWeight: 8
 excerpt: Stopping an application
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-update/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-update/index.md
@@ -4,8 +4,11 @@ navigationTitle:  dcos marathon app update
 title: dcos marathon app update
 menuWeight: 9
 excerpt: Updating an application
-
+render: mustache
+model: /data.yml
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-debug-details/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-debug-details/index.md
@@ -5,6 +5,8 @@ title: dcos marathon debug details
 menuWeight: 11
 excerpt: Displaying debugging information for Marathon applications
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-debug-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-debug-list/index.md
@@ -5,6 +5,8 @@ title: dcos marathon debug list
 menuWeight: 12
 excerpt: Displaying the current queue of Marathon app deployments
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-debug-summary/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-debug-summary/index.md
@@ -5,6 +5,8 @@ title: dcos marathon debug summary
 menuWeight: 13
 excerpt: Display the debugging queue of waiting Marathon app deployments
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-list/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon deployment list
 title: dcos marathon deployment list
 menuWeight: 14
 excerpt: Displaying a list of currently deployed applications
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-rollback/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-rollback/index.md
@@ -5,6 +5,8 @@ title: dcos marathon deployment rollback
 menuWeight: 15
 excerpt: Removing a deployed application
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-stop/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-stop/index.md
@@ -5,6 +5,8 @@ title: dcos marathon deployment stop
 menuWeight: 16
 excerpt: Cancelling in-progress application deployment
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-watch/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-deployment-watch/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon deployment watch
 title: dcos marathon deployment watch
 menuWeight: 16
 excerpt: Monitoring application deployments
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-add/index.md
@@ -5,6 +5,8 @@ title: dcos marathon group add
 menuWeight: 17
 excerpt: Adding a Marathon group
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-list/index.md
@@ -5,6 +5,8 @@ title: dcos marathon group list
 menuWeight: 18
 excerpt: Displaying the list of groups
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-remove/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon group remove
 title: dcos marathon group remove
 menuWeight: 19
 excerpt: Removing a Marathon application from DC/OS
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-scale/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-scale/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon group scale
 title: dcos marathon group scale
 menuWeight: 20
 excerpt: Scaling a group
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-show/index.md
@@ -5,6 +5,8 @@ title: dcos marathon group show
 menuWeight: 21
 excerpt: Display a list of groups
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-update/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-group-update/index.md
@@ -5,6 +5,8 @@ title: dcos marathon group update
 menuWeight: 22
 excerpt: Updating Marathon group properties
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-add/index.md
@@ -5,6 +5,8 @@ title: dcos marathon pod add
 menuWeight: 23
 excerpt: Adding a pod
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-kill/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-kill/index.md
@@ -5,6 +5,8 @@ title: dcos marathon pod kill
 menuWeight: 24
 excerpt: Stopping one or more running pod instances
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-list/index.md
@@ -5,6 +5,8 @@ title: dcos marathon pod list
 menuWeight: 25
 excerpt: Viewing the deployed pods
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-remove/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos marathon pod remove
 title: dcos marathon pod remove
 menuWeight: 26
 excerpt: Removing a pod
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-show/index.md
@@ -5,6 +5,8 @@ title: dcos marathon pod show
 menuWeight: 27
 excerpt: Displaying detailed information for a specific pod
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-update/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-pod-update/index.md
@@ -5,6 +5,8 @@ title: dcos marathon pod update
 menuWeight: 28
 excerpt: Updating a Marathon pod
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-task-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-task-list/index.md
@@ -5,6 +5,8 @@ title: dcos marathon task list
 menuWeight: 29
 excerpt: Displaying all tasks
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-task-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-task-show/index.md
@@ -5,6 +5,8 @@ title: dcos marathon task show
 menuWeight: 30
 excerpt: Displaying information about a specific task
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-task-stop/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/dcos-marathon-task-stop/index.md
@@ -4,13 +4,14 @@ navigationTitle:  dcos marathon task stop
 title: dcos marathon task stop
 menuWeight: 31
 excerpt: Stopping a task
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
 
 # Description
-the `dcos marathon task stop` command allows you to stop a task.
+The `dcos marathon task stop` command allows you to stop a task.
 
 # Usage
 

--- a/pages/1.13/cli/command-reference/dcos-marathon/index.md
+++ b/pages/1.13/cli/command-reference/dcos-marathon/index.md
@@ -5,6 +5,8 @@ title: dcos marathon
 menuWeight: 10
 excerpt: Deploying and managing applications to DC/OS using Marathon
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-decommission/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-decommission/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos node decommission
 excerpt: Decommissioning a DC/OS node
 title: dcos node decommission
 menuWeight: 1
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -5,6 +5,8 @@ title: dcos node diagnostics create
 menuWeight: 3
 excerpt: Creating a diagnostics bundle
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-delete/index.md
@@ -5,6 +5,8 @@ title: dcos node diagnostics delete
 menuWeight: 4
 excerpt: Displaying the details of diagnostics bundles
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-download/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-download/index.md
@@ -5,6 +5,8 @@ title: dcos node diagnostics download
 menuWeight: 5
 excerpt: Downloading the diagnostics bundle
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics/index.md
@@ -5,6 +5,8 @@ title: dcos node diagnostics
 menuWeight: 2
 excerpt: Displaying the details of diagnostics bundles
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-dns/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-dns/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos node dns
 title: dcos node dns
 menuWeight: 6
 excerpt: Viewing DC/OS node information
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-list-components/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-list-components/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos node list-components
 title: dcos node list-components
 menuWeight: 7
 excerpt: Displaying the available DC/OS components on a specified node
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-list/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos node list
 title: dcos node list
 menuWeight: 6
 excerpt: Displaying DC/OS node information
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-log/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-log/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos node log
 title: dcos node log
 menuWeight: 9
 excerpt: Displaying Mesos logs for nodes
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-metrics-details/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-metrics-details/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos node metrics details
 title: dcos node metrics details
 menuWeight: 10
 excerpt: Displaying the details of Mesos agent nodes
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-metrics-summary/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-metrics-summary/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos node metrics summary
 title: dcos node metrics summary
 menuWeight: 11
 excerpt: Summarizing the details of Mesos agent nodes
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-node/dcos-node-ssh/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/dcos-node-ssh/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos node ssh
 title: dcos node ssh
 menuWeight: 15
 excerpt: Establishing an SSH connection to master or agent nodes
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-node/index.md
+++ b/pages/1.13/cli/command-reference/dcos-node/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos node
 title: dcos node
 menuWeight: 11
 excerpt: Displaying DC/OS node information
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-describe/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-describe/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  dcos package describe
 title: dcos package describe
 menuWeight: 0
+render: mustache
+model: /data.yml
 excerpt: Fetching details for a package
 enterprise: false
 ---

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-install/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-install/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos package install
 title: dcos package install
 menuWeight: 1
 excerpt: Installing a package
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-list/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos package list
 title: dcos package list
 menuWeight: 2
 excerpt: Displaying a list of the installed DC/OS packages
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-add/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos package repo add
 title: dcos package repo add
 menuWeight: 3
 excerpt: Adding a package repository to DC/OS
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -21,13 +23,13 @@ dcos package repo add <repo-name> <repo-url> [--index=<index>]
 | Name | Description |
 |---------|-------------|
 | `-h`, `--help` | Display usage. |
-| `--index=<index>`   | The numerical position in the package repository list. Package repositories are searched in descending order. By default, the Universe repository first in the list. |
+| `--index=<index>`   | The numerical position in the package repository list. Package repositories are searched in descending order. By default, the {{ model.packageRepo }} repository first in the list. |
 
 ## Positional arguments
 
 | Name |  Description |
 |---------|-------------|
-| `<repo-name>`   |   Name of the package repository. For example, `Universe`. |
+| `<repo-name>`   |   Name of the package repository. For example, `{{ model.packageRepo }}`. |
 | `<repo-url>`   |   URL of the package repository. For example, https://universe.mesosphere.com/repo. |
 
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-import/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-import/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos package repo import
 title: dcos package repo import
 menuWeight: 4
 excerpt: Adding a package repository to DC/OS
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-list/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos package repo list
 title: dcos package repo list
 menuWeight: 6
 excerpt: Displaying the package repository sources
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-repo-remove/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos package repo remove
 title: dcos package repo remove
 menuWeight: 9
 excerpt: Removing a package repository from DC/OS
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -28,7 +29,7 @@ dcos package repo remove <repo-names>...
 
 | Name |  Description |
 |---------|-------------|
-| `<repo-name>`   |   Name of the package repository. For example, `Universe`. |
+| `<repo-name>`   |   Name of the package repository. For example, `{{ model.packageRepo }}`. |
 
 
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-search/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-search/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos package search
 title: dcos package search
 menuWeight: 6
 excerpt: Searching the package repository
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-package/dcos-package-uninstall/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/dcos-package-uninstall/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  dcos package uninstall
 title: dcos package uninstall
 menuWeight: 7
+render: mustache
+model: /data.yml
 excerpt: Uninstalling a package
 enterprise: false
 ---

--- a/pages/1.13/cli/command-reference/dcos-package/index.md
+++ b/pages/1.13/cli/command-reference/dcos-package/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos package
 title: dcos package
 menuWeight: 12
 excerpt: Installing and managing DC/OS service packages
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-plugin/dcos-plugin-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-plugin/dcos-plugin-add/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos plugin add
 title: dcos plugin add
 menuWeight: 1
 excerpt: Adding a CLI plugin
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-plugin/dcos-plugin-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-plugin/dcos-plugin-list/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos plugin list
 title: dcos plugin list
 menuWeight: 2
 excerpt: Displaying a list of the installed CLI plugins
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-plugin/dcos-plugin-remove/index.md
+++ b/pages/1.13/cli/command-reference/dcos-plugin/dcos-plugin-remove/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos plugin remove
 title: dcos plugin remove
 menuWeight: 7
 excerpt: Uninstalling a plugin
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-plugin/index.md
+++ b/pages/1.13/cli/command-reference/dcos-plugin/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos plugin
 title: dcos plugin
 menuWeight: 12
 excerpt: Installing and managing DC/OS CLI plugins
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-cacert/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-cacert/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster ca cacert
 title: dcos security cluster ca
 menuWeight: 12
 excerpt: Interacting with the DC/OS cluster CA
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-newcert/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-newcert/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster ca newcert
 title: dcos security cluster ca newcert
 menuWeight: 5
 excerpt: Creating and signing a new certificate
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-newkey/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-newkey/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos security cluster ca newkey
 title: dcos security cluster ca newkey
 menuWeight: 13
 excerpt: Creating a new key and a new CSR
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-profile/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-profile/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster ca profile
 title: dcos security cluster ca profile
 menuWeight: 15
 excerpt: Managing the DC/OS Certificate Authority
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-sign/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/dcos-security-cluster-ca-sign/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster ca sign
 title: dcos security cluster ca sign
 menuWeight: 20
 excerpt: Signing a CSR
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-ca/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster ca
 title: dcos security cluster ca
 menuWeight: 1
 excerpt: Interacting with the DC/OS cluster CA
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-get_config/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-get_config/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster directory get_config
 title: dcos security cluster directory get_config
 menuWeight: 32
 excerpt: Retrieving an LDAP configuration
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-import-group/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-import-group/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster directory import_group
 title: dcos security cluster directory import_group
 menuWeight: 33
 excerpt: Importing an LDAP group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-import-user/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-import-user/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster directory import_user
 title: dcos security cluster directory import_user
 menuWeight: 35
 excerpt: Importing a user from an LDAP backend
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-test/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/dcos-security-cluster-directory-test/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster directory test
 title: dcos security cluster directory test
 menuWeight: 40
 excerpt: Testing a connection to an LDAP backend
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-directory/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster directory
 title: dcos security cluster directory
 menuWeight: 30
 excerpt: Managing LDAP related settings 
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-add/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster oidc add
 title: dcos security cluster oidc add
 menuWeight: 13
 excerpt: Configuring a new OpenID Connect provider
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-delete/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster oidc delete
 title: dcos security cluster oidc delete
 menuWeight: 50
 excerpt: Deleting an OIDC provider configuration
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-modify/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-modify/index.md
@@ -4,6 +4,8 @@ navigationTitle:  cos security cluster oidc modify
 title: cos security cluster oidc modify
 menuWeight: 60
 excerpt: Modifying an existing OIDC provider configuration
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/dcos-security-cluster-oidc-show/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster oidc show
 title: dcos security cluster oidc show
 menuWeight: 65
 excerpt: Viewing the DC/OS Certificate Authority information
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-oidc/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster oidc
 title:  dcos security cluster oidc 
 menuWeight: 13
 excerpt: Managing OpenID Connect settings
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-add/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-add/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster saml add
 title: dcos security cluster saml add
 menuWeight: 70
 excerpt: Configuring a new SAML provider
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-delete/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster saml delete
 title: dcos security cluster saml delete
 menuWeight: 13
 excerpt: Deleting a SAML provider configuration
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-modify/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-modify/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster saml modify
 title: dcos security cluster saml modify
 menuWeight: 80
 excerpt: Modifying an existing SAML provider configuration
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/dcos-security-cluster-saml-show/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster saml show
 title: dcos security cluster saml show
 menuWeight: 85
 excerpt: Viewing an existing SAML provider configuration
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-saml/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster saml
 title: dcos security cluster saml 
 menuWeight: 70
 excerpt: Managing SAML settings
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-seal-status/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-seal-status/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster secret-store seal-status
 title: dcos security cluster secret-store seal-status
 menuWeight: 92
 excerpt: Viewing the seal status of a secrets store
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-show/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster secret-store show
 title: dcos security cluster secret-store show
 menuWeight: 95
 excerpt: Viewing the configured secrets stores
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-status/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-status/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster secret-store status
 title: dcos security cluster secret-store status
 menuWeight: 105
 excerpt: Managing the DC/OS Certificate Authority
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-unseal/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/dcos-security-cluster-secret-store-unseal/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster secret-store unseal
 title: dcos security cluster secret-store unseal
 menuWeight: 115
 excerpt: Unsealing a secret store
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/dcos-security-cluster-secret-store/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  dcos security cluster secret-store 
 title: dcos security cluster secret-store
 menuWeight: 80
+render: mustache
+model: /data.yml
 excerpt: Viewing your secrets store settings
 enterprise: true
 ---

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-cluster/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security cluster
 title: dcos security cluster
 menuWeight: 10
 excerpt: Cluster management commands
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-add-user/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-add-user/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups add_user
 title: dcos security org groups add_user
 menuWeight: 125
 excerpt: Adding a user to a group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-create/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-create/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups create
 title: dcos security org groups create
 menuWeight: 130
 excerpt: Creating a user group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-del-user/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-del-user/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups del_user
 title: dcos security org groups del_user
 menuWeight: 135
 excerpt: Deleting a user from a group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-delete/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups delete
 title: dcos security org groups delete
 menuWeight: 140
 excerpt: Deleting a group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-grant/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-grant/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups grant
 title: dcos security org groups grant
 menuWeight: 143
 excerpt: Granting permissions to a group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-members/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-members/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups members
 title: dcos security org groups members
 menuWeight: 145
 excerpt: Listing members of a group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-revoke/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-revoke/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups revoke
 title: dcos security org groups revoke
 menuWeight: 155
 excerpt: Revoke permission for a group to act on a resource
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/dcos-security-org-groups-show/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups show
 title: dcos security org groups show
 menuWeight: 155
 excerpt: Viewing information about a group
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-groups/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org groups
 title: dcos security org groups
 menuWeight: 120
 excerpt: Managing groups and group membership
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 # Description

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-create/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-create/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org service-accounts create
 title: dcos security org service-accounts create
 menuWeight: 165
 excerpt: Creating a service account
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-delete/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org service-accounts delete
 title: dcos security org service-accounts delete
 menuWeight: 170
 excerpt: Deleting a service account
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-keypair/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-keypair/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org service-accounts keypair
 title: dcos security org service-accounts keypair
 menuWeight: 175
 excerpt: Creating a public-private keypair
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/dcos-security-org-service-accounts-show/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org service-accounts show
 title: dcos security org service-accounts show
 menuWeight: 180
 excerpt: Showing service account details
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-service-accounts/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org service-accounts
 title: dcos security org service-accounts
 menuWeight: 160
 excerpt: Revoke permission for a group to act on a resource
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-create/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-create/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org users create
 title: dcos security org users create
 menuWeight: 190
 excerpt: Creating new users
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-delete/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org users delete
 title: dcos security org users delete
 menuWeight: 195
 excerpt: Deleting a user
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-grant/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-grant/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org users grant
 title: dcos security org users grant
 menuWeight: 205
 excerpt: Grant user permissions
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-revoke/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-revoke/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org users revoke
 title: dcos security org users revoke
 menuWeight: 205
 excerpt: Revoking user permissions
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-show/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/dcos-security-org-users-show/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org users show
 title: dcos security org users show
 menuWeight: 210
 excerpt: Showing user information
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/dcos-security-org-users/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org users
 title: dcos security org users
 menuWeight: 185
 excerpt: Managing users
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-org/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security org
 title: dcos security org
 menuWeight: 10
 excerpt: Account management commands
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 The `dcos security org` commands allow you to manage your account. You can add users, create groups, and then add or delete members of those groups. You can also control what permissions are granted to users and groups, configure service accounts, and show the details of your accounts.

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-create-sa-secret/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-create-sa-secret/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security secrets create-sa-secret
 title: dcos security secrets create-sa-secret
 menuWeight: 305
 excerpt: Creating and storing a secret
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-create/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-create/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security secrets create
 title: dcos security secrets create
 menuWeight: 300
 excerpt: Creating and storing a secret
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-delete/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-delete/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security secrets delete
 title: dcos security secrets delete
 menuWeight: 310
 excerpt: Deleting a secret
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-get/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-get/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security secrets get
 title: dcos security secrets get
 menuWeight: 315
 excerpt: Retrieving a secret
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-list/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-list/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security secrets list
 title: dcos security secrets list
 menuWeight: 315
 excerpt: Listing secrets
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-update/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/dcos-security-secrets-update/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security secrets update
 title: dcos security secrets update
 menuWeight: 320
 excerpt: Updating secrets
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/dcos-security-secrets/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos security secrets
 title: dcos security secrets
 menuWeight: 10
 excerpt: Security secrets commands
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-security/index.md
+++ b/pages/1.13/cli/command-reference/dcos-security/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos security
 title: dcos security
 menuWeight: 13
 excerpt: Managing your DC/OS cluster security
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 The `dcos security` commands allow you to manage your DC/OS cluster security. 

--- a/pages/1.13/cli/command-reference/dcos-service/dcos-service-log/index.md
+++ b/pages/1.13/cli/command-reference/dcos-service/dcos-service-log/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos service log
 title: dcos service log
 menuWeight: 1
 excerpt: Displaying the service logs
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-service/dcos-service-shutdown/index.md
+++ b/pages/1.13/cli/command-reference/dcos-service/dcos-service-shutdown/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos service shutdown
 title: dcos service shutdown
 menuWeight: 2
 excerpt: Shutting down a service
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-service/index.md
+++ b/pages/1.13/cli/command-reference/dcos-service/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos service
 title: dcos service
 menuWeight: 14
 excerpt: Managing DC/OS services
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-task/dcos-task-attach/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/dcos-task-attach/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos task attach
 title: dcos task attach
 menuWeight: 1
 excerpt: Attaching a process inside of a task's container
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-task/dcos-task-exec/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/dcos-task-exec/index.md
@@ -4,7 +4,8 @@ navigationTitle:  dcos task exec
 title: dcos task exec
 menuWeight: 2
 excerpt: Launching a process inside of a task's container
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-task/dcos-task-log/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/dcos-task-log/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos task log
 title: dcos task log
 menuWeight: 5
 excerpt: Displaying the task log
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-task/dcos-task-ls/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/dcos-task-ls/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos task ls
 title: dcos task ls
 menuWeight: 7
 excerpt: Display the list of files in the Mesos task directory
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-task/dcos-task-metrics-details/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/dcos-task-metrics-details/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos task metrics details
 title: dcos task metrics details
 menuWeight: 9
 excerpt: Display all metrics for a specified task
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos-task/dcos-task-metrics-summary/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/dcos-task-metrics-summary/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos task metrics summary
 title: dcos task metrics summary
 menuWeight: 11
 excerpt: Display key metrics for a task
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -21,7 +23,7 @@ dcos task metrics summary <task-id> [--json]
 
 | Name |  Description |
 |---------|-------------|
-| `<task-id>` | A full task ID, a partial task ID, or a Unix shell wildcard pattern (eg. 'my-task*').|
+| `<task-id>` | A full task ID, a partial task ID, or a Unix shell wildcard pattern (for example, 'my-task*').|
 | `--json`  | Print JSON-formatted list of tasks. |
 
 # Parent command

--- a/pages/1.13/cli/command-reference/dcos-task/index.md
+++ b/pages/1.13/cli/command-reference/dcos-task/index.md
@@ -4,6 +4,8 @@ navigationTitle:  dcos task
 title: dcos task
 menuWeight: 16
 excerpt: Managing DC/OS tasks
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/cli/command-reference/dcos/index.md
+++ b/pages/1.13/cli/command-reference/dcos/index.md
@@ -5,6 +5,8 @@ title: dcos
 menuWeight: 0
 excerpt: Managing your DC/OS installation
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 # Description

--- a/pages/1.13/cli/command-reference/index.md
+++ b/pages/1.13/cli/command-reference/index.md
@@ -5,6 +5,8 @@ title: Command Reference
 menuWeight: 10
 excerpt: Exploring the unique DC/OS commands
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 This Command Reference describes CLI commands that are unique to DC/OS.

--- a/pages/1.13/cli/configure/index.md
+++ b/pages/1.13/cli/configure/index.md
@@ -5,6 +5,8 @@ title: Configuring the CLI
 menuWeight: 2
 excerpt: Configuring the command line interface
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 You can access DC/OS CLI configuration with the [dcos cluster](/1.13/cli/command-reference/dcos-cluster/) and [dcos config](/1.13/cli/command-reference/dcos-config/) command groups.

--- a/pages/1.13/cli/enterprise-cli/index.md
+++ b/pages/1.13/cli/enterprise-cli/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: DC/OS Enterprise CLI
 menuWeight: 5
 excerpt: Configuring the DC/OS Enterprise command line interface
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 
@@ -25,7 +27,7 @@ The previous installation process using `dcos package install dcos-enterprise-cl
 
 The DC/OS CLI must already be [installed](/1.13/cli/install/).
 
-<p class="message--note"><strong>NOTE: </strong>The DC/OS Enterprise CLI must be installed from the DC/OS CLI. You cannot install the DC/OS Enterprise CLI from the Catalog in the web interface.</p>
+<p class="message--note"><strong>NOTE: </strong>The DC/OS Enterprise CLI must be installed from the DC/OS CLI. You cannot install the DC/OS Enterprise CLI from the {{ model.packageRepo }} in the web interface.</p>
 
 To install the DC/OS Enterprise CLI, issue the following command from a terminal prompt.
 

--- a/pages/1.13/cli/index.md
+++ b/pages/1.13/cli/index.md
@@ -5,6 +5,8 @@ title: CLI
 menuWeight: 50
 excerpt: Understanding the command line interface utility in DC/OS
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 The DC/OS command line interface (DC/OS CLI) utility allows you to manage cluster nodes, install and manage packages, inspect the cluster state, and manage services and tasks.

--- a/pages/1.13/cli/install/index.md
+++ b/pages/1.13/cli/install/index.md
@@ -5,6 +5,8 @@ title: Installing the CLI
 menuWeight: 1
 excerpt: Installing the DC/OS command line interface
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 The recommended method to install the DC/OS CLI is by getting the preformatted set of commands from the DC/OS UI and running them in the terminal. See the prerequisites and instructions for your operating system for more information:

--- a/pages/1.13/cli/plugins/index.md
+++ b/pages/1.13/cli/plugins/index.md
@@ -5,6 +5,8 @@ title: CLI Plugins
 menuWeight: 5
 excerpt: How to extend the command line interface
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 Plugins extend the functionality of the CLI for cluster specific actions.

--- a/pages/1.13/cli/uninstall/index.md
+++ b/pages/1.13/cli/uninstall/index.md
@@ -5,6 +5,8 @@ title: Uninstalling the CLI
 menuWeight: 4
 excerpt: Uninstalling the DC/OS command line interface
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 You can uninstall the CLI with these commands for your operating system.

--- a/pages/1.13/cli/update/index.md
+++ b/pages/1.13/cli/update/index.md
@@ -5,6 +5,8 @@ title: Updating the CLI
 menuWeight: 3
 excerpt: Updating the command line interface
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 Depending on the version of the DC/OS CLI you have currently installed, you can choose to either update the CLI to the latest version for your cluster or to install a specific version. Also note, if you downloaded the CLI from PyPI or from the DC/OS UI version 1.7 or earlier, you must completely <a href="/1.13/cli/uninstall/">uninstall</a> the CLI, then install a new version of the software to upgrade.

--- a/pages/1.13/data.yml
+++ b/pages/1.13/data.yml
@@ -1,0 +1,8 @@
+# Common values:
+
+packageName: dcos
+serviceName: dcos
+techName: DC/OS
+packageRepo: Catalog
+folder_version: '1.13'
+version: 1.13

--- a/pages/1.13/deploying-jobs/examples/index.md
+++ b/pages/1.13/deploying-jobs/examples/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Examples
 title: Job Examples
 menuWeight: 20
 excerpt: Examples of common usage scenarios for jobs.
+render: mustache
+model: /data.yml
 beta: true
 enterprise: true
 ---

--- a/pages/1.13/deploying-jobs/index.md
+++ b/pages/1.13/deploying-jobs/index.md
@@ -4,13 +4,15 @@ navigationTitle:  Deploying Jobs
 title: Deploying Jobs
 menuWeight: 120
 excerpt: Creating a job without installing a separate service
+render: mustache
+model: /data.yml
 beta: true
 enterprise: false
 ---
 
-You can create scheduled jobs in DC/OS without installing a separate service. Create and administer jobs in the DC/OS web interface, the DC/OS CLI, or via an API.
+You can create scheduled jobs in DC/OS without installing a separate service. Create and administer jobs in the DC/OS UI, the DC/OS CLI, or via an API.
 
-<p class="message--note"><strong>NOTE: </strong>The Jobs functionality of DC/OS is provided by the <a href="https://github.com/dcos/metronome">DC/OS Jobs (Metronome)</a> component, an open source Mesos framework that comes pre-installed with DC/OS. You may sometimes see the Jobs functionality referred to as "Metronome" in the logs, and the service endpoint is <code>service/metronome</code>.</p>
+<p class="message--note"><strong>NOTE: </strong>Job scheduling in DC/OS is provided by the <a href="https://github.com/dcos/metronome">DC/OS Jobs (Metronome)</a> component, an open source Mesos framework that comes pre-installed with DC/OS. You may sometimes see the Jobs functionality referred to as "Metronome" in the logs, and the service endpoint is <code>service/metronome</code>.</p>
 
 ## Functionality
 

--- a/pages/1.13/deploying-jobs/job-groups/index.md
+++ b/pages/1.13/deploying-jobs/job-groups/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Granting Access to Jobs
 title: Granting Access to Jobs
 menuWeight: 200
 excerpt: Granting access to jobs using the CLI or the UI
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/deploying-jobs/metronome-constraints/index.md
+++ b/pages/1.13/deploying-jobs/metronome-constraints/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Metronome Placement Constraints
 title: Metronome Placement Constraints
 menuWeight: 3
 excerpt: Understanding Metronome placement constraints
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-jobs/quickstart/index.md
+++ b/pages/1.13/deploying-jobs/quickstart/index.md
@@ -6,6 +6,8 @@ menuWeight: 10
 excerpt: Creating and administering jobs using the UI, the CLI, or the API
 # beta: true
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 You can create and administer jobs for the DC/OS cluster in any of the following ways:

--- a/pages/1.13/deploying-jobs/running-jobs-in-remote-regions/index.md
+++ b/pages/1.13/deploying-jobs/running-jobs-in-remote-regions/index.md
@@ -4,6 +4,8 @@ navigationTitle: Running Jobs in Remote Regions
 title: Running Jobs in Remote Regions
 menuWeight: 3
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 As described in [fault domain awareness and capacity extension for services](/1.13/deploying-services/fault-domain-awareness/), DC/OS supports fault domain awareness. If your cluster is configured over multiple regions or zones, it is possible to schedule your Metronome job to run in a remote region, or a specific zone.

--- a/pages/1.13/deploying-services/config-universe-service/index.md
+++ b/pages/1.13/deploying-services/config-universe-service/index.md
@@ -1,9 +1,11 @@
 ---
 layout: layout.pug
-navigationTitle:  Configuring Universe Services
-title: Configuring Universe Services
+navigationTitle:  Configuring {{ model.packageRepo }} Services
+title: Configuring {{ model.packageRepo }} Services
 menuWeight: 2
 excerpt: Using the DC/OS CLI to configure services
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/containerizers/docker-containerizer/index.md
+++ b/pages/1.13/deploying-services/containerizers/docker-containerizer/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Docker Engine
 title: Docker Engine
 menuWeight: 20
 excerpt: Launching Docker containers from Docker images
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/containerizers/index.md
+++ b/pages/1.13/deploying-services/containerizers/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Using Containerizers
 title: Using Containerizers
 menuWeight: 40
 excerpt: Using containerizers with Docker Engine and Universal Container Runtime
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/containerizers/ucr/index.md
+++ b/pages/1.13/deploying-services/containerizers/ucr/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Universal Container Runtime (UCR)
 title: Universal Container Runtime (UCR)
 menuWeight: 10
 excerpt: Launching Mesos containers using the Universal Container Runtime 
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/creating-services/deploy-docker-app/index.md
+++ b/pages/1.13/deploying-services/creating-services/deploy-docker-app/index.md
@@ -4,6 +4,8 @@ navigationTitle: Tutorial - Deploying a Docker-based Service
 title: Tutorial - Deploying a Docker-based Service
 menuWeight: 100
 excerpt: Deploying a Docker-based service
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/creating-services/health-checks/index.md
+++ b/pages/1.13/deploying-services/creating-services/health-checks/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Health Checks
 title: Health Checks
 menuWeight: 200
 excerpt: Defining health checks for your DC/OS services
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/creating-services/index.md
+++ b/pages/1.13/deploying-services/creating-services/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Creating Services
 title: Creating Services
 menuWeight: 1
 excerpt: Defining a DC/OS service using Marathon
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/deployments/index.md
+++ b/pages/1.13/deploying-services/deployments/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Deployments
 excerpt: Deploying multiple Marathon applications
 title: Deployments
+render: mustache
+model: /data.yml
 menuWeight: 5
 ---
 

--- a/pages/1.13/deploying-services/expose-service/index.md
+++ b/pages/1.13/deploying-services/expose-service/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Exposing a Service
 title: Exposing a Service
 menuWeight: 5
 excerpt: Launching a service with a Marathon app definition
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/faq/index.md
+++ b/pages/1.13/deploying-services/faq/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Frequently Asked Questions
 title: Frequently Asked Questions
 menuWeight: 120
 excerpt: Frequently asked questions about deploying Marathon services
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/fault-domain-awareness/index.md
+++ b/pages/1.13/deploying-services/fault-domain-awareness/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: Fault Domain Awareness and Capacity Extension
 title: Fault Domain Awareness and Capacity Extension
 menuWeight: 3
+render: mustache
+model: /data.yml
 excerpt: Understanding fault domains
 enterprise: false
 ---

--- a/pages/1.13/deploying-services/gpu/index.md
+++ b/pages/1.13/deploying-services/gpu/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Using GPUs
 title: Using GPUs
 menuWeight: 110
 excerpt: Adding Graphics Processing Units to your long-running DC/OS services
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/index.md
+++ b/pages/1.13/deploying-services/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Deploying Services and Pods
 title: Deploying Services and Pods
 menuWeight: 130
 excerpt: Using Marathon to manage your processes and services
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -13,13 +15,13 @@ Marathon is the "init system" for DC/OS. Marathon starts and monitors your appli
 
 A native Marathon instance is installed as a part of DC/OS installation. After DC/OS has started, you can manage the native Marathon instance through the DC/OS CLI with the [`dcos marathon`](/1.13/cli/command-reference/dcos-marathon/) command.
 
-DC/OS services are Marathon applications that are deployed on DC/OS. DC/OS services are available from a package repository, such as the [Mesosphere Universe](/1.13/overview/concepts/#mesosphere-universe), or you can create your own.
+DC/OS services are Marathon applications that are deployed on DC/OS. DC/OS services are available from a package repository, such as the [Mesosphere {{ model.packageRepo }}](/1.13/overview/concepts/#mesosphere-universe), or you can create your own.
 
 #  DC/OS Services
 
-You can run DC/OS services you create or install a package from the [Catalog](/1.13/gui/catalog/). Both the services you create and those you install from Universe appear on the **Services** tab of the DC/OS web interface when they are running.
+You can run DC/OS services you create or install a package from the [{{ model.packageRepo }}](/1.13/gui/catalog/). Both the services you create and those you install from {{ model.packageRepo }} appear on the **Services** tab of the DC/OS web interface when they are running.
 
 Services you create yourself are administered by Marathon and can be configured and run [from the DC/OS CLI](/1.13/cli/command-reference/) with `dcos marathon` subcommands (e.g. `dcos marathon app add <myapp>.json`) or via the DC/OS web interface.
 
-# Universe Package Repository
-Packaged DC/OS services created by Mesosphere or the community, like Spark or Kafka, appear on the **Catalog** tab of the DC/OS web interface, or you can search for a package from [the DC/OS CLI](/1.13/cli/command-reference/). You can configure and run Universe services from the DC/OS web interface or via the DC/OS CLI with the [`dcos package install <package-name>`](/1.13/cli/command-reference/dcos-package/dcos-package-install/) command.
+# {{ model.packageRepo }} Package Repository
+Packaged DC/OS services created by Mesosphere or the community, like Spark or Kafka, appear on the **{{ model.packageRepo }}** tab of the DC/OS web interface, or you can search for a package from [the DC/OS CLI](/1.13/cli/command-reference/). You can configure and run {{ model.packageRepo }} services from the DC/OS web interface or via the DC/OS CLI with the [`dcos package install <package-name>`](/1.13/cli/command-reference/dcos-package/dcos-package-install/) command.

--- a/pages/1.13/deploying-services/install/index.md
+++ b/pages/1.13/deploying-services/install/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Installing Services
 title: Installing Services
 menuWeight: 0
 excerpt: Installing and verifying a service using the CLI or the UI
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -25,16 +27,16 @@ dcos package install chronos
 
 ## Installing a service using the UI
 
-From the DC/OS UI you can install services from the **Services** or **Catalog** tab. The Catalog tab shows all of the available DC/OS services from package [repositories](/1.13/administering-clusters/repo/). The Services tab provides a full featured interface to the native DC/OS Marathon instance.
+From the DC/OS UI you can install services from the **Services** or **{{ model.packageRepo }}** tab. The {{ model.packageRepo }} tab shows all of the available DC/OS services from package [repositories](/1.13/administering-clusters/repo/). The Services tab provides a full featured interface to the native DC/OS Marathon instance.
 
 
-### Catalog tab
+### {{ model.packageRepo }} tab
 
-1.  Navigate to the [**Catalog**](/1.13/gui/catalog/) tab in the DC/OS UI.
+1.  Navigate to the [**{{ model.packageRepo }}**](/1.13/gui/catalog/) tab in the DC/OS UI.
 
-    ![universe](/1.13/img/GUI-Catalog-Main_View-1_12.png)
+    ![{{ model.packageRepo }}](/1.13/img/GUI-Catalog-Main_View-1_12.png)
 
-    Figure 1. Universe catalog
+    Figure 1. {{ model.packageRepo }} 
 
 2.  Click a package.
     1. Click **REVIEW & RUN**.
@@ -66,4 +68,4 @@ Go to the **Services** tab and confirm that the service is running. For more inf
 
 Figure 3. Service is running
 
-Some services from the **Community** section of the Catalog will not show up in the DC/OS service listing. For these, inspect the service's Marathon app in the Marathon UI to verify that the service is running and healthy.
+Some services from the **Community** section of the {{ model.packageRepo }} will not show up in the DC/OS service listing. For these, inspect the service's Marathon app in the Marathon UI to verify that the service is running and healthy.

--- a/pages/1.13/deploying-services/marathon-api/index.md
+++ b/pages/1.13/deploying-services/marathon-api/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Marathon API
 title: Marathon API
 menuWeight: 40
 excerpt: Using the Marathon API to manage long-running containerized services
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/deploying-services/marathon-constraints/index.md
+++ b/pages/1.13/deploying-services/marathon-constraints/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Marathon Placement Constraints
 title: Marathon Placement Constraints
 menuWeight: 3
 excerpt: Understanding Marathon placement constraints
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/marathon-on-marathon/advanced/index.md
+++ b/pages/1.13/deploying-services/marathon-on-marathon/advanced/index.md
@@ -4,6 +4,8 @@ navigationTitle: Custom Marathon with Security Features
 title: Custom Marathon with Security Features
 menuWeight: 40
 excerpt: Using an advanced, non-native instance of Marathon
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/deploying-services/marathon-on-marathon/basic/index.md
+++ b/pages/1.13/deploying-services/marathon-on-marathon/basic/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Deploying Services Using a Custom Marathon Instance
 title: Deploying Services Using a Custom Marathon Instance
 menuWeight: 39
 excerpt: Using a basic, non-native instance of Marathon
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 
@@ -132,7 +134,7 @@ In this step, a non-native Marathon instance is installed on DC/OS with the Meso
      }
     }
      ```        
-1.  Install the Marathon package from Universe with the custom JSON configuration specified (`marathon-config.json`).
+1.  Install the Marathon package from {{ model.packageRepo }} with the custom JSON configuration specified (`marathon-config.json`).
     ```bash
     dcos package install --options=marathon-config.json marathon
     ```

--- a/pages/1.13/deploying-services/marathon-on-marathon/index.md
+++ b/pages/1.13/deploying-services/marathon-on-marathon/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Using Custom Marathon
 title: Using Custom Marathon
 menuWeight: 39
 excerpt: Deploying non-native instances of Marathon
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/deploying-services/marathon-parameters/index.md
+++ b/pages/1.13/deploying-services/marathon-parameters/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Marathon Configuration Reference
 title: Marathon Configuration Reference
 menuWeight: 0
 excerpt: Understanding Marathon application definitions
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/monitor-services/index.md
+++ b/pages/1.13/deploying-services/monitor-services/index.md
@@ -4,13 +4,15 @@ navigationTitle:  Monitoring Services
 title: Monitoring Services
 menuWeight: 3
 excerpt: Monitoring deployed DC/OS services from the CLI and UI
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
 
 You can monitor deployed DC/OS services from the CLI and UI.
 
-# Monitoring Universe services
+# Monitoring {{ model.packageRepo }} services
 
 ## CLI
 

--- a/pages/1.13/deploying-services/multi-tenancy-primitives/index.md
+++ b/pages/1.13/deploying-services/multi-tenancy-primitives/index.md
@@ -4,87 +4,86 @@ navigationTitle:  Multi-Tenancy Primitives
 title: Multi-Tenancy Primitives
 menuWeight: 90
 excerpt: A primer to Multi-Tenancy in DC/OS
+render: mustache
+model: /data.yml
 ---
 
 # Overview
-Resources in DC/OS can be reserved and prioritised using a combination of roles, reservations, quotas, and weights. These features are provided by Apache Mesos, at the core of DC/OS and are referred to as `Primitives`, as they are only accessible via API and have not yet been integrated into the DC/OS UI or CLI. A user requires good monitoring in place of available/used resources when working with quotas, reservations, and weights. 
+Resources in DC/OS can be reserved and prioritized using a combination of roles, reservations, quotas, and weights. These features are provided by Apache Mesos, at the core of DC/OS and are referred to as `Primitives`, as they are only accessible via the API and have not yet been integrated into the DC/OS UI or CLI. A user requires good monitoring in place of available/used resources when working with quotas, reservations, and weights. 
 
-Resource management in this context refers to concepts such as reservations of resources on agents, resource quotas, and weights (priorities) for frameworks. These are useful for a number of scenarios, such as configuring multi-tenant environments, where multiple teams or projects co-exist on the same DC/OS cluster and the available resources (CPU, RAM, disk, and ports) must be carved up and guaranteed for each cluster with guaranteed quotas. Secondly, with mixed workloads on a single cluster where one class of frameworks may have a higher weight (priority) than another, and should be able to deploy faster than a lower weight framework.
+Resource management in this context refers to concepts such as reservations of resources on agents, resource quotas, and weights (priorities) for frameworks. These are useful for a number of scenarios, such as configuring multi-tenant environments, where multiple teams or projects co-exist on the same DC/OS cluster, and the available resources (CPU, RAM, disk, and ports) must be carved up and guaranteed for each cluster with guaranteed quotas. Secondly, with mixed workloads on a single cluster where one class of frameworks may have a higher weight (priority) than another, resources with high priority should be able to deploy faster than a lower weight framework.
 
-This page covers the multi-tenancy primitives: Multi-Tenant quota management primitives, two examples to real-world scenarios, implementation instructions, and reference links. 
+This page covers the multi-tenancy primitives: Multi-Tenant quota management primitives, two examples of real-world scenarios, implementation instructions, and reference links. 
 
 # Multi-Tenant Quota Management Primitives
 The key concepts of multi-tenancy primitives include the following:
 
 ## Roles
-Roles refer to a resource consumer within the cluster. The resource consumer could represent a user within an organization, but it could also represent a team, a group, or a service. It most commonly refers to a class or type of activity which is running. In DC/OS, schedulers subscribe to one or more roles in order to receive resources and schedule work on behalf of the resource consumer(s) they are servicing. Examples of schedulers include Marathon, Kubernetes, and a number of the certified frameworks in the DC/OS catalog such as Kafka and Cassandra, which have been built to include their own scheduler.
+Roles refer to a resource consumer within the cluster. The resource consumer could represent a user within an organization, but it could also represent a team, a group, or a service. It most commonly refers to a class or type of activity which is running. In DC/OS, schedulers subscribe to one or more roles in order to receive resources and schedule work on behalf of the resource consumer(s) they are servicing. Examples of schedulers include Marathon, Kubernetes, and a number of the certified frameworks in the DC/OS {{ model.packageRepo }} such as Kafka and Cassandra, which have been built to include their own scheduler.
 
 There are two default roles which frameworks will subscribe to:
 - `*` on private agents
 - `slave_public` on public. 
 
-Frameworks from the catalog deploy with their own roles and unique roles can be created on demand. 
+Frameworks from the {{ model.packageRepo }} deploy with their own roles and unique roles can be created on demand. 
 
 ## Reservations
-Reservations refer to where the resources are reserved on targeted public and private agents for a specific role. Statically reserved resources are applied on agent (public/private) startup and cannot be amended for other roles without restarting the agent. Dynamically reserved resources enable operators and authorized frameworks to reserve and unreserve resources after agent startup and on demand. All SDK based frameworks, like Kafka and Cassandra (certified frameworks listed in the DC/OS catalog) leverage dynamic reservations for reserving the resources they intend to use with a deployment.
+Reservations refer to where the resources are reserved on targeted public and private agents for a specific role. Statically reserved resources are applied on agent (public/private) startup and cannot be amended for other roles without restarting the agent. Dynamically reserved resources enable operators and authorized frameworks to reserve and un-reserve resources after agent startup and on demand. All SDK based frameworks, like Kafka and Cassandra (certified frameworks listed in the DC/OS {{ model.packageRepo }}) leverage dynamic reservations for reserving the resources they intend to use with a deployment.
 
 ## Quotas
-Quotas refer to a mechanism for guaranteeing that a role will receive a specific amount of resources. Today, quotas are a maximal, if a quota is defined and the task for the role is deployed, then those resources will be reserved immediately, whether the task scales up to use them or not. Other tasks will not be able to make use of those resources even though they may be unused by the task they are provided for. Dynamic quotas, where the task will only use what it needs at the time but is guaranteed to reach its quota, revocable resources and oversubscription are planned for a future release.
+Quotas refer to a mechanism for guaranteeing that a role will receive a specific amount of resources. Today, quotas are a maximal; if a quota is defined and the task for the role is deployed, then those resources will be reserved immediately, whether the task scales up to use them or not. Other tasks will not be able to make use of those resources even though they may not be used by the task they are provided for. Dynamic quotas, where the task will only use what it needs at the time but is guaranteed to reach its quota, revocable resources and over-subscription are planned for a future release.
 
 ## Weights
-Weights refer to a mechanism for prioritising one role over another, to allow all tasks assigned to that role to receive more offers (of resources) over other roles with a lower weight. This can provide faster deployment time, scaling and replacement of tasks.
+Weights refer to a mechanism for prioritizing one role over another, to allow all tasks assigned to that role to receive more offers (of resources) over other roles with a lower weight. This can provide faster deployment time, scaling and replacement of tasks.
 
 # Examples
-The concepts are described based on two real-world scenarios of existing customer use cases. 
+These concepts are described based on two real-world scenarios of existing customer use cases. 
 
 ## Analytics platform with weighted Spark roles
-This example is based on an existing customer’s use case of an analytics pipeline. The primary workload is Spark with three tiers of Spark jobs, tagged with roles; Low - 1, medium - 2, and high - 3, representing the priority and weights accordingly. 
+This example is based on a customer’s use case of an analytics pipeline. The primary workload is Spark with three tiers of Spark jobs, tagged with roles; "low" - 1, "medium" - 2, and "high" - 3, representing the priority and weights accordingly. 
 
-In practise, the high role is allocated three times the fair share of offers (resources) than medium which will be provided twice the fair share of low. Alongside weights, the high priority Spark role is provided a quota of `x` CPU shares and `y` RAM. 
+In practice, the "high" role is allocated three times the fair share of offers (resources) than "medium", which will be provided twice the fair share of "low". Alongside weights, the "high" priority Spark role is provided a quota of `x` CPU shares and `y` RAM. 
 
-As Spark jobs are deployed, the high priority Spark jobs receive their offers over the medium and low roles. Given the medium and low priority roles do not have a quota applied, medium roles will be provided offers sooner than low, but there is no quota for medium, so if medium requires `z` cores and they are not available, it will receive as many are available at that time.
+As Spark jobs are deployed, the "high" priority Spark jobs receive their offers over the "medium" and "low" roles. Given that the "medium" and "low" priority roles do not have a quota applied, "medium" roles will be provided offers sooner than "low" priority roles, but there is no quota for "medium", so if "medium" requires `z` cores and they are not available, it will receive however many are available at that time.
 
 ## Jenkins in Marathon on Marathon
-In this example, the customer runs Jenkins (CI/CD pipeline) as a service, with hundreds of instances, one instance for each development team that requires a service run.
+In this example, a customer runs Jenkins (CI/CD pipeline) as a service with hundreds of instances, one instance for each development team that requires a service run.
 
-On the DC/OS cluster, there are other applications-as-a-service deployed as Marathon tasks. Each application, including Jenkins are grouped in their own instance of Marathon referred to as Marathon on Marathon (MoM) and in DC/OS documentation as non-native Marathon - where native Marathon is the default Marathon that ships with DC/OS. Conceptually, there is a native Marathon and non-native Marathon on Marathon that are dedicated for grouping other tasks.
+On the DC/OS cluster, there are other applications-as-a-service deployed as Marathon tasks. Each application, including Jenkins, is grouped in its own instance of Marathon (referred to as Marathon on Marathon or MoM) and in DC/OS documentation as non-native Marathon - where native Marathon is the default Marathon that ships with DC/OS. Conceptually, there is a native Marathon and non-native Marathon on Marathon that are dedicated for grouping other tasks.
 
-Each MoM hosts one of the groups of the application, and they have a role and quota attached. Each role and quota provides a method to guarantee that where one of them scales frequently, like Jenkins does as it spins up its agents on demand for a new build, that it can get the resources it requires. If Jenkins requires more resources, the quota can be amended on the fly to provide them. Another common use of MoMs is for grouping environments such as Development, Testing, and Staging on one DC/OS cluster with robust resource and access management. 
+Each MoM hosts one of the groups of the application, and each has a role and quota attached. Each role and quota provides a method to guarantee that where one of them scales frequently, like Jenkins does as it spins up its agents on demand for a new build, it can get the resources it requires. If Jenkins requires more resources, the quota can be amended on the fly to provide them. Another common use of MoMs is for grouping environments such as Development, Testing, and Staging on one DC/OS cluster with robust resource and access management. 
 
-In summary, Jenkins-as-a-service is a very dynamic workload, with hundreds of Jenkins agents being run on demand. Having good visibility of the resources available and to understand when the quota is reached is an important parameter for tuning, availability and growth. The Spark example measures how much sooner the high role tasks ran than the low and to inform the tuning of the weights. 
+In summary, Jenkins-as-a-service is a very dynamic workload, with hundreds of Jenkins agents being run on demand. Having good visibility of the resources available and understanding when the quota is reached are important parameters for tuning, availability and growth. The Spark example measures how much sooner the "high" role tasks ran than the "low",  to inform the tuning of the weights. 
 
 # Implementation
 You can use the following resources to learn how to implement both Marathon on Marathon and Spark quotas:
 - [Deploying non-native instances of Marathon](/1.13/deploying-services/marathon-on-marathon/)
-- [Spark Quota](/services/spark/2.3.1-2.2.1-2/job-scheduling/#setting-quotas-for-the-drivers)
+- [Spark Quota](/services/spark/2.8.0-2.4.0/job-scheduling/#quota-for-drivers-and-executors)
 
 In the examples below, it is recommended to run the application from a host with [DC/OS CLI](/1.13/cli/) installed.
-
-<p class="message--note"><strong>NOTE: </strong> All double quotes in the JSON examples below require sanitising before use when copying and pasting into editors or a terminal.</p>
 
 ## Roles
 [Roles](https://mesos.apache.org/documentation/latest/roles/) refer to a tag or a label which is assigned to a framework, task, or an agent. The default role is called <sup>`*`</sup> and all existing roles in a cluster can be viewed through the Mesos UI: `https://<cluster-name-or-IP>/mesos/#/roles`. 
 
 
-In the following example, a role called `high` is assigned to a Spark task at runtime. Multiple instances of the Spark task can be executed, ensuring they all benefit from the resource management associated with high. 
+In the following example, a role called `high` is assigned to a Spark task at runtime. Multiple instances of the Spark task can be executed, ensuring they all benefit from the resource management associated with `high`. 
 
-`spark.mesos.role=high`
+- `spark.mesos.role=high`  Applications in the DC/OS {{ model.packageRepo }}, like Kafka and Cassandra, are automatically deployed with a common role name which is not user configurable.
 
-Applications in the DC/OS catalog, like Kafka and Cassandra, are automatically deployed with a common role name which is not user configurable.
-
-`confluent_kafka_role`
-
-Roles do not require explicit management, like configuring a new role and assigning it to a task, they are created on demand when deploying a task or configuring a weight or quota. Likewise, you should not delete roles, they exist for the duration of the cluster.
+- `confluent_kafka_role`  Roles do not require explicit management, like configuring a new role and assigning it to a task. They are created on demand when deploying a task or configuring a weight or quota. Likewise, you should not delete roles, they exist for the duration of the cluster.
 
 ## Reservations
-[Reservations](https://mesos.apache.org/documentation/latest/reservation/) can be manually configured and are used by SDK frameworks. In both cases, an authorised user must be declared which is referred to as the principal/framework or an operator. In the case of SDK frameworks in DC/OS this is also known as the service account.
+[Reservations](https://mesos.apache.org/documentation/latest/reservation/) can be manually configured and are used by SDK frameworks. In both cases, an authorized user must be declared which is referred to as the principal/framework or an operator. In the case of SDK frameworks in DC/OS this is also known as the service account.
 
 ### Adding
-Adding reserves resources on a specific agent with id `312dc1dc-9b39-474f-8295-87fc43872e7c-S0` for role low, guaranteeing `four` CPU shares and `512MB` of RAM. When any task with a role of low requests offers that match what this agent has reserved then the task will be guaranteed to the agent itself.
+Adding reserves resources on a specific agent with ID `312dc1dc-9b39-474f-8295-87fc43872e7c-S0` for role "low", guaranteeing `four` CPU shares and `512MB` of RAM. When any task with a role of "low" requests offers that match what this agent has reserved then the task will be guaranteed to the agent itself.
 
 <p class="message--note"><strong>NOTE: </strong>The principal of <code>bootstrapuser</code> differs for each user. In this example, the principal of <code>bootstrapuser</code> is my superuser account.</p>
 
-You must change the `agent_id` for the agent ID on your cluster. Use `$dcos node` to find the agent id. 
+You must change the `agent_id` for the agent ID on your cluster. Use `dcos node` to find the agent ID. 
+
+<p class="message--note"><strong>NOTE: </strong> All double quotes in the JSON examples below require sanitizing before use when copying and pasting into editors or a terminal.</p> 
+
 
 ```json
 tee add-reservation.json << EOF
@@ -155,7 +154,9 @@ If resources are not available for reservation, an `HTTP 409` response is expect
 ### Reviewing
 Reviewing is best achieved through the Mesos UI against the specific agent which you applied the reservation or by parsing the `state.json` through `jq`.
 
-`https://<cluster-URL>/mesos/#/agents/<agent-id>`
+```shell
+https://<cluster-URL>/mesos/#/agents/<agent-id>
+```
 
 ### Removing
 Removing requires amending the input `JSON` to reference only the resources in the following format:
@@ -228,7 +229,7 @@ There are further options related to dynamic and static operations and amending 
 [Quotas](https://mesos.apache.org/documentation/latest/quota/) specify a minimum amount of resources that the role is guaranteed to receive (unless the total resources in the cluster are less than the configured quota resources, which often indicates a misconfiguration). 
 
 ### Adding
-Quotas cannot be updated once applied, they must be removed and added again. The following example applies a quota of `two` CPU shares and `4GB` of RAM to a role called `high`.
+Quotas cannot be updated once applied; they must be removed and added again. The following example applies a quota of `two` CPU shares and `4GB` of RAM to a role called `high`.
 
 ```json
 tee set-quota.json << EOF
@@ -325,7 +326,7 @@ Connection: keep-alive
 If successful, expect a `HTTP/1.1 200 OK` response.
 
 ## Weights 
-[Weights](https://mesos.apache.org/documentation/latest/weights/) can be used to control the relative share of cluster resources that is offered to different roles.
+[Weights](https://mesos.apache.org/documentation/latest/weights/) are used to control the relative share of cluster resources that is offered to different roles.
 
 ### Applying
 This applies a weight of `five` to role `perf`.
@@ -380,13 +381,13 @@ Connection: keep-alive
 ```
 
 ### Removing
-Weights cannot be removed once set, they can be amended using the same method as applying to update the weight. If you wish to reset the weight for a role, you could set it back to `two` which is the same weight as the default role <sup>`*`</sup>.
+Weights cannot be removed once set; they can be amended using the same method as applying to update the weight. If you wish to reset the weight for a role, you could set it back to `two` which is the same weight as the default role <sup>`*`</sup>.
 
 
 ## Marathon on Marathon
-The DC/OS catalog includes Marathon, which can be used to deploy a MoM. It should be noted that this is only useful for DC/OS OSS installations, as it does not provide support for Strict mode, Secrets or ACLs. See the [Marathon on Marathon documentation](/1.13/deploying-services/marathon-on-marathon/basic/).
+The DC/OS {{ model.packageRepo }} includes Marathon, which can be used to deploy a MoM. It should be noted that this is only useful for DC/OS OSS installations, as it does not provide support for Strict mode, Secrets or ACLs. See the [Marathon on Marathon documentation](/1.13/deploying-services/marathon-on-marathon/basic/).
 
-To install Enterprise MoM, you must contact Mesosphere Support for the Enterprise MoM tarball, then deploy it using the root Marathon. See the [custom non-native Marathon documentation](/1.13/deploying-services/marathon-on-marathon/advanced/).
+To install DC/OS Enterprise MoM, you must contact Mesosphere Support for the Enterprise MoM tarball, then deploy it using the root Marathon. See the [custom non-native Marathon documentation](/1.13/deploying-services/marathon-on-marathon/advanced/).
 
 # Additional Resources
 You can use the following additional resources to learn more about:
@@ -394,17 +395,5 @@ You can use the following additional resources to learn more about:
 - [Oversubscription](https://mesos.apache.org/documentation/latest/oversubscription/)
 - [Authorization](https://mesos.apache.org/documentation/latest/authorization/)
 - [Mesos API](https://mesos.apache.org/documentation/latest/operator-http-api/)
-
-
-
-
-
-
-
-
-
-
-
-
 
 

--- a/pages/1.13/deploying-services/package-api/index.md
+++ b/pages/1.13/deploying-services/package-api/index.md
@@ -3,10 +3,12 @@ layout: layout.pug
 title: Package Management API
 menuWeight: 10
 excerpt: Installing DC/OS services using the Package Management API
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 
-You can install DC/OS services by using the Package Management API. DC/OS services are installed from packages that are stored in a package registry, such as the [Mesosphere Universe](/1.13/overview/concepts/#mesosphere-universe).
+You can install DC/OS services by using the Package Management API. DC/OS services are installed from packages that are stored in a package registry, such as the [Mesosphere {{ model.packageRepo }}](/1.13/overview/concepts/#mesosphere-universe).
 
 The [DC/OS Package Manager (Cosmos) component](/1.13/overview/architecture/components/#dcos-package-manager) runs on all master nodes.
 

--- a/pages/1.13/deploying-services/pods/examples/index.md
+++ b/pages/1.13/deploying-services/pods/examples/index.md
@@ -4,6 +4,8 @@ navigationTitle: Pod Examples
 title: Pod Examples
 menuWeight: 30
 excerpt: Understanding field definitions and examples of pods
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/pods/index.md
+++ b/pages/1.13/deploying-services/pods/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Pods
 title: Pods
 menuWeight: 85
 excerpt: Using pods to share group resources
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/pods/quickstart/index.md
+++ b/pages/1.13/deploying-services/pods/quickstart/index.md
@@ -3,7 +3,9 @@ layout: layout.pug
 navigationTitle:  Quick Start
 title: Quick Start
 menuWeight: 0
-excerpt: Launching a pod from the CLI or web interface
+excerpt: Launching a pod from the CLI or UI
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -44,13 +46,13 @@ enterprise: false
     dcos marathon pod show simplepod
     ```
 
-# Launching a pod from the DC/OS web interface
+# Launching a pod from the DC/OS UI
 
 You can also launch a pod from the [**Services**](/1.13/gui/) tab of the DC/OS web interface. Select **Services -> Services -> RUN A SERVICE -> Multi-container (Pod)**, then toggle to JSON mode and paste in the application definition supplied above.
 
 If you already have other services running, go to **Services -> Services**, then click the **+** on the upper right hand side.
 
-After you launch your pod, you’ll see your new pod on the **Services** tab of the DC/OS web interface. Click the pod to see information about the status of the containers in your pod.
+After you launch your pod, you’ll see your new pod on the **Services** tab of the DC/OS UI. Click the pod to see information about the status of the containers in your pod.
 
 ![Pods UI](/1.13/img/pods-service-dashboard.png)
 

--- a/pages/1.13/deploying-services/pods/technical-overview/index.md
+++ b/pages/1.13/deploying-services/pods/technical-overview/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Technical Overview
 title: Technical Overview
 menuWeight: 10
 excerpt: Understanding pods
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/pods/using-pods/index.md
+++ b/pages/1.13/deploying-services/pods/using-pods/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Using Pods
 title: Using Pods
 menuWeight: 20
 excerpt: Creating and managing pods via the CLI or the Marathon API endpoint
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/private-docker-registry/index.md
+++ b/pages/1.13/deploying-services/private-docker-registry/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Using a Private Docker Registry
 title: Using a Private Docker Registry
 menuWeight: 4
 excerpt: Creating an archive for a private Docker registry
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/scale-service/index.md
+++ b/pages/1.13/deploying-services/scale-service/index.md
@@ -5,6 +5,8 @@ title: Scaling a Service
 menuWeight: 3
 excerpt: Scaling a service using the UI and the CLI
 enterprise: false
+model: /data.yml
+enterprise: false
 ---
 
 This tutorial shows how to scale a service using the UI and the CLI.

--- a/pages/1.13/deploying-services/service-endpoints/index.md
+++ b/pages/1.13/deploying-services/service-endpoints/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Service Endpoints
 title: Service Endpoints
 menuWeight: 3
 excerpt: Using endpoints with containerized services
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/service-groups/index.md
+++ b/pages/1.13/deploying-services/service-groups/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Granting Access to Services and Groups
 title: Granting Access to Services and Groups
 menuWeight: 3
 excerpt: Implementing fine-grained user access to services using the web interface or the CLI
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/deploying-services/service-ports/index.md
+++ b/pages/1.13/deploying-services/service-ports/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Service Ports
 title: Service Ports
 menuWeight: 3
 excerpt: Using Virtual IPs to manage service ports
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/task-handling/configure-task-handling/index.md
+++ b/pages/1.13/deploying-services/task-handling/configure-task-handling/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Configure Task Handling
 title: Configure Task Handling
 menuWeight: 0
 excerpt: Configuring Marathon for unreachable tasks
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/task-handling/index.md
+++ b/pages/1.13/deploying-services/task-handling/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Task Handling
 title: Task Handling
 menuWeight: 1
 excerpt: Understanding Marathon task categories
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/deploying-services/uninstall/index.md
+++ b/pages/1.13/deploying-services/uninstall/index.md
@@ -4,12 +4,14 @@ navigationTitle:  Uninstalling Services
 title: Uninstalling Services
 menuWeight: 7
 excerpt: Uninstalling DC/OS services from the CLI
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
-Services can be uninstalled from the CLI. If a Universe service has any reserved resources that could not be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
+Services can be uninstalled from the CLI. If a {{ model.packageRepo }} service has any reserved resources that could not be cleaned up by the normal uninstall process, you may also need to run the framework cleaner script. The [framework cleaner script](#framework-cleaner) removes the service instance from ZooKeeper, along with any data associated with it.
 
-# Uninstalling Universe services
+# Uninstalling {{ model.packageRepo }} services
 
 ## CLI
 

--- a/pages/1.13/deploying-services/update-user-service/index.md
+++ b/pages/1.13/deploying-services/update-user-service/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Updating a User-Created Service
 title: Updating a User-Created Service
 menuWeight: 3
 excerpt: Updating the configuration of a deployed app
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/developing-services/cli-spec/index.md
+++ b/pages/1.13/developing-services/cli-spec/index.md
@@ -4,9 +4,11 @@ navigationTitle:  CLI Specification
 title: CLI Specification
 menuWeight: 3
 excerpt: Using the command line interface
+render: mustache
+model: /data.yml
 enterprise: false
 ---
-This document is intended for a developer creating new DC/OS CLI subcommands. See also [Universe Getting Started][1].
+This document is intended for a developer creating new DC/OS CLI subcommands. See also [{{ model.packageRepo }} Getting Started][1].
 
 The [DC/OS command-line interface (CLI)](/1.13/cli/) is a utility to manage cluster nodes, install and manage packages, inspect the cluster state, and manage services and tasks. The DC/OS CLI is open and extensible: anyone can create a new subcommand and make it available for installation by end users. For example, the [Spark DC/OS service][2] provides CLI extensions for working with Spark. When installed, you can type the following command to submit Spark jobs and query their status:
 
@@ -94,7 +96,7 @@ The logging levels are described in [Python’s logging HOWTO][7]: DEBUG, INFO, 
 
 To make your subcommand available to end users:
 
-1. Add a package entry to the Mesosphere Universe repository. See the [Universe README][9] for the specification.
+1. Add a package entry to the Mesosphere {{ model.packageRepo }} repository. See the [{{ model.packageRepo }} README][9] for the specification.
 
     The package entry must contain a file named [resource.json][10] that contains links to the executable subcommands.
 

--- a/pages/1.13/developing-services/index.md
+++ b/pages/1.13/developing-services/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Developing DC/OS Services
 menuWeight: 160
 excerpt: Developing your own DC/OS components
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -13,13 +15,13 @@ The Mesosphere Distributed Cloud Operating System (DC/OS) provides the optimal u
 
 # <a name="universe"></a>Package Repositories
 
-The DC/OS Universe contains all of the services that are installable on DC/OS. For more information on DC/OS Universe, see the [GitHub Universe repository](https://github.com/mesosphere/universe). Our general recommendation is to use the DC/OS CLI rather than the DC/OS web interface throughout the process of creating a package for the Universe.
+The DC/OS {{ model.packageRepo }} contains all of the services that are installable on DC/OS. For more information on DC/OS {{ model.packageRepo }}, see the [GitHub {{ model.packageRepo }} repository](https://github.com/mesosphere/universe). Our general recommendation is to use the DC/OS CLI rather than the DC/OS web interface throughout the process of creating a package for the {{ model.packageRepo }}.
 
-All packaged services are required to meet a certain standard as defined by Mesosphere. For details on submitting a DC/OS service, see [Getting Started with Universe](https://github.com/mesosphere/universe/blob/version-3.x/docs/tutorial/GetStarted.md).
+All packaged services are required to meet a certain standard as defined by Mesosphere. For details on submitting a DC/OS service, see [Getting Started with {{ model.packageRepo }}](https://github.com/mesosphere/universe/blob/version-3.x/docs/tutorial/GetStarted.md).
 
 # DC/OS service structure
 
-Each DC/OS service in the Universe repo is comprised of JSON configuration files. These files are used create the packages that are installed on DC/OS.
+Each DC/OS service in the {{ model.packageRepo }} repo is comprised of JSON configuration files. These files are used create the packages that are installed on DC/OS.
 
 | Filename               | Description                                                                                              | Required |
 |------------------------|----------------------------------------------------------------------------------------------------------|----------|
@@ -28,4 +30,4 @@ Each DC/OS service in the Universe repo is comprised of JSON configuration files
 | `package.json`           | Specifies the high level metadata about the package.                                                     | Yes      |
 | `resource.json`          | Specifies all of the required externally hosted resources (e.g. Docker images, HTTP objects and images). | No       |
 
-For more information, see [Getting Started with Universe](https://github.com/mesosphere/universe/blob/version-3.x/docs/tutorial/GetStarted.md).
+For more information, see [Getting Started with {{ model.packageRepo }}](https://github.com/mesosphere/universe/blob/version-3.x/docs/tutorial/GetStarted.md).

--- a/pages/1.13/developing-services/tunnel/index.md
+++ b/pages/1.13/developing-services/tunnel/index.md
@@ -4,9 +4,11 @@ title: Using a DC/OS Tunnel
 navigationTitle: Using a DC/OS Tunnel
 menuWeight: 10
 excerpt: Accessing your cluster by proxy and VPN using a DC/OS tunnel
+render: mustache
+model: /data.yml
 enterprise: false
 ---
-<p class="message--warning"><strong>WARNING: </strong>DC/OS Tunnel is appropriate for development, debugging, and testing only. Do not use DC/OS Tunnel in production.</p>
+<p class="message--warning"><strong>WARNING: </strong>DC/OS Tunnel is appropriate for development, debugging, and testing <strong>only</strong>. Do not use DC/OS Tunnel in production.</p>
 
 <p class="message--important"><strong>IMPORTANT: </strong> Mesosphere does not support Ubuntu as an operating system for DC/OS, even when using Microsoft Azure.<p>
 

--- a/pages/1.13/gui/catalog/index.md
+++ b/pages/1.13/gui/catalog/index.md
@@ -4,10 +4,13 @@ navigationTitle:  Catalog
 title: Catalog
 menuWeight: 4
 excerpt: Using the Catalog page
+render: mustache
+model: /data.yml
 ---
 
-The Catalog page shows all of the available DC/OS services. You can install packages from the DC/OS Catalog with a single click. The packages can be installed with defaults or customized directly in the web interface.
+The {{ model.packageRepo }} page shows all of the available DC/OS services. You can install packages from the DC/OS {{ model.packageRepo }} with a single click. The packages can be installed with defaults or customized directly in the web interface.
 
-![Catalog](/1.13/img/GUI-Catalog-Main_View-1_12.png)
+![{{ model.packageRepo }}](/1.13/img/GUI-Catalog-Main_View-1_12.png)
 
-Figure 1 - Catalog page
+Figure 1 - {{ model.packageRepo }} page
+

--- a/pages/1.13/gui/cluster/index.md
+++ b/pages/1.13/gui/cluster/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Cluster
 title: Cluster
 menuWeight: 8
 excerpt: Using the Cluster menu
+render: mustache
+model: /data.yml
 ---
 
 The Cluster menu has two tabs:

--- a/pages/1.13/gui/components/index.md
+++ b/pages/1.13/gui/components/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Components
 title: Components
 menuWeight: 9
 excerpt: Using the Components menu
+render: mustache
+model: /data.yml
 ---
 
 You may view the system health of your DC/OS components from the Components menu.

--- a/pages/1.13/gui/dashboard/index.md
+++ b/pages/1.13/gui/dashboard/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Dashboard
 title: Dashboard
 menuWeight: 1
 excerpt: Using the Dashboard
+render: mustache
+model: /data.yml
 ---
 The dashboard is the home page of the DC/OS UI. It provides a high-level overview of your DC/OS cluster.
 

--- a/pages/1.13/gui/index.md
+++ b/pages/1.13/gui/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  GUI
 title: GUI
 menuWeight: 40
+render: mustache
+model: /data.yml
 excerpt: Using the UI for DC/OS management
 ---
 

--- a/pages/1.13/gui/jobs/index.md
+++ b/pages/1.13/gui/jobs/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Jobs
 title: Jobs
 menuWeight: 3
 excerpt: Using the Jobs menu
+render: mustache
+model: /data.yml
 ---
 
 The Jobs page provides native support for creating and managing scheduled jobs. You can set up jobs with a scheduler using the `cron` format.

--- a/pages/1.13/gui/networking/index.md
+++ b/pages/1.13/gui/networking/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Networking
 title: Networking
 menuWeight: 6
 excerpt: Using the Network menu
+render: mustache
+model: /data.yml
 ---
 
 The Networking page provides a comprehensive view of the health of your virtual IP addresses (VIPs).

--- a/pages/1.13/gui/nodes/index.md
+++ b/pages/1.13/gui/nodes/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Nodes
 title: Nodes
 menuWeight: 5
 excerpt: Using the Nodes page
+render: mustache
+model: /data.yml
 ---
 
 The Nodes page provides a comprehensive view of all of the nodes that are used across your cluster. You can view a graph that shows the allocation percentage rate for CPU, memory, or disk.

--- a/pages/1.13/gui/organization/index.md
+++ b/pages/1.13/gui/organization/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Organization
 title: Organization
 menuWeight: 11
 excerpt: Using the Organization menu
+render: mustache
+model: /data.yml
 ---
 
 You may manage user access from the Organization page. The Organization menu comprises three tabs:
@@ -14,4 +16,4 @@ You may manage user access from the Organization page. The Organization menu com
 
 ![Organization Tab EE](/1.13/img/GUI-Organization-Users-Users_List_Empty-1_12.png)
 
-Figure 1 - Organization > Users tab
+Figure 1 - **Organization > Users** tab

--- a/pages/1.13/gui/secrets/index.md
+++ b/pages/1.13/gui/secrets/index.md
@@ -5,6 +5,8 @@ title: Secrets
 menuWeight: 7
 excerpt: Using the Secrets page
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 You can manage secrets and certificates from the Secrets page.

--- a/pages/1.13/gui/services/index.md
+++ b/pages/1.13/gui/services/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Services
 title: Services
 menuWeight: 2
 excerpt: Using the Services menu
+render: mustache
+model: /data.yml
 ---
 
 The Services page provides a full-featured interface to the native DC/OS Marathon instance. It provides a comprehensive view of all of the services that you are running. You can filter services by health, status, or service name.

--- a/pages/1.13/gui/settings/index.md
+++ b/pages/1.13/gui/settings/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Settings
 title: Settings
 menuWeight: 10
 excerpt: Using the Settings menu
+render: mustache
+model: /data.yml
 ---
 
 In the Settings menu you can manage package repositories, change the UI settings, add and manage LDAP directories, and add and manage identity providers.

--- a/pages/1.13/gui/updating-gui/index.md
+++ b/pages/1.13/gui/updating-gui/index.md
@@ -5,15 +5,17 @@ title: Updating the GUI
 menuWeight: 90
 excerpt: DCOS GUI Update Service 
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
-The DC/OS GUI Update Service updates the current version of the DC/OS GUI using new versions published to the Universe. This service allows you to update your GUI without having to update your version of DC/OS.
+The DC/OS GUI Update Service updates the current version of the DC/OS GUI using new versions published to the {{ model.packageRepo }}. This service allows you to update your GUI without having to update your version of DC/OS.
 
 The DC/OS GUI Update Service is a component that runs on all DC/OS master nodes.
 
 # Usage
 
-You can update  the current version of the DC/OS GUI by making a POST request to the update endpoint `/dcos-ui-update-service/api/v1/update/<version>/` The provided version resides on one of the Universe repositories available to the cluster. You can find the available package versions by requesting the Cosmos API `/package/list-versions/` endpoint for the `dcos-ui` package. 
+You can update  the current version of the DC/OS GUI by making a POST request to the update endpoint `/dcos-ui-update-service/api/v1/update/<version>/` The provided version resides on one of the {{ model.packageRepo }} repositories available to the cluster. You can find the available package versions by requesting the Cosmos API `/package/list-versions/` endpoint for the `dcos-ui` package. 
 
 # Latency
 

--- a/pages/1.13/hybrid-cloud/capacity-extension-with-regions/index.md
+++ b/pages/1.13/hybrid-cloud/capacity-extension-with-regions/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Capacity Extensions with Regions
 title: Capacity Extensions with Regions
 menuWeight: 10
 excerpt: Using local and remote regions
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/hybrid-cloud/cluster-links/index.md
+++ b/pages/1.13/hybrid-cloud/cluster-links/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Cluster Links
 title: Cluster Links
 menuWeight: 0
+render: mustache
+model: /data.yml
 excerpt: Managing cluster links
 enterprise: true
 ---

--- a/pages/1.13/hybrid-cloud/decommission-nodes/index.md
+++ b/pages/1.13/hybrid-cloud/decommission-nodes/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Decommission Nodes
 title: Decommission Nodes
 menuWeight: 15
 excerpt: Decommissioning nodes
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/hybrid-cloud/fault-domain-awareness-with-zones/index.md
+++ b/pages/1.13/hybrid-cloud/fault-domain-awareness-with-zones/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Fault Domain Awareness with Zones
 title: Fault Domain Awareness with Zones
 menuWeight: 5
 excerpt: Understanding fault domains
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/hybrid-cloud/index.md
+++ b/pages/1.13/hybrid-cloud/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Hybrid Cloud
 title: Hybrid Cloud
 menuWeight: 115
+render: mustache
+model: /data.yml
 excerpt: Understanding the features of the hybrid cloud
 ---
 

--- a/pages/1.13/index.md
+++ b/pages/1.13/index.md
@@ -5,6 +5,8 @@ title: Documentation for Mesosphere DC/OS 1.13
 version: 1.13
 menuWeight: 0
 excerpt: Learning DC/OS
+render: mustache
+model: /data.yml
 ---
 
 Welcome to the documentation for DC/OS 1.13. For information about new and changed features, see the [release notes](/1.13/release-notes/).

--- a/pages/1.13/installing/data.yml
+++ b/pages/1.13/installing/data.yml
@@ -1,1 +1,0 @@
-folder_version: '1.13'

--- a/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-advanced/index.md
@@ -4,7 +4,7 @@ title: Configuration Reference - AWS
 excerpt: Configuring your DC/OS installation on AWS using the Universal Installer
 navigationTitle: Configuration Reference
 menuWeight: 3
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 #include /install-include/aws-extended-example.tmpl

--- a/pages/1.13/installing/evaluation/aws/aws-remote-region/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-remote-region/index.md
@@ -5,7 +5,7 @@ title: Multi-Region DC/OS on AWS using the Universal Installer
 navigationTitle: AWS Multi-Region Support
 menuWeight: 1
 enterprise: true
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/aws/aws-replaceable-masters/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-replaceable-masters/index.md
@@ -4,7 +4,7 @@ excerpt: Replaceable Masters on AWS using the Universal Installer
 title: Replaceable masters on AWS using the Universal Installer
 navigationTitle: AWS Replaceable Masters
 menuWeight: 2
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/aws/aws-tf-faq/index.md
+++ b/pages/1.13/installing/evaluation/aws/aws-tf-faq/index.md
@@ -4,7 +4,7 @@ title: Universal Installer FAQ & Troubleshooting Guide
 excerpt: FAQ and Common Issues with Universal Installer
 navigationTitle: Universal Installer FAQ
 menuWeight: 10
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/aws/index.md
+++ b/pages/1.13/installing/evaluation/aws/index.md
@@ -4,7 +4,7 @@ excerpt: Guide for DC/OS on AWS using the Universal Installer
 title: DC/OS on AWS using the Universal Installer
 navigationTitle: AWS
 menuWeight: 0
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 #include /install-include/aws-intro-and-prereqs.tmpl

--- a/pages/1.13/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.13/installing/evaluation/azure/advanced-azure/index.md
@@ -4,7 +4,7 @@ title: Configuration Reference - Azure
 excerpt: Configuring your DC/OS installation on Azure using the Mesosphere Universal Installer
 navigationTitle: Configuration Reference
 menuWeight: 3
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/azure/index.md
+++ b/pages/1.13/installing/evaluation/azure/index.md
@@ -4,7 +4,7 @@ excerpt: Guide for DC/OS on Azure using the Mesosphere Universal Installer
 title: DC/OS on Azure using the Universal Installer
 navigationTitle: Azure
 menuWeight: 2
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/aws/advanced/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/aws/advanced/index.md
@@ -4,7 +4,7 @@ title: Running DC/OS on AWS EC2 Advanced
 navigationTitle: Advanced
 menuWeight: 10
 excerpt: Creating and extending DC/OS clusters with AWS CloudFormation templates
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/aws/advanced/template-reference/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/aws/advanced/template-reference/index.md
@@ -4,7 +4,7 @@ navigationTitle: Template Reference
 title: Template Reference
 menuWeight: 5
 excerpt: Advanced template parameters
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/aws/basic/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/aws/basic/index.md
@@ -4,7 +4,7 @@ title: Basic
 navigationTitle: Basic
 menuWeight: 5
 excerpt: Creating a DC/OS cluster using DC/OS templates
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/aws/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/aws/index.md
@@ -4,7 +4,7 @@ title: AWS
 navigationTitle: AWS
 menuWeight: 5
 excerpt: Install DC/OS cluster for Amazon Web Services using templates on AWS CloudFormation
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/aws/removeaws/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/aws/removeaws/index.md
@@ -4,7 +4,7 @@ title: Uninstalling DC/OS on AWS EC2
 navigationTitle: Uninstalling
 menuWeight: 15
 excerpt: Uninstalling DC/OS running on AWS EC2
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/azure/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/azure/index.md
@@ -5,7 +5,7 @@ title: Running DC/OS on Azure
 navigationTitle: Azure
 menuWeight: 10
 oss: true
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/digitalocean/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/digitalocean/index.md
@@ -5,7 +5,7 @@ title: Running DC/OS on DigitalOcean
 navigationTitle: DigitalOcean
 menuWeight: 40
 oss: true
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/index.md
@@ -4,7 +4,7 @@ excerpt: Use CloudFormation, AzureRM or other Terraform templates to install DC/
 title: Other Installation methods
 navigationTitle: Other Installation methods
 menuWeight: 10
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/community-supported-methods/packet/index.md
+++ b/pages/1.13/installing/evaluation/community-supported-methods/packet/index.md
@@ -5,7 +5,7 @@ title: Running DC/OS on Packet
 navigationTitle: Packet
 menuWeight: 50
 oss: true
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.13/installing/evaluation/gcp/advanced-gcp/index.md
@@ -4,7 +4,7 @@ title: Configuration Reference -  GCP
 excerpt: Configuring your DC/OS installation on GCP using the Mesosphere Universal Installer
 navigationTitle: Configuration Reference
 menuWeight: 5
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 #include /install-include/gcp-extended-example.tmpl

--- a/pages/1.13/installing/evaluation/gcp/index.md
+++ b/pages/1.13/installing/evaluation/gcp/index.md
@@ -4,7 +4,7 @@ excerpt: Guide for DC/OS on GCP using the Universal Installer
 title: DC/OS on GCP using the Universal Installer
 navigationTitle: GCP
 menuWeight: 4
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/evaluation/index.md
+++ b/pages/1.13/installing/evaluation/index.md
@@ -4,7 +4,7 @@ navigationTitle:  Cloud Installation
 title: Cloud Installation
 menuWeight: 10
 excerpt: Guide to Installing DC/OS on cloud environments using the Mesosphere Universal Installer
-model: /1.13/installing/data.yml
+model: /data.yml
 render: mustache
 ---
 

--- a/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/1.13/installing/production/advanced-configuration/configuration-reference/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Configuration Reference
 title: Configuration Reference
 menuWeight: 5
 excerpt: Configuration parameters available for DC/OS Enterprise and DC/OS Open Source
+render: mustache
+model: /1.13/data.yml
 ---
 
 # Configuration Parameters
@@ -24,7 +26,7 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [bootstrap_url](#bootstrap-url)                                       | (Required) The URI path for the DC/OS installer to store the customized DC/OS build files. |
 | [cluster_docker_credentials](#cluster-docker-credentials)             | The dictionary of Docker credentials to pass. |
 | [cluster_docker_credentials_enabled](#cluster-docker-credentials-enabled)   |  Whether to pass the Mesos `--docker_config` option to Mesos. |
-| [cluster_docker_registry_url](#cluster-docker-registry-url)           | The custom URL that Mesos uses to pull Docker images from. If changed from the default, you will need to import a local universe into your docker registry as you won’t access dockerhub to pull our images. See [deploying a local universe](/1.13/administering-clusters/deploying-a-local-dcos-universe/#selected-packages) and [using a private docker registry](/1.13/deploying-services/private-docker-registry/).  |
+| [cluster_docker_registry_url](#cluster-docker-registry-url)           | The custom URL that Mesos uses to pull Docker images from. If changed from the default, you will need to import a local {{ model.packageRepo }} into your docker registry as you won’t access dockerhub to pull our images. See [deploying a local {{ model.packageRepo }}](/1.13/administering-clusters/deploying-a-local-dcos-universe/#selected-packages) and [using a private docker registry](/1.13/deploying-services/private-docker-registry/).  |
 | [cluster_name](#cluster-name)                                         | The name of your cluster. |
 | [cosmos_config](#cosmos-config)                                       | The dictionary of packaging configuration to pass to the [DC/OS Package Manager (Cosmos)](https://github.com/dcos/cosmos). |
 | [custom_checks](#custom-checks)                                       | Custom installation checks that are added to the default check configuration process. |
@@ -271,7 +273,7 @@ Whether to pass the Mesos `--docker_config` option containing [`cluster_docker_c
 *  `cluster_docker_credentials_enabled: 'false'` Do not pass the Mesos `--docker_config` option to Mesos.
 
 ### cluster_docker_registry_url
-The custom URL that Mesos uses to pull Docker images from. If set, it will configure the Mesos' `--docker_registry` flag to the specified URL. This changes the default URL Mesos uses for pulling Docker images. By default `https://registry-1.docker.io` is used. If changed from the default, you will need to import a local universe into your docker registry as you won’t access dockerhub to pull our images. See [deploying a local universe](/1.13/administering-clusters/deploying-a-local-dcos-universe/#selected-packages) and [using a private docker registry](/1.13/deploying-services/private-docker-registry/) for more information.
+The custom URL that Mesos uses to pull Docker images from. If set, it will configure the Mesos' `--docker_registry` flag to the specified URL. This changes the default URL Mesos uses for pulling Docker images. By default `https://registry-1.docker.io` is used. If changed from the default, you will need to import a local {{ model.packageRepo }} into your docker registry as you won’t access dockerhub to pull our images. See [deploying a local {{ model.packageRepo }}](/1.13/administering-clusters/deploying-a-local-dcos-universe/#selected-packages) and [using a private docker registry](/1.13/deploying-services/private-docker-registry/) for more information.
 
 ### cluster_name
 The name of your cluster.

--- a/pages/1.13/installing/production/advanced-configuration/configuring-zones-regions/index.md
+++ b/pages/1.13/installing/production/advanced-configuration/configuring-zones-regions/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Configuring Zones and Regions
 title: Configuring Zones and Regions
 menuWeight: 15
 excerpt: Using the high-availability features in DC/OS
+render: mustache
+model: /1.13/data.yml
 ---
 
 This topic discusses the high availability (HA) features in DC/OS and best practices for building HA applications on DC/OS.
@@ -63,7 +65,7 @@ HA services should be decoupled, with responsibilities divided amongst services.
 
 ## Eliminating Single Points of Failure
 
-Single points of failure come in many forms. For example, a service like ZooKeeper can become a single point of failure when every service in your system shares one ZooKeeper cluster. You can reduce risks by running multiple ZooKeeper clusters for separate services. There's an Exhibitor [Universe package](https://github.com/mesosphere/exhibitor-dcos) that makes this easy.
+Single points of failure come in many forms. For example, a service like ZooKeeper can become a single point of failure when every service in your system shares one ZooKeeper cluster. You can reduce risks by running multiple ZooKeeper clusters for separate services. There's an Exhibitor [{{ model.packageRepo }} package](https://github.com/mesosphere/exhibitor-dcos) that makes this easy.
 
 Other common single points of failure include:
 

--- a/pages/1.13/installing/production/deploying-dcos/configuration/index.md
+++ b/pages/1.13/installing/production/deploying-dcos/configuration/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Configuration
 title: Configuration
 menuWeight: 5
 excerpt: Configuring your DC/OS parameters using a YAML file
+render: mustache
+model: /1.13/data.yml
 ---
 
 
@@ -23,9 +25,9 @@ bootstrap_url: file:///opt/dcos_install_tmp
 ```
 
 ## Config blocks and lists
-A config block is a group of settings. It consists of the following:
+A config block is a group of configuration settings. It consists of the following:
 
-- A key followed by a colon for example: `agent_list:`. The key of the config block must be on its own line, with no leading space.
+- A key followed by a colon, for example: `agent_list:`. The key of the config block must be on its own line, with no leading space.
 - A list of values formatted by using a single dash (`-`) followed by a space; or an indented set of one or more key-value pairs. The indentation for each key-value pair must be exactly two spaces. Do not use tabs.
 - Any number of empty lines or comment lines.
 
@@ -81,6 +83,6 @@ See the [configuration reference](/1.13/installing/production/advanced-configura
 
 # Configure DC/OS for Proxy
 
-By default, the DC/OS [Universe](https://github.com/mesosphere/universe) repository is hosted on the internet. If your DC/OS cluster is behind a corporate proxy, you must specify your proxy configuration in the [configuration file](/1.13/installing/production/advanced-configuration/configuration-reference/#use-proxy) file before installation. This will enable your cluster to connect to the Universe packages.
+By default, the DC/OS [{{ model.packageRepo }}](https://github.com/mesosphere/universe) repository is hosted on the internet. If your DC/OS cluster is behind a corporate proxy, you must specify your proxy configuration in the [configuration file](/1.13/installing/production/advanced-configuration/configuration-reference/#use-proxy) file before installation. This will enable your cluster to connect to the {{ model.packageRepo }} packages.
 
 <p class="message--note"><strong>NOTE: </strong>You should also configure an HTTP proxy for <a href="https://docs.docker.com/engine/admin/systemd/#/http-proxy">Docker</a>.</p>

--- a/pages/1.13/installing/production/patching/index.md
+++ b/pages/1.13/installing/production/patching/index.md
@@ -4,6 +4,8 @@ navigationTitle: Patching
 title: Patching
 menuWeight: 20
 excerpt: Understanding cluster patches
+render: mustache
+model: /1.13/data.yml
 ---
 
 A DC/OS patch describes a set of changes and supporting data designed to update, fix, or improve the features/functionality of DC/OS. A point release that consists of minor changes is also called a patch.
@@ -252,5 +254,5 @@ sudo journalctl -u dcos-mesos-slave
 
 ## Notes
 
-Packages available in the DC/OS 1.12 Universe are newer than those in the older versions of Universe. Services are not automatically patched when DC/OS is installed because not all DC/OS services have patch paths that will preserve an existing state.
+Packages available in the DC/OS 1.12 {{ model.packageRepo }} are newer than those in the older versions of the {{ model.packageRepo }}. Services are not automatically patched when DC/OS is installed because not all DC/OS services have patch paths that will preserve existing states.
 

--- a/pages/1.13/installing/production/upgrading/index.md
+++ b/pages/1.13/installing/production/upgrading/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Upgrading
 title: Upgrading
 menuWeight: 25
 excerpt: Upgrading a DC/OS cluster
+render: mustache
+model: /1.13/data.yml
 ---
 
 An upgrade is the process of moving between major releases to add new features or to replace existing features with new features/functionality. You can upgrade DC/OS only if you have used the advanced installation process to install DC/OS on your cluster.
@@ -350,7 +352,7 @@ sudo journalctl -u dcos-mesos-slave
 
 ### Notes:
 
-- Packages available in the DC/OS 1.13 Universe are newer than those in the older versions of Universe. Services are not automatically upgraded when DC/OS is installed because not all DC/OS services have upgrade paths that will preserve existing state.
+- Packages available in the DC/OS 1.13 {{ model.packageRepo }} are newer than those in the older versions of {{ model.packageRepo }}. Services are not automatically upgraded when DC/OS is installed because not all DC/OS services have upgrade paths that will preserve existing states.
 
 [install]: /1.13/installing/production/deploying-dcos/installation/#custom-build-file
 [cmd]: /1.13/installing/production/deploying-dcos/installation/#nginx-cmd

--- a/pages/1.13/metrics/architecture/index.md
+++ b/pages/1.13/metrics/architecture/index.md
@@ -4,6 +4,8 @@ title: Metrics Plugin Architecture
 navigationTitle: Metrics Plugin Architecture
 menuWeight: 0
 excerpt: How DC/OS collects and publishes metrics
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/metrics/datadog/index.md
+++ b/pages/1.13/metrics/datadog/index.md
@@ -4,6 +4,8 @@ title: Export DC/OS Metrics to Datadog
 navigationTitle: Export DC/OS Metrics to Datadog
 menuWeight: 4
 excerpt: Sending DC/OS metrics to Datadog
+render: mustache
+model: /data.yml
 beta: true
 ---
 

--- a/pages/1.13/metrics/index.md
+++ b/pages/1.13/metrics/index.md
@@ -4,6 +4,8 @@ navigationTitle: Metrics
 title: Metrics
 menuWeight: 100
 excerpt: Understanding the metrics component of DC/OS
+render: mustache
+model: /data.yml
 beta: false
 enterprise: false
 ---

--- a/pages/1.13/metrics/mesos/index.md
+++ b/pages/1.13/metrics/mesos/index.md
@@ -4,6 +4,8 @@ title: Mesos Metrics
 navigationTitle: Mesos Metrics
 menuWeight: 3
 excerpt: Monitoring Mesos with Telegraf
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/metrics/metrics-api/index.md
+++ b/pages/1.13/metrics/metrics-api/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Metrics API
 title: Metrics API
 menuWeight: 6
 excerpt: Using the Metrics API
+render: mustache
+model: /data.yml
 beta: false
 ---
 You can use the Metrics API to periodically poll for data about your cluster, hosts, containers, and applications. The Metrics API is one way to get metrics from DC/OS. It is designed for occasional targeted access to specific tasks and hosts. It is not the best way to get a comprehensive picture of all metrics on DC/OS. It is recommended to use the [DC/OS Monitoring service](/services/dcos-monitoring/1.0.0/) to monitor all the metrics on your cluster.

--- a/pages/1.13/metrics/quickstart/index.md
+++ b/pages/1.13/metrics/quickstart/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Quick Start
 title: Metrics Quick Start
 menuWeight: 1
 excerpt: Getting Started with metrics in DC/OS
+render: mustache
+model: /data.yml
 beta: false
 ---
 

--- a/pages/1.13/metrics/reference/index.md
+++ b/pages/1.13/metrics/reference/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Metrics Reference
 title: Metrics Reference
 menuWeight: 7
 excerpt: Understanding metrics collected by DC/OS
+render: mustache
+model: /data.yml
 beta: false
 enterprise: false
 ---

--- a/pages/1.13/monitoring/debugging/cli-debugging/index.md
+++ b/pages/1.13/monitoring/debugging/cli-debugging/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Debugging from the DC/OS CLI
 menuWeight: 10
 excerpt: Debugging DC/OS from the command line interface
+render: mustache
+model: /data.yml
 beta: true
 enterprise: false
 ---

--- a/pages/1.13/monitoring/debugging/debug-perms/index.md
+++ b/pages/1.13/monitoring/debugging/debug-perms/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Granting Access to dcos task exec
 title: Granting Access to dcos task exec
 menuWeight: 4
 excerpt: Granting access for debugging
+render: mustache
+model: /data.yml
 beta: true
 enterprise: true
 ---

--- a/pages/1.13/monitoring/debugging/gui-debugging/index.md
+++ b/pages/1.13/monitoring/debugging/gui-debugging/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Debugging from the DC/OS UI
 menuWeight: 0
 excerpt: Using the DC/OS UI for debugging
+render: mustache
+model: /data.yml
 beta: true
 enterprise: false
 ---

--- a/pages/1.13/monitoring/debugging/index.md
+++ b/pages/1.13/monitoring/debugging/index.md
@@ -6,6 +6,8 @@ menuWeight: 115
 excerpt: Debugging DC/OS using the CLI and UI
 beta: true
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repo for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/monitoring/debugging/slow-docker/index.md
+++ b/pages/1.13/monitoring/debugging/slow-docker/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Slow Docker Apps and Deployments
 title: Slow Docker Apps and Deployments
 menuWeight: 40
 excerpt: Troubleshooting slow Docker apps and deployments
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/debugging/stuck-deployment/index.md
+++ b/pages/1.13/monitoring/debugging/stuck-deployment/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Stuck Deployments
 title: Stuck Deployments
 menuWeight: 30
 excerpt: Understanding offer matching and failed deployments
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/debugging/task-exec/index.md
+++ b/pages/1.13/monitoring/debugging/task-exec/index.md
@@ -6,6 +6,8 @@ menuWeight: 20
 excerpt: Using the dcos task exec command inside a task container
 beta: true
 enterprise: false
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repo for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/monitoring/index.md
+++ b/pages/1.13/monitoring/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Monitoring, Logging, and Debugging
 title: Monitoring, Logging, and Debugging
 menuWeight: 110
 excerpt: Learn how to monitor the health of your datacenter operations with DC/OS
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/monitoring/logging/access-component-logs/index.md
+++ b/pages/1.13/monitoring/logging/access-component-logs/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Accessing system and component logs
 title: Accessing system and component logs
 menuWeight: 1
 excerpt: Managing user access to system and component logs
+render: mustache
+model: /data.yml
 beta: false
 enterprise: true
 ---

--- a/pages/1.13/monitoring/logging/access-task-logs/index.md
+++ b/pages/1.13/monitoring/logging/access-task-logs/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Controlling Access to Task Logs
 title: Controlling Access to Task Logs
 menuWeight: 2
 excerpt: Managing user access to task logs using Marathon groups
+render: mustache
+model: /data.yml
 beta: false
 enterprise: true
 ---

--- a/pages/1.13/monitoring/logging/aggregating/elk/index.md
+++ b/pages/1.13/monitoring/logging/aggregating/elk/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Log Management with ELK
 title: Log Management with ELK
 menuWeight: 1
 excerpt: Managing system and application logs from cluster nodes
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/logging/aggregating/filter-elk/index.md
+++ b/pages/1.13/monitoring/logging/aggregating/filter-elk/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Filtering Logs with ELK
 title: Filtering Logs with ELK
 menuWeight: 2
 excerpt: Filtering log output for specific tasks
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/logging/aggregating/filter-splunk/index.md
+++ b/pages/1.13/monitoring/logging/aggregating/filter-splunk/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Filtering Logs with Splunk
 title: Filtering Logs with Splunk
 menuWeight: 4
 excerpt: Filtering system paths of logs with Splunk
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/logging/aggregating/index.md
+++ b/pages/1.13/monitoring/logging/aggregating/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Log Aggregation
 title: Log Aggregation
 menuWeight: 3
 excerpt: Aggregating system logs with ELK and Splunk
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/logging/aggregating/splunk/index.md
+++ b/pages/1.13/monitoring/logging/aggregating/splunk/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Log Management with Splunk
 title: Log Management with Splunk
 menuWeight: 3
 excerpt: Managing system and application logs with a Splunk server
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/logging/configure-task-logs/index.md
+++ b/pages/1.13/monitoring/logging/configure-task-logs/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Configuring Task Log Output and Retention
 title: Configuring Task Log Output and Retention
 menuWeight: 2
 excerpt: Task environment variables that influence logging
+render: mustache
+model: /data.yml
 beta: false
 enterprise: false
 ---

--- a/pages/1.13/monitoring/logging/index.md
+++ b/pages/1.13/monitoring/logging/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Logging
 title: Logging
 menuWeight: 3
 excerpt: Understanding diagnostic and status logs for DC/OS core components and services
+render: mustache
+model: /data.yml
 beta: false
 enterprise: false
 ---

--- a/pages/1.13/monitoring/logging/logging-api-examples/index.md
+++ b/pages/1.13/monitoring/logging/logging-api-examples/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Logging API Examples
 title: Logging API Examples
 menuWeight: 4
 excerpt: Examples for the Logging API
+render: mustache
+model: /data.yml
 beta: false
 enterprise: false
 ---

--- a/pages/1.13/monitoring/logging/logging-reference/index.md
+++ b/pages/1.13/monitoring/logging/logging-reference/index.md
@@ -3,7 +3,9 @@ layout: layout.pug
 navigationTitle:  Logging Reference
 title: Logging Reference
 menuWeight: 3
-excerpt:
+excerpt: Using the Logging API
+render: mustache
+model: /data.yml
 beta: false
 enterprise: false
 ---
@@ -18,7 +20,7 @@ The Logging API is backed by the [DC/OS Log component](/1.13/overview/architectu
 
 The Logging API has been updated significantly for DC/OS 1.11 and later.
 
-In versions of DC/OS prior to 1.11, task logs were available via [files API](http://mesos.apache.org/documentation/latest/endpoints/#files-1). Now you can leverage the consolidated API *for both component and task logs*.
+In versions of DC/OS prior to 1.11, task logs were available via [files API](http://mesos.apache.org/documentation/latest/endpoints/#files-1). Now you can leverage the consolidated API for both component and task logs.
 
 In versions of DC/OS prior to 1.11, node and component logs were managed by `journald`. However, the [Mesos task journald log sink was disabled due to [journald performance issues](/1.13/installing/production/advanced-configuration/configuration-reference/#mesos-container-log-sink). So container log files for older versions are only accessible via the [Mesos task sandbox files API](http://mesos.apache.org/documentation/latest/sandbox/).
 
@@ -47,6 +49,7 @@ curl -k -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/agent/${AGENT_
 ```
 
 <a name="routes"></a>
+
 ## Routes
 
 Access to the Logging API is proxied through Admin Router on each node using the following route:

--- a/pages/1.13/monitoring/logging/quickstart/index.md
+++ b/pages/1.13/monitoring/logging/quickstart/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Quick Start
 title: Logging Quick Start
 menuWeight: 0
 excerpt: Getting started with DC/OS logging
+render: mustache
+model: /data.yml
 beta: false
 enterprise: false
 ---

--- a/pages/1.13/monitoring/performance-monitoring/index.md
+++ b/pages/1.13/monitoring/performance-monitoring/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Performance Monitoring
 title: Performance Monitoring
 menuWeight: 1
 excerpt: Monitoring a DC/OS cluster
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/monitoring/performance-monitoring/nagios/index.md
+++ b/pages/1.13/monitoring/performance-monitoring/nagios/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Monitoring with Nagios
 title: Monitoring with Nagios
 menuWeight: 0
 excerpt: Monitoring a DC/OS cluster with Nagios
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/DNS/mesos-dns/expose-mesos-zone/index.md
+++ b/pages/1.13/networking/DNS/mesos-dns/expose-mesos-zone/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Exposing Mesos Zones Outside
 title: Exposing Mesos Zones Outside
 menuWeight: 300
 excerpt: Exposing Mesos zones outside of DC/OS
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/DNS/mesos-dns/index.md
+++ b/pages/1.13/networking/DNS/mesos-dns/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Mesos-DNS
 title: Mesos-DNS
 menuWeight: 3
 excerpt: Understanding Mesos DNS
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/DNS/mesos-dns/mesos-dns-api/index.md
+++ b/pages/1.13/networking/DNS/mesos-dns/mesos-dns-api/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Mesos DNS API
 title: Mesos DNS API
 menuWeight: 201
 excerpt: Discovering IP addresses and ports using Mesos DNA API
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/networking/DNS/mesos-dns/service-naming/index.md
+++ b/pages/1.13/networking/DNS/mesos-dns/service-naming/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Service Naming
 title: Service Naming
 menuWeight: 0
 excerpt: Understanding Mesos-DNS service naming conventions
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/DNS/mesos-dns/troubleshooting/index.md
+++ b/pages/1.13/networking/DNS/mesos-dns/troubleshooting/index.md
@@ -4,6 +4,8 @@ navigationTitle:  'Troubleshooting'
 title: 'Troubleshooting'
 menuWeight: 400
 excerpt: Troubleshooting Mesos DNS
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/SDN/cni-plugins/index.md
+++ b/pages/1.13/networking/SDN/cni-plugins/index.md
@@ -4,6 +4,8 @@ navigationTitle:  CNI Plugin Support
 title: CNI Plugin Support
 menuWeight: 30
 excerpt: Understanding CNI plugin support
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/SDN/dcos-overlay/index.md
+++ b/pages/1.13/networking/SDN/dcos-overlay/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  DC/OS Overlay
 title: DC/OS Overlay
 menuWeight: 10
+render: mustache
+model: /data.yml
 excerpt: Understanding DC/OS Overlay
 enterprise: false
 ---

--- a/pages/1.13/networking/SDN/index.md
+++ b/pages/1.13/networking/SDN/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Software Defined Networks
 title: Software Defined Networks
 menuWeight: 4
 excerpt: Understanding DC/OS support for SDNs
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/SDN/usage/index.md
+++ b/pages/1.13/networking/SDN/usage/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Using SDNs
 title: Using an SDN
 menuWeight: 20
 excerpt: Using a software defined network
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/index.md
+++ b/pages/1.13/networking/index.md
@@ -4,10 +4,10 @@ navigationTitle:  Networking
 title: Networking
 menuWeight: 70
 excerpt: Understanding the DC/OS networking stack
+render: mustache
+model: /data.yml
 enterprise: false
 ---
-
-
 
 The DC/OS network stack provides
 - [IP connectivity to containers](#IP-connectivity)

--- a/pages/1.13/networking/load-balancing-vips/index.md
+++ b/pages/1.13/networking/load-balancing-vips/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Load Balancing and Virtual IPs (VIPs)
 title: Load Balancing and Virtual IPs (VIPs)
 menuWeight: 1
 excerpt: Understanding load balancing and virtual IPs
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/networking/load-balancing-vips/virtual-ip-addresses/index.md
+++ b/pages/1.13/networking/load-balancing-vips/virtual-ip-addresses/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Using Virtual IP Addresses
 title: Using Virtual IP Addresses
 menuWeight: 10
 excerpt: Using virtual IP addresses
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/overview/architecture/boot-sequence/index.md
+++ b/pages/1.13/overview/architecture/boot-sequence/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Boot Sequence
 title: Boot Sequence
 menuWeight: 6
 excerpt: Understanding the DC/OS component services boot sequence
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -70,7 +72,7 @@ The following is the boot sequence of DC/OS components on each agent node.
 
 ## Services
 
-After DC/OS installation and initialization is complete, you can install DC/OS services. You can install the services through DC/OS package management, either from the Mesosphere Universe or through Marathon directly.
+After DC/OS installation and initialization is complete, you can install DC/OS services. You can install the services through DC/OS package management, either from the Mesosphere {{ model.packageRepo }} or through Marathon directly.
 
 The following is the boot sequence of a DC/OS service:
 

--- a/pages/1.13/overview/architecture/components/index.md
+++ b/pages/1.13/overview/architecture/components/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Components
 title: Components
 menuWeight: 4
 excerpt: Understanding DC/OS components
+render: mustache
+model: /data.yml
 ---
 
 DC/OS is composed of many open source microservice components meticulously tuned and configured to work together. Mesosphere DC/OS Enterprise includes most of the open source DC/OS components but also includes several additional components, modules, and plugins.
@@ -415,7 +417,7 @@ Just as machine operating systems need package management to install, upgrade, c
 
 ## DC/OS package manager (Cosmos)
 
-The DC/OS package manager (Cosmos) installs and manages DC/OS packages from [DC/OS package repositories](/1.13/administering-clusters/repo/), such as the [Mesosphere Universe](https://github.com/mesosphere/universe).
+The DC/OS package manager (Cosmos) installs and manages DC/OS packages from [DC/OS package repositories](/1.13/administering-clusters/repo/), such as the [Mesosphere {{ model.packageRepo }}](https://github.com/mesosphere/universe).
 
 ### System service
 

--- a/pages/1.13/overview/architecture/distributed-process-management/index.md
+++ b/pages/1.13/overview/architecture/distributed-process-management/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Distributed Process Management
 title: Distributed Process Management
 menuWeight: 5
 excerpt: Understanding distributed process management in a DC/OS cluster
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/overview/architecture/index.md
+++ b/pages/1.13/overview/architecture/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Architecture
 title: Architecture
 menuWeight: 2
 excerpt: Understanding DC/OS architecture
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/overview/architecture/node-types/index.md
+++ b/pages/1.13/overview/architecture/node-types/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Node Types
 title: Node Types
 menuWeight: 1
 excerpt: Understanding the three types of nodes
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -65,7 +67,7 @@ A private agent node is an agent node that is on a network that does not allow a
 
 By default, the resources on private agent nodes are configured to allow undifferentiated allocation. More precisely, the resources are given the `*` role, allowing them to be allocated to any task that does not specify a role. For more information, see [Mesos resource roles](http://mesos.apache.org/documentation/latest/roles/).
 
-Because these resources are undifferentiated, most tasks are scheduled on private agent nodes and are inaccessible from outside the cluster, decreasing the surface area that could be accessed by malicious attackers. For this reason, clusters are generally comprised of mostly private agent nodes. Likewise, most [Mesosphere Universe](/1.13/overview/concepts/#mesosphere-universe) packages install by default on private agent nodes.
+Because these resources are undifferentiated, most tasks are scheduled on private agent nodes and are inaccessible from outside the cluster, decreasing the surface area that could be accessed by malicious attackers. For this reason, clusters are generally comprised of mostly private agent nodes. Likewise, most [Mesosphere {{ model.packageRepo }}](/1.13/overview/concepts/#mesosphere-universe) packages install by default on private agent nodes.
 
 ## More Information
 

--- a/pages/1.13/overview/architecture/task-types/index.md
+++ b/pages/1.13/overview/architecture/task-types/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Task Types
 title: Task Types
 menuWeight: 2
 excerpt: Understanding Mesos tasks
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -36,7 +37,7 @@ DC/OS has two built-in schedulers:
 
 ### User space schedulers
 
-Additional schedulers can be installed as [scheduler services](/1.13/overview/concepts/#dcos-scheduler-service) on Marathon, either from the [Mesosphere Universe](/1.13/overview/concepts/#mesosphere-universe) or directly through Marathon.
+Additional schedulers can be installed as [scheduler services](/1.13/overview/concepts/#dcos-scheduler-service) on Marathon, either from the [Mesosphere {{ model.packageRepo }}](/1.13/overview/concepts/#mesosphere-universe) or directly through Marathon.
 
 Example user space schedulers:
 
@@ -44,5 +45,5 @@ Example user space schedulers:
 - The Cassandra scheduler provides Cassandra nodes, which run as lifecycle managed Cassandra nodes.
 - The Spark scheduler (dispatcher) provides Spark jobs, which are themselves schedulers for Spark tasks.
 
-For a full list of installable schedulers (and other packages), see the [Mesosphere Universe package list](https://universe.dcos.io/#/).
+For a full list of installable schedulers (and other packages), see the [Mesosphere {{ model.packageRepo }} package list](https://universe.dcos.io/#/).
 

--- a/pages/1.13/overview/concepts/index.md
+++ b/pages/1.13/overview/concepts/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Concepts
 title: Concepts
 menuWeight: 5
 excerpt: Understanding DC/OS concepts and terms
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 
@@ -160,7 +161,7 @@ A Marathon service consists of zero or more containerized service instances. Eac
     - Marathon pod instances map one-to-many with tasks.
 - Service instances are restarted as a new Mesos Task when they exit prematurely.
 - Service instances may be re-scheduled onto another agent node if they exit prematurely and the agent is down or does not have enough resources any more.
-- Services can be installed directly via the [DC/OS API (Marathon)](/1.13/deploying-services/marathon-api/) or indirectly via the [DC/OS Package Manager (Cosmos)](#package-manager) from a [package repository](#dcos-package-registry) like [Mesosphere Universe](#mesosphere-universe). The [DC/OS GUI](#dcos-gui) and [DC/OS CLI](#dcos-cli) may be used to interact with the DC/OS Package Manager (Cosmos) more easily.
+- Services can be installed directly via the [DC/OS API (Marathon)](/1.13/deploying-services/marathon-api/) or indirectly via the [DC/OS Package Manager (Cosmos)](#package-manager) from a [package repository](#dcos-package-registry) like [Mesosphere {{ model.packageRepo }}](#mesosphere-universe). The [DC/OS GUI](#dcos-gui) and [DC/OS CLI](#dcos-cli) may be used to interact with the DC/OS Package Manager (Cosmos) more easily.
 - A Marathon service may be a [DC/OS scheduler](#dcos-scheduler), but not all services are schedulers.
 - A Marathon service is an abstraction around Marathon service instances which are an abstraction around Mesos tasks. Other schedulers such as DC/OS Jobs (Metronome) or Jenkins have their own names for abstractions around Mesos tasks.
 
@@ -267,11 +268,11 @@ A DC/OS package registry is a repository of DC/OS packages. The [DC/OS Package M
 
 <a name="mesosphere-universe"></a>
 
-# Mesosphere Universe
+# Mesosphere {{ model.packageRepo }}
 
-The Mesosphere Universe is a public package registry, managed by Mesosphere.
+The Mesosphere {{ model.packageRepo }} is a public package registry, managed by Mesosphere.
 
-For more information, see the [Universe repository](https://github.com/mesosphere/universe) on GitHub.
+For more information, see the [{{ model.packageRepo }} repository](https://github.com/mesosphere/universe) on GitHub.
 
 <a name="container-registry"></a>
 

--- a/pages/1.13/overview/design/auth-flow/index.md
+++ b/pages/1.13/overview/design/auth-flow/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Authentication Architecture
 excerpt: Understanding authentication operations
 title: Authentication Architecture
+render: mustache
+model: /data.yml
 menuWeight: 1
 ---
 

--- a/pages/1.13/overview/design/azure-container-service/index.md
+++ b/pages/1.13/overview/design/azure-container-service/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Understanding how DC/OS implements the Azure Container Service
 title: The Azure Container Service
 navigationTitle: ACS
+render: mustache
+model: /data.yml
 menuWeight: 2
 ---
 
@@ -32,13 +34,13 @@ Many companies [use Mesos directly with success](https://mesos.apache.org/docume
 
 1. Deploying and managing Mesos can be complex, precisely because it can manage very complex environments; DC/OS makes that complexity straightforward to use and supported by the community.
 1. DC/OS implements fault tolerance not just on an industrial but on an internet scale.
-1. The DC/OS Catalog of packages for easy installation supports developers, data scientists, and system administrators with all their favorite open source packages.
+1. The DC/OS {{ model.packageRepo }} of packages for easy installation supports developers, data scientists, and system administrators with all their favorite open source packages.
 1. The real-time metrics "firehouse" is open for use by your favorite diagnostics and analytics packages.
 1. DC/OS has three ways to administer your distributed OS: a CLI, a graphical UI, and an API.
 
-### The Universe of packages
+### The {{ model.packageRepo }} of packages
 
-Here is a list of what is in the Catalog on Day 1 of DC/OS, categorized by the type of license.
+Here is a list of what is in the {{ model.packageRepo }} on Day 1 of DC/OS, categorized by the type of license.
 
 #### Apache License V2
 
@@ -74,7 +76,7 @@ Here is a list of what is in the Catalog on Day 1 of DC/OS, categorized by the t
 - OpenVPN
 - Ruxit
 
-Not only may you use the Catalog of packages available with the DC/OS packaging system, you can also publish there to give your skills back to the community. You may also want to deploy DC/OS yourself; you can start with a reference implementation of DC/OS in "the cloud" with the Azure Container Service.
+Not only may you use the {{ model.packageRepo }} of packages available with the DC/OS packaging system, you can also publish there to give your skills back to the community. You may also want to deploy DC/OS yourself; you can start with a reference implementation of DC/OS in "the cloud" with the Azure Container Service.
 
 ## Azure Container Service infrastructure and optimizations
 

--- a/pages/1.13/overview/design/dns-proxy/index.md
+++ b/pages/1.13/overview/design/dns-proxy/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Understanding distributed DNS
 title: Design - Distributed DNS
 navigationTitle: Distributed DNS
+render: mustache
+model: /data.yml
 menuWeight: 3
 ---
 

--- a/pages/1.13/overview/design/index.md
+++ b/pages/1.13/overview/design/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Understanding DC/OS design
 title: Design
 navigationTitle: Design
+render: mustache
+model: /data.yml
 menuWeight: 10
 ---
 

--- a/pages/1.13/overview/design/installation/index.md
+++ b/pages/1.13/overview/design/installation/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Understanding how the installation process works
 title: Installation Design
 navigationTitle: Installation
+render: mustache
+model: /data.yml
 menuWeight: 4
 ---
 

--- a/pages/1.13/overview/design/overlay/index.md
+++ b/pages/1.13/overview/design/overlay/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Understanding network overlay topology
 title: DC/OS Overlay
 navigationTitle: Overlay
+render: mustache
+model: /data.yml
 menuWeight: 5
 ---
 

--- a/pages/1.13/overview/feature-maturity/index.md
+++ b/pages/1.13/overview/feature-maturity/index.md
@@ -3,7 +3,8 @@ layout: layout.pug
 navigationTitle:  Feature Maturity
 title: Feature Maturity
 menuWeight: 10
-
+render: mustache
+model: /data.yml
 excerpt: Understanding Mesosphere's feature maturity lifecycle
 
 enterprise: false

--- a/pages/1.13/overview/features/index.md
+++ b/pages/1.13/overview/features/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Features
 title: Features
 menuWeight: 3
+render: mustache
+model: /data.yml
 excerpt: Understanding the unique features of DC/OS
 ---
 
@@ -50,7 +52,7 @@ Local persistent volumes bridge the gap and provide fast, persistent storage. If
 
 DC/OS makes it easy to install both public community and private proprietary packaged services.
 
-The Mesosphere Universe Package Repository connects you with a library of open source industry-standard schedulers, services, and applications. You can take advantage of community projects to handle batch job scheduling, highly available data storage, robust message queuing, and more. DC/OS also supports installing from multiple package repositories: you can host your own private packages to be shared within your company or with your customers.
+The Mesosphere {{ model.packageRepo }} Package Repository connects you with a library of open source industry-standard schedulers, services, and applications. You can take advantage of community projects to handle batch job scheduling, highly available data storage, robust message queuing, and more. DC/OS also supports installing from multiple package repositories: you can host your own private packages to be shared within your company or with your customers.
 
 
 ## <a name="cloud-agnostic-installer"></a>Cloud-agnostic installer

--- a/pages/1.13/overview/high-availability/index.md
+++ b/pages/1.13/overview/high-availability/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  High Availability
 title: High Availability
 menuWeight: 6
+render: mustache
+model: /data.yml
 excerpt: Understanding the high availability features and best practices in DC/OS
 enterprise: false
 ---
@@ -40,7 +42,7 @@ High availability services should be decoupled, with responsibilities divided am
 
 # Eliminating Single Points of Failure
 
-Single points of failure come in many forms. For example, a service like ZooKeeper can become a single point of failure when every service in your system shares one ZooKeeper cluster. You can reduce these risks by running multiple ZooKeeper clusters for separate services. There is an Exhibitor [Universe package](https://github.com/mesosphere/exhibitor-dcos) that makes this easy.
+Single points of failure come in many forms. For example, a service like ZooKeeper can become a single point of failure when every service in your system shares one ZooKeeper cluster. You can reduce these risks by running multiple ZooKeeper clusters for separate services. There is an Exhibitor [{{ model.packageRepo }} package](https://github.com/mesosphere/exhibitor-dcos) that makes this easy.
 
 Other common single points of failure include:
 

--- a/pages/1.13/overview/index.md
+++ b/pages/1.13/overview/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Overview
 title: Overview
 menuWeight: 20
 excerpt: Getting started with DC/OS fundamentals
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/overview/telemetry/index.md
+++ b/pages/1.13/overview/telemetry/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Telemetry
 title: Telemetry
 menuWeight: 7
 excerpt: Understanding the telemetry reporting component
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/overview/what-is-dcos/index.md
+++ b/pages/1.13/overview/what-is-dcos/index.md
@@ -4,6 +4,8 @@ navigationTitle:  What is DC/OS
 title: What is DC/OS?
 menuWeight: 1
 excerpt: Understanding DC/OS
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/release-notes/1.13.0/index.md
+++ b/pages/1.13/release-notes/1.13.0/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: Release notes for 1.13.0
 title: Release notes for 1.13.0
 menuWeight: 5
+render: mustache
+model: /data.yml
 excerpt: Release notes for DC/OS 1.13.0, including Open Source attribution, and version policy.
 ---
 DC/OS 1.13.0 was released on May 8, 2019.

--- a/pages/1.13/release-notes/1.13.1/index.md
+++ b/pages/1.13/release-notes/1.13.1/index.md
@@ -4,6 +4,8 @@ navigationTitle: Release notes for 1.13.1
 title: Release notes for 1.13.1
 menuWeight: 1
 excerpt: Release notes for DC/OS 1.13.1, including Open Source attribution, and version policy.
+render: mustache
+model: /data.yml
 ---
 DC/OS 1.13.1 was released on May 31, 2019.
 

--- a/pages/1.13/release-notes/open-source-attribution/index.md
+++ b/pages/1.13/release-notes/open-source-attribution/index.md
@@ -3,7 +3,8 @@ layout: layout.pug
 title: Open Source Attribution
 menuWeight: 100
 excerpt: List of third party open source software provided by Mesosphere
-
+render: mustache
+model: /data.yml
 ---
 
 The table below lists the third party open source software which is provided by Mesosphere in connection with Mesosphere DC/OS.

--- a/pages/1.13/release-notes/version-policy/index.md
+++ b/pages/1.13/release-notes/version-policy/index.md
@@ -4,6 +4,8 @@ navigationTitle: Versioning and Release Policy
 title: Versioning and Release Policy
 menuWeight: 110
 excerpt: Understanding DC/OS versioning and releases
+render: mustache
+model: /data.yml
 ---
 The format of Mesosphere DC/OS version number is: <code>&lt;Release&gt;.&lt;Version&gt;.&lt;Minor&gt;</code>.
 

--- a/pages/1.13/security/ent/gui-permissions/catalog-tab/index.md
+++ b/pages/1.13/security/ent/gui-permissions/catalog-tab/index.md
@@ -4,12 +4,13 @@ navigationTitle:  Granting Access to the Catalog Screen
 title: Granting Access to the Catalog Screen
 menuWeight: 80
 excerpt: Granting access to the Catalog screen
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
-You can grant users access to the [**Catalog** ](/1.13/gui/catalog/) tag. By default, new users have no permissions.
+You can grant users access to the [**{{ model.packageRepo }}** ](/1.13/gui/catalog/) tag. By default, new users have no permissions.
 
 <p class="message--note"><strong>NOTE: </strong>This procedure grants full user access to the <strong>Catalog</strong> screen. If you want to configure fine-grained user access, see the <a href="/1.13/deploying-services/service-groups/">documentation</a>.</p>
 

--- a/pages/1.13/security/ent/gui-permissions/components-tab/index.md
+++ b/pages/1.13/security/ent/gui-permissions/components-tab/index.md
@@ -5,6 +5,8 @@ title: Granting Access to the Components Tab
 menuWeight: 60
 excerpt: Granting access to the Components Tab
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/gui-permissions/index.md
+++ b/pages/1.13/security/ent/gui-permissions/index.md
@@ -3,7 +3,9 @@ layout: layout.pug
 navigationTitle:  Granting Access to the UI
 title: Granting Access to the UI
 menuWeight: 10
-excerpt: Granting access to the DC/OS web interface 
+excerpt: Granting access to the DC/OS UI
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
@@ -11,4 +13,4 @@ enterprise: true
 
 By default, a [new user](/1.13/security/ent/users-groups/) has no permissions and cannot view the [DC/OS UI](/1.13/gui/). You must grant users and groups access to each screen of the web interface.
 
-<p class="message--important"><stribg>IMPORTANT: </strong> Only <a href="/1.13/security/ent/perms-reference/#superuser">superusers</a> can view the Dashboard, Nodes, and **Cluster -> Overview** tabs.</p>
+<p class="message--important"><stribg>IMPORTANT: </strong> Only <a href="/1.13/security/ent/perms-reference/#superuser">superusers</a> can view the Dashboard, Nodes, and <strong>Cluster -> Overview</strong> tabs.</p>

--- a/pages/1.13/security/ent/gui-permissions/jobs-tab/index.md
+++ b/pages/1.13/security/ent/gui-permissions/jobs-tab/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Granting Access to the Jobs Tab
 title: Granting Access to the Jobs Tab
 menuWeight: 30
 excerpt: Granting access to the Jobs tab
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/gui-permissions/marathon-ui/index.md
+++ b/pages/1.13/security/ent/gui-permissions/marathon-ui/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Granting Access to the Marathon Tab
 title: Granting Access to the Marathon Tab
 menuWeight: 32
 excerpt: Granting access to the Marathon Tab
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/gui-permissions/mesos-ui/index.md
+++ b/pages/1.13/security/ent/gui-permissions/mesos-ui/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Granting Access to the Mesos UI
 title: Granting Access to the Mesos UI
 menuWeight: 31
 excerpt: Granting access to the Mesos UI
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/gui-permissions/network-tab/index.md
+++ b/pages/1.13/security/ent/gui-permissions/network-tab/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Granting Access to the Networking Tab
 title: Granting Access to the Networking Tab
 menuWeight: 40
 excerpt: Granting access to the Networking tab
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/gui-permissions/secrets-tab/index.md
+++ b/pages/1.13/security/ent/gui-permissions/secrets-tab/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Granting Access to the Secrets Tab
 title: Granting Access to the Secrets Tab
 menuWeight: 50
 excerpt: Granting access to the Secrets tab
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/security/ent/gui-permissions/services-tab/index.md
+++ b/pages/1.13/security/ent/gui-permissions/services-tab/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Granting Access to the Services Tab
 title: Granting Access to the Services Tab
 menuWeight: 10
 excerpt: Granting access to the Services tab
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/security/ent/gui-permissions/settings-organization-tab/index.md
+++ b/pages/1.13/security/ent/gui-permissions/settings-organization-tab/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Granting Access to the Settings and Organization tabs
 title: Granting Access to the Settings and Organization tabs
 menuWeight: 70
 excerpt: Granting access to the Settings and Organization tabs using the DC/OS UI or the API
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/security/ent/hardening/index.md
+++ b/pages/1.13/security/ent/hardening/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Hardening
 title: Hardening
 menuWeight: 100
 excerpt: Increasing the security of your cluster
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/iam-api/index.md
+++ b/pages/1.13/security/ent/iam-api/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Identity and Access Management API
 title: Identity and Access Management API
 menuWeight: 110
 excerpt: Managing users and permissions with the IAM API
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/security/ent/index.md
+++ b/pages/1.13/security/ent/index.md
@@ -4,6 +4,8 @@ navigationTitle: DC/OS Enterprise Security
 title: DC/OS Enterprise Security
 menuWeight: 70
 excerpt: Understanding DC/OS Enterprise security features
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/ldap/index.md
+++ b/pages/1.13/security/ent/ldap/index.md
@@ -4,6 +4,8 @@ navigationTitle:  LDAP authentication
 title: LDAP authentication
 menuWeight: 50
 excerpt: Setting up a directory-based authentication server via LDAP
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/security/ent/ldap/ldap-auth/index.md
+++ b/pages/1.13/security/ent/ldap/ldap-auth/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Specifying Authentication and Parameters
 title: Specifying Authentication and Parameters
 menuWeight: 2
+render: mustache
+model: /data.yml
 excerpt: Specifying authentication method and parameters for your LDAP directory
 enterprise: true
 ---

--- a/pages/1.13/security/ent/ldap/ldap-conn/index.md
+++ b/pages/1.13/security/ent/ldap/ldap-conn/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Connection
 title: Connection 
 menuWeight: 1
 excerpt: Configuring your connection to the LDAP server 
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/ldap/ldap-sync/index.md
+++ b/pages/1.13/security/ent/ldap/ldap-sync/index.md
@@ -5,6 +5,8 @@ title: LDAP Synchronization
 menuWeight: 4
 excerpt: LDAP Synchronization
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/ldap/ldap-troubleshooting/index.md
+++ b/pages/1.13/security/ent/ldap/ldap-troubleshooting/index.md
@@ -5,6 +5,8 @@ title: Troubleshooting LDAP errors
 menuWeight: 5
 excerpt: Troubleshooting common authentication and configuration issues for your LDAP directory
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 The Lightweight Directory Access Protocol (LDAP) provides a lightweight client-server protocol for accessing directory services. The protocol provides a standards-based method for defining objects and their attributes for X.500-based directory services. LDAP runs over TCP/IP or other connection-oriented transfer services.
 

--- a/pages/1.13/security/ent/ldap/ldap-verify/index.md
+++ b/pages/1.13/security/ent/ldap/ldap-verify/index.md
@@ -5,6 +5,8 @@ title: Verification
 menuWeight: 3
 excerpt: Verifying your connection to the LDAP server
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/perms-management/index.md
+++ b/pages/1.13/security/ent/perms-management/index.md
@@ -5,6 +5,8 @@ title: Permissions Management
 menuWeight: 30
 excerpt: Managing permissions
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/perms-reference/index.md
+++ b/pages/1.13/security/ent/perms-reference/index.md
@@ -5,6 +5,8 @@ title: Permissions Reference
 menuWeight: 40
 excerpt: Understanding DC/OS access and permissions references
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
@@ -80,7 +82,7 @@ through Admin Router.
 | `dcos:adminrouter:ops:system-logs` <br>Controls access to [System logs API](/1.13/api/master-routes/#system).                                                                                                                                                                                           | x      |     |     |     |     |
 | `dcos:adminrouter:ops:system-metrics`<br> Controls access to [System metrics API](/1.13/api/master-routes/#system).                                                                                                                                                                                     | x      |     |     |     |     |
 | `dcos:adminrouter:licensing` <br> Controls access to the Licensing API.                                                                                                                                                                                                                                 | x      |     |     |     |     |
-| `dcos:adminrouter:package` <br> Controls access to the [Cosmos API](/1.13/api/master-routes/#cosmos), which provides access to the DC/OS Universe.                                                                                                                                                      | x      |     |     |     |     |
+| `dcos:adminrouter:package` <br> Controls access to the [Cosmos API](/1.13/api/master-routes/#cosmos), which provides access to the DC/OS {{ model.packageRepo }}.                                                                                                                                                      | x      |     |     |     |     |
 | `dcos:adminrouter:service:[<group-name>/]<service-name>`<br> Controls access the UI and API of an installed DC/OS service.                                                                                                                                                                              | x      |     |     |     |     |
 | `dcos:adminrouter:service:marathon` <br>Controls access to the native Marathon instance.                                                                                                                                                                                                                | x      |     |     |     |     |
 | `dcos:adminrouter:service:metronome`<br>  Controls access to [DC/OS Jobs (Metronome)](/1.13/deploying-jobs/).                                                                                                                                                                                           | x      |     |     |     |     |

--- a/pages/1.13/security/ent/restrict-service-access/index.md
+++ b/pages/1.13/security/ent/restrict-service-access/index.md
@@ -5,6 +5,8 @@ navigationTitle: Restricting Access to DC/OS Service Groups
 menuWeight: 90
 excerpt: Using the DC/OS UI to achieve multi-tenancy in permissive mode
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
@@ -117,7 +119,7 @@ This tutorial demonstrates how to implement user permissions for DC/OS services 
 
 ## Log in to the DC/OS UI as user
 
-1.  Log in as Cory to the DC/OS UI. You can see that user Cory only has access to the **Services** and **Universe** tabs. Also, Cory can only see the **prod-a** services.
+1.  Log in as Cory to the DC/OS UI. You can see that user Cory only has access to the **Services** and **{{ model.packageRepo }}** tabs. Also, Cory can only see the **prod-a** services.
 
 
   ![prod-a-group](/1.13/img/GUI-Services-Limited_User_Access_List-1_12.png)

--- a/pages/1.13/security/ent/secrets/create-secrets/index.md
+++ b/pages/1.13/security/ent/secrets/create-secrets/index.md
@@ -5,6 +5,8 @@ title: Creating secrets
 menuWeight: 1
 excerpt: Creating secrets with a key-value pair or file
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/secrets/custom-key/index.md
+++ b/pages/1.13/security/ent/secrets/custom-key/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Reinitializing the Secret Store with a custom GPG keypair
 title: Reinitializing the Secret Store with a custom GPG keypair
 menuWeight: -1
 excerpt: Using a custom GPG pair to reinitialize the Secret Store
-
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/secrets/index.md
+++ b/pages/1.13/security/ent/secrets/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Secrets
 title: Secrets
 menuWeight: 60
 excerpt: Understanding the Secret Store
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/secrets/seal-store/index.md
+++ b/pages/1.13/security/ent/secrets/seal-store/index.md
@@ -5,6 +5,8 @@ title: Sealing the Secret Store
 menuWeight: 3
 excerpt: Manually sealing the Secret Store
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/secrets/secrets-api/index.md
+++ b/pages/1.13/security/ent/secrets/secrets-api/index.md
@@ -5,6 +5,8 @@ title: Secrets API
 menuWeight: 7
 excerpt: Understanding the Secrets API
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/secrets/unseal-store/index.md
+++ b/pages/1.13/security/ent/secrets/unseal-store/index.md
@@ -5,6 +5,10 @@ title: Unsealing the Secret Store
 menuWeight: 5
 excerpt: Understanding how to unseal the Secret Store
 enterprise: true
+render: mustache
+model: /data.yml
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/secrets/use-secrets/index.md
+++ b/pages/1.13/security/ent/secrets/use-secrets/index.md
@@ -5,6 +5,8 @@ title: Configuring services and pods
 menuWeight: 2
 excerpt: Configuring services and pods to use secrets
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/service-auth/auth-tokens/index.md
+++ b/pages/1.13/security/ent/service-auth/auth-tokens/index.md
@@ -5,6 +5,8 @@ title: Managing JSON Web Tokens
 menuWeight: 200
 excerpt: Managing JSON web tokens
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/service-auth/custom-service-auth/index.md
+++ b/pages/1.13/security/ent/service-auth/custom-service-auth/index.md
@@ -4,6 +4,8 @@ title: Authenticating DC/OS Services
 menuWeight: 100
 excerpt: Configuring authentication for custom apps and pods
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/service-auth/index.md
+++ b/pages/1.13/security/ent/service-auth/index.md
@@ -5,6 +5,8 @@ title: Service Authentication
 menuWeight: 80
 excerpt: Authenticating service accounts
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/sso/index.md
+++ b/pages/1.13/security/ent/sso/index.md
@@ -5,6 +5,8 @@ title: Identity provider-based authentication
 menuWeight: 70
 excerpt: Configuring identity provider-based authentication
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/sso/setup-openid/index.md
+++ b/pages/1.13/security/ent/sso/setup-openid/index.md
@@ -5,6 +5,8 @@ title: Configuring an OpenID identity provider
 menuWeight: 2
 excerpt: Configuring an OpenID identity provider
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/sso/setup-saml/index.md
+++ b/pages/1.13/security/ent/sso/setup-saml/index.md
@@ -5,6 +5,8 @@ title: Configuring a SAML Identity Provider
 menuWeight: 1
 excerpt: Configuring a SAML Identity Provider and OneLogin IdP
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/tls-ssl/ca-api/index.md
+++ b/pages/1.13/security/ent/tls-ssl/ca-api/index.md
@@ -3,8 +3,10 @@ layout: layout.pug
 navigationTitle:  Using the Certificate Authority API
 title: Using the Certificate Authority API
 menuWeight: 500
-excerpt: Viewing, creating and signing certificates
+excerpt: Viewing, creating, and signing certificates
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
@@ -91,7 +93,7 @@ curl -H "Authorization: token=$(dcos config show core.dcos_acs_token)"
 
 ## Refreshing the authentication token
 
-Authentication tokens expire after five days by default. If your program needs to run longer than five days, you will need a service account. Please see [Provisioning custom services](/1.13/security/ent/service-auth/custom-service-auth/) for more information.
+Authentication tokens expire after five days by default. If your program needs to run longer than five days, you will need a service account. See [Provisioning custom services](/1.13/security/ent/service-auth/custom-service-auth/) for more information.
 
 # API reference
 

--- a/pages/1.13/security/ent/tls-ssl/ca-custom/index.md
+++ b/pages/1.13/security/ent/tls-ssl/ca-custom/index.md
@@ -5,6 +5,8 @@ title: Configuring a Custom CA Certificate
 menuWeight: 50
 excerpt: Configuring DC/OS Enterprise to use a custom CA certificate
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/tls-ssl/ca-trust-browser/index.md
+++ b/pages/1.13/security/ent/tls-ssl/ca-trust-browser/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Establishing trust in your DC/OS CA
 title: Establishing trust in your DC/OS CA
 menuWeight: 200
 excerpt: Configuring Chrome and Firefox to trust your DC/OS CA.
+render: mustache
+model: /data.yml
 beta: true
 enterprise: true
 ---

--- a/pages/1.13/security/ent/tls-ssl/ca-trust-cli/index.md
+++ b/pages/1.13/security/ent/tls-ssl/ca-trust-cli/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Establishing trust in your CLI
 title: Establishing trust in your CLI
 menuWeight: 300
 excerpt: Establishing trust in your CLI
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/tls-ssl/ca-trust-curl/index.md
+++ b/pages/1.13/security/ent/tls-ssl/ca-trust-curl/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Establishing trust in your curl commands
 title: Establishing trust in your curl commands
 menuWeight: 400
 excerpt: Establishing trust in your curl commands
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/tls-ssl/get-cert/index.md
+++ b/pages/1.13/security/ent/tls-ssl/get-cert/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Obtaining the DC/OS CA bundle
 menuWeight: 100
 excerpt: Obtaining the DC/OS CA bundle
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/1.13/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Configuring HAProxy in Front of Admin Router
 title: Configuring HAProxy in Front of Admin Router
 menuWeight: 6
 excerpt: Using the HAProxy to set up an HTTP proxy for the DC/OS Admin Router
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/security/ent/tls-ssl/index.md
+++ b/pages/1.13/security/ent/tls-ssl/index.md
@@ -5,6 +5,8 @@ title: Securing Communication with TLS
 menuWeight: 120
 excerpt: Securing encrypted communications using TLS certificates
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/ent/users-groups/add-external-user/index.md
+++ b/pages/1.13/security/ent/users-groups/add-external-user/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Adding external users
 title: Adding external users
 menuWeight: 20
 excerpt: Adding an external user to DC/OS
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/users-groups/add-local-user/index.md
+++ b/pages/1.13/security/ent/users-groups/add-local-user/index.md
@@ -5,6 +5,8 @@ title: Adding local users
 menuWeight: 10
 excerpt: Adding a local user with the web interface or CLI
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/ent/users-groups/config-linux-user/index.md
+++ b/pages/1.13/security/ent/users-groups/config-linux-user/index.md
@@ -5,6 +5,8 @@ title: Overriding the default Linux user
 menuWeight: 31
 excerpt: Overriding the default Linux user
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
@@ -12,15 +14,15 @@ The default Linux user of a service or job can vary according to the security mo
 
 The procedure for overriding the default Linux user varies by the type of service or job.
 
-- [Overriding the default Linux user of a Universe service](#universe)
+- [Overriding the default Linux user of a {{ model.packageRepo }} service](#universe)
 - [Overriding the default user of a service via Marathon app definition](#marathon-app-def)
 - [Overriding the default user of a job via Metronome job definition](#metronome-job-def)
 
-# <a name="universe"></a>Overriding the default Linux user of a Universe service
+# <a name="universe"></a>Overriding the default Linux user of a {{ model.packageRepo }} service
 
-Many Universe services ignore overrides of their user accounts except in `strict` mode. We provide detailed steps for overriding the default Linux user for services that support this in [Service Accounts](/1.13/security/ent/service-auth/). Refer to the section pertaining to the service of interest for step-by-step instructions. The procedures also describe how to configure the service to use encryption and service accounts.
+Many {{ model.packageRepo }} services ignore overrides of their user accounts except in `strict` mode. We provide detailed steps for overriding the default Linux user for services that support this in [Service Accounts](/1.13/security/ent/service-auth/). Refer to the section pertaining to the service of interest for step-by-step instructions. The procedures also describe how to configure the service to use encryption and service accounts.
 
-Remember to grant permission to perform the `create` action on the `dcos:mesos:master:task:user[:<linux-user-name>]` resource to the service account user that the Universe service is launched with. See [Mesos Permissions](/1.13/security/ent/perms-reference/#mesos-permissions) for more information.
+Remember to grant permission to perform the `create` action on the `dcos:mesos:master:task:user[:<linux-user-name>]` resource to the service account user that the {{ model.packageRepo }} service is launched with. See [Mesos Permissions](/1.13/security/ent/perms-reference/#mesos-permissions) for more information.
 
 # <a name="marathon-app-def"></a>Overriding the default Linux user via Marathon app definition
 

--- a/pages/1.13/security/ent/users-groups/index.md
+++ b/pages/1.13/security/ent/users-groups/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Managing users and groups
 title: Managing Users and Groups
 menuWeight: 0
 excerpt: Managing users and groups
+render: mustache
+model: /data.yml
 enterprise: true
 ---
 

--- a/pages/1.13/security/ent/users-groups/reset-superuser/index.md
+++ b/pages/1.13/security/ent/users-groups/reset-superuser/index.md
@@ -5,6 +5,8 @@ title: Resetting the Superuser
 menuWeight: 30
 excerpt: Reset an existing user or create a new user with the DC/OS reset superuser script
 enterprise: true
+render: mustache
+model: /data.yml
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 

--- a/pages/1.13/security/index.md
+++ b/pages/1.13/security/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Security
 title: Security
 menuWeight: 80
 excerpt: Configuring security for Enterprise and Open Source deployments
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 Security configurations are different for Enterprise and Open Source deployments. This section will guide you through the configuration process for each one.

--- a/pages/1.13/security/oss/authentication/authentication-token/index.md
+++ b/pages/1.13/security/oss/authentication/authentication-token/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: DC/OS Authentication Token
 title: DC/OS Authentication Token
 excerpt: Getting familiar with DC/OS Authentication tokens
+render: mustache
+model: /data.yml
 menuWeight: 10
 ---
 

--- a/pages/1.13/security/oss/authentication/index.md
+++ b/pages/1.13/security/oss/authentication/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Authentication
 title: Authentication
 excerpt: Authenticating users against DC/OS
+render: mustache
+model: /data.yml
 menuWeight: 30
 ---
 

--- a/pages/1.13/security/oss/authentication/out-of-band-verification/index.md
+++ b/pages/1.13/security/oss/authentication/out-of-band-verification/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Out-of-band Token Verification
 title: Out-of-band Token Verification
 excerpt: Verifying DC/OS Authentication tokens out-of-band
+render: mustache
+model: /data.yml
 menuWeight: 20
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/oss/authentication/troubleshooting/index.md
+++ b/pages/1.13/security/oss/authentication/troubleshooting/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: Troubleshooting
 title: Troubleshooting Authentication 
 excerpt: Troubleshooting authentication issues in DC/OS
+render: mustache
+model: /data.yml
 menuWeight: 50
 ---
 # Ad Blockers and the DC/OS UI

--- a/pages/1.13/security/oss/haproxy-adminrouter/index.md
+++ b/pages/1.13/security/oss/haproxy-adminrouter/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Configuring HAProxy in front of an Admin Router
 title: HAProxy and Admin Router
 navigationTitle: HAProxy and Admin Router
+render: mustache
+model: /data.yml
 menuWeight: 50
 ---
 

--- a/pages/1.13/security/oss/iam-api/index.md
+++ b/pages/1.13/security/oss/iam-api/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Identity and Access Management API
 title: Identity and Access Management API
 menuWeight: 40
 excerpt: Using the DC/OS Identity and Access Management API
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/oss/index.md
+++ b/pages/1.13/security/oss/index.md
@@ -2,6 +2,8 @@
 layout: layout.pug
 excerpt: Managing security in your datacenter using DC/OS Open Source
 title: DC/OS Open Source Security
+render: mustache
+model: /data.yml
 menuWeight: 80
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/oss/login/external-user-login/index.md
+++ b/pages/1.13/security/oss/login/external-user-login/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  External User Login
 title: External User Login
 excerpt: Logging in to DC/OS as an external user
+render: mustache
+model: /data.yml
 menuWeight: 10
 ---
 

--- a/pages/1.13/security/oss/login/index.md
+++ b/pages/1.13/security/oss/login/index.md
@@ -4,6 +4,8 @@ navigationTitle: Login
 title: Login
 excerpt: Logging in to your DC/OS cluster
 menuWeight: 20
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/oss/login/local-user-login/index.md
+++ b/pages/1.13/security/oss/login/local-user-login/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Local User Login
 title: Local User Login
 excerpt: Logging in to DC/OS as a local user
+render: mustache
+model: /data.yml
 menuWeight: 20
 ---
 

--- a/pages/1.13/security/oss/login/service-login/index.md
+++ b/pages/1.13/security/oss/login/service-login/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Service Login
 title: Service Login
 excerpt: Logging in to DC/OS as a service
+render: mustache
+model: /data.yml
 menuWeight: 30
 ---
 

--- a/pages/1.13/security/oss/secure-compute-profiles/index.md
+++ b/pages/1.13/security/oss/secure-compute-profiles/index.md
@@ -3,7 +3,9 @@ layout: layout.pug
 navigationTitle:  Secure computing profiles
 title: Secure computing profiles
 menuWeight: 31
-excerpt: Describes how to configure DC/OS to work with Linux secure computing (seccomp) profiles 
+excerpt: Describes how to configure DC/OS to work with Linux secure computing (seccomp) profiles
+render: mustache
+model: /data.yml 
 enterprise: true
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/oss/user-account-management/external-user-accounts/index.md
+++ b/pages/1.13/security/oss/user-account-management/external-user-accounts/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: External User Accounts
 title: External User Account Management
 excerpt: Managing external user accounts
+render: mustache
+model: /data.yml
 menuWeight: 10
 ---
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/oss/user-account-management/index.md
+++ b/pages/1.13/security/oss/user-account-management/index.md
@@ -4,6 +4,8 @@ navigationTitle:  User Account Management
 title: User Account Management
 menuWeight: 10
 excerpt: Managing DC/OS user accounts
+render: mustache
+model: /data.yml
 ---
 
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->

--- a/pages/1.13/security/oss/user-account-management/local-user-accounts/index.md
+++ b/pages/1.13/security/oss/user-account-management/local-user-accounts/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: Local User Accounts
 title: Local User Account Management
 excerpt: Managing local user accounts
+render: mustache
+model: /data.yml
 menuWeight: 20
 ---
 

--- a/pages/1.13/security/oss/user-account-management/service-accounts/index.md
+++ b/pages/1.13/security/oss/user-account-management/service-accounts/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: Service Accounts
 title: Service Account Management
 excerpt: Managing service accounts
+render: mustache
+model: /data.yml
 menuWeight: 30
 ---
 

--- a/pages/1.13/security/oss/user-account-management/troubleshooting/index.md
+++ b/pages/1.13/security/oss/user-account-management/troubleshooting/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle: Troubleshooting
 title: Troubleshooting User Account Management
 excerpt: Troubleshooting user account management issues
+render: mustache
+model: /data.yml
 menuWeight: 50
 ---
 

--- a/pages/1.13/storage/external-storage/index.md
+++ b/pages/1.13/storage/external-storage/index.md
@@ -4,6 +4,8 @@ navigationTitle:  External Persistent Volumes
 title: External Persistent Volumes
 menuWeight: 20
 excerpt: Using external persistent volumes with Marathon
+render: mustache
+model: /data.yml
 beta: true
 enterprise: false
 ---

--- a/pages/1.13/storage/index.md
+++ b/pages/1.13/storage/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Storage
 title: Storage
 menuWeight: 90
 excerpt: Preserving your application in case of termination and relaunch
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/storage/mount-disk-resources/index.md
+++ b/pages/1.13/storage/mount-disk-resources/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Mount Disk Resources
 title: Mount Disk Resources
 menuWeight: 0
 excerpt: Using Mesos to mount storage resources
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/storage/nfs/index.md
+++ b/pages/1.13/storage/nfs/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  NFS Server
 excerpt: Mounting a shared network drive
 title: NFS Server
+render: mustache
+model: /data.yml
 menuWeight: 1
 ---
 

--- a/pages/1.13/storage/persistent-volume/index.md
+++ b/pages/1.13/storage/persistent-volume/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Local Persistent Volumes
 title: Local Persistent Volumes
 menuWeight: 10
 excerpt: Using local persistent volumes
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/1.13/tutorials/autoscaling/cpu-memory/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Autoscaling Marathon services using CPU and memory
 title: Tutorial - Autoscaling Marathon services using CPU and memory
 menuWeight: 0
 excerpt: Autoscaling Marathon services using CPU and memory
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/tutorials/autoscaling/index.md
+++ b/pages/1.13/tutorials/autoscaling/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Autoscaling with Marathon
 title: Tutorials - Autoscaling with Marathon
 menuWeight: 3
 excerpt: Understanding autoscaling
+render: mustache
+model: /data.yml
 ---
 
 

--- a/pages/1.13/tutorials/autoscaling/microscaling-queue/index.md
+++ b/pages/1.13/tutorials/autoscaling/microscaling-queue/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Understanding microscaling
 title: Tutorial - Microscaling based on queue length
 navigationTitle: Microscaling
+render: mustache
+model: /data.yml
 menuWeight: 2
 ---
 

--- a/pages/1.13/tutorials/autoscaling/requests-second/index.md
+++ b/pages/1.13/tutorials/autoscaling/requests-second/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Understanding Autoscaling
 title: Tutorial - Autoscaling using requests per second
 menuWeight: 1
 excerpt: Setting up microscaling based on requests per second
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/tutorials/create-service/index.md
+++ b/pages/1.13/tutorials/create-service/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Creating and Running a Service
 title: Tutorial - Creating and Running a Service
 menuWeight: 1
 excerpt: Creating and deploying a service and a containerized service
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/tutorials/dcos-101/app1/index.md
+++ b/pages/1.13/tutorials/dcos-101/app1/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Deploying First Application
 excerpt: Part 3 of the DC/OS 101 Tutorial
 title: Tutorial - Deploying First Application
+render: mustache
+model: /data.yml
 menuWeight: 3
 ---
 

--- a/pages/1.13/tutorials/dcos-101/app2/index.md
+++ b/pages/1.13/tutorials/dcos-101/app2/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Part 5 of the DC/OS 101 tutorial
 title: Tutorial -  Deploying native applications
 navigationTitle: Native Applications
+render: mustache
+model: /data.yml
 menuWeight: 5
 ---
 

--- a/pages/1.13/tutorials/dcos-101/cli/index.md
+++ b/pages/1.13/tutorials/dcos-101/cli/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Part 1 of the DC/OS 101 tutorial
 title: Tutorial - First Steps
 navigationTitle: First Steps
+render: mustache
+model: /data.yml
 menuWeight: 1
 ---
 
@@ -45,4 +47,4 @@ Here are the DC/OS components that are relevant to this tutorial. A full descrip
 * [Mesos DNS](/overview/architecture/components/#mesos-dns) provides service discovery within the cluster.
 * [Minuteman](/overview/architecture/components/#minuteman) is the internal layer 4 load balancer.
 * [Admin Router](/overview/architecture/components/#admin-router) is an open source NGINX configuration that provides central authentication and proxy to DC/OS services.
-* [Universe](/overview/architecture/components/#dcos-package-manager) is the package repository that holds the DC/OS services (e.g. Apache Spark or Apache Cassandra) that you can install on your cluster directly from the DC/OS GUI and CLI.
+* [{{ model.packageRepo }}](/overview/architecture/components/#dcos-package-manager) is the package repository that holds the DC/OS services (e.g. Apache Spark or Apache Cassandra) that you can install on your cluster directly from the DC/OS GUI and CLI.

--- a/pages/1.13/tutorials/dcos-101/index.md
+++ b/pages/1.13/tutorials/dcos-101/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  DC/OS 101
 excerpt: Understanding the basics of DC/OS
 title: Tutorial - DC/OS 101
+render: mustache
+model: /data.yml
 menuWeight: 0
 ---
 

--- a/pages/1.13/tutorials/dcos-101/loadbalancing/index.md
+++ b/pages/1.13/tutorials/dcos-101/loadbalancing/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Load-Balancing
 excerpt: Part 8 of the DC/OS 101 tutorial
 title: Tutorial - Load-Balancing
+render: mustache
+model: /data.yml
 menuWeight: 8
 ---
 

--- a/pages/1.13/tutorials/dcos-101/marathon-lb/index.md
+++ b/pages/1.13/tutorials/dcos-101/marathon-lb/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Part 6 of the DC/OS 101 tutorial
 title: Tutorial -  Exposing Apps Publicly
 navigationTitle: Exposing Apps Publicly
+render: mustache
+model: /data.yml
 menuWeight: 6
 ---
 
@@ -42,13 +44,13 @@ You will revisit the topic of load balancing and the different choices for load 
   * Use the web form to add a new Key:Value pair
   * You can verify the new key was added in two ways:
     1. Check the total number of keys using app1: `dcos task log app1`
-    2. Check redis directly
-       *  [SSH](/1.13/administering-clusters/sshcluster/) into node where redis is running:
+    2. Check Redis directly
+       *  [SSH](/1.13/administering-clusters/sshcluster/) into node where Redis is running:
 
            ```bash
            dcos node ssh --master-proxy --mesos-id=$(dcos task  redis --json |  jq -r '.[] | .slave_id')
            ```
-       * Because Redis is running in a Docker container you can list all the Docker containers using `docker ps` and get the ContainerID of the redis task.
+       * Because Redis is running in a Docker container you can list all the Docker containers using `docker ps` and get the ContainerID of the Redis task.
        * Create a bash session in the running container using the ContainerID from the previous step: `sudo docker exec -i -t CONTAINER_ID  /bin/bash`.
        * Start the Redis CLI: `redis-cli`.
        * Check the value is there: `get <newkey>`.

--- a/pages/1.13/tutorials/dcos-101/redis-package/index.md
+++ b/pages/1.13/tutorials/dcos-101/redis-package/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Installing the First Package
 excerpt: Part 2 of the DC/OS 101 tutorial
 title: Tutorial - Installing the First Package
+render: mustache
+model: /data.yml
 menuWeight: 2
 ---
 
@@ -17,11 +19,11 @@ By now, you should have a running DC/OS cluster and the DC/OS CLI installed and 
 The next stage of this tutorial uses [jq](https://stedolan.github.io/jq/), a command line JSON processor to simplify some of the commands. Follow the instructions [here](https://stedolan.github.io/jq/download/) to install JQ for your operating system.
 
 # Objective
-By the end of this session you will have installed your first service - [Redis](https://redislabs.com/) - from the DC/OS Universe repository. Redis is a key-value store, which you will use for persisting data in this tutorial.
+By the end of this session you will have installed your first service - [Redis](https://redislabs.com/) - from the DC/OS {{ model.packageRepo }} repository. Redis is a key-value store, which you will use for persisting data in this tutorial.
 
 # Steps
   * Install Redis
-      * Search the Universe repository for redis packages:
+      * Search the {{ model.packageRepo }} repository for Redis packages:
 
         ```bash
         dcos package search redis
@@ -29,25 +31,25 @@ By the end of this session you will have installed your first service - [Redis](
 
         This should return two entries (mr-redis and redis).
 
-      * You are interested in the redis package, which installs a single Redis container. Install the package with this command:
+      * You are interested in the Redis package, which installs a single Redis container. Install the package with this command:
 
         ```bash
         dcos package install redis
         ```
 
-  * You can use any of the following methods to check that redis is running:
+  * You can use any of the following methods to check that Redis is running:
       * By looking at the GUI: The Redis task should be displayed in the Service Health tab along with the health status.
       * By looking at all DC/OS tasks with the `dcos task` command. This command will show us all running DC/OS tasks (i.e. Mesos tasks).
       * By looking at all Marathon apps: `dcos marathon app list`. This command will show us all running Marathon apps. Since services are started via Marathon, you should see Redis here as well. Note that the health status (i.e. 1/1) is also shown here.
-      * By looking at the Redis log: `dcos task log redis`. This command will show us the logs (stdout and stderr) of the redis task. This allows you to check whether the actual startup was successful. You can increase the number of log lines displayed by using the `--lines=` argument, the default is 10.  
+      * By looking at the Redis log: `dcos task log redis`. This command will show us the logs (stdout and stderr) of the Redis task. This allows you to check whether the actual startup was successful. You can increase the number of log lines displayed by using the `--lines=` argument, the default is 10.  
   * Let's use Redis by storing a key manually via the redis-cli command
-      * [SSH](/administering-clusters/sshcluster/) into the node where redis is running:
+      * [SSH](/administering-clusters/sshcluster/) into the node where Redis is running:
 
         ```bash
         dcos node ssh --master-proxy --mesos-id=$(dcos task  redis --json |  jq -r '.[] | .slave_id')
         ```
 
-      * Because Redis is running in a Docker container, you can list all Docker containers using `docker ps` and get the ContainerID of the container running the redis service.
+      * Because Redis is running in a Docker container, you can list all Docker containers using `docker ps` and get the ContainerID of the container running the Redis service.
       * Start a bash session in the running container, substituting CONTAINER_ID with the ContainerID you got from the previous command:
 
         ```bash
@@ -73,11 +75,11 @@ By the end of this session you will have installed your first service - [Redis](
         ```
 
 # Outcome
-  You have just successfully installed your first service from the Universe repository and verified it is running!
+  You have just successfully installed your first service from the {{ model.packageRepo }} repository and verified it is running!
 
 # Deep Dive
-  [Universe](https://github.com/mesosphere/universe) is a package repository made available for DC/OS Clusters.
-  It enables you to easily install services such as Apache Spark or Apache Cassandra in your cluster without having to deal with manual configuration. Universe packages are developed and maintained by many different contributors.
+  [{{ model.packageRepo }}](https://github.com/mesosphere/universe) is a package repository made available for DC/OS Clusters.
+  It enables you to easily install services such as Apache Spark or Apache Cassandra in your cluster without having to deal with manual configuration. {{ model.packageRepo }} packages are developed and maintained by many different contributors.
 
   There are currently two categories of packages:
   1. Curated packages that have undergone testing and certification.

--- a/pages/1.13/tutorials/dcos-101/resources/index.md
+++ b/pages/1.13/tutorials/dcos-101/resources/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Part 7 of the DC/OS 101 tutorial
 title: Tutorial - Understanding Resources
 navigationTitle: Understanding Resources
+render: mustache
+model: /data.yml
 menuWeight: 7
 ---
 

--- a/pages/1.13/tutorials/dcos-101/service-discovery/index.md
+++ b/pages/1.13/tutorials/dcos-101/service-discovery/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 excerpt: Part 4 of the DC/OS 101 tutorial
 title: Tutorial - Connecting Apps/Service Discovery
 navigationTitle: Service Discovery
+render: mustache
+model: /data.yml
 menuWeight: 4
 ---
 
@@ -83,7 +85,7 @@ SSH into the Mesos master node in your cluster to see how these different servic
   The full name is then generated using the following schema:
   *vip-name.scheduler.l4lb.thisdcos.directory:vip-port*.
 
-  As we can see from the example [application](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.py), this is the mechanism used by the redis package, and so you can access the Redis service from within the cluster at `redis.marathon.l4lb.thisdcos.directory:6379`.
+  As we can see from the example [application](https://raw.githubusercontent.com/joerg84/dcos-101/master/app1/app1.py), this is the mechanism used by the Redis package, and so you can access the Redis service from within the cluster at `redis.marathon.l4lb.thisdcos.directory:6379`.
 
 # Outcome
 You know how to use service discovery to connect to your application from within your DC/OS cluster, and have learned about the two mechanisms for service discovery available in DC/OS.

--- a/pages/1.13/tutorials/dcos-debug/gen-strat/index.md
+++ b/pages/1.13/tutorials/dcos-debug/gen-strat/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Strategy
 title: Strategy
 excerpt: Tutorial - Applying troubleshooting strategies
+render: mustache
+model: /data.yml
 menuWeight: 21
 ---
 #include /include/tutorial-disclaimer.tmpl

--- a/pages/1.13/tutorials/dcos-debug/index.md
+++ b/pages/1.13/tutorials/dcos-debug/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Debugging Applications on DC/OS
 title: Tutorial -  Debugging Applications on DC/OS
 excerpt: Debugging application deployment issues in distributed systems
+render: mustache
+model: /data.yml
 menuWeight: 55
 ---
 

--- a/pages/1.13/tutorials/dcos-debug/problems/index.md
+++ b/pages/1.13/tutorials/dcos-debug/problems/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Problems
 navigationTitle:  Problems
 excerpt: Tutorial - Troubleshooting issues on DC/OS deployments
+render: mustache
+model: /data.yml
 menuWeight: 1
 ---
 

--- a/pages/1.13/tutorials/dcos-debug/scenarios/index.md
+++ b/pages/1.13/tutorials/dcos-debug/scenarios/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 navigationTitle:  Practice Deployment Debugging Scenarios on DC/OS
 title: Practice Deployment Debugging Scenarios on DC/OS
 excerpt: Tutorial - Practicing some debugging scenarios
+render: mustache
+model: /data.yml
 menuWeight: 31
 ---
 #include /include/tutorial-disclaimer.tmpl

--- a/pages/1.13/tutorials/dcos-debug/scenarios/scen-1/index.md
+++ b/pages/1.13/tutorials/dcos-debug/scenarios/scen-1/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Scenario 1
 navigationTitle: Scenario 1
 excerpt: Tutorial - Resource Allocation
+render: mustache
+model: /data.yml
 menuWeight: 1
 ---
 #include /include/tutorial-disclaimer.tmpl

--- a/pages/1.13/tutorials/dcos-debug/scenarios/scen-2/index.md
+++ b/pages/1.13/tutorials/dcos-debug/scenarios/scen-2/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Scenario 2
 navigationTitle: Scenario 2
 excerpt: Tutorial - Out of Memory
+render: mustache
+model: /data.yml
 menuWeight: 11
 ---
 

--- a/pages/1.13/tutorials/dcos-debug/scenarios/scen-3/index.md
+++ b/pages/1.13/tutorials/dcos-debug/scenarios/scen-3/index.md
@@ -3,6 +3,8 @@ layout: layout.pug
 title: Scenario 3
 navigationTitle: Scenario 3
 excerpt: Tutorial - Docker Images
+render: mustache
+model: /data.yml
 menuWeight: 21
 ---
 #include /include/tutorial-disclaimer.tmpl

--- a/pages/1.13/tutorials/deploy-on-marathon/index.md
+++ b/pages/1.13/tutorials/deploy-on-marathon/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Deploying Marathon Apps with Jenkins
 title: Deploying Marathon Apps with Jenkins
 menuWeight: 4
 excerpt: Tutorial - Deploying applications on Marathon using Jenkins for DC/OS
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/tutorials/index.md
+++ b/pages/1.13/tutorials/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Tutorials
 title: Tutorials
 menuWeight: 140
 excerpt: Getting started with DC/OS 
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.13/tutorials/iot_pipeline/index.md
+++ b/pages/1.13/tutorials/iot_pipeline/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Deploying a Load-Balanced Data Pipeline
 title: Deploying a Load-Balanced Data Pipeline
 menuWeight: 3
 excerpt: Tutorial - Building a complete load-balanced data pipeline on DC/OS
-
+render: mustache
+model: /data.yml
 ---
 
 #include /include/tutorial-disclaimer.tmpl
@@ -53,17 +54,17 @@ Tweeter stores tweets in the DC/OS Cassandra service, streams tweets to the DC/O
 
 ## Install DC/OS services
 
-In this step you install Cassandra, Kafka, Marathon-LB, and Zeppelin from the DC/OS web interface [**Catalog**](/gui/catalog/) tab. You can also install DC/OS packages from the DC/OS CLI with the [`dcos package install`][11] command.
+In this step you install Cassandra, Kafka, Marathon-LB, and Zeppelin from the DC/OS web interface [**{{ model.packageRepo }}**](/gui/catalog/) tab. You can also install DC/OS packages from the DC/OS CLI with the [`dcos package install`][11] command.
 
 1.  Find and click the **cassandra** package, click **REVIEW & RUN**, and accept the default installation, by clicking **REVIEW & RUN** again, then **RUN SERVICE**. Cassandra spins up to 3 nodes. When prompted by the modal alert, click **OPEN SERVICE**.
 
-2.  Click the **Catalog** tab. Find and click the **kafka** package, click the **REVIEW & RUN** button, then again, then **RUN SERVICE**. Kafka spins up 3 brokers. When prompted by the modal alert, click **OPEN SERVICE**.
+2.  Click the **{{ model.packageRepo }}** tab. Find and click the **kafka** package, click the **REVIEW & RUN** button, then again, then **RUN SERVICE**. Kafka spins up 3 brokers. When prompted by the modal alert, click **OPEN SERVICE**.
 
-3.  Click the **Catalog** tab. Find and click the **marathon-lb** package, click the **REVIEW & RUN** button, then again, then **RUN SERVICE**. When prompted by the modal alert, click **OPEN SERVICE**.
+3.  Click the **{{ model.packageRepo }}** tab. Find and click the **marathon-lb** package, click the **REVIEW & RUN** button, then again, then **RUN SERVICE**. When prompted by the modal alert, click **OPEN SERVICE**.
 
 If you are having trouble getting Marathon-LB up and running on an Enterprise cluster, try installing it following [these instructions](/services/marathon-lb/1.13/mlb-install/). Depending on your [security mode](/security/ent/#security-modes), Marathon-LB may require service authentication for access to DC/OS.
 
-4.  Click the **Catalog** tab. Click the **zeppelin** package, then click the **REVIEW & RUN** button.
+4.  Click the **{{ model.packageRepo }}** tab. Click the **zeppelin** package, then click the **REVIEW & RUN** button.
     1.  Click the **spark** tab on the left and set `cores_max` to `8`.
     2.  Click **REVIEW AND RUN** and click **RUN**. Click **OPEN SERVICE**.
 

--- a/pages/1.13/tutorials/stateful-services/index.md
+++ b/pages/1.13/tutorials/stateful-services/index.md
@@ -4,6 +4,8 @@ title: Running Stateful Services on DC/OS
 navigationTitle: Running Stateful Services on DC/OS
 menuWeight: 2
 excerpt: Tutorial - Running stateful services on DC/OS
+render: mustache
+model: /data.yml
 ---
 
 #include /include/tutorial-disclaimer.tmpl

--- a/pages/1.13/tutorials/task-labels/index.md
+++ b/pages/1.13/tutorials/task-labels/index.md
@@ -4,7 +4,8 @@ navigationTitle:  Labeling Tasks and Jobs
 title: Labeling Tasks and Jobs
 menuWeight: 5
 excerpt: Tutorial - Defining labels using the DC/OS web interface and the Marathon HTTP API
-
+render: mustache
+model: /data.yml
 enterprise: false
 ---
 

--- a/pages/1.14/installing/data.yml
+++ b/pages/1.14/installing/data.yml
@@ -1,1 +1,1 @@
-folder_version: '1.13'
+folder_version: '1.14'

--- a/pages/1.14/installing/evaluation/aws/aws-advanced/index.md
+++ b/pages/1.14/installing/evaluation/aws/aws-advanced/index.md
@@ -4,7 +4,7 @@ title: Configuration Reference - AWS
 excerpt: Configuring your DC/OS installation on AWS using the Universal Installer
 navigationTitle: Configuration Reference
 menuWeight: 3
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 #include /install-include/aws-extended-example.tmpl

--- a/pages/1.14/installing/evaluation/aws/aws-remote-region/index.md
+++ b/pages/1.14/installing/evaluation/aws/aws-remote-region/index.md
@@ -5,7 +5,7 @@ title: Multi-Region DC/OS on AWS using the Universal Installer
 navigationTitle: AWS Multi-Region Support
 menuWeight: 1
 enterprise: true
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/aws/aws-replaceable-masters/index.md
+++ b/pages/1.14/installing/evaluation/aws/aws-replaceable-masters/index.md
@@ -4,7 +4,7 @@ excerpt: Replaceable Masters on AWS using the Universal Installer
 title: Replaceable masters on AWS using the Universal Installer
 navigationTitle: AWS Replaceable Masters
 menuWeight: 2
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/aws/aws-tf-faq/index.md
+++ b/pages/1.14/installing/evaluation/aws/aws-tf-faq/index.md
@@ -4,7 +4,7 @@ title: Universal Installer FAQ & Troubleshooting Guide
 excerpt: FAQ and Common Issues with Universal Installer
 navigationTitle: Universal Installer FAQ
 menuWeight: 10
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/aws/index.md
+++ b/pages/1.14/installing/evaluation/aws/index.md
@@ -4,7 +4,7 @@ excerpt: Guide for DC/OS on AWS using the Universal Installer
 title: DC/OS on AWS using the Universal Installer
 navigationTitle: AWS
 menuWeight: 0
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 #include /install-include/aws-intro-and-prereqs.tmpl

--- a/pages/1.14/installing/evaluation/azure/advanced-azure/index.md
+++ b/pages/1.14/installing/evaluation/azure/advanced-azure/index.md
@@ -4,7 +4,7 @@ title: Configuration Reference - Azure
 excerpt: Configuring your DC/OS installation on Azure using the Mesosphere Universal Installer
 navigationTitle: Configuration Reference
 menuWeight: 3
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/azure/index.md
+++ b/pages/1.14/installing/evaluation/azure/index.md
@@ -4,7 +4,7 @@ excerpt: Guide for DC/OS on Azure using the Mesosphere Universal Installer
 title: DC/OS on Azure using the Universal Installer
 navigationTitle: Azure
 menuWeight: 2
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/aws/advanced/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/aws/advanced/index.md
@@ -4,7 +4,7 @@ title: Running DC/OS on AWS EC2 Advanced
 navigationTitle: Advanced
 menuWeight: 10
 excerpt: Creating and extending DC/OS clusters with AWS CloudFormation templates
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/aws/advanced/template-reference/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/aws/advanced/template-reference/index.md
@@ -4,7 +4,7 @@ navigationTitle: Template Reference
 title: Template Reference
 menuWeight: 5
 excerpt: Advanced template parameters
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/aws/basic/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/aws/basic/index.md
@@ -4,7 +4,7 @@ title: Basic
 navigationTitle: Basic
 menuWeight: 5
 excerpt: Creating a DC/OS cluster using DC/OS templates
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/aws/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/aws/index.md
@@ -4,7 +4,7 @@ title: AWS
 navigationTitle: AWS
 menuWeight: 5
 excerpt: Install DC/OS cluster for Amazon Web Services using templates on AWS CloudFormation
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/aws/removeaws/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/aws/removeaws/index.md
@@ -4,7 +4,7 @@ title: Uninstalling DC/OS on AWS EC2
 navigationTitle: Uninstalling
 menuWeight: 15
 excerpt: Uninstalling DC/OS running on AWS EC2
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/azure/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/azure/index.md
@@ -5,7 +5,7 @@ title: Running DC/OS on Azure
 navigationTitle: Azure
 menuWeight: 10
 oss: true
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/digitalocean/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/digitalocean/index.md
@@ -5,7 +5,7 @@ title: Running DC/OS on DigitalOcean
 navigationTitle: DigitalOcean
 menuWeight: 40
 oss: true
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/index.md
@@ -4,7 +4,7 @@ excerpt: Use CloudFormation, AzureRM or other Terraform templates to install DC/
 title: Other Installation methods
 navigationTitle: Other Installation methods
 menuWeight: 10
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/community-supported-methods/packet/index.md
+++ b/pages/1.14/installing/evaluation/community-supported-methods/packet/index.md
@@ -5,7 +5,7 @@ title: Running DC/OS on Packet
 navigationTitle: Packet
 menuWeight: 50
 oss: true
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/gcp/advanced-gcp/index.md
+++ b/pages/1.14/installing/evaluation/gcp/advanced-gcp/index.md
@@ -4,7 +4,7 @@ title: Configuration Reference -  GCP
 excerpt: Configuring your DC/OS installation on GCP using the Mesosphere Universal Installer
 navigationTitle: Configuration Reference
 menuWeight: 5
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 #include /install-include/gcp-extended-example.tmpl

--- a/pages/1.14/installing/evaluation/gcp/index.md
+++ b/pages/1.14/installing/evaluation/gcp/index.md
@@ -4,7 +4,7 @@ excerpt: Guide for DC/OS on GCP using the Universal Installer
 title: DC/OS on GCP using the Universal Installer
 navigationTitle: GCP
 menuWeight: 4
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/1.14/installing/evaluation/index.md
+++ b/pages/1.14/installing/evaluation/index.md
@@ -4,7 +4,7 @@ navigationTitle:  Cloud Installation
 title: Cloud Installation
 menuWeight: 10
 excerpt: Guide to Installing DC/OS on cloud environments using the Mesosphere Universal Installer
-model: /1.13/installing/data.yml
+model: /1.14/installing/data.yml
 render: mustache
 ---
 

--- a/pages/data.yml
+++ b/pages/data.yml
@@ -1,0 +1,8 @@
+# Common values:
+
+packageName: dcos
+serviceName: dcos
+techName: DC/OS
+packageRepo: Catalog
+version: '1.13'
+folder_version: '1.13'

--- a/pages/sdk/index.md
+++ b/pages/sdk/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 # navigationTitle:  SDK Docs
 title: SDK Docs
 # menus: ['header']
-menuWeight: 6
+menuWeight: -1
 excerpt:
 enterprise: false
 ---

--- a/pages/sdk/releases/0.40.0/index.md
+++ b/pages/sdk/releases/0.40.0/index.md
@@ -4,6 +4,8 @@ navigationTitle:  0.40.0
 title: 0.40.0
 menuWeight: 0
 excerpt:
+render: mustache
+model: /data.yml
 ---
 
 Documentation for SDK version 0.40.0

--- a/pages/sdk/releases/0.40.0/release-briefing/index.md
+++ b/pages/sdk/releases/0.40.0/release-briefing/index.md
@@ -4,6 +4,8 @@ navigationTitle:  0.40.x Releaase Briefing
 title: DC/OS SDK - 0.40.x Release Briefing
 menuWeight: 0
 excerpt:
+render: mustache
+model: /data.yml
 ---
 
 We are moving closer toward the GA release of the DC/OS SDK.  We’d like to take this opportunity to thank you, our partners and early adopters of the SDK, for you continued dedication to our platform.  Starting with this latest release, 0.40, we will be sending out a release briefing for each major and minor release of the SDK.  This briefing will explain what you need to know at a high level to adopt new releases; the linked release notes and guides will contain specific details.  We’ve included a special section at the end of this briefing that outlines our commitment to improving the SDK release process.

--- a/pages/sdk/releases/index.md
+++ b/pages/sdk/releases/index.md
@@ -4,6 +4,8 @@ navigationTitle:  Releases
 title: Releases
 menuWeight: 0
 excerpt:
+render: mustache
+model: /data.yml
 ---
 
 These are the SDK releases currently being supported.


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS-48825
Replace all references to "Universe" with "Catalog"


## Description of changes being made
Replaced all instances of Universe with Catalog except when found as part of code sample.
Also corrected lowercase redis to Redis where appropriate in tutorials.

## Checklist
Only 1.13 is affected by this change.