### PR TITLE
moving section on konvoy cluster creation

### DIFF
--- a/pages/ksphere/konvoy/partner-solutions/aqua/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/aqua/index.md
@@ -49,6 +49,19 @@ cd aqua-helm
 
 **Note:** Konvoy is using `containerd`. There is currently an issue with the Aqua container registry when pulling private images. Thats why we need the additional steps described in this section until the issue gets resolved.
 
+**Note:** In your Konvoy `cluster.yaml file` remove the line `-  AlwaysPullImages` before creating the cluster with `konvoy up`.
+```yaml
+...
+spec:
+  kubernetes:
+    admissionPlugins:
+      enabled:
+      - NodeRestriction
+      - AlwaysPullImages
+      disabled: []
+...
+```
+
 Use your `Aqua credentials` to login to the `Aqua container registry`.
 
 ```sh
@@ -80,20 +93,6 @@ for ip in $IPS; do
   scp -o StrictHostKeyChecking=no -i $KEY_FILE aqua.tar.gz centos@$ip:/tmp;
   ssh -o StrictHostKeyChecking=no -i $KEY_FILE centos@$ip sudo ctr -n k8s.io image import /tmp/aqua.tar.gz;
 done
-```
-
-In your Konvoy `cluster.yaml file` remove the line `-  AlwaysPullImages` and do a `konvoy up`.
-
-```yaml
-...
-spec:
-  kubernetes:
-    admissionPlugins:
-      enabled:
-      - NodeRestriction
-      - AlwaysPullImages
-      disabled: []
-...
 ```
 
 ### install the Aqua server, database, and gateway

--- a/pages/ksphere/konvoy/partner-solutions/lightbend/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/lightbend/index.md
@@ -31,6 +31,19 @@ helm repo update
 
 **Note:** Konvoy is using `containerd`. There is currently an issue with the Lightbend container registry (i.e. bintray, JFrog internal JIRA JBT-2988) when pulling private images. Thats why we need the additional steps described in this section until the issue gets resolved.
 
+**Note:** In your Konvoy `cluster.yaml file` remove the line `-  AlwaysPullImages` before creating the cluster with `konvoy up`.
+```yaml
+...
+spec:
+  kubernetes:
+    admissionPlugins:
+      enabled:
+      - NodeRestriction
+      - AlwaysPullImages
+      disabled: []
+...
+```
+
 Use your `Lightbend credentials` to login to the `Lightbend container registry`.
 
 ```sh
@@ -60,20 +73,6 @@ for ip in $IPS; do
   scp -o StrictHostKeyChecking=no -i $KEY_FILE lb.tar.gz centos@$ip:/tmp;
   ssh -o StrictHostKeyChecking=no -i $KEY_FILE centos@$ip sudo ctr -n k8s.io image import /tmp/lb.tar.gz;
 done
-```
-
-In your Konvoy `cluster.yaml file` remove the line `-  AlwaysPullImages` and do a `konvoy up`.
-
-```yaml
-...
-spec:
-  kubernetes:
-    admissionPlugins:
-      enabled:
-      - NodeRestriction
-      - AlwaysPullImages
-      disabled: []
-...      
 ```
 
 ### installing the Lightbend console


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS-61027

## Description of changes being made
Moving section on that Konvoy cluster has to be created with AlwaysPullImages removed from cluster yaml.

## Checklist
- [ ] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
