### PR TITLE
Publish DCOS 2.1 

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,15 +2,13 @@
   "master": {
     "DO_NOT_BUILD": [
       "test/**",
-      "mesosphere/dcos/1.14/**",
-      "mesosphere/dcos/2.1/**"
+      "mesosphere/dcos/1.14/**"
     ],
     "DO_NOT_INDEX": []
   },
   "staging": {
     "DO_NOT_BUILD": [
-      "test/**",
-      "mesosphere/dcos/2.1/**"
+      "test/**"
     ],
     "DO_NOT_INDEX": [
       "^cn"
@@ -46,7 +44,7 @@
       "mesosphere/dcos/1.11/**",
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2,1/**"
+      "mesosphere/dcos/2.1/**"
     ],
     "DO_NOT_INDEX": []
   },
@@ -59,9 +57,7 @@
       "mesosphere/dcos/1.11/**",
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2.1/**",
-      "mesosphere/dcos/services/**",
-      "mesosphere/dcos/cn/**"
+      "mesosphere/dcos/2.1/**"
     ],
     "DO_NOT_INDEX": []
   },

--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -1,7 +1,4 @@
-~^/mesosphere/dcos/latest/(.*)$ /mesosphere/dcos/2.0/$1;
-~^/ksphere/konvoy/latest/(.*)$ /ksphere/konvoy/1.4/$1;
-~^/ksphere/dispatch/latest/(.*)$ /ksphere/dispatch/1.1/$1;
-~^/ksphere/kommander/latest/(.*)$ /ksphere/kommander/1.0/$1;
+~^/mesosphere/dcos/latest/(.*)$ /mesosphere/dcos/2.1/$1;
 ~^/mesosphere/dcos/services/cassandra/latest/(.*) /mesosphere/dcos/services/cassandra/2.9.0-3.11.6/$1;
 ~^/mesosphere/dcos/services/confluent-kafka/latest/(.*) /mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/$1;
 ~^/mesosphere/dcos/services/confluent-zookeeper/latest/(.*) /mesosphere/dcos/services/confluent-zookeeper/2.7.0-5.1.2e/$1;

--- a/pages/mesosphere/dcos/1.12/index.md
+++ b/pages/mesosphere/dcos/1.12/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Mesosphere DC/OS 1.12
 title: Documentation for Mesosphere DC/OS 1.12
 version: 1.12
-menuWeight: 1
+menuWeight: 5
 excerpt: Learning DC/OS
 ---
 

--- a/pages/mesosphere/dcos/1.13/index.md
+++ b/pages/mesosphere/dcos/1.13/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Mesosphere DC/OS 1.13
 title: Documentation for Mesosphere DC/OS 1.13
 version: 1.13
-menuWeight: 0
+menuWeight: 2
 excerpt: Learning DC/OS
 render: mustache
 model: /mesosphere/dcos/1.13/data.yml

--- a/pages/mesosphere/dcos/2.0/index.md
+++ b/pages/mesosphere/dcos/2.0/index.md
@@ -4,7 +4,7 @@ navigationTitle:  Mesosphere DC/OS 2.0
 title: Documentation for Mesosphere DC/OS 2.0
 version: 2.0
 menuWeight: 1
-excerpt: Learning DC/OS
+excerpt: Learning DC/OS 
 render: mustache
 model: /mesosphere/dcos/2.0/data.yml
 ---

--- a/pages/mesosphere/dcos/2.0/index.md
+++ b/pages/mesosphere/dcos/2.0/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle:  Mesosphere DC/OS 2.0
 title: Documentation for Mesosphere DC/OS 2.0
 version: 2.0
-menuWeight: 0
+menuWeight: 1
 excerpt: Learning DC/OS
 render: mustache
 model: /mesosphere/dcos/2.0/data.yml

--- a/pages/mesosphere/dcos/2.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/2.0/release-notes/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Release Notes
 title: Release Notes
-menuWeight: 0
+menuWeight: 2
 excerpt: Release notes, Open Source attribution, and version policy for DC/OS 2.0
 ---
 

--- a/pages/mesosphere/dcos/2.1/index.md
+++ b/pages/mesosphere/dcos/2.1/index.md
@@ -9,4 +9,4 @@ render: mustache
 model: /mesosphere/dcos/2.1/data.yml
 ---
 
-Welcome to the documentation for Mesosphere&reg; DC/OS&trade; 2.0. For information about new and changed features, see the [release notes](/mesosphere/dcos/2.0/release-notes/).
+Welcome to the documentation for Mesosphere&reg; DC/OS&trade; 2.1. For information about new and changed features, see the [release notes](/mesosphere/dcos/2.1/release-notes/2.1.0/). 

--- a/pages/mesosphere/dcos/2.1/index.md
+++ b/pages/mesosphere/dcos/2.1/index.md
@@ -1,13 +1,12 @@
 ---
 layout: layout.pug
-navigationTitle:  Mesosphere DC/OS 2.1
-title: Documentation for Mesosphere DC/OS 2.1
-version: 2.1
+navigationTitle:  Mesosphere DC/OS 2.1.0
+title: Documentation for Mesosphere DC/OS 2.1.0
+version: 2.1.0
 menuWeight: 0
-beta: true
 excerpt: Learning DC/OS
 render: mustache
 model: /mesosphere/dcos/2.1/data.yml
 ---
 
-Welcome to the documentation for DC/OS 2.1. For information about new and changed features, see the [release notes](/mesosphere/dcos/2.1/release-notes/).
+Welcome to the documentation for Mesosphere&reg; DC/OS&trade; 2.0. For information about new and changed features, see the [release notes](/mesosphere/dcos/2.0/release-notes/).

--- a/pages/mesosphere/dcos/2.1/index.md
+++ b/pages/mesosphere/dcos/2.1/index.md
@@ -5,6 +5,7 @@ title: Documentation for Mesosphere DC/OS 2.1.0
 version: 2.1.0
 menuWeight: 0
 excerpt: Learning DC/OS
+beta: true
 render: mustache
 model: /mesosphere/dcos/2.1/data.yml
 ---

--- a/pages/mesosphere/dcos/2.1/index.md
+++ b/pages/mesosphere/dcos/2.1/index.md
@@ -4,6 +4,7 @@ navigationTitle:  Mesosphere DC/OS 2.1
 title: Documentation for Mesosphere DC/OS 2.1
 version: 2.1
 menuWeight: 0
+beta: true
 excerpt: Learning DC/OS
 render: mustache
 model: /mesosphere/dcos/2.1/data.yml

--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
@@ -9,7 +9,7 @@ beta: true
 model: /mesosphere/dcos/2.1/data.yml
 excerpt: Release notes for DC/OS 2.1.0, including Open Source attribution, and version policy.
 ---
-DC/OS 2.1.0 Beta was released on 27 April, 2020.
+DC/OS 2.1.0 Beta was released on 7 May, 2020.
 
 [button color="light" href="https://downloads.dcos.io/dcos/stable/2.1.0/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 
@@ -24,24 +24,36 @@ This release provides new features and enhancements to improve the user experien
 
 If you have DC/OS deployed in a production environment, see [Known Issues and Limitations](#known-issues-and-limitations) to see if any potential operational changes for specific scenarios apply to your environment.
 
-- Updated DC/OS UI to master+v2.150.2.
-- Updated to Mesos ???
-- Updated Marathon to ???
+# DC/OS 
 
+## Components
+
+DC/OS 2.1.0 includes the following component versions:
+
+- Apache&reg; Mesos&reg; 1.8.2-dev
+- OpenSSL 1.1.1d	
+- DC/OS UI to master+v2.150.2.
+- Grafana 6.0 
 
 # New Features and Capabilities 
 
-## Multi-Tenancy Support
+### Vertical Container Bursting
 
-DC/OS has improved Multi-Tenancy support by adding quota management for service groups. Specifically, DC/OS enables managing quota limits through UI and CLI for Marathon based and SDK based services. For more details, see [Quota Management](/mesosphere/dcos/2.1/multi-tenancy/quota-management/#quotas). (DCOS-54186) 
+### Resource Limits for Containers
 
-## Resource Limits for Containers
+DC/OS now allows you to set CPU and memory limits on services that are greater than the minimum guaranteed CPU/memory resources specified. This means that services can run with a guarantee of some amount of CPU and memory, while being allowed to consume up to a greater amount of these resources when free CPU cycles and/or memory is available. For more information, see [Creating Services](/mesosphere/dcos/2.1/deploying-services/creating-services/).
 
-It is now possible to set CPU and memory limits on services that are greater than the minimum guaranteed CPU/memory resources specified. This means that services can run with a guarantee of some amount of CPU and memory, while being allowed to consume up to a greater amount of these resources when free CPU cycles and/or memory is available. For more information, see [Creating Services](/mesosphere/dcos/2.1/deploying-services/creating-services/).
+### Custom Certificate for Admin Router
 
-# Previous Releases
-To review changes from the most recent previous releases, see the following links:
-- [Release version 1.10.11](/mesosphere/dcos/1.10/release-notes/1.10.11/) - 12 February 2019.
-- [Release version 1.11.12](/mesosphere/dcos/1.11/release-notes/1.11.12/) - 10 October  2019.
-- [Release version 1.12.4](/mesosphere/dcos/1.12/release-notes/1.12.4/) - 2 July 2019.
-- [Release version 1.13.5](/mesosphere/dcos/1.13/release-notes/1.13.5/) - 2 October 2019
+This feature allows operators to provide a custom non-CA certificate that is used by Admin Router for external clients connecting to the cluster.
+
+### Calico for Network Policy
+Calico is now pre-installed in a DC/OS cluster and can be used by containers to join overlay networks and set network policies.
+
+### Jobs support of Container Network
+Metronome based jobs can now join container networks to be able to communicate with other services/jobs in that network.
+
+
+### Domain Sockets for Agent Executor Communication
+
+Agents and Executors now communicate over Unix Domain sockets making operators life easy in the presence of container overlay networks.

--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
@@ -2,13 +2,14 @@
 layout: layout.pug
 navigationTitle: Release notes for 2.1.0
 title: Release notes for 2.1.0
-menuWeight: 5
+beta: true
+menuWeight: 0
 render: mustache
 beta: true
 model: /mesosphere/dcos/2.1/data.yml
 excerpt: Release notes for DC/OS 2.1.0, including Open Source attribution, and version policy.
 ---
-DC/OS 2.1.0 was released on Day Month, 2020.
+DC/OS 2.1.0 was released on 10 April, 2020.
 
 [button color="light" href="https://downloads.dcos.io/dcos/stable/2.1.0/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 

--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
@@ -9,7 +9,7 @@ beta: true
 model: /mesosphere/dcos/2.1/data.yml
 excerpt: Release notes for DC/OS 2.1.0, including Open Source attribution, and version policy.
 ---
-DC/OS 2.1.0 was released on 10 April, 2020.
+DC/OS 2.1.0 Beta was released on 27 April, 2020.
 
 [button color="light" href="https://downloads.dcos.io/dcos/stable/2.1.0/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 
@@ -25,8 +25,8 @@ This release provides new features and enhancements to improve the user experien
 If you have DC/OS deployed in a production environment, see [Known Issues and Limitations](#known-issues-and-limitations) to see if any potential operational changes for specific scenarios apply to your environment.
 
 - Updated DC/OS UI to master+v2.150.2.
-- Updated to Mesos ??
-- Updated Marathon to 
+- Updated to Mesos ???
+- Updated Marathon to ???
 
 
 # New Features and Capabilities 

--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
@@ -11,9 +11,9 @@ excerpt: Release notes for DC/OS 2.1.0, including Open Source attribution, and v
 ---
 DC/OS 2.1.0 Beta was released on 24 April, 2020.
 
-[button color="light" href="https://downloads.dcos.io/dcos/stable/2.1.0/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
+[button color="light" href="https://downloads.dcos.io/dcos/testing/2.1.0-beta4/commit/24132bebea79dc1f75dfa295be4542020e8bae11/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 
-[button color="purple" href="https://downloads.mesosphere.com/dcos-enterprise/stable/2.1.0/dcos_generate_config.ee.sh"]Download DC/OS Enterprise* [/button]
+[button color="purple" href="https://downloads.mesosphere.io/dcos-enterprise/testing/2.1.0-beta4/commit/1179b61542093274c2578a5e4a074a751bcbbb1a/dcos_generate_config.ee.sh"]Download DC/OS Enterprise* [/button]
 
 Registered DC/OS Enterprise customers can access the DC/OS Enterprise configuration file from the <a href="https://support.mesosphere.com/s/downloads">support website</a>. For new customers, contact your sales representative or <a href="mailto:sales@mesosphere.io">sales@mesosphere.io</a> before attempting to download and install DC/OS Enterprise.
 
@@ -28,7 +28,7 @@ If you have DC/OS deployed in a production environment, see [Known Issues and Li
 
 ## Components
 
-DC/OS 2.1.0 includes the following component versions:
+DC/OS 2.1.0 Beta includes the following component versions:
 
 - Apache&reg; Mesos&reg; 1.8.2-dev
 - OpenSSL 1.1.1d	

--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
@@ -9,7 +9,7 @@ beta: true
 model: /mesosphere/dcos/2.1/data.yml
 excerpt: Release notes for DC/OS 2.1.0, including Open Source attribution, and version policy.
 ---
-DC/OS 2.1.0 Beta was released on 7 May, 2020.
+DC/OS 2.1.0 Beta was released on 24 April, 2020.
 
 [button color="light" href="https://downloads.dcos.io/dcos/stable/2.1.0/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 
@@ -37,23 +37,20 @@ DC/OS 2.1.0 includes the following component versions:
 
 # New Features and Capabilities 
 
-### Vertical Container Bursting
-
-### Resource Limits for Containers
+## Resource Limits for Containers
 
 DC/OS now allows you to set CPU and memory limits on services that are greater than the minimum guaranteed CPU/memory resources specified. This means that services can run with a guarantee of some amount of CPU and memory, while being allowed to consume up to a greater amount of these resources when free CPU cycles and/or memory is available. For more information, see [Creating Services](/mesosphere/dcos/2.1/deploying-services/creating-services/).
 
-### Custom Certificate for Admin Router
+## Custom Certificate for Admin Router
 
 This feature allows operators to provide a custom non-CA certificate that is used by Admin Router for external clients connecting to the cluster.
 
-### Calico for Network Policy
+## Calico for Network Policy
 Calico is now pre-installed in a DC/OS cluster and can be used by containers to join overlay networks and set network policies.
 
-### Jobs support of Container Network
+## Jobs support of Container Network
 Metronome based jobs can now join container networks to be able to communicate with other services/jobs in that network.
 
-
-### Domain Sockets for Agent Executor Communication
+## Domain Sockets for Agent Executor Communication
 
 Agents and Executors now communicate over Unix Domain sockets making operators life easy in the presence of container overlay networks.

--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
@@ -2,14 +2,12 @@
 layout: layout.pug
 navigationTitle: Release notes for 2.1.0
 title: Release notes for 2.1.0
-beta: true
-menuWeight: 0
+menuWeight: 1
 render: mustache
-beta: true
-model: /mesosphere/dcos/2.1/data.yml
+model:  /mesosphere/dcos/2.1/data.yml
 excerpt: Release notes for DC/OS 2.1.0, including Open Source attribution, and version policy.
 ---
-DC/OS 2.1.0 Beta was released on 24 April, 2020.
+Mesosphere&reg; DC/OS&trade; 2.1.0 was released on 24 April 2020.
 
 [button color="light" href="https://downloads.dcos.io/dcos/testing/2.1.0-beta4/commit/24132bebea79dc1f75dfa295be4542020e8bae11/dcos_generate_config.sh"]Download DC/OS Open Source[/button]
 

--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.0/index.md
@@ -4,6 +4,7 @@ navigationTitle: Release notes for 2.1.0
 title: Release notes for 2.1.0
 menuWeight: 1
 render: mustache
+beta: true
 model:  /mesosphere/dcos/2.1/data.yml
 excerpt: Release notes for DC/OS 2.1.0, including Open Source attribution, and version policy.
 ---

--- a/pages/mesosphere/dcos/2.1/release-notes/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/index.md
@@ -6,4 +6,4 @@ menuWeight: 0
 excerpt: Release notes, Open Source attribution, and version policy for DC/OS 2.1
 ---
 
-This section includes the release notes for DC/OS 2.1, Open Source attribution, and version policy.
+This section includes the release notes for DC/OS&trade; 2.1, Open Source attribution, and version policy.

--- a/pages/mesosphere/dcos/2.1/release-notes/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/index.md
@@ -3,6 +3,7 @@ layout: layout.pug
 navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 0
+beta: true
 excerpt: Release notes, Open Source attribution, and version policy for DC/OS 2.1
 ---
 


### PR DESCRIPTION
DC/OS 2.1 is currently blocked from building on staging/master. This allows local preview work. Once the 2.1 content is in and approved, simply merge this PR into staging and promote. The block is released by deleting the lines. The build will pick up the change and add 2.1 in.