### PR TITLE
SSO for Kubernetes API of attached non-Konvoy clusters

### DIFF
--- a/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
+++ b/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
@@ -14,7 +14,7 @@ Selecting the **Connect Cluster** option displays the **Connection Information**
 
 ![Add Cluster Connect](../../../img/add-cluster-connect.png)
 
-To enable Single Sign-On (SSO) for accessing the Kubernetes API across connected clusters with the Kommander administrator credentials, a Certificate Authority must be posted as a secret to the API server first. The following script creates a Certificate Authority (CA) including the CA certificate and a private key. The `kubectl` command then posts this CA using the current context under the name `kubernetes-root-ca` into the namespace `cert-manager` which is created if it does not already exist.
+To enable Single Sign-On (SSO) for accessing the Kubernetes API across connected clusters with the Kommander administrator credentials, a Certificate Authority must be created as a secret first. The following script creates a Certificate Authority (CA) including the CA certificate and a private key. The `kubectl` command then creates this CA using the current context under the name `kubernetes-root-ca` into the namespace `cert-manager` which is created if it does not already exist.
 
 ```bash
 #!/usr/bin/env bash

--- a/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
+++ b/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
@@ -14,3 +14,39 @@ Selecting the **Connect Cluster** option displays the **Connection Information**
 
 ![Add Cluster Connect](../../../img/add-cluster-connect.png)
 
+To enable Single Sign-On (SSO) for accessing the Kubernetes API across connected clusters with the Kommander administrator credentials, a Certificate Authority must be posted as a secret to the API server first. The following script creates a Certificate Authority (CA) including the CA certificate and a private key. The `kubectl` command then posts this CA using the current context under the name `kubernetes-root-ca` into the namespace `cert-manager` which is created if it does not already exist.
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+KEY_SIZE=4096
+PRIV_KEY_FILE=root-ca-private-key.pem
+CA_CERT_FILE=root-ca-certificate.pem
+
+if [ ! -f $PRIV_KEY_FILE ]; then
+    openssl genrsa -out $PRIV_KEY_FILE $KEY_SIZE
+fi
+
+if [ ! -f $CA_CERT_FILE ]; then
+    openssl req -x509 -new -nodes -key $PRIV_KEY_FILE -sha256 -days 1825 -out $CA_CERT_FILE
+fi
+
+kubectl create namespace cert-manager || true
+
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-root-ca
+  namespace: cert-manager
+type: kubernetes.io/tls
+data:
+  tls.crt: $(base64 -w0 < ${CA_CERT_FILE})
+  tls.key: $(base64 -w0 < ${PRIV_KEY_FILE})
+EOF
+```
+
+After the CA secret has been posted successfully, a custom kubeconfig can be retrieved shortly by visiting the `/token` endpoint on the Kommander cluster domain. Selecting the attached cluster name displays the instructions to assemble a kubeconfig for accessing its Kubernetes API.

--- a/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
+++ b/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
@@ -14,7 +14,7 @@ Selecting the **Connect Cluster** option displays the **Connection Information**
 
 ![Add Cluster Connect](../../../img/add-cluster-connect.png)
 
-To enable Single Sign-On (SSO) for accessing the Kubernetes API across connected clusters with the Kommander administrator credentials, a Certificate Authority must be created as a secret first. The following script creates a Certificate Authority (CA) including the CA certificate and a private key. The `kubectl` command then creates this CA using the current context under the name `kubernetes-root-ca` into the namespace `cert-manager` which is created if it does not already exist.
+To enable Single Sign-On (SSO), for accessing the Kubernetes API across connected clusters, with Kommander administrator credentials, a Certificate Authority(CA) must be created as a secret, first. The following script creates a CA including the CA certificate and a private key. The kubectl command then creates this CA using the current context under the name kubernetes-root-ca into the namespace cert-manager which is created if it does not already exist.
 
 ```bash
 #!/usr/bin/env bash

--- a/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
+++ b/pages/ksphere/kommander/latest/clusters/attach-cluster/index.md
@@ -49,4 +49,4 @@ data:
 EOF
 ```
 
-After the CA secret has been posted successfully, a custom kubeconfig can be retrieved shortly by visiting the `/token` endpoint on the Kommander cluster domain. Selecting the attached cluster name displays the instructions to assemble a kubeconfig for accessing its Kubernetes API.
+After the CA secret has been created successfully, a custom kubeconfig can be retrieved by visiting the `/token` endpoint on the Kommander cluster domain. Selecting the attached cluster name displays the instructions to assemble a kubeconfig for accessing its Kubernetes API.


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->
https://jira.d2iq.com/browse/D2IQ-64528

## Description of changes being made
This PR adds documentation for the user on how to deploy a custom Certificate Authority to a Kubernetes cluster attached to Kommander. This procedure is a prerequisite at the time of writing to enable centralized API access to said cluster via Kommander.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
