### PR TITLE
fix: feedback button query

### DIFF
--- a/layouts/components/content-actions.pug
+++ b/layouts/components/content-actions.pug
@@ -14,7 +14,7 @@ if (!title)
 - feedbackPath += '&labels=documentation'
 - feedbackPath += '&components=19804'
 - feedbackPath += '&priority=3'
-- feedbackPath += '&customfield_12300=44' // Sets the team field to Documentation Team
+- feedbackPath += '&customfield_12300=44&' // Sets the team field to Documentation Team
 
 div(class='actions')
   ul(class='actions__list')

--- a/layouts/components/content-actions.pug
+++ b/layouts/components/content-actions.pug
@@ -6,7 +6,7 @@
 
 if (!title)
   - throw `File ${path} does not contain a title`
-- var feedbackPath = 'https://jira.dcos.io/secure/CreateIssueDetails!init.jspa'
+- var feedbackPath = 'https://jira.d2iq.com/secure/CreateIssueDetails!init.jspa'
 - feedbackPath += '?pid=14105'
 - feedbackPath += '&issuetype=1'
 - feedbackPath += '&summary=Feedback+for+' + title.replace(' ', '+')
@@ -14,7 +14,7 @@ if (!title)
 - feedbackPath += '&labels=documentation'
 - feedbackPath += '&components=19804'
 - feedbackPath += '&priority=3'
-- feedbackPath += '&customfield_12300=44&' // Sets the team field to Documentation Team
+- feedbackPath += '&customfield_12300=44' // Sets the team field to Documentation Team
 
 div(class='actions')
   ul(class='actions__list')


### PR DESCRIPTION
## Description of changes being made

This is a workaround fix for the feedback button not properly setting the Doc team when linking out to Jira. 

There's a bug in the redirect server that duplicates and appends the entire query to the URL string so instead of setting `team=44`, JIRA bugs out and doesn't know to set `team=44?pid=10415&blahblah` (@jaxesn has more info) but this change should solve the immediate problem until we sort out the redirect issue.


