### PR TITLE
[DCOS-45892] updated flag feature_dcos_storage_enabled to have default described as "true"

### DIFF
--- a/pages/mesosphere/dcos/1.11/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/1.11/installing/production/advanced-configuration/configuration-reference/index.md
@@ -467,8 +467,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. 
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/1.12/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/1.12/installing/production/advanced-configuration/configuration-reference/index.md
@@ -481,8 +481,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuration-reference/index.md
@@ -489,8 +489,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/2.0/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/advanced-configuration/configuration-reference/index.md
@@ -499,8 +499,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS.This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/2.1/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/advanced-configuration/configuration-reference/index.md
@@ -499,8 +499,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.


### PR DESCRIPTION
…ll versions of dcos documentation

## Jira Ticket
<!-- https://jira.mesosphere.com/browse/DCOS-45892 -->

## Description of changes being made
Updating documentation for flag "feature_dcos_storage_enabled" with default value to true in all the versions wherever its applicable.
feature_dcos_storage_enabled default should be described as "true"