### PR TITLE
docs(kommander): fix cloud providers image

### DIFF
--- a/pages/ksphere/kommander/latest/operations/cloud-providers/index.md
+++ b/pages/ksphere/kommander/latest/operations/cloud-providers/index.md
@@ -14,9 +14,9 @@ In order to provision new clusters and manage them, Kommander needs cloud provid
 
 Cloud Provider credentials are configured within each workspace, so you must first select a workspace. Then, navigate to the Cloud Providers option under Administration.
 
-![Cloud Provider Form](/ksphere/kommander/latest/img/add-cloud-provider.png)
+![Cloud Provider Form](/ksphere/kommander/img/add-cloud-provider.png)
 
-Figure 1 - Cloud Provider Form
+Cloud Provider Form
 
 - [Configure AWS with Role Credentials](/ksphere/kommander/latest/operations/configure-aws-cloud-provider-roles) (Recommended)
 - [Configure AWS with Static Credentials](/ksphere/kommander/latest/operations/configure-aws-cloud-provider-static-credentials)


### PR DESCRIPTION
## Jira Ticket
Resolves [D2IQ-64511](https://jira.d2iq.com/browse/D2IQ-64511)

## Description of changes being made
This commit fixes the cloud providers image (public site shows [empty image](https://docs.d2iq.com/ksphere/kommander/latest/operations/cloud-providers/)) and deletes the figure number