### PR TITLE
ss/DCOS-53751 Removing unsupported claim of zone awareness  in hybrid…

### DIFF
--- a/pages/mesosphere/dcos/1.13/deploying-services/fault-domain-awareness/index.md
+++ b/pages/mesosphere/dcos/1.13/deploying-services/fault-domain-awareness/index.md
@@ -72,10 +72,6 @@ You must have less than 100ms latency between regions.
 
 Alternatively, click the **Nodes** tab in the DC/OS GUI. The Nodes table will show region and zone columns for each agent.
 
-# Use
-
-User-created Marathon services and pods support both zone and region awareness. The following beta versions of DC/OS data services support zone awareness: Cassandra, Elastic, HDFS, Kafka, and Spark. Consult the individual service documentation for more information about configuring zone awareness for DC/OS data services. <!-- todo: link to appropriate pages when the betas are released -->
-
 ## Marathon services and pods
 
 In your Marathon service or pod definition, you can use [placement constraints](/mesosphere/dcos/1.13/deploying-services/marathon-constraints/) to:

--- a/pages/mesosphere/dcos/1.13/hybrid-cloud/capacity-extension-with-regions/index.md
+++ b/pages/mesosphere/dcos/1.13/hybrid-cloud/capacity-extension-with-regions/index.md
@@ -70,9 +70,6 @@ Alternatively, click the **Nodes** tab in the DC/OS GUI. The Nodes table will di
 
 # Use
 
-User-created Marathon services and pods support both zone and region awareness. The following beta versions of DC/OS data services support zone awareness: Cassandra, Elastic, HDFS, Kafka, and Spark. Consult the individual service documentation for more information about configuring zone awareness for DC/OS data services. 
-
-
 ## Marathon services and pods
 
 In your Marathon service or pod definition, you can use [placement constraints](/mesosphere/dcos/1.13/deploying-services/marathon-constraints/) to:

--- a/pages/mesosphere/dcos/2.0/deploying-services/fault-domain-awareness/index.md
+++ b/pages/mesosphere/dcos/2.0/deploying-services/fault-domain-awareness/index.md
@@ -72,9 +72,6 @@ You must have less than 100ms latency between regions.
 
 Alternatively, click the **Nodes** tab in the DC/OS GUI. The Nodes table will show region and zone columns for each agent.
 
-# Use
-
-User-created Marathon services and pods support both zone and region awareness. The following beta versions of DC/OS data services support zone awareness: Cassandra, Elastic, HDFS, Kafka, and Spark. Consult the individual service documentation for more information about configuring zone awareness for DC/OS data services. <!-- todo: link to appropriate pages when the betas are released -->
 
 ## Marathon services and pods
 

--- a/pages/mesosphere/dcos/2.0/hybrid-cloud/capacity-extension-with-regions/index.md
+++ b/pages/mesosphere/dcos/2.0/hybrid-cloud/capacity-extension-with-regions/index.md
@@ -68,11 +68,6 @@ enterprise: false
 
 Alternatively, click the **Nodes** tab in the DC/OS GUI. The Nodes table will display the region and zone columns for each agent.
 
-# Use
-
-User-created Marathon services and pods support both zone and region awareness. The following beta versions of DC/OS data services support zone awareness: Cassandra, Elastic, HDFS, Kafka, and Spark. Consult the individual service documentation for more information about configuring zone awareness for DC/OS data services. 
-
-
 ## Marathon services and pods
 
 In your Marathon service or pod definition, you can use [placement constraints](/mesosphere/dcos/2.0/deploying-services/marathon-constraints/) to:

--- a/pages/mesosphere/dcos/2.1/deploying-services/fault-domain-awareness/index.md
+++ b/pages/mesosphere/dcos/2.1/deploying-services/fault-domain-awareness/index.md
@@ -72,10 +72,6 @@ You must have less than 100ms latency between regions.
 
 Alternatively, click the **Nodes** tab in the DC/OS GUI. The Nodes table will show region and zone columns for each agent.
 
-# Use
-
-User-created Marathon services and pods support both zone and region awareness. The following beta versions of DC/OS data services support zone awareness: Cassandra, Elastic, HDFS, Kafka, and Spark. Consult the individual service documentation for more information about configuring zone awareness for DC/OS data services. <!-- todo: link to appropriate pages when the betas are released -->
-
 ## Marathon services and pods
 
 In your Marathon service or pod definition, you can use [placement constraints](/mesosphere/dcos/2.1/deploying-services/marathon-constraints/) to:

--- a/pages/mesosphere/dcos/2.1/hybrid-cloud/capacity-extension-with-regions/index.md
+++ b/pages/mesosphere/dcos/2.1/hybrid-cloud/capacity-extension-with-regions/index.md
@@ -68,11 +68,6 @@ enterprise: false
 
 Alternatively, click the **Nodes** tab in the DC/OS GUI. The Nodes table will display the region and zone columns for each agent.
 
-# Use
-
-User-created Marathon services and pods support both zone and region awareness. The following beta versions of DC/OS data services support zone awareness: Cassandra, Elastic, HDFS, Kafka, and Spark. Consult the individual service documentation for more information about configuring zone awareness for DC/OS data services. 
-
-
 ## Marathon services and pods
 
 In your Marathon service or pod definition, you can use [placement constraints](/mesosphere/dcos/2.1/deploying-services/marathon-constraints/) to:


### PR DESCRIPTION
…-cloud and deploying-services pages.

## Jira Ticket
https://jira.mesosphere.com/browse/DCOS-53751

## Description of changes being made
"User-created Marathon services and pods support both zone and region awareness. The following beta versions of DC/OS data services support zone awareness: Cassandra, Elastic, HDFS, Kafka, and Spark. Consult the individual service documentation for more information about configuring zone awareness for DC/OS data services."

We do not currently support or display beta versions of any of these services. I could not find any supported versions of these documents which mention zone or region awareness. If the above statement is incorrect, please authorize its deletion.

 
## Versions affected
- [x] 1.13/hybrid-cloud/
- [x] 1.13/deploying-services/fault-domain-awareness
- [x] 2.0/hybrid-cloud/
- [x] 2.0/deploying-services/fault-domain-awareness
- [x] 2.1/hybrid-cloud/
- [x] 2.1/deploying-services/fault-domain-awareness