### PR TITLE
[D2IQ-64606] Add release docs for confluent-kafka 2.9.0-5.4.0

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -1,6 +1,6 @@
 ~^/mesosphere/dcos/latest/(.*)$ /mesosphere/dcos/2.0/$1;
 ~^/mesosphere/dcos/services/cassandra/latest/(.*) /mesosphere/dcos/services/cassandra/2.9.0-3.11.6/$1;
-~^/mesosphere/dcos/services/confluent-kafka/latest/(.*) /mesosphere/dcos/services/confluent-kafka/2.8.0-5.3.1/$1;
+~^/mesosphere/dcos/services/confluent-kafka/latest/(.*) /mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/$1;
 ~^/mesosphere/dcos/services/confluent-zookeeper/latest/(.*) /mesosphere/dcos/services/confluent-zookeeper/2.6.0-5.1.2e/$1;
 ~^/mesosphere/dcos/services/couchbase/latest/(.*) /mesosphere/dcos/services/couchbase/0.3.0-5.5.3/$1;
 ~^/mesosphere/dcos/services/data-science-engine/latest/(.*) /mesosphere/dcos/services/data-science-engine/1.0.0/$1;

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/advanced/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/advanced/index.md
@@ -1,0 +1,173 @@
+---
+layout: layout.pug
+navigationTitle: Advanced Features 
+excerpt: Advanced Features of Confluent Kafka
+title: Advanced Features of Confluent Kafka
+menuWeight: 15
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/advanced.tmpl
+
+
+[enterprise]
+## Secure JMX
+[/enterprise]
+
+{{ model.techName }} supports Secure JMX allowing you to remotely manage and monitor the Kafka JRE.
+
+### Configuration Options
+
+| Option | Description |
+|----------------------|-------------|
+| jmx.enabled | Enables the secure JMX |
+| jmx.port | JMX port |
+| jmx.rmi_port | JMX RMI port |
+| jmx.access_file | The path to the secret in the Secret Store that has the contents of the access file. |
+| jmx.password_file | The path to the secret in the Secret Store that has the contents of the password file. |
+| jmx.key_store | The path to the secret in the Secret Store that has the contents of the key store. |
+| jmx.key_store_password_file | The path to the secret in the Secret Store that has the contents of the key store password file. |
+| jmx.add_trust_store | Enables the user provided trust store. |
+| jmx.trust_store | The path to the secret in the Secret Store that has the contents of the trust store. |
+| jmx.trust_store_password_file | The path to the secret in the Secret Store that has the contents of the trust store password file. |
+
+Read more about using JMX options <a href="https://docs.oracle.com/javadb/10.10.1.2/adminguide/radminjmxenablepwdssl.html">here</a>.
+
+### Configuring JMX with self-signed certificate
+
+1. Generate a self-signed key store and trust store.
+
+    ```bash
+    $ keytool -genkey -alias server-cert -keyalg rsa  -dname "CN=kafka.example.com,O=Example Company,C=US"  -keystore keystore.ks -storetype JKS -storepass changeit -keypass changeit
+    ```
+
+    ```bash
+    $ keytool -genkey -alias server-cert -keyalg rsa  -dname "CN=kafka.example.com,O=Example Company,C=US"  -keystore truststore.ks -storetype JKS -storepass changeit -keypass changeit
+    ```
+
+1. Generate files containing the trust store and key store passwords.
+
+    ```bash
+    $ cat <<EOF >> trust_store_pass
+    changeit
+    EOF
+    ```
+
+    ```bash
+    $ cat <<EOF >> key_store_pass
+    changeit
+    EOF
+    ```
+
+1. Create a JMX access file.
+
+    ```bash
+    $ cat <<EOF >> access_file
+    admin readwrite
+    user  readonly
+    EOF
+    ```
+
+1. Create a JMX password file.
+
+    ```bash
+    $ cat <<EOF >> password_file
+    admin  adminpassword
+    user   userpassword
+    EOF
+    ```
+
+1. Create necessary secrets in DC/OS for JMX.
+
+    ```bash
+    dcos package install dcos-enterprise-cli --yes
+    dcos security secrets create -f keystore.ks kafka/keystore
+    dcos security secrets create -f key_store_pass kafka/keystorepass
+    dcos security secrets create -f truststore.ks kafka/truststore
+    dcos security secrets create -f trust_store_pass kafka/truststorepass
+    dcos security secrets create -f password_file kafka/passwordfile
+    dcos security secrets create -f access_file kafka/access
+    ```
+
+1. Create a custom service configuration `options.json` with JMX enabled.
+
+    ```json
+    {
+      "service": {
+        "jmx": {
+          "enabled": true,
+          "port": 31299,
+          "rmi_port": 31298,
+          "access_file": "kafka/access",
+          "password_file": "kafka/passwordfile",
+          "key_store": "kafka/keystore",
+          "key_store_password_file": "kafka/keystorepass",
+          "add_trust_store": true,
+          "trust_store": "kafka/truststore",
+          "trust_store_password_file": "kafka/truststorepass"
+        }
+      }
+    }
+    ```
+
+1. Install {{ model.techName }} with the options file you created.
+
+    ```bash
+    dcos package install {{ model.packageName }} --options="options.json"
+    ```
+
+## Service Health Check
+
+DC/OS {{ model.techName }} supports service oriented health checks allowing you to monitor your service health in details.
+
+### Configuration Options
+
+| Option | Description |
+|----------------------|-------------|
+| health_check.enabled | Enables the health checks |
+| health_check.method | "PORT" or "FUNCTIONAL" |
+| health_check.interval | The period in seconds to wait after the last health check has completed to start the next check. |
+| health_check.delay | An amount of time in seconds to wait before starting the health check attempts. |
+| health_check.timeout | An amount of time in seconds to wait for a health check to succeed. |
+| health_check.grace-period | An amount of time in seconds after the task is launched during which health check failures are ignored. Once a health check succeeds for the first time, the grace period does not apply anymore. Note that it includes delay seconds, i.e., setting grace_period seconds < delay seconds has no effect. |
+| health_check.max-consecutive-failures | It is the maximum consecutive number of failures after which task will be killed. |
+| health_check.health-check-topic-prefix | Prefix for the health check topic name. Used when "FUNCTIONAL" health check method is selected. |
+| service.security.kerberos.health_check_primary | The [Kerberos](/mesosphere/dcos/services/confluent-kafka/latest/security/#authentication) primary used by Kafka health check if enabled. |
+
+### Health Check Methods
+
+#### Port Check
+
+This method will check if the broker port is open. Only the broker on which the health check is running will be checked as each broker will have its own health check.
+
+```json
+{
+  "service": {
+    "name": "confluent-kafka",
+    "health_check": {
+      "enabled": true,
+      "method": "PORT",
+    }
+  }
+}
+```
+
+####  Functional Check
+
+This method checks if the broker can send and receive messages from a client. Only the broker on which the health check is running will be checked, as each broker will have its own health check.
+The health check produces a random message to a user configurable topic and then tries to consume the last produced message.
+When [Kerberos](/mesosphere/dcos/services/confluent-kafka/latest/security/#authentication) and/or [Transport Encryption](mesosphere/dcos/services/kafka/latest/security/#transport-encryption) is enabled, the health check produces only a single random message to a topic and will attempt to consume that same first message of the topic at each health-check interval.
+
+```json
+{
+  "service": {
+    "name": "confluent-kafka",
+    "health_check": {
+      "enabled": true,
+      "method": "FUNCTIONAL",
+      "health-check-topic-prefix": "MyHealthCheckTopic"
+    }
+  }
+}
+```

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/api-reference/index.md
@@ -1,0 +1,271 @@
+---
+layout: layout.pug
+navigationTitle: API Reference 
+excerpt: API Reference for Confluent-Kafka
+title: API Reference for Confluent-Kafka
+menuWeight: 90
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/api-reference.tmpl
+
+# Topic Operations
+
+These operations mirror what is available with `bin/kafka-topics.sh`.
+
+## List Topics
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic list
+[
+  "topic1",
+  "topic0"
+]
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics"
+[
+  "topic1",
+  "topic0"
+]
+```
+
+## Describe Topic
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic describe topic1
+{
+  "partitions": [
+  {
+    "0": {
+      "controller_epoch": 1,
+      "isr": [
+        0,
+        1,
+        2
+      ],
+      "leader": 0,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "1": {
+      "controller_epoch": 1,
+      "isr": [
+        1,
+        2,
+        0
+      ],
+      "leader": 1,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "2": {
+      "controller_epoch": 1,
+      "isr": [
+        2,
+        0,
+        1
+      ],
+      "leader": 2,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  }
+  ]
+}
+```
+
+```bash
+$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1"
+{
+  "partitions": [
+  {
+    "0": {
+      "controller_epoch": 1,
+      "isr": [
+        0,
+        1,
+        2
+      ],
+      "leader": 0,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "1": {
+      "controller_epoch": 1,
+      "isr": [
+        1,
+        2,
+        0
+      ],
+      "leader": 1,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  },
+  {
+    "2": {
+      "controller_epoch": 1,
+      "isr": [
+        2,
+        0,
+        1
+      ],
+      "leader": 2,
+      "leader_epoch": 0,
+      "version": 1
+    }
+  }
+  ]
+}
+
+```
+
+## Create Topic
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic create topic1 --partitions=3 --replication=3
+{
+  "message": "Output: Created topic \"topic1\"\n"
+}
+```
+
+```bash
+$ curl -X POST -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1?partitions=3&replication=3"
+{
+  "message": "Output: Created topic \"topic1\"\n"
+}
+```
+
+## View Topic Offsets
+
+There is an optional `--time` parameter which may be set to either "first", "last", or a timestamp in milliseconds as [described in the Kafka documentation](https://kafka.apache.org/documentation/).
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic offsets topic1 --time=last
+[
+  {
+    "2": "334"
+  },
+  {
+    "1": "333"
+  },
+  {
+    "0": "333"
+  }
+]
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1/offsets?time=-1"
+[
+  {
+    "2": "334"
+  },
+  {
+    "1": "333"
+  },
+  {
+    "0": "333"
+  }
+]
+```
+
+## Alter Topic Partition Count
+
+```
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic partitions topic1 2
+{
+  "message": "Output: WARNING: If partitions are increased for a topic that has a key, the partition logic or ordering of the messages will be affected\nAdding partitions succeeded!\n"
+}
+```
+
+```bash
+$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1?operation=partitions&partitions=2"
+{
+  "message": "Output: WARNING: If partitions are increased for a topic that has a key, the partition logic or ordering of the messages will be affected\nAdding partitions succeeded!\n"
+}
+```
+
+## Run Producer Test on Topic
+
+```
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic producer_test topic1 10
+{
+  "message": "10 records sent, 70.422535 records/sec (0.07 MB/sec), 24.20 ms avg latency, 133.00 ms max latency, 13 ms 50th, 133 ms 95th, 133 ms 99th, 133 ms 99.9th.\n"
+}
+
+```bash
+$ curl -X PUT -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1?operation=producer-test&messages=10"
+{
+  "message": "10 records sent, 70.422535 records/sec (0.07 MB/sec), 24.20 ms avg latency, 133.00 ms max latency, 13 ms 50th, 133 ms 95th, 133 ms 99th, 133 ms 99.9th.\n"
+}
+```
+
+This runs the equivalent of the following command from the machine running the Kafka Scheduler:
+```bash
+$ kafka-producer-perf-test.sh \
+  --topic <topic> \
+  --num-records <messages> \
+  --throughput 100000 \
+  --record-size 1024 \
+  --producer-props bootstrap.servers=<current broker endpoints>
+```
+
+## Delete Topic
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic delete topic1
+{
+  "message": "Topic topic1 is marked for deletion.\nNote: This will have no impact if delete.topic.enable is not set to true.\n"
+}
+```
+
+```bash
+$ curl -X DELETE -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/topic1"
+{
+  "message": "Topic topic1 is marked for deletion.\nNote: This will have no impact if delete.topic.enable is not set to true.\n"
+}
+```
+
+Note the warning in the output from the commands above. You can change the indicated `delete.topic.enable` configuration value as a configuration change.
+
+## List Under Replicated Partitions
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic under_replicated_partitions
+{
+  "message": ""
+}
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/under_replicated_partitions"
+{
+  "message": ""
+}
+```
+
+## List Unavailable Partitions
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} topic unavailable_partitions
+{
+  "message": ""
+}
+```
+
+```bash
+$ curl -H "Authorization: token=$auth_token" "<dcos_url>/service/{{ model.serviceName }}/v1/topics/unavailable_partitions"
+{
+  "message": ""
+}
+```

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/configuration/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/configuration/index.md
@@ -1,0 +1,54 @@
+---
+layout: layout.pug
+navigationTitle: Configuring 
+excerpt: Configuring Confluent Kafka
+title: Configuring 
+menuWeight: 20
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/configuration-install-with-options.tmpl
+#include /mesosphere/dcos/services/include/configuration-service-settings.tmpl
+#include /mesosphere/dcos/services/include/configuration-regions.tmpl
+
+## Configuring the ZooKeeper Connection.
+
+{{ model.techName }} requires a running ZooKeeper ensemble to perform its own internal accounting. By default, the DC/OS {{ model.techName }} Service uses the ZooKeeper ensemble made available on the Mesos masters of a DC/OS cluster at `master.mesos:2181/dcos-service-<servicename>`. At install time, you can configure an alternate ZooKeeper for {{ model.techName }} to use. This enables you to increase {{ model.techName }}'s capacity and removes the DC/OS System ZooKeeper ensemble's involvement in running it.
+
+<p class="message--note"><strong>NOTE: </strong>If you are using the <a href="/mesosphere/dcos/services/confluent-zookeeper/">DC/OS Apache ZooKeeper service</a>, use the DNS addresses provided by the <tt>dcos confluent-zookeeper endpoints clientport</tt> command as the value of <tt>kafka_zookeeper_uri</tt>.</p>
+To configure an alternate Zookeeper instance:
+
+1. Create a file named `options.json` with the following contents. Here is an example `options.json` which points to a `confluent-zookeeper` instance named `confluent-zookeeper`:
+
+    ```json
+    {
+      "kafka": {
+        "kafka_zookeeper_uri": "zookeeper-0-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.{{ model.kafka.zookeeperServiceName }}.autoip.dcos.thisdcos.directory:1140"
+      }
+    }
+    ```
+
+1. Install {{ model.techName }} with the options file you created.
+
+    ```bash
+    $ dcos package install {{ model.packageName }} --options="options.json"
+    ```
+
+You can also update an already-running {{ model.techName }} instance from the DC/OS CLI, in case you need to migrate your ZooKeeper data elsewhere.
+
+<p class="message--note"><strong>NOTE: </strong>Before performing this configuration change, you must first copy the data from your current ZooKeeper ensemble to the new ZooKeeper ensemble. The new location must have the same data as the previous location during the migration.</p>
+
+```bash
+$ dcos {{ model.packageName }} --name={{ model.serviceName }} update start --options=options.json
+```
+
+## Extend the Kill Grace Period
+
+When performing a requested restart or replace of a running broker, the Kafka service will wait a default of `30` seconds for a broker to exit, before killing the process. This grace period may be customized via the `brokers.kill_grace_period` setting. In this example we will use the DC/OS CLI to increase the grace period delay to `60` seconds. This example assumes that the Kafka service instance is named `{{ model.serviceName }}`.
+
+During the configuration update, each of the Kafka broker tasks are restarted. During the shutdown portion of the task restart, the previous configuration value for `brokers.kill_grace_period` is in effect. Following the shutdown, each broker task is launched with the new effective configuration value. Take care to monitor the amount of time Kafka brokers take to cleanly shut down by observing their logs.
+
+### Replacing a Broker with Grace
+
+The grace period must also be respected when a broker is shut down before replacement. While it is not ideal that a broker must respect the grace period even if it is going to lose persistent state, this behavior will be improved in future versions of the SDK. Broker replacement generally requires complex and time-consuming reconciliation activities at startup if there was not a graceful shutdown, so the respect of the grace kill period still provides value in most situations. We recommend setting the kill grace period only sufficiently long enough to allow graceful shutdown. Monitor the Kafka broker clean shutdown times in the broker logs to keep this value tuned to the scale of data flowing through the Kafka service. 

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/getting-started/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/getting-started/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle: Getting Started
+excerpt: Getting started with Confluent Kafka
+title: Getting Started
+menuWeight: 12
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/getting-started.tmpl

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/index.md
@@ -1,0 +1,39 @@
+---
+layout: layout.pug
+navigationTitle: Confluent Kafka 2.9.0-5.4.0
+excerpt: DC/OS Confluent Kafka is a distributed high-throughput publish-subscribe messaging system with strong ordering guarantees.
+title: Confluent Kafka 2.8.0-5.3.1
+menuWeight: 1
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+featureMaturity:
+enterprise: true
+---
+
+
+DC/OS {{ model.techName }} is an automated service that makes it easy to deploy and manage {{ model.techName }} on Mesosphere DC/OS, eliminating nearly all of the complexity traditionally associated with managing a {{ model.techShortName }} cluster. {{ model.techName }} is a distributed high-throughput publish-subscribe messaging system with strong ordering guarantees. {{ model.techShortName }} clusters are highly available, fault tolerant, and very durable. DC/OS {{ model.techName }} gives you direct access to the {{ model.techName }} API so that existing producers and consumers can interoperate. You can configure and install DC/OS {{ model.techName }} in moments. Multiple {{ model.techName }} clusters can be installed on DC/OS and managed independently, so you can offer {{ model.techName }} as a managed service to your organization.
+
+## Benefits
+
+DC/OS {{ model.techName }} offers the following benefits of a semi-managed service:
+
+*   Easy installation
+*   Multiple {{ model.techName }} clusters
+*   Elastic scaling of brokers
+*   Replication and graceful shutdown for high availability
+*   {{ model.techName }} cluster and broker monitoring
+
+## Features
+
+DC/OS {{ model.techName }} provides the following features:
+
+*   Single-command installation for rapid provisioning
+*   Multiple clusters for multiple tenancy with DC/OS
+*   High availability runtime configuration and software updates
+*   Storage volumes for enhanced data durability, known as Mesos Dynamic Reservations and Persistent Volumes
+*   Integration with syslog-compatible logging services for diagnostics and troubleshooting
+*   Integration with `statsd`-compatible metrics services for capacity and performance monitoring
+
+# Related Services
+
+*   [DC/OS Spark](/mesosphere/dcos/services/spark/)

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Confluent Kafka 2.9.0-5.4.0
 excerpt: DC/OS Confluent Kafka is a distributed high-throughput publish-subscribe messaging system with strong ordering guarantees.
-title: Confluent Kafka 2.8.0-5.3.1
+title: Confluent Kafka 2.9.0-5.4.0
 menuWeight: 1
 model: /mesosphere/dcos/services/confluent-kafka/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/limitations/index.md
@@ -1,0 +1,38 @@
+---
+layout: layout.pug
+navigationTitle: Limitations 
+excerpt: Limitations of Confluent Kafka 
+title: Limitations of Confluent Kafka 
+menuWeight: 120
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/limitations.tmpl
+#include /mesosphere/dcos/services/include/limitations-zones.tmpl
+#include /mesosphere/dcos/services/include/limitations-regions.tmpl
+
+## Log Retention Bytes
+
+The "disk" configuration value is denominated in MB. We recommend you set the configuration value `log_retention_bytes` to a value smaller than the indicated "disk" configuration. See the [Configuring](/mesosphere/dcos/services/confluent-kafka/latest/configuration/) section for instructions for customizing these values.
+
+## Security
+
+### Kafka CLI
+
+When any security functions are enabled, the Kafka service CLI sub-command `topic` will not function. While the service CLI convenience functions will not work, the tooling bundled with [Apache Kafka](https://cwiki.apache.org/confluence/display/KAFKA/System+Tools) and other tools that support the enabled security modes will work.
+
+
+### Kerberos
+
+When Kerberos is enabled, the broker VIP is disabled since Kerberized clients will not be able to use it. This is because each Kafka broker uses a specific Kerberos principal and cannot accept connections from a single unified principal which the VIP would require.
+
+### Toggling Kerberos
+
+Kerberos authentication can be toggled (enabled/disabled), but this triggers a rolling restart of the cluster. Clients configured with the old security settings will lose connectivity during and after this process. It is recommended that backups are made and downtime is scheduled.
+
+### Toggling Transport Encryption
+
+Transport encryption using TLS can be toggled (enabled / disabled), but will trigger a rolling restart of the cluster. As each broker restarts, a client may lose connectivity based on its security settings and the value of the `service.security.transport_encryption.allow_plaintext` configuration option. It is recommended that backups are made and downtime is scheduled.
+
+In order to enable TLS, a service account and corresponding secret is required. Since it is not possible to change the service account used by a service, it is recommended that the service is deployed with an explicit service account to allow for TLS to be enabled at a later stage.

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/operations/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/operations/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle: Operations
+excerpt: Managing Confluent Kafka
+title: Operations
+menuWeight: 30
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/operations.tmpl

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/release-notes/index.md
@@ -1,0 +1,149 @@
+---
+layout: layout.pug
+navigationTitle: Release Notes 
+excerpt: Release Notes for version 2.9.0-5.4.0
+title: Release Notes
+menuWeight: 10
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+## Version 2.9.0-5.4.0
+
+### Updates
+- Upgrade the base tech version of Confluent Kafka to `5.4.0`. See Confluent Kafka's Release Notes for [5.4.0](https://docs.confluent.io/5.4.0/release-notes/index.html) for details.
+- Updated the SDK to version [0.57.3](https://github.com/mesosphere/dcos-commons/releases/tag/0.57.3)
+  - [#3215](https://github.com/mesosphere/dcos-commons/pull/3215) is a major bug-fix since `v0.57.0`. Frameworks are recommended to upgrade to `v0.57.3` and issue `pod replace` commands to exisiting deployments to mitigate the risks. Existing procedures for [migrating a existing service to the quotated role](https://github.com/mesosphere/dcos-commons/releases/tag/0.57.0#migrate-an-existing-deployed-service-to-use-quota-support) should be followed.
+- Updated the scheduler JRE to `v11`.
+
+### Important Notes
+- Confluent Kafka 5.4.0 introduces `[KAFKA-7335] - Store clusterId locally to ensure broker joins the right cluster`, which means that kafka cluster will store the clusterId locally so that it does not join the wrong zookeeper cluster accidentally. Therefore, if your kafka service is connected to default DC/OS zookeeper, changing the zookeeper path is not permitted. Please check [here](https://issues.apache.org/jira/browse/KAFKA-7335) for more information.
+
+
+## Version 2.8.0-5.3.1
+
+### Updates
+- Update the base tech version of Confluent Kafka to `5.3.1`.
+- Update the SDK to version `0.57.0`. For more information, see release notes for previous SDK releases:
+  - [0.57.0](https://github.com/mesosphere/dcos-commons/releases/tag/0.57.0)
+  - [0.56.3](https://github.com/mesosphere/dcos-commons/releases/tag/0.56.3)
+
+### New Features
+- By upgrading the SDK, Confluent-Kafka now comes with support for:
+  - Quota enforcement
+  - Node draining
+
+
+# Version 2.7.0-5.3.0
+
+## Updates
+
+- Upgrade the base dcos-commons SDK version to `0.56.2`.
+- Upgrade the base tech version of Confluent Kafka to `5.3.0`. 
+- Oracle JDK is replaced by OpenJDK 8
+- Option to configure new listener config `max.connections` which limits the number of active connections on each listener.
+
+## New Features
+
+- Added support for DC/OS Storage Service (DSS). See official [DSS docs](https://docs.d2iq.com/mesosphere/dcos/services/storage/1.0.0) for more details.
+- User can enable advanced service health checks. Option to choose between a simple port-based check and an advanced producer-consumer check based on a custom heartbeat topic.
+- Support for Secure JMX
+- Added marathon service scheduler checks
+- Service will fetch all required resources over HTTPS
+- Autosuggestion available for Service Account and Secrets when launching the service from DC/OS UI
+
+<!--
+# Version 2.6.0-5.1.2
+
+## Updates
+
+- Update to {{ model.techName }} version `5.1.2`.
+- SDK bumped to `0.55.2`.
+
+## New Features
+
+- The inter_broker_protocol_version now defaults to the 2.1. Check how to upgrade without downtime [upgrade](/mesosphere/dcos/services/confluent-kafka/2.6.0-5.1.2/updates/#upgrading-from-412-to-512)
+
+# Version 2.4.0-4.1.1
+
+## Updates
+
+- Update to Confluent Kafka version 4.1.1
+- Upgrade JRE to 1.8u192 to address CVEs
+
+## New Features
+
+
+# Version 2.3.0-4.0.0e
+
+## New Features
+
+- Support for configuring Kafka transport encryption ciphers with secure defaults.
+
+# Version 2.2.0-4.0.0e
+
+## New Features
+
+- Support for using a custom top level domain to facilitate exposing the service securely outside of the cluster. Details [here](/mesosphere/dcos/services/confluent-kafka/2.2.0-4.0.0e/security/#securely-exposing-dcos-confluent-kafka-outside-the-cluster).
+- Support for deploying the service in a remote region.
+
+
+# Version 2.1.0-4.0.0e
+
+## New Features
+
+- Ability to pause a service pod for debugging and recovery purposes. ([#1989](https://github.com/mesosphere/dcos-commons/pull/1989))
+- Support for the automated provisioning of TLS artifacts to secure Kafka communication.
+- Support for Kerberos and SSL authorization and authentication.
+- Support for Zone placement constraints in DC/OS 1.11
+
+## Updates
+
+- Major Improvements to the stability and performance of service orchestration
+- Upgrade JRE to 1.8u162. ([#2135](https://github.com/mesosphere/dcos-commons/pull/2135))
+- Set protocol to 1.0 by default.  ([#2085](https://github.com/mesosphere/dcos-commons/pull/2085))
+- The service now uses the Mesos V1 API. The service can be set back to the V0 API using the service property `service.mesos_api_version`.
+
+# Version 2.0.2-3.3.1e
+
+See [Confluent Platform 3.3.1 release notes](https://docs.confluent.io/3.3.1/release-notes.html)
+
+# Version 2.0.2-3.3.0e
+
+## Bug fixes
+* Uninstall now handles failed tasks correctly.
+* The brokers may fail to start due to the broker VIP taking slightly too long to create relative to how fast the brokers start.
+* The brokers may be stuck in the STARTING state due to the readiness check in this version being too time sensitive when the brokers start quickly.
+* Fixes to scheduler behavior during task status transitions.
+* Dynamic ports are no longer sticky across pod replaces.
+
+# Version 2.0.1.1-3.3.0e
+
+2.0.1.1-3.3.0e release of DC/OS Confluent Kafka.
+
+## Bug Fixes
+
+* The brokers may fail to start due to the broker VIP taking slightly too long to create relative to how fast the brokers start.
+* The brokers may be stuck in the STARTING state due to the readiness check in this version being too time sensitive when the brokers start quickly.
+
+# Version 2.0.1-3.3.0e
+
+2.0.1-3.3.0e release of DC/OS Confluent Kafka.
+
+## Bug fixes
+- The correct IP address is now always selected in DC/OS 1.10
+
+# Version 2.0.0-3.3.0e
+
+## Improvements
+- Based on the latest stable release of the dcos-commons SDK, which provides numerous benefits:
+  - Integration with DC/OS features such as virtual networking and integration with DC/OS access controls.
+  - Orchestrated software and configuration update, enforcement of version upgrade paths, and ability to pause/resume updates.
+  - Placement constraints for pods.
+  - Uniform user experience across a variety of services.
+- Update to version 3.3.0 of Confluent Kafka.
+- Graceful shutdown for brokers.
+
+## Breaking Changes
+- This is a major release.  You cannot upgrade to 2.0.0-3.3.0e from a 1.0.x version of the package.  To upgrade, you must perform a fresh install and replicate data across clusters.
+-->

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/security/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/security/index.md
@@ -1,0 +1,276 @@
+---
+layout: layout.pug
+navigationTitle: Security
+excerpt: Securing your service
+title: Security
+menuWeight: 50
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+enterprise: true
+quota-aware: true
+---
+
+
+# DC/OS {{ model.techName }} Security
+
+- The DC/OS {{ model.techName }} service supports {{ model.techShortName }}'s native transport encryption, authentication, and authorization mechanisms. The service provides automation and orchestration to simplify the usage of these important features.
+
+- A good overview of these features can be found [here](https://www.confluent.io/blog/apache-kafka-security-authorization-authentication-encryption/), and {{ model.techShortName }}'s security documentation can be found [here](http://kafka.apache.org/documentation/#security).
+
+<p class="message--note"><strong>NOTE: </strong>These security features are only available on DC/OS Enterprise 1.10 and later.</p>
+
+#include /mesosphere/dcos/services/include/service-account.tmpl
+
+#include /mesosphere/dcos/services/include/security-create-permissions.tmpl
+
+## Transport Encryption
+
+#include /mesosphere/dcos/services/include/security-transport-encryption-lead-in.tmpl
+
+<p class="message--note"><strong>NOTE: </strong> Enabling transport encryption is <strong>required</strong> in order to use <a href="/mesosphere/dcos/services/confluent-kafka/latest/security/#ssl-authentication">SSL authentication</a> for <a href="http://localhost:3000/mesosphere/dcos/services/confluent-kafka/latest/security/#authentication">authentication</a>, but is optional for <a href="http://localhost:3000/mesosphere/dcos/services/confluent-kafka/latest/security/#kerberos-authentication">Kerberos authentication</a>.</p>
+
+#include /mesosphere/dcos/services/include/security-configure-transport-encryption.tmpl
+
+<p class="message--note"><strong>NOTE: </strong>It is possible to update a running DC/OS {{ model.techName }} service to enable transport encryption after initial installation, but the service may be unavailable during the transition. Additionally, your {{ model.techShortName }} clients will need to be reconfigured unless <tt>service.security.transport_encryption.allow_plaintext</tt> is set to true.</p>
+
+#### Verify Transport Encryption Enabled
+
+After service deployment completes, check the list of [{{ model.techShortName }} endpoints](../api-reference/#connection-information) for the endpoint `broker-tls`. If `service.security.transport_encryption.allow_plaintext` is `true`, then the `broker` endpoint will also be available.
+
+#include /mesosphere/dcos/services/include/security-transport-encryption-clients.tmpl
+
+## Authentication
+
+DC/OS {{ model.techName }} supports two authentication mechanisms, SSL and Kerberos. The two are supported independently and may not be combined. If both SSL and Kerberos authentication are enabled, the service will use Kerberos authentication.
+
+<p class="message--note"><strong>NOTE: </strong>Kerberos authentication can, however, be combined with transport encryption.</p>
+
+<a name="kerberos-authentication"></a>
+
+### Kerberos Authentication
+
+Kerberos authentication relies on a central authority to verify that {{ model.techShortName }} clients (be it broker, consumer, or producer) are who they say they are. DC/OS {{ model.techName }} integrates with your existing Kerberos infrastructure to verify the identity of clients.
+
+#### Prerequisites
+- The hostname and port of a KDC reachable from your DC/OS cluster
+- Sufficient access to the KDC to create Kerberos principals
+- Sufficient access to the KDC to retrieve a keytab for the generated principals
+- [The DC/OS Enterprise CLI](/mesosphere/dcos/latest/cli/enterprise-cli/)
+- DC/OS Superuser permissions
+
+#### Configure Kerberos Authentication
+
+#### Create principals
+
+The DC/OS {{ model.techName }} service requires a Kerberos principal for each broker to be deployed. Each principal must be of the form
+```
+<service primary>/kafka-<broker index>-broker.<service subdomain>.autoip.dcos.thisdcos.directory@<service realm>
+```
+with:
+- `service primary = service.security.kerberos.primary`
+- `broker index = 0 up to brokers.count - 1`
+- `service subdomain = service.name with all `/`'s removed`
+- `service realm = service.security.kerberos.realm`
+
+For example, if installing with these options:
+```json
+{
+    "service": {
+        "name": "a/good/example",
+        "security": {
+            "kerberos": {
+                "primary": "example",
+                "realm": "EXAMPLE"
+            }
+        }
+    },
+    "brokers": {
+        "count": 3
+    }
+}
+```
+then the principals to create would be:
+```
+example/kafka-0-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+example/kafka-1-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+example/kafka-2-broker.agoodexample.autoip.dcos.thisdcos.directory@EXAMPLE
+```
+#include /mesosphere/dcos/services/include/security-kerberos-ad.tmpl
+
+#include /mesosphere/dcos/services/include/security-service-keytab.tmpl
+
+#### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own:
+
+```json
+{
+    "service": {
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "enabled_for_zookeeper": <true|false default false>,
+                "kdc": {
+                    "hostname": "<kdc host>",
+                    "port": <kdc port>
+                },
+                "primary": "<service primary default kafka>",
+                "realm": "<realm>",
+                "keytab_secret": "<path to keytab secret>",
+                "debug": <true|false default false>
+            }
+        }
+    }
+}
+```
+
+<p class="message--note"><strong>NOTE: </strong>If <tt>service.kerberos.enabled_for_zookeeper</tt> is set to true, then the additional setting <tt>kafka.kafka_zookeeper_uri</tt> must be configured to point at a kerberized Confluent Zookeeper as shown below. </p>
+
+```json
+{
+    "kafka": {
+        "kafka_zookeeper_uri": <list of zookeeper hosts>
+    }
+}
+```
+The DC/OS {{ model.kafka.zookeeperTechName }} service (`{{ model.kafka.zookeeperPackageName }}` package) is intended for this purpose and supports Kerberos.
+
+It is possible to enable Kerberos after initial installation but the service may be unavailable during the transition. Additionally, your {{ model.techShortName }} clients will need to be reconfigured.
+
+
+### SSL Authentication
+
+SSL authentication requires that all clients be they brokers, producers, or consumers present a valid certificate from which their identity can be derived. DC/OS {{ model.techName }} uses the `CN` of the SSL certificate as the principal for a given client. For example, from the certificate `CN=bob@example.com,OU=,O=Example,L=London,ST=London,C=GB` the principal `bob@example.com` will be extracted.
+
+#### Prerequisites
+- Completion of the section [Transport Encryption](#transport-encryption) above
+
+#### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own:
+```json
+{
+    "service": {
+        "service_account": "<service-account>",
+        "service_account_secret": "<secret path>",
+        "security": {
+            "transport_encryption": {
+                "enabled": true
+            },
+            "ssl_authentication": {
+                "enabled": true
+            }
+        }
+    }
+}
+```
+
+<p class="message--note"><strong>NOTE: </strong> It is possible to enable SSL authentication after initial installation, but the service may be unavailable during the transition. Additionally, your {{ model.techShortName }} clients will need to be reconfigured.</p>
+
+#### Authenticating a Client
+
+To authenticate a client against DC/OS {{ model.techName }}, you will need to configure it to use a certificate signed by the DC/OS CA. After generating a [certificate signing request](https://www.ssl.com/how-to/manually-generate-a-certificate-signing-request-csr-using-openssl/), you can issue it to the DC/OS CA by calling the API `<dcos-cluster>/ca/api/v2/sign`. Using `curl` the request would look like:
+```bash
+$ curl -X POST \
+    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
+    <dcos-cluster>/ca/api/v2/sign \
+    -d '{"certificate_request": "<json-encoded-value-of-request.csr>"}'
+```
+The `<json-encoded-value-of-request.csr>` field represents the content of the `csr` file as a single line, where new lines are replaced with `\n`.
+
+```bash
+curl -X POST \
+    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
+    <dcos-cluster>/ca/api/v2/sign \
+    -d '{"certificate_request": ""-----BEGIN CERTIFICATE REQUEST-----\nMIIC<snipped for brevity>o39lBi1w=\n-----END CERTIFICATE REQUEST-----\n""}'
+```
+
+The response will contain a signed public certificate. Full details on the DC/OS CA API can be found [here](/mesosphere/dcos/latest/security/ent/tls-ssl/ca-api/).
+
+## Authorization
+
+The DC/OS {{ model.techName }} service supports {{ model.techShortName }}'s [ACL-based](https://docs.confluent.io/current/kafka/authorization.html#using-acls) authorization system. To use {{ model.techShortName }}'s ACLs, either SSL or Kerberos authentication must be enabled as detailed above.
+
+### Enable Authorization
+
+#### Prerequisites
+- Completion of either [SSL](#ssl-authentication) or [Kerberos](#kerberos-authentication) authentication above.
+
+#### Install the Service
+
+Install the DC/OS {{ model.techName }} service with the following options in addition to your own (remember, either SSL authentication or Kerberos _must_ be enabled):
+```json
+{
+    "service": {
+        "security": {
+            "authorization": {
+                "enabled": true,
+                "super_users": "<list of super users>",
+                "allow_everyone_if_no_acl_found": <true|false default false>
+            }
+        }
+    }
+}
+```
+
+`service.security.authorization.super_users` should be set to a semi-colon delimited list of principals to treat as super users (all permissions). The format of the list is `User:<user1>;User:<user2>;...`. Using Kerberos authentication, the "user" value is the Kerberos primary, and for SSL authentication the "user" value is the `CN` of the certificate. The {{ model.techShortName }} brokers themselves are automatically designated as super users.
+
+<p class="message--important"><strong>IMPORTANT: </strong>It is possible to enable authorization after initial installation, but the service may be unavailable during the transition. Additionally, Kafka clients may fail to function if they do not have the correct ACLs assigned to their principals. During the transition, <tt>service.security.authorization.allow_everyone_if_no_acl_found</tt> can be set to <tt>true</tt> to prevent clients from failing until their ACLs can be set correctly. After the transition, <tt>service.security.authorization.allow_everyone_if_no_acl_found</tt> should be reversed to <tt>false</tt>.</p>
+
+
+## Securely Exposing DC/OS {{ model.techName }} Outside the Cluster.
+
+Both transport encryption and Kerberos are tightly coupled to the DNS hosts of the Kafka brokers. As such, exposing a secure {{ model.techName }} service outside of the cluster requires additional setup.
+
+### Broker to Client Connection
+
+To expose a secure {{ model.techName }} service outside of the cluster, any client connecting to it must be able to access all brokers of the service via the IP address assigned to the broker. This IP address will be one of: an IP address on a virtual network or the IP address of the agent the broker is running on.
+
+### Forwarding DNS and Custom Domain
+
+Every DC/OS cluster has a unique cryptographic ID which can be used to forward DNS queries to that Cluster. To securely expose the service outside the cluster, external clients must have an upstream resolver configured to forward DNS queries to the DC/OS cluster of the service as described [here](/mesosphere/dcos/latest/networking/DNS/mesos-dns/expose-mesos-zone/).
+
+With only forwarding configured, DNS entries within the DC/OS cluster will be resolvable at `<task-domain>.autoip.dcos.<cryptographic-id>.dcos.directory`. However, if you configure a DNS alias, you can use a custom domain. For example, `<task-domain>.cluster-1.acmeco.net`. In either case, the DC/OS {{ model.techName }} service will need to be installed with an additional security option:
+```json
+{
+    "service": {
+        "security": {
+            "custom_domain": "<custom-domain>"
+        }
+    }
+}
+```
+where `<custom-domain>` is one of `autoip.dcos.<cryptographic-id>.dcos.directory` or your organization specific domain (e.g., `cluster-1.acmeco.net`).
+
+As a concrete example, using the custom domain of `cluster-1.acmeco.net` the broker 0 task would have a host of `kafka-0-broker.<service-name>.cluster-1.acmeco.net`.
+
+### Kerberos Principal Changes
+
+Transport encryption alone does not require any additional changes. Endpoint discovery will work as normal, and clients will be able to connect securely with the custom domain as long as they are configured as described [here](#transport-encryption-for-clients).
+
+Kerberos, however, does require slightly different configuration. As noted in the section [Create Principals](#create-principals), the principals of the service depend on the hostname of the service. When creating the Kerberos principals, be sure to use the correct domain.
+
+For example, if installing with these settings:
+```json
+{
+    "service": {
+        "name": "a/good/example",
+        "security": {
+            "custom_domain": "cluster-1.example.net",
+            "kerberos": {
+                "primary": "example",
+                "realm": "EXAMPLE"
+            }
+        }
+    },
+    "brokers": {
+        "count": 3
+    }
+}
+```
+then the principals to create would be:
+```
+example/kafka-0-broker.agoodexample.cluster-1.example.net@EXAMPLE
+example/kafka-1-broker.agoodexample.cluster-1.example.net@EXAMPLE
+example/kafka-2-broker.agoodexample.cluster-1.example.net@EXAMPLE
+```

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/support-policy/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/support-policy/index.md
@@ -1,0 +1,15 @@
+---
+layout: layout.pug
+navigationTitle: Support Policy 
+title: Support Policy for Confluent Kafka
+menuWeight: 190
+excerpt: Support Policy for Confluent Kafka
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/support-policy.tmpl
+
+## Confluent Support
+
+Confluent Enterprise customers can use their normal support channel (support@confluent.io) to submit a case. Questions regarding the integration of Confluent with DC/OS can be sent to partner-support@confluent.io.

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/troubleshooting/index.md
@@ -1,0 +1,23 @@
+---
+layout: layout.pug
+navigationTitle: Troubleshooting 
+excerpt: Troubleshooting Confluent Kafka
+title: Troubleshooting Confluent Kafka
+menuWeight: 170
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/troubleshooting.tmpl
+
+## Partition replication
+
+{{ model.techShortName }} may become unhealthy when it detects any under-replicated partitions. This error condition usually indicates a malfunctioning broker. Use the `dcos {{ model.packageName }} --name={{ model.serviceName }} topic under_replicated_partitions` and `dcos {{ model.packageName }} --name={{ model.serviceName }} topic describe <topic-name>` commands to find the problem broker and determine what actions are required.
+
+Possible repair actions include [restarting the affected broker](#restarting-a-node) and [destructively replacing the affected broker](#replacing-a-permanently-failed-node). The replace operation is destructive and will irrevocably lose all data associated with the broker. The restart operation is not destructive and indicates an attempt to restart a broker process.
+
+
+## Broker Shutdown
+
+If the {{ model.techShortName }} brokers are not completing the clean shutdown within the configured
+`brokers.kill_grace_period` (Kill Grace Period), extend the Kill Grace Period.

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/uninstall/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle: Uninstalling 
+excerpt: Uninstalling Confluent Kafka
+title: Uninstalling Confluent Kafka
+menuWeight: 160
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/uninstall.tmpl

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/updates/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/updates/index.md
@@ -1,0 +1,50 @@
+---
+layout: layout.pug
+navigationTitle: Updating 
+excerpt: Updating Confluent Kafka
+title: Updating Confluent Kafka
+menuWeight: 140
+model: /mesosphere/dcos/services/confluent-kafka/data.yml
+render: mustache
+---
+
+#include /mesosphere/dcos/services/include/update.tmpl
+
+
+## Upgrading from 4.1.2 to 5.1.2(or higher)
+  
+* The `inter_broker_protocol_version` now defaults to the newer, `2.1`. This has a few implications, as described below:
+
+  - Confluent 4.1.2 supports `inter_broker_protocol_version`: `1.1` maximum, and by default it is set to `1.0`.
+  - Confluent 5.1.2 supports `inter_broker_protocol_version`s up to `2.1`. 
+  - Confluent 5.3.0 supports `inter_broker_protocol_version`s up to `2.3`.
+  - Confluent 5.4.0 supports `inter_broker_protocol_version`s up to `2.4`.
+  - If you haven't specified a `inter_broker_protocol_version` in your options file, the new default will be used and changed to `2.1`.
+
+To avoid any downtime, during the upgrade, some Kafka nodes will be on Confluent 4.1.2 using `inter_broker_protocol_version` `1.0` and others will be on Kafka 5.1.2 using protocol `2.1`.
+
+To avoid any potential downtime caused by this, change the protocol version used when upgrading Confluent.
+
+1. Set up CLI to connect to a soak cluster.
+1. Update your `options_file.json` with the following contents:
+
+	```
+	{
+		...
+		"kafka": {
+			...
+			"inter_broker_protocol_version": "1.0"
+			...
+		}
+		...
+	}
+		```
+
+1. And update your service like so:
+
+	```
+	~$ dcos package install --cli --yes {{ model.packageName }}
+	~$ dcos {{ model.packageName }} --name={{ model.serviceName }} update start \
+		--package-version=2.9.0-5.4.0 \
+		--options=options_file.json
+	```

--- a/pages/mesosphere/dcos/version-policy/index.md
+++ b/pages/mesosphere/dcos/version-policy/index.md
@@ -314,7 +314,7 @@ The designations are as follows:
         <td><p style="text-align: center;">⚫</p></td>
     </tr>
     <tr>
-        <td>Confluent-Kafka 2.7.x-5.3.0 (Recommended)</td>
+        <td>Confluent-Kafka 2.9.x-5.4.0 (Recommended)</td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>
         <td><p style="text-align: center;">⚫</p></td>


### PR DESCRIPTION

Updated PR to cover #2780 for a clean rebase and merge. 

Keeping the 2.8 folder because it creates a weird gap of available docs versions but can also delete if it needs to be taken down for whatever reason.

This PR has 15 files instead of 16, a changed file in 2780 was a line space addition to an outside file and the change not kept.




