### PR TITLE
Update CODEOWNERS for konvoy docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,9 @@
 # change to not notify
 # /pages/services/ @SarahStegall @jpe442
 
+# Konvoy
+/pages/ksphere/konvoy/ @dkoshkin @samvantran
+
 # Networking
 # change to notify networking team only 
 /pages/mesosphere/dcos/services/edge-lb/ @networking-team


### PR DESCRIPTION
## Description of changes being made

This sets @dkoshkin and me as codeowners so that we're made aware of docs changes in docs-site.

The process for updating docs is to update them directly in the Konvoy repo and only use automation to update docs here in this repo. So basically, contributors _should not_ be making Konvoy docs changes in this repo. 