### PR TITLE
[D2IQ-63349] Upgrade Hive-Metastore sdk to 0.57.3

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -25,4 +25,4 @@
 ~^/mesosphere/dcos/services/dcos-monitoring/latest/(.*) /mesosphere/dcos/services/dcos-monitoring/1.1.0/$1;
 ~^/mesosphere/dcos/services/beta-jupyter/latest/(.*) /mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/$1;
 ~^/mesosphere/dcos/cn/services/kubernetes/latest/(.*) /mesosphere/dcos/cn/services/kubernetes/1.2.1-1.10.6/$1;
-~^/mesosphere/dcos/services/hive-metastore/latest/(.*) /mesosphere/dcos/services/hive-metastore/1.1.0-3.0.0/$1;
+~^/mesosphere/dcos/services/hive-metastore/latest/(.*) /mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/$1;

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/advanced/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/advanced/index.md
@@ -1,0 +1,15 @@
+---
+layout: layout.pug
+navigationTitle: Advanced
+excerpt: Advanced features of Hive Metastore service
+title: Advanced features
+menuWeight: 45
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/advanced.tmpl
+
+# Deploy service using DSS Volume Profile
+
+#include /mesosphere/dcos/services/include/dcos-storage-service-volume-profile-tutorial.tmpl

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/cli/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/cli/index.md
@@ -1,0 +1,80 @@
+---
+layout: layout.pug
+navigationTitle: Beeline CLI
+excerpt: Interact with the Hive Metastore using the Beeling CLI
+title: Using the Beeline CLI in Hive Metastore
+menuWeight: 50
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+enterprise: true
+---
+
+You can interact with the {{ model.techName }} via the Beeline CLI.
+
+# <a name="Using MySQL Database"></a> Using MySQL Database
+
+- Please make sure the `Hive Metastore` & `MySQL` services are deployed and successfully runnning.
+
+- Find the load balanced address for MySQL. You will need this to set up the connection with Beeline. You can find the LB address in the DC/OS UI under the `Services > mysql > Endpoints` tab. It should look similar to:
+   ``` 
+   mysql.marathon.l4lb.thisdcos.directory:3306
+   ```
+
+- Next, find the task-id for the `node-0-server` task of {{ model.serviceName }}. It starts with `<Hive-Metastore Service name>__node-0-server`.
+
+  ```
+  dcos task | grep node-0-server
+  ```
+- Exec into the `node-0-server` task with the following command:
+
+  ```
+  dcos task exec -ti <NODE_0_SERVER_TASK_ID> bash -c \
+    'export HADOOP_HOME=hadoop-3.2.0 \
+    && export JAVA_HOME=$(ls -d jdk*) \
+    && export HIVE_HOME=$(ls -d apache-{{ model.serviceName }}-*) \
+    && bash apache-{{ model.serviceName }}-3.0.0-bin/bin/beeline \
+    -u jdbc:mysql://<MYSQL_LOAD_BALANCED_ADDRESS> \
+    -n root \
+    -p root'
+  ```
+  
+- Lastly, use the metastore database.
+
+  ```
+  use metastore_db;
+  ```
+<p class="message--note"><strong>NOTE: </strong>See detailed documentation for using <a href="https://docs.d2iq.com/mesosphere/dcos/2.0/monitoring/debugging/task-exec/"><tt>dcos task exec</tt></a>.</p>
+  
+# <a name="Reconnecting an inactive session"></a> Reconnecting an inactive session
+  
+  In the Beeline prompt, type `!reconnect` and it will reconnect to MySQL.
+  
+  ```
+  !reconnect
+  ```
+
+# <a name="Ending an active session"></a> Ending an active session
+  
+  In the Beeline prompt, type `!quit` and it will end the session.
+  
+  ```
+  !quit
+  ```
+  
+# <a name="Basic Beeline Queries"></a> Basic Beeline Queries
+
+  Beeline supports a rich set of SQL query functions. Here are a few examples:
+  ```
+  SHOW DATABASES;
+  USE <database>;
+
+  SHOW TABLES;
+  DESC <table>;
+  DESC FORMATTED <table>;
+
+  Simple limited select statements
+
+  SELECT * FROM <TABLE_NAME> limit 25;
+  ```
+
+For a list of all Beeline commands, see the [Beeline docs](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-BeelineCommands).

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/configuration/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/configuration/index.md
@@ -1,0 +1,15 @@
+---
+layout: layout.pug
+navigationTitle: Configuring 
+excerpt: Installation options, configuration regions, node settings, and more information
+title: Configuring Hive Metastore
+menuWeight: 42
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+
+#include /mesosphere/dcos/services/include/configuration-install-with-options.tmpl
+#include /mesosphere/dcos/services/include/configuration-create-json-file.tmpl
+#include /mesosphere/dcos/services/include/configuration-service-settings.tmpl
+#include /mesosphere/dcos/services/include/configuration-regions.tmpl

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/getting-started/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/getting-started/index.md
@@ -1,0 +1,77 @@
+---
+layout: layout.pug
+navigationTitle: Getting Started
+excerpt: Getting started with Hive Metastore
+title: Getting Started
+menuWeight: 20
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+Getting started with a test instance of the DC/OS {{ model.techName }} service is straightforward.
+
+## Prerequisites
+
+- Depending on your security mode in Enterprise DC/OS, you may need to [provision a service account](/mesosphere/dcos/services/{{ model.serviceName }}/1.1.0-3.0.0/security/#provisioning-a-service-account) before you install {{ model.techName }}. You will be able to create the service account only if you have `superuser` permission.
+	- `strict` [security mode](/mesosphere/dcos/latest/security/ent/#security-modes) requires a service account.
+	- `permissive` security mode: a service account is optional.
+	- `disabled` security mode does not require a service account.
+- Your cluster must have at least {{ model.install.minNodeCount }} private nodes.
+{{ model.install.customRequirements }}
+
+<p class="message--note"><strong>NOTE: </strong>The default DC/OS {{ model.techShortName }} installation provides reasonable defaults for trying out the service, but may not be sufficient for production use. You may require different configurations depending on the context of the deployment.</p>
+
+
+## Installation from the DC/OS CLI
+
+To start a basic test cluster, run the following command on the DC/OS CLI. Enterprise DC/OS users must follow additional instructions. More information about installing DC/OS {{ model.techShortName }} on Enterprise DC/OS is available in the [Authenticating DC/OS Services](/mesosphere/dcos/2.0/security/ent/service-auth/custom-service-auth/) documentation. 
+
+```shell
+dcos package install {{ model.serviceName }}
+```
+You can specify a custom configuration in an `options.json` file and pass it to `dcos package install` using the `--options` parameter.
+
+```json
+dcos package install {{ model.serviceName }} --options=<options>.json
+```
+
+It is recommended that this custom configuration is stored in source control.
+
+For more information about building the `options.json` file, see  [Configuring Services](/mesosphere/dcos/2.0/deploying-services/config-universe-service/).
+
+## Installation from the DC/OS UI
+
+You can [install DC/OS Apache {{ model.techShortName }} from the DC/OS UI](/mesosphere/dcos/2.0/deploying-services/install/). If you install DC/OS {{ model.techShortName }} from the web interface, you must install the DC/OS {{ model.techShortName }} CLI subcommands separately. From the DC/OS CLI, enter the following command:
+```bash
+dcos package install {{ model.serviceName }} --cli
+```
+Choose `ADVANCED INSTALLATION` to perform a custom installation.
+
+## Integration with DC/OS access controls
+
+In Enterprise DC/OS 1.10 and later, you can integrate your SDK-based service with DC/OS ACLs to restrict users and groups  to certain services. You will install your service into a folder, and then restrict access to some number of folders. Folders also allow you to assign namespaces to services; for example, `staging/{{ model.serviceName }}` and `production/{{ model.serviceName }}`.
+
+Use the following steps to integrate with DC/OS access controls:
+
+1. In the DC/OS UI, you must create a group and then add a user to the group or create an user. Click **Organization** > **Groups** > **+** or **Organization** > **Users** > **+**. If you create a group, you must also create a user and add them to the group.
+1. Give the user permissions for the folder where you will install your service. In this example, we are creating a user called `developer`, who will have access to the `/testing` folder.
+   Select the group or user you created. Select **ADD PERMISSION** and then toggle to **INSERT PERMISSION STRING**. Add each of the following permissions to your user or group and then click **ADD PERMISSIONS**.
+
+   ```
+   dcos:adminrouter:service:marathon full
+   dcos:service:marathon:marathon:services:/testing full
+   dcos:adminrouter:ops:mesos full
+   dcos:adminrouter:ops:slave full
+   ```
+1. Install your service into a folder called `test`. Go to **Catalog**, then search for **{{ model.serviceName }}**.
+1. Click **CONFIGURE** and change the service name to `/testing/{{ model.serviceName }}`, then deploy.
+
+   The slashes in your service name are interpreted as folders. You are deploying {{ model.techShortName }} in the `/testing` folder. Any user with access to the `/testing` folder will have access to the service.
+
+<p class="message--note"><strong>NOTE: </strong>Services cannot be renamed because the location of the service is specified in the name and you cannot move services between folders. DC/OS 1.9 does not accept slashes in service names. You may be able to create the service, but you will encounter unexpected problems.</p>
+
+### Interacting with your foldered service
+
+- Interact with your foldered service via the DC/OS CLI with this flag: `--name=/path/to/myservice`.
+- To interact with your foldered service over the web directly, use `http://<dcos-url>/service/path/to/myservice`. For example, `http://<dcos-url>/service/testing/{{ model.serviceName }}/v1/endpoints`.
+

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/getting-started/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/getting-started/index.md
@@ -12,7 +12,7 @@ Getting started with a test instance of the DC/OS {{ model.techName }} service i
 
 ## Prerequisites
 
-- Depending on your security mode in Enterprise DC/OS, you may need to [provision a service account](/mesosphere/dcos/services/{{ model.serviceName }}/1.1.0-3.0.0/security/#provisioning-a-service-account) before you install {{ model.techName }}. You will be able to create the service account only if you have `superuser` permission.
+- Depending on your security mode in Enterprise DC/OS, you may need to [provision a service account](/mesosphere/dcos/services/{{ model.serviceName }}/1.2.0-3.0.0/security/#provisioning-a-service-account) before you install {{ model.techName }}. You will be able to create the service account only if you have `superuser` permission.
 	- `strict` [security mode](/mesosphere/dcos/latest/security/ent/#security-modes) requires a service account.
 	- `permissive` security mode: a service account is optional.
 	- `disabled` security mode does not require a service account.

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/index.md
@@ -1,0 +1,38 @@
+---
+layout: layout.pug
+navigationTitle: Hive Metastore 1.2.0-3.0.0
+excerpt: DC/OS Hive Metastore is an automated service that makes it easy to deploy and manage Hive Metastore on Mesosphere DC/OS.
+title: Hive Metastore 1.2.0-3.0.0
+menuWeight: 1
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+DC/OS {{ model.techName }} is an automated service that makes it easy to deploy 
+and manage {{ model.techName }} on Mesosphere DC/OS, eliminating nearly all of 
+the complexity traditionally associated with managing a {{ model.techShortName }} 
+cluster. {{ model.techName }} is a metadata store for all Hive object definitions 
+such as databases, tables, and functions. The Metastore can persist these definitions
+to a relational database (RDBMS) and can be configured to embed the Apache Derby 
+RDBMS or connect to an external RDBMS (such as MySQL). The {{ model.techShortName }} 
+can be configured to be highly available, fault tolerant, and durable. 
+For more information on {{ model.techName }}, see the {{ model.techName }} 
+[documentation](https://cwiki.apache.org/confluence/display/Hive/AdminManual+Metastore+3.0+Administration). 
+
+
+## Benefits
+
+DC/OS {{ model.techShortName }} offers the following benefits of a semi-managed service:
+
+*   Easy installation
+*   Simple horizontal scaling of {{ model.techShortName }} nodes
+*   Multiple {{ model.techShortName }} nodes enable high availability
+
+## Features
+
+DC/OS {{ model.techShortName }} provides the following features:
+
+*   Single-command installation for rapid provisioning
+*   Multiple clusters for multi-tenancy with DC/OS
+*   High availability runtime configuration and software updates
+

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/limitations/index.md
@@ -1,0 +1,31 @@
+---
+layout: layout.pug
+navigationTitle: Limitations
+excerpt: Limitations on backups, node counts, security
+title: Limitations
+menuWeight: 100
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/limitations.tmpl
+#include /mesosphere/dcos/services/include/limitations-zones.tmpl
+#include /mesosphere/dcos/services/include/limitations-regions.tmpl
+
+## Percona-MySQL
+
+PXC Strict Mode is designed to avoid the use of experimental and unsupported features in Percona XtraDB Cluster. It performs a number of validations at startup and during runtime.
+
+| PXC Strict Mode| Restrictions |
+| -------------- | ------------ |
+| DISABLED       | Do not perform strict mode validations and run as normal. |
+| PERMISSIVE     | If a validation fails, log a warning and continue running as normal. |
+| ENFORCING      | If a validation fails during startup, halt the server and throw an error. If a validation fails during runtime, deny the operation and throw an error. |
+| MASTER         | The same as ENFORCING except that the validation of explicit table locking is not performed. This mode can be used with clusters in which write operations are isolated to a single node. |
+
+
+### Compatible modes
+Using `percona-pxc-mysql` under mode `PERMISSIVE` or `DISABLED` works with {{ model.techName }} out of the box.
+
+### Non-Compatible modes
+Using `percona-pxc-mysql` under mode `ENFORCING` or `MASTER` is not supported in the current {{ model.techName }} version.

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/operations/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/operations/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle: Operations
+excerpt: Managing, repairing, and monitoring your DC/OS Hive Metastore service
+title: Operations
+menuWeight: 40
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/operations.tmpl

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/release-notes/index.md
@@ -1,0 +1,43 @@
+---
+layout: layout.pug
+navigationTitle: Release Notes  
+excerpt: Discover the new features, updates, and known limitations in this release of the Hive Metastore Service
+title: Release Notes 
+menuWeight: 10
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+# Release Notes for the {{ model.techName }} Service version 1.2.0-3.0.0
+
+## Updates
+
+- Upgraded SDK library to version `0.57.3`. For more information see [SDK Release Notes](https://github.com/mesosphere/dcos-commons/releases/tag/0.57.3)
+
+## Upgrading your cluster from 1.1.0-3.0.0 to 1.2.0-3.0.0
+
+It is possible to upgrade from 1.1.0-3.0.0 to 1.2.0-3.0.0
+  
+  See the [update section](/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/updates/) for specific instructions.
+
+# Release Notes for the {{ model.techName }} Service version 1.1.0-3.0.0
+
+## Updates
+
+- Upgraded SDK library to version `0.57.0`. For more information see [SDK Release Notes](https://github.com/mesosphere/dcos-commons/releases/tag/0.57.0)
+- Added support for Kerberos Authentication
+- Added support for TLS/SSL
+- Added support for Storage Based Authorization
+
+
+# Release Notes for the {{ model.techName }} Service version 1.0.0-3.0.0
+
+## Updates
+
+- Support for the following databases: Derby, MySQL, Percona-MySQL
+- Ability to easily configure each node's resources
+- Support for high-availability with the ability to horizontally scale out
+- Automatic generation of the `metastore-site.xml` file and exposure of it through the `endpoints` CLI command
+- Beeline CLI support
+- Uses SDK version 0.56.1
+- Support for the [DC/OS Storage Service](https://docs.d2iq.com/mesosphere/dcos/services/storage/)
+- For more information, see the release notes for version [0.56.1](https://github.com/mesosphere/dcos-commons/releases/tag/0.56.1)

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/security/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/security/index.md
@@ -1,0 +1,214 @@
+---
+layout: layout.pug
+navigationTitle: Security
+excerpt: Securing your service
+title: DC/OS Hive Metastore security
+menuWeight: 50
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+enterprise: true
+quota-aware: true
+---
+
+# DC/OS {{ model.techName }} Security
+
+- The DC/OS {{ model.techName }} service allows you to create a service account to configure access for {{ model.techName }}. The service allows you to create and assign permissions as required for access.  
+
+- The DC/OS {{ model.techName }} service supports {{ model.techName }}'s native transport encryption mechanisms. The service provides automation and orchestration to simplify the usage of the following features.
+
+<p class="message--note"><strong>NOTE: </strong>These security features are only available on DC/OS Enterprise 1.10 and later.</p>
+
+#include /mesosphere/dcos/services/include/service-account.tmpl
+
+#include /mesosphere/dcos/services/include/security-create-permissions.tmpl
+
+# Using the Secret Store for Passwords
+
+Enterprise DC/OS provides a Secrets store to enable access to sensitive data such as database passwords, private keys, and API tokens. DC/OS manages secure transportation of secret data, access control and authorization, and secure storage of secret content. Detailed information can be found [here](https://docs.d2iq.com/mesosphere/dcos/latest/security/ent/secrets).
+
+All tasks defined in the pod will have access to secret data. If the content of the secret is changed, the relevant pod needs to be restarted so that it can get updated content from the secret store.
+
+We can use secrets in {{ model.techName }} to store database passwords. We can use the secret store as follows in order to store and use secrets in {{ model.techName }} service:
+
+1. From the left-side navigation menu, click on `Secrets`.
+
+2. From the Secrets page, click on the `+` icon in the top-right corner of the screen to create a new secret key-value pair.
+
+3. In the `ID` field, provide a unique ID for the key-pair we want to create. This ID will be used later to enable secrets. In the `Value` field, enter the value of the secret; for example, a database password, private key, or API token. Lastly, click on `Create Secret`. 
+
+![Creating Secrets](https://downloads.mesosphere.com/hive-metastore/assets/secret_docs_screen1.png)
+
+4. Go to the {{ model.techName }}'s service configuration page for a fresh deployment of service using secrets. Click on  the {{ model.techName }}  configuration menu to proceed.
+
+![{{ model.techName }} Configuration](https://downloads.mesosphere.com/hive-metastore/assets/secret_docs_screen2.png)
+
+5. Scroll down and look for the `Enable Secrets` checkbox. Check the box to enable secrets. 
+
+1. Now, enter the `ID` of the secret created earlier in the `Database Password` field. Click **Review & Run**. The service will now be deployed using secrets.
+
+![Using Secrets as the Database Password](https://downloads.mesosphere.com/hive-metastore/assets/secret_docs_screen3.png)
+
+# Authentication
+
+DC/OS {{ model.techName }} supports Kerberos authentication.
+
+## Kerberos Authentication
+
+Kerberos authentication relies on a central authority to verify that {{ model.techShortName }} clients are who they say they are. DC/OS {{ model.techName }} integrates with your existing Kerberos infrastructure to verify the identity of clients.
+
+### Prerequisites
+- The hostname and port of a KDC reachable from your DC/OS cluster
+- Sufficient access to the KDC to create Kerberos principals
+- Sufficient access to the KDC to retrieve a keytab for the generated principals
+- [The DC/OS Enterprise CLI](/mesosphere/dcos/latest/cli/enterprise-cli/#installing-the-dcos-enterprise-cli)
+- DC/OS Superuser permissions
+
+### Configure Kerberos Authentication
+
+### Create principals
+
+The DC/OS {{ model.techName }} service requires Kerberos principals for each node to be deployed. The overall topology of the {{ model.techShortName }} service is:
+- 1 init node
+- A configurable number of server nodes
+
+The required Kerberos principals will have the form:
+```shell
+<service primary>/node-0-init.<service subdomain>.autoip.dcos.thisdcos.directory@<service realm>
+<service primary>/node-<data-index>-server.<service subdomain>.autoip.dcos.thisdcos.directory@<service realm>
+```
+with:
+- service primary = service.security.kerberos.primary
+- data index = 0 up to n
+- service subdomain = service.name with all `/`'s removed
+- service realm = service.security.kerberos.realm
+
+For example, if installing with these options:
+```json
+{
+    "service": {
+        "name": "a/good/example",
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "primary": "example",
+                "realm": "EXAMPLE"
+            }
+        }
+    },
+    "hive_metastore": {
+        "count": 3
+    }
+}
+```
+then the principals to create would be:
+```shell
+example/node-0-init.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+example/node-0-server.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+example/node-1-server.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+example/node-2-server.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+```
+
+#include /mesosphere/dcos/services/include/security-kerberos-ad.tmpl
+
+#include /mesosphere/dcos/services/include/security-service-keytab.tmpl
+
+### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own:
+```json
+{
+    "service": {
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "kdc": {
+                    "hostname": "<kdc host>",
+                    "port": <kdc port>
+                },
+                "primary": "<service primary default hive-metastore>",
+                "realm": "<realm>",
+                "keytab_secret": "<path to keytab secret>",
+                "debug": <true|false default false>
+            }
+        }
+    }
+}
+```
+
+# Authorization
+
+DC/OS {{ model.techName }} supports Storage Based Authorization.
+
+## Storage Based Authorization
+
+The DC/OS {{ model.techName }} service supports {{ model.techShortName }}'s storage based authorization. When metastore server security is configured to use Storage Based Authorization, it uses the file system permissions for folders corresponding to the different metadata objects as the source of truth for the authorization policy.
+- Storage based authorization authorizes read privilege on database and tables. 
+- Use of Storage Based Authorization in metastore is recommended.
+
+### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own:
+```json
+{
+    "service": {
+        "security": {
+            "authorization": {
+                "enabled": true
+            },
+        }
+    }
+}
+```
+
+# <a name="transport_encryption"></a> Transport Encryption
+
+#include /mesosphere/dcos/services/include/security-transport-encryption-lead-in.tmpl
+
+### Prerequisites
+- [A DC/OS Service Account with a secret stored in the DC/OS Secret Store](/mesosphere/dcos/latest/security/ent/service-auth/custom-service-auth/).
+- DC/OS Superuser permissions for modifying the permissions of the Service Account.
+
+### Configure Transport Encryption
+
+#### Set up the service account
+
+[Grant](/mesosphere/dcos/latest/security/ent/perms-management/) the service account the correct permissions.
+- In DC/OS 1.10, the required permission is `dcos:superuser full`.
+- In DC/OS 1.11 and later, the required permissions are:
+```shell
+dcos:secrets:default:/<service name>/* full
+dcos:secrets:list:default:/<service name> read
+dcos:adminrouter:ops:ca:rw full
+dcos:adminrouter:ops:ca:ro full
+```
+where `<service name>` is the name of the service to be installed.
+
+<!-- Not clear if this is the right location DCOS-39455 --> 
+Run the following DC/OS Enterprise CLI commands to set permissions for the service account on a strict cluster:
+
+```shell
+dcos security org users grant ${SERVICE_ACCOUNT} dcos:mesos:master:task:app_id:<service/name> create
+dcos security org users grant ${SERVICE_ACCOUNT} dcos:mesos:master:reservation:principal:dev_hdfs create
+dcos security org users grant ${SERVICE_ACCOUNT} dcos:mesos:master:volume:principal:dev_hdfs create
+```
+
+#### Install the service
+Install the DC/OS {{ model.techName }} service including the following options in addition to your own:
+```json
+{
+    "service": {
+        "service_account": "<your service account name>",
+        "service_account_secret": "<full path of service secret>",
+        "security": {
+            "ssl_enabled": true
+        }
+    }
+}
+```
+
+#include /mesosphere/dcos/services/include/security-transport-encryption-clients.tmpl
+
+# <a name="Forwarding DNS and Custom Domain"></a> Forwarding DNS and Custom Domain
+
+#include /mesosphere/dcos/services/include/forwarding-dns-custom-domain.tmpl
+

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/support-policy/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/support-policy/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle: Support Policy
+title: Support Policy
+menuWeight: 190
+excerpt: DC/OS and certified package version support policy
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/support-policy.tmpl

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/supported-databases/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/supported-databases/index.md
@@ -101,5 +101,5 @@ Percona-MySQL is an enterprise-grade HA drop-in replacement for MySQL. To enable
       ```
    
 - #### Limitations
-  Currently, {{ model.techName }} is only compatible with Percona's `PERMISSIVE` and `DISABLED` modes. See the [limitations](/mesosphere/dcos/services/hive-metastore/1.1.0-3.0.0/limitations/) page for more details.
+  Currently, {{ model.techName }} is only compatible with Percona's `PERMISSIVE` and `DISABLED` modes. See the [limitations](/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/limitations/) page for more details.
   

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/supported-databases/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/supported-databases/index.md
@@ -1,0 +1,105 @@
+---
+layout: layout.pug
+navigationTitle: Supported Databases
+excerpt: Supported Databases
+title: Getting Started
+menuWeight: 25
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+## Supported Databases
+
+The DC/OS {{ model.techName }} supports the following relational databases (RDBMS):
+ - Derby
+ - MySQL
+ - Percona-MySQL
+
+### Install the {{ model.techShortName }} with Derby
+By default, the {{ model.techName }} configuration is set to the default embedded Derby database for development usage. However, it is not intended for use beyond simple testing.
+
+```shell
+dcos package install {{ model.packageName }}
+```
+
+
+### Install the {{ model.techShortName }}  with MySQL
+The {{ model.techShortName }} can also be backed by a MySQL database. 
+
+- Users must deploy MySQL:
+
+   ```shell
+   dcos package install mysql
+   ```
+
+- Next, find the load balanced address for mysql. You'll need this to configure hive-metastore properly. You can find the LB address in the DC/OS UI under Services > mysql > Endpoints tab. It should look similar to:
+   `mysql.marathon.l4lb.thisdcos.directory:3306`.
+
+- Next, configure the `{{ model.packageName }}` package with the following configs:
+   
+   - Create a custom config file that will be used to install `{{ model.serviceName }} `, and save it as `metastore-options.json`.
+
+      ```json
+      {
+        "hive_metastore": {
+          "database": "mysql",
+          "database_user_name": "root",
+          "database_password": "root",
+          "database_address": "mysql.marathon.l4lb.thisdcos.directory:3306"
+        }
+      }
+      ```
+        
+    - Deploy the `{{ model.techShortName }}` package:
+      ```shell
+      dcos package install hive-metastore --options=metastore-options.json
+      ```
+
+### Install Metastore with Percona-MySQL
+Percona-MySQL is an enterprise-grade HA drop-in replacement for MySQL. To enable usage with Percona-MySQL:
+
+- Users must deploy Percona-MySQL with the following configurations:
+   
+  - Create a custom config file that will be used to install `percona-pxc-mysql`, and save it as `percona-options.json`.
+
+      ```json
+      {
+        "pxc-advanced": {
+          "pxc_strict_mode": "PERMISSIVE"
+        }
+      }
+      ```
+      - `pxc_strict_mode` can also be set to `DISABLED`.
+  - Deploy the Percona-MySQL package
+      ```shell
+      dcos package install percona-pxc-mysql --options=percona-options.json
+      ```
+  
+- Next, configure the `{{ model.packageName }}` package with the following configurations:
+   
+   - Create a custom configuration file that will be used to install `hive-metastore`, and save it as `metastore-options.json`.
+
+      ```json
+      {
+        "hive_metastore": {
+          "database": "mysql",
+          "database_user_name": "root",
+          "database_password": "root",
+          "database_address": "pxc-db.percona-pxc-mysql.l4lb.thisdcos.directory:3306"
+        }
+      }
+      ```
+    - The `database_address` assumes default installation of `percona-pxc-mysql`. If using custom configs, users can find the `vip` endpoint using percona's CLI command:
+
+      ```shell
+      dcos percona-pxc-mysql endpoints pxc-db-port
+      ```
+
+    - Deploy the `hive-metastore` package:
+      ```shell
+      dcos package install hive-metastore --options=metastore-options.json
+      ```
+   
+- #### Limitations
+  Currently, {{ model.techName }} is only compatible with Percona's `PERMISSIVE` and `DISABLED` modes. See the [limitations](/mesosphere/dcos/services/hive-metastore/1.1.0-3.0.0/limitations/) page for more details.
+  

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/troubleshooting/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle: Troubleshooting
+excerpt: Diagnosing service problems
+title: Troubleshooting DC/OS Hive Metastore
+menuWeight: 70
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/troubleshooting.tmpl

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/uninstall/index.md
@@ -1,0 +1,108 @@
+---
+layout: layout.pug
+navigationTitle: Uninstall
+excerpt: Uninstalling Hive Metastore
+title: Uninstalling Hive Metastore
+menuWeight: 55
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+Uninstalling the service is simple.
+
+From the DC/OS CLI, enter 
+
+```shell
+dcos package uninstall --app-id=<service-name> {{ model.packageName }}
+```
+
+### Uninstall process
+
+<p class="message--warning"><strong>WARNING: </strong>Once the uninstall operation has begun, it cannot be cancelled because doing so can leave the service in an uncertain, half-destroyed state. Any data stored in reserved disk resources will be irretrievably lost.</p>
+
+Uninstalling the service consists of the following steps:
+
+1. The service scheduler is relaunched with the environment variable `SDK_UNINSTALL` set to "true". This puts the service into an uninstall mode.
+1. The service scheduler performs the uninstall with the following actions:
+    - All running tasks for the service are terminated.
+    - All reserved resources are unreserved by the scheduler.
+    - Once all known resources have been unreserved, the scheduler's persistent state is deleted.
+1. The cluster automatically removes the scheduler task once it advertises the completion of the uninstall process.
+
+## Debugging an uninstall
+
+There are certain situations under which the automated uninstall process cannot complete without manual intervention.
+
+### <a name="zombie-service-scheduler"></a>Zombie service scheduler
+
+If the service scheduler reports in its `stdout` that the uninstall is complete, but the scheduler is not removed from the system, you can safely delete it via Marathon.
+
+### Missing DC/OS agent
+
+The service will not complete the uninstall if it is not able to unreserve all the resources it has previously reserved. A common cause of this is a DC/OS agent for which the service had reserved resources, which is no longer part of the DC/OS cluster.
+
+- If the agent is only temporarily gone due to maintenance, the service will unreserve the resources when the agent returns to the cluster.
+
+- If the agent has been permanently removed, then the uninstall will hang indefinitely. The easiest way to prevent this, is to perform `pod replace` on any pod deployed to the lost agent before initiating the uninstall.
+
+- If the missing agent is only discovered after the uninstall is initiated, then the following process can be used to allow the uninstall to complete.
+
+First determine what resources the service is waiting on.
+
+- CLI: `dcos {{ model.packageName }} --name={{ model.serviceName }} plan show deploy` (after running `dcos package install --cli {{ model.packageName }}` if needed)
+- HTTP: `https://yourcluster.com/service/{{ model.serviceName }}/v1/plans/deploy`
+
+```bash
+dcos {{ model.packageName }} --name={{ model.serviceName }} plan show deploy
+deploy (IN_PROGRESS)
+├─ kill-tasks (COMPLETE)
+│  ├─ kill-task-node-0-server__1a4114bc-48bb-47f6-be99-1b5ca6d55c4e (COMPLETE)
+│  ├─ kill-task-node-1-server__0c42118e-04fd-40e1-b49d-0d3f71d2d243 (COMPLETE)
+│  └─ kill-task-node-2-server__e00cad38-f27f-4332-b1df-5118ca480d50 (COMPLETE)
+├─ unreserve-resources (IN_PROGRESS)
+│  ├─ unreserve-f41351a2-b478-4e13-a94c-705f530989ef (COMPLETE)
+│  ├─ unreserve-48f64612-8427-4cde-86f4-4edeb9efff37 (COMPLETE)
+│  ├─ unreserve-402d51f5-6014-4ca3-bd13-324dae62b888 (PENDING)
+│  ├─ unreserve-cb95e869-277f-48b9-954f-08c0d7a26bcf (PENDING)
+│  ├─ unreserve-cbd748d0-df7b-4d01-b0b7-6acf915d8f98 (COMPLETE)
+│  ├─ unreserve-00ed63d6-427c-4492-9713-772390cc5241 (COMPLETE)
+│  ├─ unreserve-5dd56b1d-4522-4bbd-88b5-de9fa0f181f2 (PENDING)
+│  └─ unreserve-c9915f07-f446-4e14-a6b4-12c8dd2f914b (COMPLETE)
+└─ deregister-service (PENDING)
+   └─ deregister (PENDING)
+```
+
+As we can see above, some of the resources to unreserve are stuck in a `PENDING` state. We can force them into a `COMPLETE` state, and thereby allow the scheduler to finish the uninstall operation. This may be done using either of the following methods:
+- CLI: `dcos {{ model.packageName }} --name={{ model.serviceName }} plan show deploy`
+- HTTP: `https://yourcluster.com/service/{{ model.serviceName }}/v1/plans/deploy/forceComplete?phase=unreserve-resources&step=unreserve-<UUID>`
+
+```bash
+dcos {{ model.packageName }} --name={{ model.serviceName }} plan force-complete deploy unreserve-resources unreserve-402d51f5-6014-4ca3-bd13-324dae62b888
+dcos {{ model.packageName }} --name={{ model.serviceName }} plan force-complete deploy unreserve-resources unreserve-cb95e869-277f-48b9-954f-08c0d7a26bcf
+dcos {{ model.packageName }} --name={{ model.serviceName }} plan force-complete deploy unreserve-resources unreserve-5dd56b1d-4522-4bbd-88b5-de9fa0f181f2
+```
+
+At this point the scheduler should show a `COMPLETE` state for these steps in the plan, allowing it to proceed normally with the uninstall operation:
+
+```shell
+dcos {{ model.packageName }} --name={{ model.serviceName }} plan show deploy
+deploy (IN_PROGRESS)
+├─ kill-tasks (COMPLETE)
+│  ├─ kill-task-node-0-server__1a4114bc-48bb-47f6-be99-1b5ca6d55c4e (COMPLETE)
+│  ├─ kill-task-node-1-server__0c42118e-04fd-40e1-b49d-0d3f71d2d243 (COMPLETE)
+│  └─ kill-task-node-2-server__e00cad38-f27f-4332-b1df-5118ca480d50 (COMPLETE)
+├─ unreserve-resources (COMPLETE)
+│  ├─ unreserve-f41351a2-b478-4e13-a94c-705f530989ef (COMPLETE)
+│  ├─ unreserve-48f64612-8427-4cde-86f4-4edeb9efff37 (COMPLETE)
+│  ├─ unreserve-402d51f5-6014-4ca3-bd13-324dae62b888 (COMPLETE)
+│  ├─ unreserve-cb95e869-277f-48b9-954f-08c0d7a26bcf (COMPLETE)
+│  ├─ unreserve-cbd748d0-df7b-4d01-b0b7-6acf915d8f98 (COMPLETE)
+│  ├─ unreserve-00ed63d6-427c-4492-9713-772390cc5241 (COMPLETE)
+│  ├─ unreserve-5dd56b1d-4522-4bbd-88b5-de9fa0f181f2 (COMPLETE)
+│  └─ unreserve-c9915f07-f446-4e14-a6b4-12c8dd2f914b (COMPLETE)
+└─ deregister-service (PENDING)
+   └─ deregister (PENDING)
+```
+
+<p class="message--note"><strong>NOTE: </strong>As it may take the operator some time to complete these actions, the service scheduler may be left in a zombie state after the uninstall is complete.
+See the "Zombie service scheduler" section above for instructions on how to correct this.</p>

--- a/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/updates/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/updates/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle: Update
+excerpt: Updates and patches
+title: Updating DC/OS Hive Metastore
+menuWeight: 47
+model: /mesosphere/dcos/services/hive-metastore/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/update.tmpl


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-65568
Changes done regarding https://jira.d2iq.com/browse/D2IQ-63349

## Description of changes being made
The changes are regarding new Hive-Metastore 1.2.0-3.0.0 release.
- Upgraded SDK library to version 0.57.3.