### PR TITLE
Added details for DSEngine service accounts setup and configuration

### DIFF
--- a/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
+++ b/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
@@ -16,9 +16,9 @@ When running in DC/OS strict security mode, both the {{ model.techName }} and Sp
 # Create and assign permissions
 In strict mode, any Spark applications launched by the {{ model.techName }} will require additional permissions for authenticating with Mesos. This includes the launching of executors (worker tasks) on the cluster.
 
-<p class="message--note"><strong>NOTE: </strong> Spark applications launched by the {{ model.techName }} do not require an additional service account setup and will reuse service account created for {{ model.techName }} with additional required permissions.</p>
+<p class="message--note"><strong>NOTE: </strong> Spark applications launched by the {{ model.techName }} do not require an additional service account setup and will reuse the service account created for {{ model.techName }} with additional required permissions.</p>
 
-Use the following `DCOS CLI` commands to rapidly provision a service account with the required permissions:
+Use the following DC/OS CLI commands to rapidly provision a service account with the required permissions:
 
 ```bash
 # Allows the default user 'nobody' to execute tasks
@@ -35,10 +35,10 @@ dcos security org users grant <service-account-id> dcos:mesos:master:volume:prin
 # Allows Spark framework to launch tasks using <service-account-id> role and principal
 dcos security org users grant <service-account-id> dcos:mesos:master:task:role:<service-account-id> create
 dcos security org users grant <service-account-id> dcos:mesos:master:task:principal:<service-account-id> create
-dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:{{ model.serviceName }} create
+dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:<service-account-name> create
 ```
 
-<p class="message--note"><strong>NOTE: </strong> For the permission that allows an app launching tasks which has a form  <code>dcos:mesos:master:task:app_id:&#60service-name&#62</code>, <tt>&#60service-name&#62</tt> must be equal to the service name specified in the options.json or as entered into the UI when {{ model.techName }} is installed.
+<p class="message--note"><strong>NOTE: </strong> The default service account name is <tt>data-science-engine</tt>, however, please ensure that the <tt>&#60service-account-name&#62</tt> entered here is the same as the service name specified in the options.json or in the UI when {{ model.techName }} is installed.
 
 <!-- You can also provision a service account using the UI. -->
 

--- a/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
+++ b/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
@@ -42,6 +42,15 @@ dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id
 
 <!-- You can also provision a service account using the UI. -->
 
+To configure Spark for using created service account and permissions, add the following configuration under `spark` section:
+```json
+"spark": {
+    "spark_mesos_principal": "<service-account-id>",
+    "spark_mesos_secret": "<service-account-secret>",
+    "spark_mesos_role": "<service-account-id>"
+}
+```
+
 ## Using the secret store
 
 DC/OS Enterprise allows users to add privileged information in the form of a file to the DC/OS secret store. These files can be referenced in {{ model.nickName }} jobs and used for authentication and authorization with various external services (for example, HDFS). For example, you can use this functionality to pass Kerberos `keytab` files. For details about how to use secrets, see understanding secrets.

--- a/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
+++ b/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
@@ -16,7 +16,7 @@ When running in DC/OS strict security mode, both the {{ model.techName }} and Sp
 # Create and assign permissions
 In strict mode, any Spark applications launched by the {{ model.techName }} will require additional permissions for authenticating with Mesos. This includes the launching of executors (worker tasks) on the cluster.
 
-<p class="message--note"><strong>NOTE: </strong> Spark applications launched by the {{ model.techName }} do not require an additional service account setup and will reuse service account created for {{ model.techName }} with additional required permissions.
+<p class="message--note"><strong>NOTE: </strong> Spark applications launched by the {{ model.techName }} do not require an additional service account setup and will reuse service account created for {{ model.techName }} with additional required permissions.</p>
 
 Use the following `DCOS CLI` commands to rapidly provision a service account with the required permissions:
 
