### PR TITLE
Add cache-control to header

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -28,7 +28,7 @@ server {
 
   location / {
     error_page 404 /404/index.html;
-    expires 1m;
+    expires 5s;
     add_header Cache-Control "no-cache, must-revalidate";
   }
 }

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -25,13 +25,10 @@ server {
   if ( $redirect_uri_307 ) {
     return 307 $redirect_uri_307;
   }
-  
-  location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-    expires 1m;
-    add_header Cache-Control "no-cache, must-revalidate";
-  }
 
   location / {
     error_page 404 /404/index.html;
+    expires 1m;
+    add_header Cache-Control "no-cache, must-revalidate";
   }
 }

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -25,6 +25,11 @@ server {
   if ( $redirect_uri_307 ) {
     return 307 $redirect_uri_307;
   }
+  
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    expires 1m;
+    add_header Cache-Control "no-cache, must-revalidate";
+  }
 
   location / {
     error_page 404 /404/index.html;


### PR DESCRIPTION
Purpose of this change is to take out caching of the docs site as much as possible.

I could even set the expiration to 0

The regex for the file names/types may need to be adjusted, see what you think, it's borrowed


## Checklist
- [ ] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
