### PR TITLE
chore: update indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "rss": "^1.2.2",
     "sanitize-html": "^1.14.1",
     "sass-loader": "^6.0.6",
+    "semver": "^7.3.2",
     "semver-regex": "^1.0.0",
     "semver-sort": "0.0.4",
     "shortcode-parser": "0.0.1",


### PR DESCRIPTION
- konvoy versions are not properly indexed with the right versions/weights
- kommander and dispatch should be ready to handle versions
- documents are not limited to the 500 characters when indexing
- beta versions are given a lower weight than stable versions in the index
- konvoy partner docs are given a specific version