### PR TITLE
add 'dcos diagnostics' documentation; deprecate 'dcos node diagnostics ...'

### DIFF
--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-create/index.md
@@ -1,0 +1,39 @@
+---
+layout: layout.pug
+navigationTitle:  dcos diagnostics create
+title: dcos diagnostics create
+menuWeight: 3
+excerpt: Creating a diagnostics bundle
+enterprise: false
+render: mustache
+model: /mesosphere/dcos/1.14/data.yml
+---
+
+# Description
+The `dcos diagnostics create` command allows you to create a diagnostics bundle.
+
+# Usage
+
+```bash
+dcos diagnostics create (<nodes>)
+```
+
+# Options
+
+| Name |  Description |
+|---------|-------------|
+| `--help, h`   |   Displays usage. |
+
+# Example
+
+```bash
+$ dcos diagnostics create
+a697769a-2d5d-4b2a-a2ec-055b9fe9eecf
+```
+
+# Parent command
+
+| Command | Description |
+|---------|-------------|
+| [dcos diagnostics](/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/) | Handling DC/OS diagnostics bundles |
+

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-delete/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-delete/index.md
@@ -1,0 +1,39 @@
+---
+layout: layout.pug
+navigationTitle:  dcos diagnostics delete
+title: dcos diagnostics delete
+menuWeight: 4
+excerpt: Deleting bundles
+enterprise: false
+render: mustache
+model: /mesosphere/dcos/1.14/data.yml
+---
+
+
+# Description
+The dcos diagnostics delete command allows you to delete diagnostics bundles.
+
+# Usage
+
+```bash
+dcos diagnostics delete <bundle-id>
+```
+
+# Options
+
+| Name |  Description |
+|---------|-------------|
+| `--help, h`   |   Displays usage. |
+
+## Positional arguments
+
+| Name |  Description |
+|---------|-------------|
+| `<bundle-id>`   |   The bundle ID. For example, `a697769a-2d5d-4b2a-a2ec-055b9fe9eecf`. |
+
+# Parent command
+
+| Command | Description |
+|---------|-------------|
+| [dcos diagnostics](/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/) | Handling DC/OS diagnostics bundles |
+

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-delete/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-delete/index.md
@@ -11,7 +11,7 @@ model: /mesosphere/dcos/1.14/data.yml
 
 
 # Description
-The dcos diagnostics delete command allows you to delete diagnostics bundles.
+The `dcos diagnostics delete` command allows you to delete diagnostics bundles.
 
 # Usage
 

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-download/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-download/index.md
@@ -1,0 +1,41 @@
+---
+layout: layout.pug
+navigationTitle:  dcos diagnostics download
+title: dcos diagnostics download
+menuWeight: 5
+excerpt: Downloading a diagnostics bundle
+enterprise: false
+render: mustache
+model: /mesosphere/dcos/1.14/data.yml
+---
+
+
+
+# Description
+The `dcos diagnostics download` command allows you to download the diagnostics bundle to a specific location.
+
+# Usage
+
+```bash
+dcos diagnostics download <bundle-id> [flags]
+```
+
+# Options
+
+| Name | Default | Description |
+|---------|-------------|-------------|
+| `--help, -h`   |   |  Displays usage. |
+| `--output=<location>`   |  ./<bundle-id>.zip |  Download the diagnostics bundle to a specific location. If not set, the default location is your current working directory. |
+
+## Positional arguments
+
+| Name |  Description |
+|---------|-------------|
+| `<bundle-id>`   |  The bundle ID. For example, `a697769a-2d5d-4b2a-a2ec-055b9fe9eecf`. |
+
+# Parent command
+
+| Command | Description |
+|---------|-------------|
+| [dcos diagnostics](/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/) | Handling DC/OS diagnostics bundles |
+

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-list/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/dcos-diagnostics-list/index.md
@@ -1,0 +1,35 @@
+---
+layout: layout.pug
+navigationTitle:  dcos diagnostics list
+title: dcos diagnostics list
+menuWeight: 5
+excerpt: Listing diagnostics bundles
+enterprise: false
+render: mustache
+model: /mesosphere/dcos/1.14/data.yml
+---
+
+
+
+# Description
+The `dcos diagnostics list` command allows you to list all avaliable diagnostics bundles.
+
+# Usage
+
+```bash
+dcos diagnostics list [flags]
+```
+
+# Options
+
+| Name | Default | Description |
+|---------|-------------|-------------|
+| `--help, h`   |   |  Displays usage. |
+| `--json`   |  |  Prints the list in JSON format. |
+
+# Parent command
+
+| Command | Description |
+|---------|-------------|
+| [dcos diagnostics](/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/) | Handling DC/OS diagnostics bundles |
+

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-diagnostics/index.md
@@ -1,0 +1,29 @@
+---
+layout: layout.pug
+navigationTitle:  dcos diagnostics
+title: dcos diagnostics
+menuWeight: 5
+excerpt: Handling DC/OS diagnostics bundles
+render: mustache
+model: /mesosphere/dcos/1.14/data.yml
+enterprise: false
+---
+
+
+# Description
+The `dcos diagnostics` commands allow you to handle DC/OS diagnostics bundles.
+
+# Usage
+
+```bash
+dcos diagnostics [OPTION] COMMAND
+```
+
+# Options
+
+| Name |  Description |
+|---------|-------------|
+| `--help, h`   |   Displays usage. |
+
+
+# Commands

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -12,6 +12,8 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The `dcos node diagnostics create` command allows you to create a diagnostics bundle.
 
