### PR TITLE
Change the download link per COPS-4304 (http://downloads.mesosphere.c…

### DIFF
--- a/pages/services/beta-jupyter/1.2.0-0.33.7-beta/example/index.md
+++ b/pages/services/beta-jupyter/1.2.0-0.33.7-beta/example/index.md
@@ -229,7 +229,7 @@ Next let us use [TensorFlowOnSpark](https://github.com/yahoo/TensorFlowOnSpark) 
 2. Retrieve and extract raw MNIST Dataset using the notebook's Terminal:
   ``` bash
   cd $MESOS_SANDBOX
-  curl -fsSL -O https://s3.amazonaws.com/vishnu-mohan/tensorflow/mnist/mnist.zip
+  curl -fsSL -O http://downloads.mesosphere.com/data-science/assets/mnist.zip
   unzip mnist.zip
   ```
 3.  Check HDFS


### PR DESCRIPTION
…om/data-science/assets/mnist.zip)

## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.
https://jira.mesosphere.com/browse/COPS-4304
<!-- Link to DOCS work ticket for reviewing and merging this PR -->
(From Anitha's queue)

## Description of changes being made
https://docs.mesosphere.com/services/beta-jupyter/example/
has an entry of:
curl -fsSL -O https://s3.amazonaws.com/vishnu-mohan/tensorflow/mnist/mnist.zip
unzip mnist.zip

Changed to point to:
http://downloads.mesosphere.com/data-science/assets/mnist.zip

## Checklist
- [ ] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
