### PR TITLE
[DCOS-57317] Changes for some minor issues and inconsistencies

### DIFF
--- a/pages/services/data-science-engine/1.0.0/quick-start/index.md
+++ b/pages/services/data-science-engine/1.0.0/quick-start/index.md
@@ -32,12 +32,6 @@ Click the `Review & Run` button to display the Edit Configuration page.
 
 Configure the package settings using  the DC/OS UI or by clicking JSON Editor and modifying the app definition manually. For example, you might customize the package by enabling HDFS support.
 
-At a minimum, you must specify the external public agent host name as a Networking configuration setting. For more information about customizing the configuration, see the Install and Customize pages.
-
-Click Networking.
-
-Under External Access, select Enabled, and enter name of the public agent host used to access the JupyterLab package.
-
 Click Review & Run.
 
 Review the installation notes, then click Run Service to deploy the {{ model.packageName }} package.
@@ -68,7 +62,7 @@ From DC/OS, select Services, then click on the "Open" icon for the `jupyter` ser
 
 ![Open JupyterLab](img/dcos-jupyter-new-window.png)
 
-This will open a new window or tab in the browser for JupyterLab.  Log in using the password you specified during the installation of the {{ model.packageName }} package
+This will open a new window or tab in the browser for JupyterLab.  Log in using the password specified during the installation of the {{ model.packageName }} package in "Service" -> "Jupyter Password" option or use `jupyter` by default.
 
    - In JupyterLab, create a new notebook by selecting File -> New -> Notebook
    
@@ -114,5 +108,4 @@ This will open a new window or tab in the browser for JupyterLab.  Log in using 
 # Next steps
 
 - To view the logs, see the documentation for Mesosphere DC/OS monitoring.
-- To view details about your {{ model.packageName }} job, run the `dcos task log --completed <submissionId>` command.
 

--- a/pages/services/data-science-engine/1.0.0/security/index.md
+++ b/pages/services/data-science-engine/1.0.0/security/index.md
@@ -17,24 +17,24 @@ In strict mode, any Spark applications launched by the {{ model.techName }} will
 
 Use the following `DCOS CLI` commands to rapidly provision a service account with the required permissions:
 
+```bash
+# Allows the default user 'nobody' to execute tasks
+dcos security org users grant <service-account-id> dcos:mesos:master:task:user:nobody create
+dcos security org users grant <service-account-id> dcos:mesos:agent:task:user:nobody create
 
-    ```bash
-    # Allows the default user 'nobody' to execute tasks
-    dcos security org users grant <service-account-id> dcos:mesos:master:task:user:nobody create
-    dcos security org users grant <service-account-id> dcos:mesos:agent:task:user:nobody create
+# Allows Spark framework to reserve cluster resources using <service-account-id> role and principal
+dcos security org users grant <service-account-id> dcos:mesos:master:framework:role:<service-account-id> create
+dcos security org users grant <service-account-id> dcos:mesos:master:reservation:role:<service-account-id> create
+dcos security org users grant <service-account-id> dcos:mesos:master:reservation:principal:<service-account-id> delete
+dcos security org users grant <service-account-id> dcos:mesos:master:volume:role:<service-account-id> create
+dcos security org users grant <service-account-id> dcos:mesos:master:volume:principal:<service-account-id> delete
 
-    # Allows Spark framework to reserve cluster resources using <service-account-id> role and principal
-    dcos security org users grant <service-account-id> dcos:mesos:master:framework:role:<service-account-id> create
-    dcos security org users grant <service-account-id> dcos:mesos:master:reservation:role:<service-account-id> create
-    dcos security org users grant <service-account-id> dcos:mesos:master:reservation:principal:<service-account-id> delete
-    dcos security org users grant <service-account-id> dcos:mesos:master:volume:role:<service-account-id> create
-    dcos security org users grant <service-account-id> dcos:mesos:master:volume:principal:<service-account-id> delete
-
-    # Allows Spark framework to launch tasks using <service-account-id> role and principal
-    dcos security org users grant <service-account-id> dcos:mesos:master:task:role:<service-account-id> create
-    dcos security org users grant <service-account-id> dcos:mesos:master:task:principal:<service-account-id> create
-    dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:/{{ model.serviceName }} create
-    ```
+# Allows Spark framework to launch tasks using <service-account-id> role and principal
+dcos security org users grant <service-account-id> dcos:mesos:master:task:role:<service-account-id> create
+dcos security org users grant <service-account-id> dcos:mesos:master:task:principal:<service-account-id> create
+dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:/{{ model.serviceName }} create
+```
+    
 You can also provision a service account using the UI.
 
 ## Using the secret store

--- a/pages/services/data-science-engine/1.0.0/tensorflow/index.md
+++ b/pages/services/data-science-engine/1.0.0/tensorflow/index.md
@@ -50,7 +50,7 @@ Here is an example:
     }
     ```
 
-3. Open TensorBoard at `https://<dcos-url>/service/{{ model.service-name }}/tensorboard/` and confirm the change.
+3. Open TensorBoard at `https://<dcos-url>/service/{{ model.serviceName }}/tensorboard/` and confirm the change.
 
 ## Disabling TensorBoard
 

--- a/pages/services/include/service-account.tmpl
+++ b/pages/services/include/service-account.tmpl
@@ -51,7 +51,7 @@ Create a secret (`{{ model.packageName }}/<secret-name>`) with your service acco
 ## Permissive
 
 ```bash
-dcos security secrets create-sa-secret <private-key>.pem model.serviceName {{ model.serviceName }}/<secret-name>
+dcos security secrets create-sa-secret <private-key>.pem {{ model.serviceName }} {{ model.serviceName }}/<secret-name>
 ```
 
 ## Strict


### PR DESCRIPTION
## Jira Ticket
[DCOS-57317 - Test Data Science Engine documentation](https://jira.mesosphere.com/browse/DCOS-57317)

## Description of changes being made
- [Quick Start] Removed outdated instructions to set public agent host name
Doesn't seem to be necessary after migration from marathon-lb to Admin Router

- [Quick Start] Clarified default password to Jupyter UI

- [Quick Start] Removed 'To view job details ...' line 
It looks to be a carry-over bit from Spark documentation, but here the mention of submission id is confusing

- [TensorFlow] Fixed missing service name in a URL

- [Security] Fixed a service name place holder in the Service Account Template

- [Security] Removed indentation from "Create and assign permissions" command listing, that caused markdown characters to be shown on the page
