### PR TITLE
chore: fix the revision-plugin

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -23,3 +23,8 @@ require('./js/msphere-menu.js');
 require('./js/ksphere-menu.js');
 require('./js/localization.js');
 require('./js/services-landing.js');
+if ( ENV === "development" ){
+  var script = document.createElement('script');
+  script.src = 'http://localhost:35729/livereload.js';
+  document.getElementsByTagName('head')[0].appendChild(script);
+}

--- a/index.js
+++ b/index.js
@@ -334,6 +334,7 @@ if (process.env.NODE_ENV === 'development' && RENDER_PATH_PATTERN) {
             [`pages/${RENDER_PATH_PATTERN}/*`]: '**/*.{md,tmpl}',
             'layouts/**/*': '**/*.pug',
         },
+        livereload: true,
     }));
     CB.use(timer('CB: Watch'));
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
       ALGOLIA_PROJECT_ID: JSON.stringify(process.env.ALGOLIA_PROJECT_ID),
       ALGOLIA_PUBLIC_KEY: JSON.stringify(process.env.ALGOLIA_PUBLIC_KEY),
       ALGOLIA_INDEX: JSON.stringify(process.env.ALGOLIA_INDEX),
-    })
+      ENV: JSON.stringify(process.env.NODE_ENV),
+    }),
   ],
 };


### PR DESCRIPTION
# ⚠️ EDIT

1. the numbers and depicted speeds you can see in the screencasts below changed because #2873 merged.
2. you'll only want to review the last commit (`chore: fix the revision-plugin`) here. the other commits came here due to rebasing and are already approved/merged.

----------------------

to speed up builds, we now make use of the revision-plugin and
assume that all files that need processing are changed after the
markdown-step. the revision-plugin will then generate a hash out of the
current state of that file and not apply further transformers in case
the hash is the same as in the previous run.

note that the official revision plugin would introduce caching issues as it does not care about changes in frontmatter.

here are two (almost) identical cycles of starting the server, making a change and waiting for that change to be visible in the browser: 

## Before (96 secs total; time until a change can be seen in browser: 34 secs)

![before_small](https://user-images.githubusercontent.com/300861/80484718-7a49b680-8958-11ea-9836-babf87a232eb.gif)

## After (44 secs total, time until a change can be seen in browser: 11 secs)

![after_small](https://user-images.githubusercontent.com/300861/80484721-7c137a00-8958-11ea-9c17-0f66dbc09a6e.gif)

## Checklist
- [x] Make sure you change all affected versions (e.g. 1.10, 1.11, 1.12, 1.13).
- [x] Test all commands and procedures where applicable.
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