+**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics create` instead.**
+
 # Usage
 
 ```bash

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -12,7 +12,7 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The `dcos node diagnostics create` command allows you to create a diagnostics bundle.
 
-**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics create` instead.**
+**This command is deprecated since DC/OS 1.14; please use `dcos diagnostics create` instead.**
 
 # Usage
 

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-delete/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-delete/index.md
@@ -13,6 +13,8 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The dcos node diagnostics delete command allows you to view the details of diagnostics bundles.
 
+**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics delete` instead.**
+
 # Usage
 
 ```bash

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-delete/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-delete/index.md
@@ -13,7 +13,7 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The dcos node diagnostics delete command allows you to view the details of diagnostics bundles.
 
-**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics delete` instead.**
+**This command is deprecated since DC/OS 1.14; please use `dcos diagnostics delete` instead.**
 
 # Usage
 

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-download/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-download/index.md
@@ -14,6 +14,8 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The `dcos node diagnostics download` command allows you to download the diagnostics bundle to a specific location.
 
+**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics download` instead.**
+
 # Usage
 
 ```bash

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-download/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics-download/index.md
@@ -14,7 +14,7 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The `dcos node diagnostics download` command allows you to download the diagnostics bundle to a specific location.
 
-**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics download` instead.**
+**This command is deprecated since DC/OS 1.14; please use `dcos diagnostics download` instead.**
 
 # Usage
 

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics/index.md
@@ -13,6 +13,8 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The `dcos node diagnostics` command allows you to view the details of diagnostics bundles.
 
+**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics` instead.**
+
 # Usage
 
 ```bash

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-node/dcos-node-diagnostics/index.md
@@ -13,7 +13,7 @@ model: /mesosphere/dcos/1.14/data.yml
 # Description
 The `dcos node diagnostics` command allows you to view the details of diagnostics bundles.
 
-**This command is deprecated since DC/OS 1.14, please use `dcos diagnostics` instead.**
+**This command is deprecated since DC/OS 1.14; please use `dcos diagnostics` instead.**
 
 # Usage
 

--- a/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-task/index.md
+++ b/pages/mesosphere/dcos/1.14/cli/command-reference/dcos-task/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 The `dcos task` commands let you manage DC/OS tasks.
 
-**This command is deprecated since DC/OS 1.14, use `dcos task list` instead.**
+**This command is deprecated since DC/OS 1.14; use `dcos task list` instead.**
 
 # Usage
 


### PR DESCRIPTION
## Jira Tickets

https://jira.mesosphere.com/browse/DCOS_OSS-5446
https://jira.mesosphere.com/browse/DCOS_OSS-5437

## Description of changes being made

* Add deprecation notice for diagnostics to docs site
* Create documentation for new diagnostics subcommand

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
