### PR TITLE
Adding a missing closing tag (</tt>)

### DIFF
--- a/pages/mesosphere/dcos/1.13/administering-clusters/package-registry/index.md
+++ b/pages/mesosphere/dcos/1.13/administering-clusters/package-registry/index.md
@@ -265,7 +265,7 @@ Mesosphere hosts all its certified packages at [downloads.mesosphere.com/univers
       ```
       In the rest of the instructions on this page, we assume you have downloaded the subcommand from an attached DC/OS Cluster. If that is not the case, replace `dcos` with `./dcos-registry` in your instructions whilst retaining the `registry` suffix.
 
-      <p class="message--note"><strong>NOTE: </strong> You must use the aforementioned binary with `./dcos-registry registry <your-subcommand>` style of syntax. Eliminating the <tt>registry<tt> suffix does not work.</p>
+      <p class="message--note"><strong>NOTE: </strong> You must use the aforementioned binary with `./dcos-registry registry <your-subcommand>` style of syntax. Eliminating the <tt>registry</tt> suffix does not work.</p>
 
 ### Instructions to generate `.dcos` bundle
 

--- a/pages/mesosphere/dcos/2.0/administering-clusters/package-registry/index.md
+++ b/pages/mesosphere/dcos/2.0/administering-clusters/package-registry/index.md
@@ -264,7 +264,7 @@ Mesosphere hosts all its certified packages at [downloads.mesosphere.com/univers
       ```
       In the rest of the instructions in this page, we assume you have downloaded the subcommand from an attached DC/OS Cluster. If that is not the case, replace `dcos` with `./dcos-registry` in your instructions whilst retaining the `registry` suffix.
 
-      <p class="message--note"><strong>NOTE: </strong> You must use the aforementioned binary with `./dcos-registry registry <your-subcommand>` style of syntax. Eliminating the <tt>registry<tt> suffix does not work.</p>
+      <p class="message--note"><strong>NOTE: </strong> You must use the aforementioned binary with `./dcos-registry registry <your-subcommand>` style of syntax. Eliminating the <tt>registry</tt> suffix does not work.</p>
 
 ### Instructions to generate `.dcos` bundle
 

--- a/pages/mesosphere/dcos/2.1/administering-clusters/package-registry/index.md
+++ b/pages/mesosphere/dcos/2.1/administering-clusters/package-registry/index.md
@@ -264,7 +264,7 @@ Mesosphere hosts all its certified packages at [downloads.mesosphere.com/univers
       ```
       In the rest of the instructions in this page, we assume you have downloaded the subcommand from an attached DC/OS Cluster. If that is not the case, replace `dcos` with `./dcos-registry` in your instructions whilst retaining the `registry` suffix.
 
-      <p class="message--note"><strong>NOTE: </strong> You must use the aforementioned binary with `./dcos-registry registry <your-subcommand>` style of syntax. Eliminating the <tt>registry<tt> suffix does not work.</p>
+      <p class="message--note"><strong>NOTE: </strong> You must use the aforementioned binary with `./dcos-registry registry <your-subcommand>` style of syntax. Eliminating the <tt>registry</tt> suffix does not work.</p>
 
 ### Instructions to generate `.dcos` bundle
 


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made

A missing `</tt>` was changing the look of the end of the page as well as the links on the right.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
