### PR TITLE
Added workaround to use the DC/OS CLI on Fedora >= 30.

### DIFF
--- a/pages/1.11/cli/install/index.md
+++ b/pages/1.11/cli/install/index.md
@@ -51,6 +51,7 @@ The recommended method to install the DC/OS CLI is from the DC/OS web interface.
 - You must be able to open a command-line shell terminal on the external system hosting the CLI.
 - You nust be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
 - You must not be using the `noexec` to mount the `/tmp` directory unless you have set a `TMPDIR` environment variable to something other than the `/tmp` directory. Mounting the `/tmp` directory with the `noexec` option can prevent CLI operations.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
 
 ### Installing the DC/OS CLI
 
@@ -86,7 +87,7 @@ The recommended method to install the DC/OS CLI is from the DC/OS web interface.
 
     Follow the instructions in the DC/OS CLI. For more information about security, see [Security](/1.11/security/).
 
-    Your CLI should now be authenticated with your cluster! 
+    Your CLI should now be authenticated with your cluster!
 1. Type `dcos` view usage information and get started.
 
 ## <a name="osx"></a>Installing on macOS
@@ -127,7 +128,7 @@ The recommended method to install the DC/OS CLI is from the DC/OS web interface.
 
     Follow the instructions in the DC/OS CLI. For more information about security, see [Security](/1.11/security/).
 
-    Your CLI should now be authenticated with your cluster! 
+    Your CLI should now be authenticated with your cluster!
 1. Type `dcos` to view usage information and get started.
 
 ## <a name="windows"></a>Installing on Windows
@@ -157,6 +158,6 @@ The recommended method to install the DC/OS CLI is from the DC/OS web interface.
 
     Follow the instructions in the DC/OS CLI. For more information about security, see [Security](/1.11/security/).
 
-    Your CLI should now be authenticated with your cluster! 
-    
+    Your CLI should now be authenticated with your cluster!
+
 1. Type `dcos` to view usage information and get started.

--- a/pages/1.11/cli/install/index.md
+++ b/pages/1.11/cli/install/index.md
@@ -51,7 +51,7 @@ The recommended method to install the DC/OS CLI is from the DC/OS web interface.
 - You must be able to open a command-line shell terminal on the external system hosting the CLI.
 - You nust be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
 - You must not be using the `noexec` to mount the `/tmp` directory unless you have set a `TMPDIR` environment variable to something other than the `/tmp` directory. Mounting the `/tmp` directory with the `noexec` option can prevent CLI operations.
-- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. You can install the library by running `sudo dnf install libxcrypt-compat`.
 
 ### Installing the DC/OS CLI
 

--- a/pages/1.12/cli/install/index.md
+++ b/pages/1.12/cli/install/index.md
@@ -7,7 +7,7 @@ excerpt: Installing the DC/OS command line interface
 
 enterprise: false
 ---
-These instructions will show you how to install the core DC/OS CLI commands on your cluster. 
+These instructions will show you how to install the core DC/OS CLI commands on your cluster.
 For instructions on installing DC/OS Enterprise CLI commands, see the [DC/OS Enterprise CLI section](/1.12/cli/enterprise-cli/).
 
 The recommended method to install the DC/OS CLI is by getting the preformatted set of commands from the DC/OS GUI and running them in the terminal. See the prerequisites and instructions for your operating system for more information:
@@ -26,6 +26,7 @@ The recommended method to install the DC/OS CLI is by getting the preformatted s
 - You must be able to open a command-line shell terminal on the external system hosting the CLI.
 - You must be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
 - You must not be using the `noexec` to mount the `/tmp` directory unless you have set a `TMPDIR` environment variable to something other than the `/tmp` directory. Mounting the `/tmp` directory with the `noexec` option can prevent CLI operations.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
 
 ## Installing the CLI on Linux from the GUI
 
@@ -47,7 +48,7 @@ The recommended method to install the DC/OS CLI is by getting the preformatted s
 
     Figure 3. Code snippet window
 
