### PR TITLE
[DCOS-58684] Fix broken links for hive metastore v1.0.0-3.0.0

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -25,3 +25,4 @@
 ~^/mesosphere/dcos/services/dcos-monitoring/latest/(.*) /mesosphere/dcos/services/dcos-monitoring/1.1.0/$1;
 ~^/mesosphere/dcos/services/beta-jupyter/latest/(.*) /mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/$1;
 ~^/mesosphere/dcos/cn/services/kubernetes/latest/(.*) /mesosphere/dcos/cn/services/kubernetes/1.2.1-1.10.6/$1;
+~^/mesosphere/dcos/services/hive-metastore/latest/(.*) /mesosphere/dcos/services/hive-metastore/1.0.0-3.0.0/$1;


### PR DESCRIPTION
## Jira Ticket
Parent JIRA ticket : [here](https://jira.mesosphere.com/browse/DCOS-58684)

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
Updated the redirect-309 map to point `hive-metastore`'s latest version i.e. `1.0.0-3.0.0` over the live [URL](https://docs.d2iq.com/mesosphere/dcos/services/hive-metastore/latest/)

## Checklist
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.