### PR TITLE
[kommander] Delete istio 'coming soon' page

### DIFF
--- a/pages/ksphere/kommander/latest/tutorials/using-istio/index.md
+++ b/pages/ksphere/kommander/latest/tutorials/using-istio/index.md
@@ -1,8 +1,0 @@
----
-layout: layout.pug
-navigationTitle: Using Istio with Kommander
-title: Using Istio with Kommander
-menuWeight: 1
-excerpt: Using Istio with Kommander
----
-Istio is not yet supported for use with Kommander, but is coming SOON. 


### PR DESCRIPTION

## Description of changes being made
Empty page in the tutorial section for a feature 'Coming Soon' is misleading. I recommend deleting it and adding an actual tutorial when we have something worked out.

Note: I'm creating a PR off @ck4adventure's branch that includes a number of kommander doc fixes.