-1. Once the DC/OS information screen has been displayed, run the command `dcos cluster list` to verify the connection to the cluster has been established. 
+1. Once the DC/OS information screen has been displayed, run the command `dcos cluster list` to verify the connection to the cluster has been established.
 
 ## Installing the DC/OS CLI manually
 
@@ -126,7 +127,7 @@ It is strongly recommended that you copy and paste the installation commands fro
 
     Figure 3. Code snippet window
 
-1. Once the `dcos` information screen has been displayed, run the command `dcos cluster list` to verify the connection to the cluster has been established. 
+1. Once the `dcos` information screen has been displayed, run the command `dcos cluster list` to verify the connection to the cluster has been established.
 
 ## Installing the CLI on macOS manually
 
@@ -158,7 +159,7 @@ It is strongly recommended that you copy and paste the installation commands fro
     Follow the instructions in the DC/OS CLI. For more information about security, see the [documentation](/1.12/security/).
 
     Your CLI should now be authenticated with your cluster!
-    
+
 1. Type `dcos` to view usage information and get started.
 
 <a name="windows"></a>
@@ -193,7 +194,7 @@ It is strongly recommended that you copy and paste the installation commands fro
 
     Figure 3. Code snippet window
 
-1. Once the `dcos` information screen has been displayed, run the command `dcos cluster list` to verify the connection to the cluster has been established. 
+1. Once the `dcos` information screen has been displayed, run the command `dcos cluster list` to verify the connection to the cluster has been established.
 
 ## Installing the CLI on Windows manually
 

--- a/pages/1.12/cli/install/index.md
+++ b/pages/1.12/cli/install/index.md
@@ -26,7 +26,7 @@ The recommended method to install the DC/OS CLI is by getting the preformatted s
 - You must be able to open a command-line shell terminal on the external system hosting the CLI.
 - You must be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
 - You must not be using the `noexec` to mount the `/tmp` directory unless you have set a `TMPDIR` environment variable to something other than the `/tmp` directory. Mounting the `/tmp` directory with the `noexec` option can prevent CLI operations.
-- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. You can install the library by running `sudo dnf install libxcrypt-compat`.
 
 ## Installing the CLI on Linux from the GUI
 

--- a/pages/1.13/cli/install/index.md
+++ b/pages/1.13/cli/install/index.md
@@ -25,6 +25,7 @@ The recommended method to install the DC/OS CLI is by getting the preformatted s
 
 # Prerequisites for Linux
 - You must be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
 
 
 # Prerequisites for macOS

--- a/pages/1.13/cli/install/index.md
+++ b/pages/1.13/cli/install/index.md
@@ -25,7 +25,7 @@ The recommended method to install the DC/OS CLI is by getting the preformatted s
 
 # Prerequisites for Linux
 - You must be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
-- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. You can install the library by running `sudo dnf install libxcrypt-compat`.
 
 
 # Prerequisites for macOS

--- a/pages/1.14/cli/install/index.md
+++ b/pages/1.14/cli/install/index.md
@@ -25,6 +25,7 @@ The recommended method to install the DC/OS CLI is by getting the preformatted s
 
 # Prerequisites for Linux
 - You must be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
 
 
 # Prerequisites for macOS

--- a/pages/1.14/cli/install/index.md
+++ b/pages/1.14/cli/install/index.md
@@ -25,7 +25,7 @@ The recommended method to install the DC/OS CLI is by getting the preformatted s
 
 # Prerequisites for Linux
 - You must be able to run `cURL` program on the system hosting the CLI. The `curl` command is installed by default on most Linux distributions.
-- If you are using Fedora 30 or above, you must install the `libcrypt` library. This can be done by running `sudo dnf install libxcrypt-compat`.
+- If you are using Fedora 30 or above, you must install the `libcrypt` library. You can install the library by running `sudo dnf install libxcrypt-compat`.
 
 
 # Prerequisites for macOS


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS_OSS-5364

## Description of changes being made
Added step for DC/OS CLI installation on Fedora 30. Some whitespaces have also been removed by my text editor.

## Checklist
- [X] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [X] Test all commands and procedures where applicable.
- [X] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
