### PR TITLE
Add service role examples for enforceRole=true and quota aware versions of packages

### DIFF
--- a/pages/mesosphere/dcos/services/cassandra/2.7.0-3.11.4/security/index.md
+++ b/pages/mesosphere/dcos/services/cassandra/2.7.0-3.11.4/security/index.md
@@ -7,6 +7,7 @@ menuWeight: 50
 model: /mesosphere/dcos/services/cassandra/data.yml
 render: mustache
 enterprise: true
+quota-aware: true
 ---
 
 # DC/OS {{ model.techName }} Security

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.8.0-5.3.1/security/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.8.0-5.3.1/security/index.md
@@ -7,6 +7,7 @@ menuWeight: 50
 model: /mesosphere/dcos/services/confluent-kafka/data.yml
 render: mustache
 enterprise: true
+quota-aware: true
 ---
 
 

--- a/pages/mesosphere/dcos/services/confluent-zookeeper/2.7.0-5.1.2e/security/index.md
+++ b/pages/mesosphere/dcos/services/confluent-zookeeper/2.7.0-5.1.2e/security/index.md
@@ -6,6 +6,7 @@ title: Security
 menuWeight: 50
 model: /mesosphere/dcos/services/confluent-zookeeper/data.yml
 render: mustache
+quota-aware: true
 ---
 
 # DC/OS {{ model.techName }} Security

--- a/pages/mesosphere/dcos/services/hive-metastore/1.0.0-3.0.0/security/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.0.0-3.0.0/security/index.md
@@ -7,6 +7,7 @@ menuWeight: 50
 model: /mesosphere/dcos/services/hive-metastore/data.yml
 render: mustache
 enterprise: true
+quota-aware: true
 ---
 
 # DC/OS {{ model.techName }} Security

--- a/pages/mesosphere/dcos/services/include/security-create-permissions.tmpl
+++ b/pages/mesosphere/dcos/services/include/security-create-permissions.tmpl
@@ -4,7 +4,19 @@ Use the following DC/OS CLI commands to rapidly provision the {{ model.techName 
 
 1.  Create the permission.
 
-<p class="message--important"><strong>IMPORTANT: </strong>The value to be used for <tt>&lt;service-role&gt;</tt> will be based on the service name. The table below shows a few examples to show the pattern used by the service as it Mesos role to use. If you need help configuring the permissions for {{ model.packageName }}, please feel to reach out to D2iQ support by filing a support ticket. Replace the instances of <tt>&lt;service-role&gt;</tt> with the correct name (<tt>&lt;name&gt;-role</tt>).</p>
+{{#quota-aware}}
+<p class="message--important"><strong>IMPORTANT: </strong>The value to be used for <tt>&lt;service-role&gt;</tt> will be based on the service name, package version and DC/OS version. The table below shows a few examples of service names and the corresponding Mesos roles they would use. This version of {{ model.packageName }} is quota support built in. To determine whether the service group, you are deploying a service to, has <tt>enforceRole</tt> set to <tt>true</tt> or <tt>false</tt> please check this [KB article](https://support.d2iq.com/s/article/How-to-determine-if-a-top-level-group-is-quota-limited). If you need help configuring the permissions for {{ model.packageName }}, please feel to reach out to D2iQ support by filing a support ticket. Replace the instances of <tt>&lt;service-role&gt;</tt> with the correct name (<tt>&lt;name&gt;-role</tt>).</p>
+
+| **Service name**                       | **&lt;service-role&gt;**<br>DC/OS 1.13 or older<br>DC/OS 2.0 or newer AND enforceRole=false  | **&lt;service-role&gt;**<br>DC/OS 2.0 or newer AND enforceRole=true |
+|----------------------------------------|-----------------------------------------------|-----------------------------------------------|
+| `/{{ model.packageName }}`             |`{{ model.packageName }}-role`                 |`{{ model.packageName }}-role`                 |
+| `/{{ model.packageName }}-prod`        |`{{ model.packageName }}-prod-role`            |`{{ model.packageName }}-prod-role`            |
+| `/team01/{{ model.packageName }}`      |`team01__{{ model.packageName }}-role`         |`team01`                                       |
+| `/team01/prod/{{ model.packageName }}` |`team01__prod__{{ model.packageName }}-role`   |`team01`                                       |
+
+{{/quota-aware}}
+{{^quota-aware}}
+<p class="message--important"><strong>IMPORTANT: </strong>The value to be used for <tt>&lt;service-role&gt;</tt> will be based on the service name. The table below shows a few examples of service names and the corresponding Mesos roles they would use. If you need help configuring the permissions for {{ model.packageName }}, please feel to reach out to D2iQ support by filing a support ticket. Replace the instances of <tt>&lt;service-role&gt;</tt> with the correct name (<tt>&lt;name&gt;-role</tt>).</p>
 
 | Service name                           | &lt;service-role&gt;                           |
 |----------------------------------------|------------------------------------------------|
@@ -12,6 +24,7 @@ Use the following DC/OS CLI commands to rapidly provision the {{ model.techName 
 | `/{{ model.packageName }}-prod`        | `{{ model.packageName }}-prod-role`            |
 | `/team01/{{ model.packageName }}`      | `team01__{{ model.packageName }}-role`         |
 | `/team01/prod/{{ model.packageName }}` | `team01__prod__{{ model.packageName }}-role`   |
+{{/quota-aware}}
 
 ## Permissive 
 

--- a/pages/mesosphere/dcos/services/kafka-zookeeper/2.7.0-3.4.14/security/index.md
+++ b/pages/mesosphere/dcos/services/kafka-zookeeper/2.7.0-3.4.14/security/index.md
@@ -6,6 +6,7 @@ title: Security
 menuWeight: 50
 model: /mesosphere/dcos/services/kafka-zookeeper/data.yml
 render: mustache
+quota-aware: true
 ---
 
 # DC/OS {{ model.techName }} Security

--- a/pages/mesosphere/dcos/services/kafka/2.8.0-2.3.0/security/index.md
+++ b/pages/mesosphere/dcos/services/kafka/2.8.0-2.3.0/security/index.md
@@ -7,6 +7,7 @@ menuWeight: 50
 model: /mesosphere/dcos/services/kafka/data.yml
 render: mustache
 enterprise: true
+quota-aware: true
 ---
 
 

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/security/index.md
@@ -8,6 +8,7 @@ featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache
+quota-aware: true
 ---
 
 # DC/OS {{ model.techName }} Security


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-61934

## Description of changes being made
Mofified the service role table for package versions that are quota aware to have a column that shows the role that will be used if installing the service in `enforceRole=true` group.

## Checklist
- [ ] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [X] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
