### PR TITLE
konvoy: Update docs for konvoy release v1.5.0-beta.2

### DIFF
--- a/pages/ksphere/konvoy/1.5.0-beta/install/install-airgapped/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/install/install-airgapped/index.md
@@ -331,20 +331,20 @@ spec:
   - configRepository: /opt/konvoy/artifacts/kubernetes-base-addons
     configVersion: stable-1.16-1.6.0
     helmRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.4.2
+      image: mesosphere/konvoy-addons-chart-repo:v1.5.0-beta.2
     addonsList:
     ...
   - configRepository: /opt/konvoy/artifacts/kubeaddons-dispatch
     configVersion: stable-1.16-1.1.0
     helmRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.4.2
+      image: mesosphere/konvoy-addons-chart-repo:v1.5.0-beta.2
     addonsList:
     - name: dispatch # Dispatch is currently in Beta
       enabled: false
   - configRepository: /opt/konvoy/artifacts/kubeaddons-kommander
     configVersion: testing-1.16-1.1.0-beta.2
     helmRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.4.2
+      image: mesosphere/konvoy-addons-chart-repo:v1.5.0-beta.2
     addonsList:
     - name: kommander
       enabled: false

--- a/pages/ksphere/konvoy/1.5.0-beta/release-notes/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/release-notes/index.md
@@ -15,6 +15,19 @@ enterprise: false
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. For new customers, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download Konvoy.</p>
 
+### Version v1.5.0-beta.2 - April 28 March 2020
+
+| Kubernetes Support | Version |
+| ------------------ | ------- |
+|**Minimum** | 1.15.4 |
+|**Maximum** | 1.16.x |
+|**Default** | 1.16.8 |
+
+#### Bug fixes
+
+- Fix a bug where `konvoy config images seed` could incorrectly try to load or pull certain images, even when they are already present in the docker agent.
+- Fix a bug that would cause `konvoy init` to fail with `already up-to-date` when using local directories as the addon git repos.
+
 ### Version v1.5.0-beta.1 - April 26 March 2020
 
 | Kubernetes Support | Version |
@@ -49,7 +62,7 @@ enterprise: false
           maxSize: 10
     ```
 
-    You will also use the new `konvoy pull` and `konvoy push` commands to upload the cluster state to the Kubernetes API, and sync your local `cluster.yaml` and terraform state from the Kubernetes API.
+    You will also use the new `konvoy pull` and `konvoy push` commands to upload the cluster state to the Kubernetes API, and sync your local `cluster.yaml` and terraform state from the Kubernetes API. To use the autoscaling feature you need to user `kommander` version `testing-1.16-1.1.0-beta.2`.
 -   Print more logs for debugging when using `konvoy up --verbose`. This shows the output of `kubeadm token create --print-join-command`.
 -   Add `AWS_SDK_LOAD_CONFIG` to the konvoy docker image, so `konvoy` can use the AWS ClI configuration.
 -   Configmaps are now encrypted at rest in etcd in all new clusters.


### PR DESCRIPTION
Docs for Konvoy `v1.5.0-beta.2`.

* Release-notes
* `install-airgapped` snippet fix that was missed in `v1.5.0-beta.1`.