### PR TITLE
[DCOS-59412] Fix broken link in Kafka release notes

### DIFF
--- a/pages/mesosphere/dcos/services/kafka/2.7.0-2.3.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/kafka/2.7.0-2.3.0/release-notes/index.md
@@ -28,7 +28,7 @@ render: mustache
 
 ### New Features
 - Autosuggestion is available for Service Account and Secrets when launching the service from DC/OS UI
-- Support for <a href="/mesosphere/dcos/services/kafka/2.6.0-2.2.1/advanced/#secure-jmx-enterprise">Secure JMX</a>
+- Support for <a href="/mesosphere/dcos/services/kafka/latest/advanced/#secure-jmx-enterprise">Secure JMX</a>
 - Added marathon service scheduler checks
 - Service will fetch all required resources over HTTPS
 


### PR DESCRIPTION
This link was broken in the release notes. Changing it to `latest` makes sure it points to the right page for every release.