### PR TITLE
redirecting services/kubernetes to version 2.4.6-1.15.6

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -10,7 +10,7 @@
 ~^/mesosphere/dcos/services/hdfs/latest/(.*) /mesosphere/dcos/services/hdfs/2.7.0-3.2.1/$1;
 ~^/mesosphere/dcos/services/jenkins/latest/(.*) /mesosphere/dcos/services/jenkins/3.6.0-2.190.1/$1;
 ~^/mesosphere/dcos/services/kafka/latest/(.*) /mesosphere/dcos/services/kafka/2.8.0-2.3.0/$1;
-~^/mesosphere/dcos/services/kubernetes/latest/(.*) /mesosphere/dcos/services/kubernetes/2.4.4-1.15.4/$1;
+~^/mesosphere/dcos/services/kubernetes/latest/(.*) /mesosphere/dcos/services/kubernetes/2.4.6-1.15.6/$1;
 ~^/mesosphere/dcos/services/kafka-zookeeper/latest/(.*) /mesosphere/dcos/services/kafka-zookeeper/2.6.0-3.4.14/$1;
 ~^/mesosphere/dcos/services/marathon-lb/latest/(.*) /mesosphere/dcos/services/marathon-lb/1.14/$1;
 ~^/mesosphere/dcos/services/minio/latest/(.*) /mesosphere/dcos/services/minio/0.1.1/$1;


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

https://jira.mesosphere.com/browse/DCOS-62747

Does not have it's own doc ticket as too small to need one. 

changing redirects. 


## Checklist
- [ ] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
