### PR TITLE
docs(kommander): Add distributed authnz pages

### DIFF
--- a/pages/ksphere/kommander/latest/operations/identity-providers/index.md
+++ b/pages/ksphere/kommander/latest/operations/identity-providers/index.md
@@ -10,7 +10,7 @@ excerpt: Grant access to users in your organization
 
 By default, you login to konvoy with a credential given by `konvoy up`. You can retrieve it later by using `konvoy get ops-portal`.
 
-These static credentials should be used only to access **operations portal** for configuring an external identity provider. Since these are static credentials and there is currently no way of updating them they should be treated only as backup credentials and not used for normal access. Always login with own identity from external identity provider that usually provide additional security features like Multi Factor Authentication.
+Static credentials should only be used to access **operations portal** for configuring an external identity provider. Since there is  no way of updating static credentials they should be treated as backup credentials and not used for normal access. Always login with your own identity from external identity providers that provide additional security features like Multi Factor Authentication.
 
 ## Identity Providers
 

--- a/pages/ksphere/kommander/latest/operations/identity-providers/index.md
+++ b/pages/ksphere/kommander/latest/operations/identity-providers/index.md
@@ -10,6 +10,8 @@ excerpt: Grant access to users in your organization
 
 By default, you login to konvoy with a credential given by `konvoy up`. You can retrieve it later by using `konvoy get ops-portal`.
 
+These static credentials should be used only to access **operations portal** for configuring an external identity provider. Since these are static credentials and there is currently no way of updating them they should be treated only as backup credentials and not used for normal access. Always login with own identity from external identity provider that usually provide additional security features like Multi Factor Authentication.
+
 ## Identity Providers
 
 To provide simple access for the users of your organization, Identity Providers can be set up.

--- a/pages/ksphere/kommander/latest/security/distributed-authnz/index.md
+++ b/pages/ksphere/kommander/latest/security/distributed-authnz/index.md
@@ -20,7 +20,7 @@ A user identity is shared across a Kommander cluster and all other provisioned c
 
 ### Kommander provisioned clusters
 
