### PR TITLE
Fix erroenous comma in dcos marathon app add CLI example

### DIFF
--- a/pages/mesosphere/dcos/1.10/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
+++ b/pages/mesosphere/dcos/1.10/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
@@ -44,20 +44,18 @@ In this example, a simple app is deployed to DC/OS Marathon.
 
 1.  Create an app definition file named `my-app.json` with these contents.
 
-    ```bash
+    ```json
     {
         "id": "/my-app",
         "networks": [
-              { "mode": "container/bridge" }
+            { "mode": "container/bridge" }
         ],
         "container": {
-        "type": "DOCKER",
-        "docker": {
-              "image": "group/image",
-            }
+            "type": "DOCKER",
+            "docker": { "image": "group/image" }
         },
         "portMappings": [
-          { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
+            { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
         ],
         "instances": 1,
         "cpus": 0.1,

--- a/pages/mesosphere/dcos/1.11/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
+++ b/pages/mesosphere/dcos/1.11/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
@@ -42,17 +42,15 @@ In this example, a simple app is deployed to DC/OS Marathon.
 
 1.  Create an app definition file named `my-app.json` with these contents.
 
-    ```bash
+    ```json
     {
         "id": "/my-app",
         "networks": [
-              { "mode": "container/bridge" }
+            { "mode": "container/bridge" }
         ],
         "container": {
-        "type": "DOCKER",
-        "docker": {
-              "image": "group/image",
-            }
+            "type": "DOCKER",
+            "docker": { "image": "group/image" }
         },
         "portMappings": [
           { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}

--- a/pages/mesosphere/dcos/1.12/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
+++ b/pages/mesosphere/dcos/1.12/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
@@ -40,20 +40,18 @@ In this example, a simple app is deployed to DC/OS Marathon.
 
 1.  Create an app definition file named `my-app.json` with these contents.
 
-    ```bash
+    ```json
     {
         "id": "/my-app",
         "networks": [
-              { "mode": "container/bridge" }
+            { "mode": "container/bridge" }
         ],
         "container": {
-        "type": "DOCKER",
-        "docker": {
-              "image": "group/image",
-            }
+            "type": "DOCKER",
+            "docker": { "image": "group/image" }
         },
         "portMappings": [
-          { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
+            { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
         ],
         "instances": 1,
         "cpus": 0.1,

--- a/pages/mesosphere/dcos/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
+++ b/pages/mesosphere/dcos/1.13/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
@@ -41,20 +41,18 @@ In this example, a simple app is deployed to DC/OS Marathon.
 
 1.  Create an app definition file named `my-app.json` with these contents.
 
-    ```bash
+    ```json
     {
         "id": "/my-app",
         "networks": [
-              { "mode": "container/bridge" }
+            { "mode": "container/bridge" }
         ],
         "container": {
-        "type": "DOCKER",
-        "docker": {
-              "image": "group/image",
-            }
+            "type": "DOCKER",
+            "docker": { "image": "group/image" }
         },
         "portMappings": [
-          { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
+            { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
         ],
         "instances": 1,
         "cpus": 0.1,

--- a/pages/mesosphere/dcos/2.0/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
+++ b/pages/mesosphere/dcos/2.0/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
@@ -41,20 +41,18 @@ In this example, a simple app is deployed to DC/OS Marathon.
 
 1.  Create an app definition file named `my-app.json` with these contents.
 
-    ```bash
+    ```json
     {
         "id": "/my-app",
         "networks": [
-              { "mode": "container/bridge" }
+            { "mode": "container/bridge" }
         ],
         "container": {
-        "type": "DOCKER",
-        "docker": {
-              "image": "group/image",
-            }
+            "type": "DOCKER",
+            "docker": { "image": "group/image" }
         },
         "portMappings": [
-          { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
+            { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
         ],
         "instances": 1,
         "cpus": 0.1,

--- a/pages/mesosphere/dcos/2.1/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
+++ b/pages/mesosphere/dcos/2.1/cli/command-reference/dcos-marathon/dcos-marathon-app-add/index.md
@@ -41,27 +41,24 @@ In this example, a simple app is deployed to DC/OS Marathon.
 
 1.  Create an app definition file named `my-app.json` with these contents.
 
-    ```bash
+    ```json
     {
         "id": "/my-app",
         "networks": [
-              { "mode": "container/bridge" }
+            { "mode": "container/bridge" }
         ],
         "container": {
-        "type": "DOCKER",
-        "docker": {
-              "image": "group/image",
-            }
+            "type": "DOCKER",
+            "docker": { "image": "group/image" }
         },
         "portMappings": [
-          { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
+            { "hostPort": 80, "containerPort": 80, "protocol": "tcp"}
         ],
         "instances": 1,
         "cpus": 0.1,
         "mem": 64
     }
     ```
-
 1.  Add your app to Marathon:
 
     ```bash


### PR DESCRIPTION
## Description of changes being made
This commit removes the extra comma that resulted in invalid JSON and a parse error when attempting to use the example verbatim.

It also applies the correct language syntax tag and tidies the formatting slightly.

## Checklist
- [X] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [X] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
