### PR TITLE
Add `dcos task download` to cmd reference

### DIFF
--- a/pages/1.14/cli/command-reference/dcos-task/dcos-task-download/index.md
+++ b/pages/1.14/cli/command-reference/dcos-task/dcos-task-download/index.md
@@ -21,15 +21,15 @@ dcos task download <task> [<path>] [OPTION]
 
 | Name, shorthand |  Description |
 |---------|-------------|
-| `--target-dir`   | Target directory of the download. Defaults to `$PWD`. |
+| `--target-dir`   | Specifies the target directory of the download. Defaults to the current working directory (`$PWD`). |
 
 
 # Positional arguments
 
 | Name, shorthand | Default | Description |
 |---------|-------------|-------------|
-| `<task>`   |             |  A full task ID, a partial task ID, or a regular expression. |
-| `<path>`   |     `/`      |  The Mesos sandbox directory path to a file or directory. Can be a UNIX shell wildcard pattern (e.g. `/std*`)|
+| `<task>`   |             | Specifies a full task ID, a partial task ID, or a UNIX shell wildcard pattern (for example, `my-task*`). |
+| `<path>`   |     `/`      | Specifies the Mesos sandbox directory path to a file or directory. You can also specify the path using a UNIX shell wildcard pattern (for example, `/std*`)|
 
 # Parent command
 

--- a/pages/1.14/cli/command-reference/dcos-task/dcos-task-download/index.md
+++ b/pages/1.14/cli/command-reference/dcos-task/dcos-task-download/index.md
@@ -1,0 +1,38 @@
+---
+layout: layout.pug
+navigationTitle:  dcos task download
+title: dcos task download
+menuWeight: 2
+excerpt: Download files from the Mesos task sandbox directory
+
+enterprise: false
+---
+
+# Description
+The `dcos task download` command downloads files from the Mesos task sandbox directory.
+
+# Usage
+
+```bash
+dcos task download <task> [<path>] [OPTION]
+```
+
+# Options
+
+| Name, shorthand |  Description |
+|---------|-------------|
+| `--target-dir`   | Target directory of the download. Defaults to `$PWD`. |
+
+
+# Positional arguments
+
+| Name, shorthand | Default | Description |
+|---------|-------------|-------------|
+| `<task>`   |             |  A full task ID, a partial task ID, or a regular expression. |
+| `<path>`   |     `/`      |  The Mesos sandbox directory path to a file or directory. Can be a UNIX shell wildcard pattern (e.g. `/std*`)|
+
+# Parent command
+
+| Command | Description |
+|---------|-------------|
+| [dcos task](/1.14/cli/command-reference/dcos-task/)   | Manage DC/OS tasks. |


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS_OSS-5315

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
We added a new command (`dcos task download`) to the CLI. This adds the respective docs page.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
