### PR TITLE
Removing incorrect note about using quotes with the DC/OS diagnostics CLI - COPS-5280

### DIFF
--- a/pages/mesosphere/dcos/1.10/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/1.10/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -28,7 +28,7 @@ None.
 
 | Name, shorthand | Default | Description |
 |---------|-------------|-------------|
-| `<nodes>`   |             |  Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords "all", "masters", "agents". You must use quotation marks around keywords. |
+| `<nodes>`   |             |  Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords `all`, `masters`, `agents`. |
 
 # Parent command
 

--- a/pages/mesosphere/dcos/1.11/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/1.11/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -27,7 +27,7 @@ None.
 
 | Name, shorthand |  Description |
 |---------|-------------|-------------|
-| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords "all", "masters", "agents". You must use quotation marks around keywords. |
+| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords `all`, `masters`, `agents`. |
 
 # Parent command
 

--- a/pages/mesosphere/dcos/1.12/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/1.12/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -26,7 +26,7 @@ dcos node diagnostics create (<nodes>)
 
 | Name |  Description |
 |---------|-------------|-------------|
-| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords "`all`", "`masters`", "`agents`". You must use quotation marks around keywords. |
+| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords `all`, `masters`, `agents`. |
 
 # Example
 

--- a/pages/mesosphere/dcos/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/1.13/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -28,7 +28,7 @@ dcos node diagnostics create (<nodes>)
 
 | Name |  Description |
 |---------|-------------|-------------|
-| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords "`all`", "`masters`", "`agents`". You must use quotation marks around keywords. |
+| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords `all`, `masters`, `agents`. |
 
 # Example
 

--- a/pages/mesosphere/dcos/2.0/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/2.0/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -30,7 +30,7 @@ dcos node diagnostics create (<nodes>)
 
 | Name |  Description |
 |---------|-------------|-------------|
-| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords "`all`", "`masters`", "`agents`". You must use quotation marks around keywords. |
+| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords `all`, `masters`, `agents`. |
 
 # Example
 

--- a/pages/mesosphere/dcos/2.1/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
+++ b/pages/mesosphere/dcos/2.1/cli/command-reference/dcos-node/dcos-node-diagnostics-create/index.md
@@ -30,7 +30,7 @@ dcos node diagnostics create (<nodes>)
 
 | Name |  Description |
 |---------|-------------|-------------|
-| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords "`all`", "`masters`", "`agents`". You must use quotation marks around keywords. |
+| `<nodes>`   |   Node to run command upon. A node can be any of the following: IP address, hostname, Mesos ID, or the keywords `all`, `masters`, `agents`. |
 
 # Example
 


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

https://jira.mesosphere.com/browse/COPS-5280

## Description of changes being made

* Removing incorrect note about using quotes with the DC/OS diagnostics CLI.
* Adding backticks to the 1.10 and 1.11 version so they match the current docs.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.