### PR TITLE
ksphere: bring back redirects from latest/

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -1,4 +1,7 @@
 ~^/mesosphere/dcos/latest/(.*)$ /mesosphere/dcos/2.1/$1;
+~^/ksphere/konvoy/latest/(.*)$ /ksphere/konvoy/1.4/$1;
+~^/ksphere/dispatch/latest/(.*)$ /ksphere/dispatch/1.1/$1;
+~^/ksphere/kommander/latest/(.*)$ /ksphere/kommander/1.0/$1;
 ~^/mesosphere/dcos/services/cassandra/latest/(.*) /mesosphere/dcos/services/cassandra/2.9.0-3.11.6/$1;
 ~^/mesosphere/dcos/services/confluent-kafka/latest/(.*) /mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/$1;
 ~^/mesosphere/dcos/services/confluent-zookeeper/latest/(.*) /mesosphere/dcos/services/confluent-zookeeper/2.7.0-5.1.2e/$1;


### PR DESCRIPTION
These were incorrectly removed in https://github.com/mesosphere/dcos-docs-site/pull/2828/files#diff-ffadabb9049686535404014ce18e6a3bL1-L4 and broke the `/latest` redirects.

Bringing it back.