### PR TITLE
[DCOS-60485] Update docs for cassandra 2.7.0-3.11.4

### DIFF
--- a/pages/mesosphere/dcos/services/cassandra/2.7.0-3.11.4/limitations/index.md
+++ b/pages/mesosphere/dcos/services/cassandra/2.7.0-3.11.4/limitations/index.md
@@ -16,10 +16,6 @@ render: mustache
 
 Custom JVM options are not currently supported in this version or earlier versions.
 
-## Backup/Restore
-
-The service does not support performing backup and restore with authentication/authorization enabled in this version or earlier versions.
-
 ## Node Count
 
 The DC/OS {{ model.techName }} service must be deployed with at least {{ model.install.minNodeCount }} nodes.


### PR DESCRIPTION
## Description
Resolves [DCOS-60485](https://jira.mesosphere.com/browse/DCOS-60485)

This PR remove info from limitation page of latest Cassandra which stat that `Cassandra does not support  backup and restore with authN/Z` but does supports it.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
