### PR TITLE
pages/services/storage/1.0.0: rename beta-cassandra -> cassandra

### DIFF
--- a/pages/services/storage/1.0.0/troubleshooting/index.md
+++ b/pages/services/storage/1.0.0/troubleshooting/index.md
@@ -486,7 +486,7 @@ NODE                                     NAME   SIZE  STATUS
 ```
 
 If this happens, here are the steps to bring the data service back online.
-<p class="message--note"><strong>NOTE: </strong>We will use the <code>beta-cassandra</code> data service to illustrate
+<p class="message--note"><strong>NOTE: </strong>We will use the <code>cassandra</code> data service to illustrate
 how to recover a data service that uses local volumes served by the DC/OS Storage Service in the following example.</p>
 <p class="message--warning"><strong>WARNING: </strong>DC/OS Storage Service does not support preserving local volumes
 when the agent changes its Mesos ID. The following steps will wipe data on the stale volume to prevent any unauthorized
@@ -590,7 +590,7 @@ access to the data, then create a new volume so the data service could replicate
 
   6. Replace the missing pod so the data service will create a new pod instance to restore data back to the new volume:
      ```bash
-     dcos beta-cassandra pod replace node-0
+     dcos cassandra pod replace node-0
      ```
      ```
      {

--- a/pages/services/storage/1.0.0/tutorials/cassandra-dss-volumes/index.md
+++ b/pages/services/storage/1.0.0/tutorials/cassandra-dss-volumes/index.md
@@ -245,20 +245,20 @@ Volumes that have profile `cassandra` will be formatted with the `xfs` filesyste
     ```bash
     cat > cassandra-options.json <<EOF
     {
-        "data-node": {
-            "disk_profile": "cassandra",
+        "nodes": {
+            "volume_profile": "cassandra",
             "disk_type": "MOUNT"
         }
     }
     EOF
-    dcos package install beta-cassandra --options=cassandra-options.json
+    dcos package install cassandra --options=cassandra-options.json
     ```
 
     Once the Cassandra service is installed, it will start its tasks. After a while,
     its deployment should be completed.
 
     ```bash
-    dcos beta-cassandra update status
+    dcos cassandra update status
     ```
     ```
     deploy (serial strategy) (COMPLETE)


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-56418

## Description of changes being made

The cassandra package has been promoted to GA. This updates the dcos-storage documentation to use the GA'd version and its accompanied configuration change where `disk_profile` got renamed to `volume_profile` when it switched from beta- to GA.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
