### PR TITLE
DCOS-60471: Fix broken links for 3.6.0-2.190.1

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -8,7 +8,7 @@
 ~^/mesosphere/dcos/services/edge-lb/latest/(.*) /mesosphere/dcos/services/edge-lb/1.5/$1;
 ~^/mesosphere/dcos/services/elastic/latest/(.*) /mesosphere/dcos/services/elastic/2.7.0-6.8.1/$1;
 ~^/mesosphere/dcos/services/hdfs/latest/(.*) /mesosphere/dcos/services/hdfs/2.7.0-3.2.1/$1;
-~^/mesosphere/dcos/services/jenkins/latest/(.*) /mesosphere/dcos/services/jenkins/3.5.4-2.150.1/$1;
+~^/mesosphere/dcos/services/jenkins/latest/(.*) /mesosphere/dcos/services/jenkins/3.6.0-2.190.1/$1;
 ~^/mesosphere/dcos/services/kafka/latest/(.*) /mesosphere/dcos/services/kafka/2.8.0-2.3.0/$1;
 ~^/mesosphere/dcos/services/kubernetes/latest/(.*) /mesosphere/dcos/services/kubernetes/2.4.4-1.15.4/$1;
 ~^/mesosphere/dcos/services/kafka-zookeeper/latest/(.*) /mesosphere/dcos/services/kafka-zookeeper/2.6.0-3.4.14/$1;

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/architecture/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/architecture/index.md
@@ -16,13 +16,13 @@ The DC/OS Jenkins service bundles the [Jenkins Automation Server](https://github
 
 #### Docker
 
-By default the DC/OS Jenkins service uses the [Docker Engine](../../../../2.0/deploying-services/containerizers/docker-containerizer/index.md) as its default containerizer for both the Jenkins Master and the Agents. Users are recommended to use this runtime if they intend to ugprade from existing installations of the Jenkins service.
+By default the DC/OS Jenkins service uses the [Docker Engine](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/docker-containerizer/) as its default containerizer for both the Jenkins Master and the Agents. Users are recommended to use this runtime if they intend to ugprade from existing installations of the Jenkins service.
 
 #### Universal Container Runtime (UCR)
 
-The [Universal Container Runtime](../../../../2.0/deploying-services/containerizers/ucr/index.md) (UCR) is optionally supported on the Jenkins Master. UCR is available as the containerizer on the Jenkins agents but its use is opt-in and not supported at this time.
+The [Universal Container Runtime](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/ucr/) (UCR) is optionally supported on the Jenkins Master. UCR is available as the containerizer on the Jenkins agents but its use is opt-in and not supported at this time.
 
 ### Multi-tenancy
 
-The DC/OS Jenkins service starting with DC/OS 2.0 supports multi-tenancy. Users should familiarize themselves with [Quota](../../../../2.0/multi-tenancy/quota-management/index.md) and [Resource Managment Primitives](../../../../2.0/multi-tenancy/resource-mgmt-primitives/index.md) in DC/OS.
+The DC/OS Jenkins service starting with DC/OS 2.0 supports multi-tenancy. Users should familiarize themselves with [Quota](https://docs.d2iq.com/mesosphere/dcos/latest/multi-tenancy/quota-management/) and [Resource Managment Primitives](https://docs.d2iq.com/mesosphere/dcos/latest/multi-tenancy/resource-mgmt-primitives/) in DC/OS.
 In particular, service-accounts in a quota enforced group must be given the correct role permissions for the service to launch and perform its operations.

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/quickstart/index.md
@@ -11,7 +11,7 @@ enterprise: false
 
 As a package available in the Universe, Jenkins for DC/OS can be installed using either the web interface or the DC/OS CLI. With its sensible defaults, you can get up and running very quickly.
 
-<strong>Important:</strong> The default installation will use a <code>/tmp</code> directory on the local host to store configuration and build data. This configuration will not scale to accommodate multiple Jenkins masters. In addition, it will result in the loss of data when the agent goes down. Before going into production, you must perform a <a href="/mesosphere/dcos/services/jenkins/custom-install/">custom install</a> and set up either a shared file system (recommended) or pin to a single agent.
+<strong>Important:</strong> The default installation will use a <code>/tmp</code> directory on the local host to store configuration and build data. This configuration will not scale to accommodate multiple Jenkins masters. In addition, it will result in the loss of data when the agent goes down. Before going into production, you must perform a <a href="https://docs.d2iq.com/mesosphere/dcos/services/jenkins/latest/custom-install/">custom install</a> and set up either a shared file system (recommended) or pin to a single agent.
 
 <h1>Prerequisites</h1>
 
@@ -26,7 +26,7 @@ DC/OS 1.10 or later
 <ol>
 <li>Click <strong>Universe</strong>.</p></li>
 <li><p>Click the <strong>Install Package</strong> button for the Jenkins package.</p></li>
-<li><p>To accept the default settings, click <strong>Install Package</strong> on the pop-up. To customize the installation parameters, click <strong>Advanced Installation</strong> instead. Refer to <a href="/mesosphere/dcos/services/jenkins/custom-install/">Customizing your install</a> for more information about each option.</p></li>
+<li><p>To accept the default settings, click <strong>Install Package</strong> on the pop-up. To customize the installation parameters, click <strong>Advanced Installation</strong> instead. Refer to <a href="https://docs.d2iq.com/mesosphere/dcos/services/jenkins/latest/custom-install/">Customizing your install</a> for more information about each option.</p></li>
 </ol>
 
 <h2>Using the CLI</h2>
@@ -38,7 +38,7 @@ From the CLI, type the following command to install Jenkins for DC/OS.
 <pre><code class="bash">dcos package install jenkins
 </code></pre>
 
-<strong>Note:</strong> You can use the <code>--options</code> flag to pass custom configuration parameters. Refer to <a href="/mesosphere/dcos/services/jenkins/custom-install/">Customizing your install</a> for more information.
+<strong>Note:</strong> You can use the <code>--options</code> flag to pass custom configuration parameters. Refer to <a href="https://docs.d2iq.com/mesosphere/dcos/services/jenkins/latest/custom-install/">Customizing your install</a> for more information.
 
 <h1>Verifying your installation</h1>
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/release-notes/index.md
@@ -12,7 +12,7 @@ Jenkins 3.6.0-2.190.1
 ## Improvements
 - Updates to version 2.190.1 (LTS)
 - Updates [jenkins-mesos-plugin](https://github.com/jenkinsci/mesos-plugin) to 1.0.0 which includes offer-suppression to improve scalability in a mixed-framework cluster.
-- Users can optionally select the [Universal Container Runtime](../../../../2.0/deploying-services/containerizers/ucr/index.md) (UCR) for the Jenkins Master which offers greater stability and emits metrics to the [DC/OS Monitoring Service](../../../../services/dcos-monitoring/1.1.0/index.md).
+- Users can optionally select the [Universal Container Runtime](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/ucr) (UCR) for the Jenkins Master which offers greater stability and emits metrics to the [DC/OS Monitoring Service](https://docs.d2iq.com/mesosphere/dcos/services/dcos-monitoring/latest/).
 - Support for multi-tenancy features on DC/OS 2.0
 - Bundled plugins have been updated to their latest versions.
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/upgrade/index.md
@@ -11,15 +11,15 @@ enterprise: false
 
 To upgrade from one version of the Jenkins for DC/OS package to another, simply uninstall the current version, update your package repository cache, and install a new version.
 
-- Uninstall Jenkins as per the instructions in [Uninstalling](../uninstall/index.md). Any builds that are currently in progress or queued will be lost.
+- Uninstall Jenkins as per the instructions in [Uninstalling](https://docs.d2iq.com/mesosphere/dcos/services/jenkins/latest/uninstall/). Any builds that are currently in progress or queued will be lost.
 - Use the CLI to update your local cache of the package repository. 
     `dcos package update`
-- Install Jenkins, again following the instructions on [Customizing your install](../custom-install/index.md). Make sure you use the same configuration file as previously, specifically pointing Jenkins to the same <code>host-volume</code>.
+- Install Jenkins, again following the instructions on [Customizing your install](https://docs.d2iq.com/mesosphere/dcos/services/jenkins/latest/custom-install/). Make sure you use the same configuration file as previously, specifically pointing Jenkins to the same <code>host-volume</code>.
 - Currently it is necessary to upgrade plugins by hand using the Jenkins UI at <code>&lt;dcos_url&gt;/service/jenkins/pluginManager</code>.
 
 ## Upgrading to UCR Containerizer
 
-This release supports the optional use of [Universal Container Runtime](../../../../2.0/deploying-services/containerizers/ucr/index.md) (UCR) for the Jenkins Master which offers greater stability and emits metrics to the [DC/OS Monitoring Service](../../../../services/dcos-monitoring/1.1.0/index.md).
+This release supports the optional use of [Universal Container Runtime](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/ucr/) (UCR) for the Jenkins Master which offers greater stability and emits metrics to the [DC/OS Monitoring Service](https://docs.d2iq.com/mesosphere/dcos/services/dcos-monitoring/latest/).
 
 Customers can specify use of UCR via the following options:
 ```
@@ -35,7 +35,7 @@ Users with data on persistent volumes need to ensure the user running with the U
 It is *strongly recommended* that a backup of the persistent volume is performed before proceeding.
 
 By default, the Docker containerizer uses the `root` user, and volumes may be populated by the `root` user. To upgrade to UCR in this scenario, the following steps need to be taken to allow UCR to read & write to volumes:
-- [Grant Marathon priviledges](../../../../2.0/security/ent/users-groups/config-linux-user/index.md#overriding-the-default-linux-user-of-a-universe-service) for the`root` user
+- [Grant Marathon priviledges](https://docs.d2iq.com/mesosphere/dcos/latest/security/ent/users-groups/config-linux-user/#overriding-the-default-linux-user-of-a-catalog-service) for the`root` user
 - Specify the `root` user to run UCR containerizer via the following options
 ```
     "service": {


### PR DESCRIPTION
Fix broken links on service page.
Point `latest` to `3.6.0-2.190.1`

## Jira Ticket
JIRA [DCOS-60471](https://jira.mesosphere.com/browse/DCOS-60471)

## Description of changes being made
Fix broken links.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
