### PR TITLE
Incorrect default path suggestion

### DIFF
--- a/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuration-reference/index.md
@@ -221,7 +221,7 @@ The [secret access key](http://docs.aws.amazon.com/general/latest/gr/aws-sec-cre
 Whether to upload the customized advanced AWS templates to an S3 bucket.
 
 ### bootstrap_url
- (Required) The URL path for the DC/OS installer to store the customized DC/OS build files. If you are using the automated DC/OS installer, you should specify `bootstrap_url: file:///opt/dcos_install_tmp` unless you have moved the installer assets. By default the automated DC/OS installer places the build files in `file:///opt/dcos_install_tmp`.
+ (Required) The URL path for the DC/OS installer to store the customized DC/OS build files. If you are using the automated DC/OS installer, you should specify `bootstrap_url: file:///opt/dcos-install` unless you have moved the installer assets. By default the automated DC/OS installer places the build files in `file:///opt/dcos-install`.
 
 ### bouncer_expiration_auth_token_days [enterprise type="inline" size="small" /]
 This parameter sets the auth token time-to-live (TTL) for Identity and Access Management. You must specify the value in Python float syntax wrapped in a YAML string. By default, the token expires after five days. For example, to set the token lifetime to half a day:


### PR DESCRIPTION
My path on the bootstrap node with default values was `/opt/dcos-install/450f27d17908e25c54a5ac4d861d522d6363e85c/genconf/serve`

## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->
I've checked https://dcosjira.atlassian.net/secure/Dashboard.jspa, but I don't have permission to even look at anything, let alone create tickets

## Description of changes being made


## Checklist
- [ ] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
