### PR TITLE
UI change where Try Kommander button moved Apps dropdown now in nav

### DIFF
--- a/pages/ksphere/kommander/1.0/install/index.md
+++ b/pages/ksphere/kommander/1.0/install/index.md
@@ -41,7 +41,7 @@ Check version
 konvoy --version
 ```
 
-Once you have the newest version of Konvoy, move into the directory where you would like to test. Please note, you will have to confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
+After you have the newest version of Konvoy, move into the directory where you would like to test. Note, you will have to confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
 
 Once done, run this command:
 
@@ -53,7 +53,7 @@ konvoy up
 
 ### Logging in with Username and Password
 
-After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Once in Konvoy, you should see a button labelled "Try Kommander" button at the bottom of the page, or an Apps dropdown menu in the top nav with a Kommander icon. If not, ensure you've installed the Konvoy release that includes Kommander.
+After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Log in to Konvoy, and look for the "Try Kommander" button. If it's not there, ensure you've installed the Konvoy release that includes Kommander.
 
 To retrieve this information again, you can use the following command:
 

--- a/pages/ksphere/kommander/1.0/install/index.md
+++ b/pages/ksphere/kommander/1.0/install/index.md
@@ -53,9 +53,7 @@ konvoy up
 
 ### Logging in with Username and Password
 
-After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Once in Konvoy, you should see a button labelled "Try Kommander". If not, ensure you've installed the Konvoy release that includes Kommander.
-
-![Try Kommander button](/ksphere/kommander/1.0/img/try-kommander.png)
+After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Once in Konvoy, you should see a button labelled "Try Kommander" button at the bottom of the page, or an Apps dropdown menu in the top nav with a Kommander icon. If not, ensure you've installed the Konvoy release that includes Kommander.
 
 To retrieve this information again, you can use the following command:
 

--- a/pages/ksphere/kommander/1.1.0-beta/install/index.md
+++ b/pages/ksphere/kommander/1.1.0-beta/install/index.md
@@ -53,9 +53,7 @@ konvoy up
 
 ### Logging in with Username and Password
 
-After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Once in Konvoy, you should see a button labelled "Try Kommander". If not, ensure you've installed the Konvoy release that includes Kommander.
-
-![Try Kommander button](/ksphere/kommander/1.1.0-beta/img/try-kommander.png)
+After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Once in Konvoy, you should see a button labelled "Try Kommander" button at the bottom of the page, or an Apps dropdown menu in the top nav with a Kommander icon. If not, ensure you've installed the Konvoy release that includes Kommander.
 
 To retrieve this information again, you can use the following command:
 

--- a/pages/ksphere/kommander/1.1.0-beta/install/index.md
+++ b/pages/ksphere/kommander/1.1.0-beta/install/index.md
@@ -41,7 +41,7 @@ Check version
 konvoy --version
 ```
 
-Once you have the newest version of Konvoy, move into the directory where you would like to test. Please note, you will have to confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
+After you have the newest version of Konvoy, move into the directory where you would like to test. Note, you will have to confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
 
 Once done, run this command:
 
@@ -53,7 +53,7 @@ konvoy up
 
 ### Logging in with Username and Password
 
-After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Once in Konvoy, you should see a button labelled "Try Kommander" button at the bottom of the page, or an Apps dropdown menu in the top nav with a Kommander icon. If not, ensure you've installed the Konvoy release that includes Kommander.
+After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Log in to Konvoy, and look for the "Try Kommander" button. If it's not there, ensure you've installed the Konvoy release that includes Kommander.
 
 To retrieve this information again, you can use the following command:
 


### PR DESCRIPTION
## Jira Ticket
N/A - quick update for docs where a button was removed.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
Button no longer in the header in the UI. Just making sure that this is in the docs. Updating where it is.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