@@ -38,11 +38,12 @@ dcos security org users grant <service-account-id> dcos:mesos:master:task:princi
 dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:{{ model.serviceName }} create
 ```
 
-<p class="message--note"><strong>NOTE: </strong> For the permission that allows an app launching tasks which has a form  `dcos:mesos:master:task:app_id:<service name>`, `<service name>` must be equal to the service name specified in options.json or in UI when {{ model.techName }} is installed.
+<p class="message--note"><strong>NOTE: </strong> For the permission that allows an app launching tasks which has a form  <code>dcos:mesos:master:task:app_id:&#60service-name&#62</code>, <tt>&#60service-name&#62</tt> must be equal to the service name specified in the options.json or as entered into the UI when {{ model.techName }} is installed.
 
 <!-- You can also provision a service account using the UI. -->
 
-To configure Spark for using created service account and permissions, add the following configuration under `spark` section:
+To configure Spark for using created service account and permissions, add the following configuration under the `spark` section:
+
 ```json
 "spark": {
     "spark_mesos_principal": "<service-account-id>",

--- a/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
+++ b/pages/mesosphere/dcos/services/data-science-engine/1.0.0/security/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
 navigationTitle: Security
-excerpt: Configuring secure DC/OS service accounts 
+excerpt: Configuring secure DC/OS service accounts
 title: Security
 enterprise: true
 menuWeight: 10
@@ -15,6 +15,8 @@ When running in DC/OS strict security mode, both the {{ model.techName }} and Sp
 
 # Create and assign permissions
 In strict mode, any Spark applications launched by the {{ model.techName }} will require additional permissions for authenticating with Mesos. This includes the launching of executors (worker tasks) on the cluster.
+
+<p class="message--note"><strong>NOTE: </strong> Spark applications launched by the {{ model.techName }} do not require an additional service account setup and will reuse service account created for {{ model.techName }} with additional required permissions.
 
 Use the following `DCOS CLI` commands to rapidly provision a service account with the required permissions:
 
@@ -33,9 +35,11 @@ dcos security org users grant <service-account-id> dcos:mesos:master:volume:prin
 # Allows Spark framework to launch tasks using <service-account-id> role and principal
 dcos security org users grant <service-account-id> dcos:mesos:master:task:role:<service-account-id> create
 dcos security org users grant <service-account-id> dcos:mesos:master:task:principal:<service-account-id> create
-dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:/{{ model.serviceName }} create
+dcos security org users grant <service-account-id> dcos:mesos:master:task:app_id:{{ model.serviceName }} create
 ```
-    
+
+<p class="message--note"><strong>NOTE: </strong> For the permission that allows an app launching tasks which has a form  `dcos:mesos:master:task:app_id:<service name>`, `<service name>` must be equal to the service name specified in options.json or in UI when {{ model.techName }} is installed.
+
 <!-- You can also provision a service account using the UI. -->
 
 ## Using the secret store
@@ -112,7 +116,7 @@ Each instance can have different authentication mechanisms configured.
 
 The default {{ model.techName }} password is set to`jupyter`. You can override it with the `service.jupyter_password` option.
 
-## OpenID Connect 
+## OpenID Connect
 
 You can choose to enable OpenID Connect authentication. The OpenID Connect flow will be triggered if `oidc.enabled` is
 `true` and both `oidc.discovery_uri` and `oidc.client_secret` are set, since they are the minimal options.
@@ -135,7 +139,7 @@ Here is an example of a simple OpenID Connect configuration for {{ model.techNam
 <!-- There are a few more options for advanced OpenID Connect configuration, that can be found in the `Oidc` section when
 installing {{ model.techName }} from the catalog in the DC/OS UI.  -->
 
- 
+
 
 
 [11]: https://docs.d2iq.com/latest/overview/architecture/components/


### PR DESCRIPTION
## Jira Ticket
This PR adds details for service accounts setup page as per [COPS-5233: Only 1 service account should be created for DSE, current docs are unclear](https://jira.mesosphere.com/browse/COPS-5233)
## Description of changes being made
- added a note that only a single service account should be used(no need for a new account for Spark)
- added a note about `app_id` permission setting
- added a configuration snippet for mapping of service account to Spark principals

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
