### PR TITLE
Ignore more DC/OS documentation for the dispatch branch build

### DIFF
--- a/config.json
+++ b/config.json
@@ -59,7 +59,9 @@
       "mesosphere/dcos/1.11/**",
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2,1/**"
+      "mesosphere/dcos/2.1/**",
+      "mesosphere/dcos/services/**",
+      "mesosphere/dcos/cn/**"
     ],
     "DO_NOT_INDEX": []
   },


### PR DESCRIPTION
## Description of changes being made

Optimize the `dispatch` branch build so that our dispatch CI builds do not have to build all of the DC/OS documentation.