### PR TITLE
Simplify service account provisioning commands using DC/OS CLI

### DIFF
--- a/pages/mesosphere/dcos/services/include/security-create-permissions.tmpl
+++ b/pages/mesosphere/dcos/services/include/security-create-permissions.tmpl
@@ -1,89 +1,38 @@
 
 # <a name="give-perms"></a>Create and Assign Permissions
-Use the following `curl` commands to rapidly provision the {{ model.techName }} service account with the required permissions.
-
-<p class="message--note"><strong>NOTE: </strong>Any forward slash ("/") in a resource must be replaced with `%252F` before it can be passed in a curl command.</p>
-
-When using the API to manage permissions, you must first create the permissions and then assign them. Sometimes, the permission may already exist. In this case, the API returns an informative message. You can regard this as a confirmation and continue to the next command.
+Use the following DC/OS CLI commands to rapidly provision the {{ model.techName }} service account with the required permissions.
 
 1.  Create the permission.
 
-<p class="message--important"><strong>IMPORTANT: </strong>These commands use the default {{ model.techName }} <tt>role</tt> value of <tt>{{ model.packageName }}-role</tt>. If you are running multiple instances of {{ model.techName }}, replace the instances of <tt>{{ model.packageName }}-role</tt> with the correct name (<tt>&lt;name&gt;-role</tt>). For example, if you have a {{ model.techName }} instance named <tt>{{ model.packageName }}2</tt>, you would replace each role value in the code samples to <tt>{{ model.packageName }}2-role</tt>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>The value to be used for <tt>&lt;service-role&gt;</tt> will be based on the service name. The table below shows a few examples to show the pattern used by the service as it Mesos role to use. If you need help configuring the permissions for {{ model.packageName }}, please feel to reach out to D2iQ support by filing a support ticket. Replace the instances of <tt>&lt;service-role&gt;</tt> with the correct name (<tt>&lt;name&gt;-role</tt>).</p>
+
+| Service name                           | &lt;service-role&gt;                           |
+|----------------------------------------|------------------------------------------------|
+| `/{{ model.packageName }}`             | `{{ model.packageName }}-role`                 |
+| `/{{ model.packageName }}-prod`        | `{{ model.packageName }}-prod-role`            |
+| `/team01/{{ model.packageName }}`      | `team01__{{ model.packageName }}-role`         |
+| `/team01/prod/{{ model.packageName }}` | `team01__prod__{{ model.packageName }}-role`   |
 
 ## Permissive 
 
-Run these commands with your service account name (`<service-account-id>`) specified.
+Run these commands with the service account name you created for the service in the *Create a Service Account* step above. For example we are using {{ model.packageName }}
 
 ```bash
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:task:user:nobody \
--d '{"description":"Allows Linux user nobody to execute tasks"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:framework:role:{{ model.packageName }}-role \
--d '{"description":"Controls the ability of {{ model.packageName }}-role to register as a framework with the Mesos master"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:reservation:role:{{ model.packageName }}-role \
--d '{"description":"Controls the ability of {{ model.packageName }}-role to reserve resources"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:volume:role:{{ model.packageName }}-role \
--d '{"description":"Controls the ability of {{ model.packageName }}-role to access volumes"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:reservation:principal:<service-account-id> \
--d '{"description":"Controls the ability of <service-account-id> to reserve resources"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:volume:principal:<service-account-id> \
--d '{"description":"Controls the ability of <service-account-id> to access volumes"}' \
--H 'Content-Type: application/json'
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:framework:role:<service-role> create --description "Allow registering as a framework of role <service-role> with Mesos master"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:reservation:role:<service-role> create --description "Allow creating Mesos resource reservations of role <service-role>"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:volume:role:<service-role> create --description "Allow creating Mesos persistent volumes of role <service-role>"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:reservation:principal:{{ model.packageName }} delete --description "Allow unreserving Mesos resource reservations with principal {{ model.packageName }}"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:volume:principal:{{ model.packageName }} delete --description "Allow deleting Mesos persistent volumes with principal {{ model.packageName }}"
 ```
 
 ## Strict
-Run these commands with your service account name (`<service-account-id>`) specified.
+Run these commands with the service account name you created for the service in the *Create a Service Account* step above. For example we are using {{ model.packageName }}
 
 ```bash
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:framework:role:{{ model.packageName }}-role \
--d '{"description":"Controls the ability of {{ model.packageName }}-role to register as a framework with the Mesos master"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:reservation:role:{{ model.packageName }}-role \
--d '{"description":"Controls the ability of {{ model.packageName }}-role to reserve resources"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:volume:role:{{ model.packageName }}-role \
--d '{"description":"Controls the ability of {{ model.packageName }}-role to access volumes"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:reservation:principal:<service-account-id> \
--d '{"description":"Controls the ability of <service-account-id> to reserve resources"}' \
--H 'Content-Type: application/json'
-curl -X PUT --cacert dcos-ca.crt \
--H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:volume:principal:<service-account-id> \
--d '{"description":"Controls the ability of <service-account-id> to access volumes"}' \
--H 'Content-Type: application/json'
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:task:user:nobody create --description "Allow running a task as linux user nobody"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:framework:role:<service-role> create --description "Allow registering as a framework of role <service-role> with Mesos master"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:reservation:role:<service-role> create --description "Allow creating Mesos resource reservations of role <service-role>"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:volume:role:<service-role> create --description "Allow creating Mesos persistent volumes of role <service-role>"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:reservation:principal:{{ model.packageName }} delete --description "Allow unreserving Mesos resource reservations with principal {{ model.packageName }}"
+dcos security org users grant {{ model.packageName }} dcos:mesos:master:volume:principal:{{ model.packageName }} delete --description "Allow deleting Mesos persistent volumes with principal {{ model.packageName }}"
 ```
