### PR TITLE
ss/DCOS-62543 Correcting missing back ticks in code sample.

### DIFF
--- a/pages/mesosphere/dcos/1.12/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/1.12/deploying-services/private-docker-registry/index.md
@@ -272,6 +272,7 @@ To configure a custom certificate for accessing the private Docker registry and 
     ```bash
     cd /var/lib/dcos/pki/tls/certs/
     openssl x509 -hash -noout -in docker-registry-ca.crt
+    ```
 
 1. Create a symbolic link from the trusted certificate to the `/var/lib/dcos/pki/tls/certs` directory on the public agent.
 

--- a/pages/mesosphere/dcos/1.13/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/1.13/deploying-services/private-docker-registry/index.md
@@ -274,6 +274,7 @@ To configure a custom certificate for accessing the private Docker registry and 
     ```bash
     cd /var/lib/dcos/pki/tls/certs/
     openssl x509 -hash -noout -in docker-registry-ca.crt
+    ```
 
 1. Create a symbolic link from the trusted certificate to the `/var/lib/dcos/pki/tls/certs` directory on the public agent.
 

--- a/pages/mesosphere/dcos/2.0/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/2.0/deploying-services/private-docker-registry/index.md
@@ -274,6 +274,7 @@ To configure a custom certificate for accessing the private Docker registry and 
     ```bash
     cd /var/lib/dcos/pki/tls/certs/
     openssl x509 -hash -noout -in docker-registry-ca.crt
+    ```
 
 1. Create a symbolic link from the trusted certificate to the `/var/lib/dcos/pki/tls/certs` directory on the public agent.
 

--- a/pages/mesosphere/dcos/2.1/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/2.1/deploying-services/private-docker-registry/index.md
@@ -274,6 +274,7 @@ To configure a custom certificate for accessing the private Docker registry and 
     ```bash
     cd /var/lib/dcos/pki/tls/certs/
     openssl x509 -hash -noout -in docker-registry-ca.crt
+    ```
 
 1. Create a symbolic link from the trusted certificate to the `/var/lib/dcos/pki/tls/certs` directory on the public agent.
 

--- a/pages/mesosphere/dcos/cn/1.12/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/cn/1.12/deploying-services/private-docker-registry/index.md
@@ -272,6 +272,7 @@ Docker 镜像现在将使用提供的安全凭证进行拉取。
     ```bash
     cd /var/lib/dcos/pki/tls/certs/
     openssl x509 -hash -noout -in docker-registry-ca.crt
+    ```
 
 1. 从可信的证书创建一个标志性的链接到公共代理的 `/var/lib/dcos/pki/tls/certs` 注册表。
 

--- a/pages/mesosphere/dcos/cn/1.12/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/cn/1.12/deploying-services/private-docker-registry/index.md
@@ -301,10 +301,10 @@ Docker 镜像现在将使用提供的安全凭证进行拉取。
 
   您应可以看到类似这样的输出:
 
-```bash
-存储库标记镜像 ID 创建大小
-mesosphere/marathon-dcos-ee 1.4.0-RC4_1.9.4 d1ffa68a50c0 3 months ago 926.4 MB
-```
+  ```bash
+  REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
+  mesosphere/marathon-dcos-ee   1.4.0-RC4_1.9.4     d1ffa68a50c0        3 months ago        926.4 MB
+  ```
 
 ## 第2步: 将镜像推送到注册表
 

--- a/pages/mesosphere/dcos/cn/1.13/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/cn/1.13/deploying-services/private-docker-registry/index.md
@@ -274,6 +274,7 @@ enterprise: false
     ```bash
     cd /var/lib/dcos/pki/tls/certs/
     openssl x509 -hash -noout -in docker-registry-ca.crt
+    ```
 
 1. Create a symbolic link from the trusted certificate to the `/var/lib/dcos/pki/tls/certs` directory on the public agent.
 

--- a/pages/mesosphere/dcos/cn/1.13/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/cn/1.13/deploying-services/private-docker-registry/index.md
@@ -299,15 +299,15 @@ enterprise: false
   您可以用这个指令显示 Marathon 镜像。
 
   ```
-  Docker images
+  docker images
   ```
 
   您应可以看到类似这样的输出:
 
-```bash
-存储库标记镜像 ID 创建大小
-mesosphere/marathon-dcos-ee 1.4.0-RC4_1.9.4 d1ffa68a50c0 3 months ago 926.4 MB
-```
+  ```bash
+  REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
+  mesosphere/marathon-dcos-ee   1.4.0-RC4_1.9.4     d1ffa68a50c0        3 months ago        926.4 MB
+  ```
 
 ## 第2步: 将镜像推送到注册表
 

--- a/pages/mesosphere/dcos/cn/2.0/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/cn/2.0/deploying-services/private-docker-registry/index.md
@@ -298,14 +298,14 @@ If you asked your sales representative for an enterprise version of Marathon, yo
     **Tip:** You can view the Marathon image with this command.
 
     ```
-    Docker 镜像
+    docker images
     ```
 
     You should see output similar to this:
 
     ```bash
-    存储库                    标记                 镜像 ID            已创建             大小
-    mesosphere/marathon-dcos-ee 1.4.0-RC4_1.9.4 d1ffa68a50c0 3 months ago 926.4 MB
+    REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
+    mesosphere/marathon-dcos-ee   1.4.0-RC4_1.9.4     d1ffa68a50c0        3 months ago        926.4 MB
     ```
 
 ## Step 2: Push the image to the repository

--- a/pages/mesosphere/dcos/cn/2.0/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/cn/2.0/deploying-services/private-docker-registry/index.md
@@ -274,6 +274,7 @@ enterprise: false
     ```bash
     cd /var/lib/dcos/pki/tls/certs/
     openssl x509 -hash -noout -in docker-registry-ca.crt
+    ```
 
 1. Create a symbolic link from the trusted certificate to the `/var/lib/dcos/pki/tls/certs` directory on the public agent.
 


### PR DESCRIPTION
## Jira Ticket
https://jira.mesosphere.com/browse/DCOS-62543

## Description of changes being made

Code sample in /deploying-services/private-docker-registry/ section is missing triple back ticks at end of sample

## Versions corrected:

- [x] 1.12
- [x] 1.13
- [x] 2.0
- [x] 2.1
- [x] cn/1.12
- [x] cn/1.13
- [x] cn/2.0