-A newly provisioned is federated `kube-oidc-proxy`, `dex-k8s-authenticator` and `traefik-forward-auth` Addons that are configured to trust Kommander cluster Dex issued id tokens.
+A newly provisioned cluster gets federated `kube-oidc-proxy`, `dex-k8s-authenticator` and `traefik-forward-auth` Addons. These Addons are configured to accept Kommander cluster Dex issued id tokens.
 
 When the `traefik-forward-auth` is used as a [Traefik ingress authenticator](https://docs.traefik.io/v1.7/configuration/backends/kubernetes/#annotations) it checks if the user identity was issued by the Kommander cluster Dex service. An anonymous user is redirected to the Kommander cluster Dex service to authenticate and confirm their identity.
 

--- a/pages/ksphere/kommander/latest/security/distributed-authnz/index.md
+++ b/pages/ksphere/kommander/latest/security/distributed-authnz/index.md
@@ -1,0 +1,40 @@
+---
+layout: layout.pug
+navigationTitle: Authentication and authorization
+title: Authentication and authorization architecture
+menuWeight: 9
+excerpt: Details on distributed authentication and authorization between clusters
+---
+
+## Authentication
+
+A Kommander is part of a Konvoy cluster installation. Konvoy comes with pre-configured authentication [Dex][dex_service] identity broker and provider.
+
+**Important:** Kubernetes, Konvoy and Dex do not store any user identities. Konvoy installation comes with default admin static credentials. These credentials should be used only to access **operations portal** for configuring an external identity provider. Since there is currently no way of updating them they should be treated only as backup credentials and not used for normal access. Always login with own identity from [external identity provider](../../operations/identity-providers/) that usually provide additional security features like Multi Factor Authentication. For more information review [Konvoy security documentation](/ksphere/konvoy/latest/security/).
+
+The operational portal admin credentials are stored as a secret. They never leave the boundary of the Kommander cluster and are never shared to any other cluster.
+
+The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other Konvoy components use the id token as an authentication proof. User identity to the Kubernetes API server is provided by [`kube-oidc-proxy`](https://github.com/jetstack/kube-oidc-proxy) Addon that reads the identity from an id token. Web requests to operations portal access are authenticated by [traefik forward auth](https://github.com/mesosphere/traefik-forward-auth) Addon.
+
+A user identity is shared across Kommander cluster and all other provisioned clusters.
+
+### Kommander provisioned clusters
+
+A newly provisioned is federated `kube-oidc-proxy`, `dex-k8s-authenticator` and `traefik-forward-auth` Addons that are configured to trust Kommander cluster Dex issued id tokens.
+
+When the `traefik-forward-auth` is used as a [Traefik ingress authenticator](https://docs.traefik.io/v1.7/configuration/backends/kubernetes/#annotations) it checks if the user identity was issued by the Kommander's cluster Dex service. An anonymous user is redirected to Kommander cluster Dex service to authenticate and confirm its identity.
+
+A user never enters its own credentials on any of the provisioned clusters but always only on Kommander cluster (when using static admin credentials) or external identity provider.
+
+## Authorization
+
+There is no centralized authorization component in Kommander. Each component and service makes own authorization decision based on user identity.
+
+Kommander provides an [interface to federate authorization RBAC rules](../../operations/access-control/) across multiple clusters.
+
+* Kubernetes API server is using [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+
+* `traefik-forward-auth` applies [RBAC rules to authorize](/ksphere/konvoy/latest/security/external-idps/rbac/#portal-authorization) access based on an HTTP request. The [default Kommander workspace](../../workspaces/) comes with preconfigured Roles for accessing different operational portal services with View, Edit or Admin permissions.
+
+[dex_service]: https://github.com/dexidp/dex
+[oidc_id_token]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken

--- a/pages/ksphere/kommander/latest/security/distributed-authnz/index.md
+++ b/pages/ksphere/kommander/latest/security/distributed-authnz/index.md
@@ -8,31 +8,31 @@ excerpt: Details on distributed authentication and authorization between cluster
 
 ## Authentication
 
-A Kommander is part of a Konvoy cluster installation. Konvoy comes with pre-configured authentication [Dex][dex_service] identity broker and provider.
+Kommander is part of a Konvoy cluster installation. Konvoy comes with a pre-configured authentication [Dex][dex_service] identity broker and provider.
 
-**Important:** Kubernetes, Konvoy and Dex do not store any user identities. Konvoy installation comes with default admin static credentials. These credentials should be used only to access **operations portal** for configuring an external identity provider. Since there is currently no way of updating them they should be treated only as backup credentials and not used for normal access. Always login with own identity from [external identity provider](../../operations/identity-providers/) that usually provide additional security features like Multi Factor Authentication. For more information review [Konvoy security documentation](/ksphere/konvoy/latest/security/).
+<p class="message--important"><strong>IMPORTANT: </strong> Kubernetes, Konvoy and Dex do not store any user identities. The Konvoy installation comes with default admin static credentials. These credentials should only be used to access the <strong>operations portal</strong> for configuring an external identity provider. There is currently no way to update these credentials so they should be treated as backup credentials and not used for normal access. Always login with your own identity from an <a href="../../operations/identity-providers/">external identity provider</a>. These provide additional security features like Multi Factor Authentication. For more information refer to the <a href="/ksphere/konvoy/latest/security/">Konvoy security documentation</a>.</p>
 
 The operational portal admin credentials are stored as a secret. They never leave the boundary of the Kommander cluster and are never shared to any other cluster.
 
-The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other Konvoy components use the id token as an authentication proof. User identity to the Kubernetes API server is provided by [`kube-oidc-proxy`](https://github.com/jetstack/kube-oidc-proxy) Addon that reads the identity from an id token. Web requests to operations portal access are authenticated by [traefik forward auth](https://github.com/mesosphere/traefik-forward-auth) Addon.
+The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other Konvoy components use the id token as an authentication proof. User identity to the Kubernetes API server is provided by the [`kube-oidc-proxy`](https://github.com/jetstack/kube-oidc-proxy) Addon that reads the identity from an id token. Web requests to operations portal access are authenticated by the [traefik forward auth](https://github.com/mesosphere/traefik-forward-auth) Addon.
 
-A user identity is shared across Kommander cluster and all other provisioned clusters.
+A user identity is shared across a Kommander cluster and all other provisioned clusters.
 
 ### Kommander provisioned clusters
 
 A newly provisioned is federated `kube-oidc-proxy`, `dex-k8s-authenticator` and `traefik-forward-auth` Addons that are configured to trust Kommander cluster Dex issued id tokens.
 
-When the `traefik-forward-auth` is used as a [Traefik ingress authenticator](https://docs.traefik.io/v1.7/configuration/backends/kubernetes/#annotations) it checks if the user identity was issued by the Kommander's cluster Dex service. An anonymous user is redirected to Kommander cluster Dex service to authenticate and confirm its identity.
+When the `traefik-forward-auth` is used as a [Traefik ingress authenticator](https://docs.traefik.io/v1.7/configuration/backends/kubernetes/#annotations) it checks if the user identity was issued by the Kommander cluster Dex service. An anonymous user is redirected to the Kommander cluster Dex service to authenticate and confirm their identity.
 
-A user never enters its own credentials on any of the provisioned clusters but always only on Kommander cluster (when using static admin credentials) or external identity provider.
+Never enter your own credentials on any of the provisioned clusters. On the Kommander cluster use the static admin credentials or an external identity provider.
 
 ## Authorization
 
-There is no centralized authorization component in Kommander. Each component and service makes own authorization decision based on user identity.
+There is no centralized authorization component in Kommander. Each component and service makes its own authorization decisions based on user identity.
 
 Kommander provides an [interface to federate authorization RBAC rules](../../operations/access-control/) across multiple clusters.
 
-* Kubernetes API server is using [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+* The Kubernetes API server is using [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
 * `traefik-forward-auth` applies [RBAC rules to authorize](/ksphere/konvoy/latest/security/external-idps/rbac/#portal-authorization) access based on an HTTP request. The [default Kommander workspace](../../workspaces/) comes with preconfigured Roles for accessing different operational portal services with View, Edit or Admin permissions.
 

--- a/pages/ksphere/kommander/latest/security/index.md
+++ b/pages/ksphere/kommander/latest/security/index.md
@@ -1,0 +1,8 @@
+---
+layout: layout.pug
+navigationTitle: Security
+title: Security
+menuWeight: 9
+excerpt: Security architecture
+---
+

--- a/pages/ksphere/konvoy/latest/install/install-airgapped/index.md
+++ b/pages/ksphere/konvoy/latest/install/install-airgapped/index.md
@@ -487,7 +487,7 @@ Specifically, the `konvoy up` command does the following:
   * [Velero][velero] to back up and restore Kubernetes cluster resources and persistent volumes.
   * [Dex identity service][dex] to provide identity service (authentication) to the Kubernetes clusters.
   * [Dex Kubernetes client authenticator][dex_k8s_authenticator] to enable authentication flow to obtain `kubectl` token for accessing the cluster.
-  * [Traefik forward authorization proxy][traefik_foward_auth] to provide basic authorization for Traefik ingress.
+  * [Traefik forward authorization proxy][traefik_forward_auth] to provide basic authorization for Traefik ingress.
   * Kommander for multi-cluster management.
 
 This set of configuration options is the recommended environment for small clusters.
@@ -558,7 +558,7 @@ When the `konvoy up` completes its setup operations, the following files are gen
 [velero]: https://velero.io/
 [dex]: https://github.com/dexidp/dex
 [dex_k8s_authenticator]: https://github.com/mintel/dex-k8s-authenticator
-[traefik_foward_auth]: https://github.com/thomseddon/traefik-forward-auth
+[traefik_forward_auth]: https://github.com/thomseddon/traefik-forward-auth
 [static_lvp]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [selinux-rpm]: http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm
 [containerd_mirrors]: https://github.com/containerd/cri/blob/master/docs/registry.md#configure-registry-endpoint

--- a/pages/ksphere/konvoy/latest/install/install-onprem/index.md
+++ b/pages/ksphere/konvoy/latest/install/install-onprem/index.md
@@ -511,7 +511,7 @@ Specifically, the `konvoy up` command does the following:
   * [Velero][velero] to back up and restore Kubernetes cluster resources and persistent volumes.
   * [Dex identity service][dex] to provide identity service (authentication) to the Kubernetes clusters.
   * [Dex Kubernetes client authenticator][dex_k8s_authenticator] to enable authentication flow to obtain `kubectl` token for accessing the cluster.
-  * [Traefik forward authorization proxy][traefik_foward_auth] to provide basic authorization for Traefik ingress.
+  * [Traefik forward authorization proxy][traefik_forward_auth] to provide basic authorization for Traefik ingress.
   * Kommander for multi-cluster management.
 
 This set of configuration options is the recommended environment for small clusters.
@@ -607,7 +607,7 @@ When the `konvoy up` completes its setup operations, the following files are gen
 [velero]: https://velero.io/
 [dex]: https://github.com/dexidp/dex
 [dex_k8s_authenticator]: https://github.com/mintel/dex-k8s-authenticator
-[traefik_foward_auth]: https://github.com/thomseddon/traefik-forward-auth
+[traefik_forward_auth]: https://github.com/thomseddon/traefik-forward-auth
 [static_lvp]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [kubernetes_base_addons_repo]: https://github.com/mesosphere/kubernetes-base-addons
 [kubeaddons_kommander_repo]: https://github.com/mesosphere/kubeaddons-kommander

--- a/pages/ksphere/konvoy/latest/operations/accessing-the-cluster/index.md
+++ b/pages/ksphere/konvoy/latest/operations/accessing-the-cluster/index.md
@@ -40,7 +40,7 @@ This UI is hosted on a web application within the cluster, which runs on the clu
 
 You will then see Konvoy's operations portal, which offers an overview of cluster status, and shortcuts to several dashboards to addon services such as Grafana.
 
-These static credentials should be used only to access **operations portal** for configuring an [external identity provider](../../security/external-idps/). Since these are static credentials and there is currently no way of updating them they should be treated only as backup credentials and not used for normal access. Always login with own identity from external identity provider that usually provide additional security features like Multi Factor Authentication.
+Static credentials should only be used to access the **operations portal** for configuring an [external identity provider](../../security/external-idps/). There is currently no way of updating static credentials so they should be used as backup credentials and not used for normal access. Always login with your own identity from an external identity provider. This provides additional security features like Multi Factor Authentication.
 
 ## Using kubectl
 

--- a/pages/ksphere/konvoy/latest/operations/accessing-the-cluster/index.md
+++ b/pages/ksphere/konvoy/latest/operations/accessing-the-cluster/index.md
@@ -40,6 +40,8 @@ This UI is hosted on a web application within the cluster, which runs on the clu
 
 You will then see Konvoy's operations portal, which offers an overview of cluster status, and shortcuts to several dashboards to addon services such as Grafana.
 
+These static credentials should be used only to access **operations portal** for configuring an [external identity provider](../../security/external-idps/). Since these are static credentials and there is currently no way of updating them they should be treated only as backup credentials and not used for normal access. Always login with own identity from external identity provider that usually provide additional security features like Multi Factor Authentication.
+
 ## Using kubectl
 
 One of the most common ways to perform administrative tasks and interact with a Kubernetes cluster is through the `kubectl` command line interface.

--- a/pages/ksphere/konvoy/latest/quick-start/index.md
+++ b/pages/ksphere/konvoy/latest/quick-start/index.md
@@ -97,7 +97,7 @@ Before starting the Konvoy installation, you should verify the following:
         - [Velero][velero] to back up and restore Kubernetes cluster resources and persistent volumes.
         - [Dex identity service][dex] to provide identity service (authentication) to the Kubernetes clusters.
         - [Dex Kubernetes client authenticator][dex_k8s_authenticator] to enable authentication flow to obtain `kubectl` token for accessing the cluster.
-        - [Traefik forward authorization proxy][traefik_foward_auth] to provide basic authorization for Traefik ingress.
+        - [Traefik forward authorization proxy][traefik_forward_auth] to provide basic authorization for Traefik ingress.
         - Kommander for multi-cluster management.
 
 # Verifying your installation
@@ -231,5 +231,5 @@ For more details, see the following topics:
 [velero]: https://velero.io/
 [dex]: https://github.com/dexidp/dex
 [dex_k8s_authenticator]: https://github.com/mintel/dex-k8s-authenticator
-[traefik_foward_auth]: https://github.com/thomseddon/traefik-forward-auth
+[traefik_forward_auth]: https://github.com/thomseddon/traefik-forward-auth
 [brew]: https://brew.sh/


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-63368

Source COPS: https://jira.d2iq.com/browse/COPS-5800
<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
Adds new page that describes distributed authentication and authorization architecture of Kommander.

As I am not a native speaker please review also grammar and style.

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [ ] Test all commands and procedures where applicable.
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
