### PR TITLE
fix: search landing path

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -46,7 +46,7 @@ if (landingContainer) {
                     }
 
                     return `
-            <a href="${data.path}" class="landing__results-link">
+            <a href="/${data.path}" class="landing__results-link">
               <strong class="landing__results-title">${title}</strong>
               <div class="landing__results-snippet">&hellip; ${description} &hellip;</div>
             </a>


### PR DESCRIPTION
## Description of changes being made

Fix the path for the search landing so that it redirects to the actual page instead of a 404.

The issue is without the forward slash the URL was a relative path and you'd end up with something like `/dcos/pages/docs/` instead of `/pages/dcos/`