-
-1.  Grant the permissions and the allowed actions to the service account using the following commands.
-
-    <p class="message--important"><strong>IMPORTANT: </strong>These commands use the default {{ model.techName }} <tt>role</tt> value of <tt>{{ model.packageName }}-role</tt>. If you are running multiple instances of {{ model.techName }}, replace the instances of <tt>{{ model.packageName }}-role</tt> with the correct name (<tt><name>-role</tt>). For example, if you have a {{ model.techName }} instance named <tt>{{ model.packageName }}2</tt>, you would replace each role value in the code samples to <tt>{{ model.packageName }}2-role</tt>.</p>
-
-    Run these commands with your service account name (`<service-account-id>`) specified.
-
-    ```bash
-    curl -X PUT --cacert dcos-ca.crt \
-    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:framework:role:{{ model.packageName }}-role/users/<service-account-id>/create
-    curl -X PUT --cacert dcos-ca.crt \
-    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:reservation:role:{{ model.packageName }}-role/users/<service-account-id>/create
-    curl -X PUT --cacert dcos-ca.crt \
-    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:volume:role:{{ model.packageName }}-role/users/<service-account-id>/create
-    curl -X PUT --cacert dcos-ca.crt \
-    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:task:user:nobody/users/<service-account-id>/create
-    curl -X PUT --cacert dcos-ca.crt \
-    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:reservation:principal:<service-account-id>/users/<service-account-id>/delete
-    curl -X PUT --cacert dcos-ca.crt \
-    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:volume:principal:<service-account-id>/users/<service-account-id>/delete
-    ```

--- a/pages/mesosphere/dcos/services/include/service-account.tmpl
+++ b/pages/mesosphere/dcos/services/include/service-account.tmpl
@@ -2,6 +2,8 @@
 
 This section describes how to configure DC/OS access for {{ model.techName }}. Depending on your [security mode](/mesosphere/dcos/latest/security/ent/#security-modes/), {{ model.techName }} may require [service authentication](/mesosphere/dcos/latest/security/ent/service-auth/) for access to DC/OS.
 
+A service like {{ model.techName }} typically performs certain privileged actions on the cluster, which might require authenticating with the cluster. A service account associated with the service is used to authenticate with the DC/OS cluster. It is recommended to provisioning a separate service account for each service that would perform privileged operations. Service accounts authenticate using public-private keypair. The public key is used to create the service account in the cluster, while the corresponding private key is stored in the [secret store](/mesosphere/dcos/latest/security/ent/secrets/). The service account and the service account secret are passed to the service as install time options.
+
 | Security mode | Service Account |
 |---------------|-----------------------|
 | Disabled      | Not available   |
@@ -14,7 +16,6 @@ If you install a service in permissive mode and do not specify a service account
 
 - [DC/OS CLI installed](/mesosphere/dcos/latest/cli/install/) and be logged in as a superuser.
 - [Enterprise DC/OS CLI 0.4.14 or later installed](/mesosphere/dcos/latest/cli/enterprise-cli/#ent-cli-install).
-- If your [security mode](/mesosphere/dcos/latest/security/ent/#security-modes/) is `permissive` or `strict`, you must [get the root cert](/mesosphere/dcos/latest/networking/tls-ssl/get-cert/) before issuing the `curl` commands in this section.
 
 # <a name="create-a-keypair"></a>Create a Key Pair
 In this step, a 2048-bit RSA public-private key pair is created using the Enterprise DC/OS CLI.
@@ -47,18 +48,11 @@ Create a secret (`{{ model.packageName }}/<secret-name>`) with your service acco
 
 <p class="message--note"><strong>NOTE: </strong>If you store your secret in a path that matches the service name, for example, service name and secret path are both {{ model.serviceName }}, then only the service named {{ model.serviceName }} can access it.</p>
 
-
-## Permissive
-
 ```bash
 dcos security secrets create-sa-secret <private-key>.pem <service-account-id> {{ model.serviceName }}/<secret-name>
 ```
 
-## Strict
-
-```bash
-dcos security secrets create-sa-secret --strict <private-key>.pem <service-account-id> {{ model.packageName }}/<secret-name>
-```
+<p class="message--note"><strong>NOTE: </strong>If you are running, now EOL-ed, DC/OS 1.11 or older you would need to add <tt>--strict</tt> to the above command. For example, <tt>dcos security secrets --strict create-sa-secret <private-key>.pem <service-account-id> {{ model.serviceName }}/sa-secret</tt> .</p>
 
 You can list the secrets with this command:
 


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS-60933

This is an effort to simplify/clean-up docs for service account provisioning by using DC/OS CLI commands instead of curl based commands. Since I changed a template file used in multiple services I need to verify ACLs are accurate by deploying those services. So please do not merge this until all the services listed below are checked

- [X] Kafka
- [X] HDFS
- [] confluent zookeeper
- [ ] NiFi
- [ ] Hive metastore
- [X] Cassandra
- [ ] Kafka Zookeeper

I still want to get some feedback on the changes I have made,irrespective of the testing I'm going to do for ACL accuracy

## Checklist
- [X] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [X] Test all commands and procedures where applicable.
- [X] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
