### PR TITLE
[DCOS-47688] Added ports 2888 and updated 3888 to master

### DIFF
--- a/pages/mesosphere/dcos/1.10/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/1.10/installing/production/system-requirements/ports/index.md
@@ -47,7 +47,8 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
+| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |

--- a/pages/mesosphere/dcos/1.11/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/1.11/installing/production/advanced-configuration/configuration-reference/index.md
@@ -467,8 +467,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. 
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/1.11/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/1.11/installing/production/system-requirements/ports/index.md
@@ -47,7 +47,8 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
+| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |

--- a/pages/mesosphere/dcos/1.12/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/1.12/installing/production/advanced-configuration/configuration-reference/index.md
@@ -481,8 +481,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/1.12/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/1.12/installing/production/system-requirements/ports/index.md
@@ -47,7 +47,8 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
+| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |

--- a/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuration-reference/index.md
@@ -489,8 +489,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/1.13/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/1.13/installing/production/system-requirements/ports/index.md
@@ -47,7 +47,8 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
+| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |

--- a/pages/mesosphere/dcos/2.0/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/advanced-configuration/configuration-reference/index.md
@@ -499,8 +499,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS.This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/2.0/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/system-requirements/ports/index.md
@@ -47,7 +47,8 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
+| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |

--- a/pages/mesosphere/dcos/2.1/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/advanced-configuration/configuration-reference/index.md
@@ -499,8 +499,8 @@ By default, fault domain awareness is enabled and the installer will expect inpu
 ### feature_dcos_storage_enabled [enterprise type="inline" size="small" /]
 
 Enables advanced storage features in DC/OS including [CSI](https://github.com/container-storage-interface/spec) support for Mesos, and support for pre-installed CSI device plugins.
-* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS. This is the default value.
-* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
+* `feature_dcos_storage_enabled: 'false'` Disables CSI support in  DC/OS.
+* `feature_dcos_storage_enabled: 'true'` Enables CSI support in DC/OS. This is the default value and it is necessary to use the [DC/OS Storage Service (DSS)](/mesosphere/dcos/services/storage/)
 
 ### gc_delay
 The maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of two days.

--- a/pages/mesosphere/dcos/2.1/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/system-requirements/ports/index.md
@@ -47,7 +47,8 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | agent/master | master |
+| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |


### PR DESCRIPTION
## Jira Ticket
<!-- https://jira.mesosphere.com/browse/DCOS-47688 -->

## Description of changes being made
In https://docs.mesosphere.com/1.12/installing/production/system-requirements/ports/#tcp-2 updated port 3888 with to master and added port 2888 with the same values as the modified 3888 port for versions 1.10,1.11,1.12,1.13,2.0 and 2.1
