### PR TITLE
Livereload for layouts and assets

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -23,8 +23,3 @@ require('./js/msphere-menu.js');
 require('./js/ksphere-menu.js');
 require('./js/localization.js');
 require('./js/services-landing.js');
-if ( ENV === "development" ){
-  var script = document.createElement('script');
-  script.src = 'http://localhost:35729/livereload.js';
-  document.getElementsByTagName('head')[0].appendChild(script);
-}

--- a/index.js
+++ b/index.js
@@ -175,6 +175,12 @@ if (process.env.NODE_ENV === 'development' && RENDER_PATH_PATTERN) {
 CB.use(ignore(METALSMITH_SKIP_SECTIONS));
 CB.use(timer('CB: Ignore'));
 
+CB.use(assets({
+  source: 'assets',
+  destination: 'assets',
+}));
+CB.use(timer('AB: Assets'));
+
 CB.use(copy({
     pattern: '**/README.md',
     transform: file => file.replace(/README/, 'index'),
@@ -335,6 +341,8 @@ if (process.env.NODE_ENV === 'development' && RENDER_PATH_PATTERN) {
         paths: {
             [`pages/${RENDER_PATH_PATTERN}/*`]: '**/*.{md,tmpl}',
             'layouts/**/*': '**/*',
+            'js/**/*': '**/*',
+            'scss/**/*': '**/*',
         },
         livereload: true,
     }));
@@ -357,45 +365,10 @@ if (process.env.NODE_ENV === 'development') {
     CB.use(timer('CB: Webserver'));
 }
 
-//
-// Assets Branch
-//
-
-const AB = branch();
-
-// Start timer
-AB.use(timer('AB: Init'));
-
-// Watch
-// Can only watch with a RENDER_PATH_PATTERN because there are too many
-// files without it.
-if (process.env.NODE_ENV === 'development' && RENDER_PATH_PATTERN) {
-    AB.use(watch({
-        paths: {
-            'js/**/*': '**/*.js',
-            'scss/**/*': '**/*.scss',
-        },
-    }));
-    AB.use(timer('AB: Watch'));
-}
-
-// Assets
-AB.use(assets({
-    source: 'assets',
-    destination: 'assets',
-}));
-AB.use(timer('AB: Assets'));
-
-// Webpack
-AB.use(webpack('./webpack.config.js'));
-AB.use(timer('AB: Webpack'));
-
-//
-// Metalsmith
-//
+CB.use(webpack('./webpack.config.js'));
+CB.use(timer('AB: Webpack'));
 
 MS.use(CB);
-MS.use(AB);
 
 // Build
 MS.build((err, files) => {

--- a/js/search.js
+++ b/js/search.js
@@ -1,3 +1,5 @@
+try {
+
 const landingContainer = document.querySelector('.landing');
 
 //
@@ -268,3 +270,7 @@ function handleFilterWidth() {
 }
 
 window.addEventListener('resize', handleFilterWidth);
+
+} catch(e) {
+  console.error("Error in search script" + e);
+}

--- a/layouts/partials/scripts.pug
+++ b/layouts/partials/scripts.pug
@@ -4,6 +4,8 @@ script(src='/assets/js/prism.js')
 
 if env == 'production'
   script(src='//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-59c6dc5017f3462f', async)
+if env == 'development'
+  script(src='//localhost:35729/livereload.js', async)
 
 script(src='https://cdn.jsdelivr.net/npm/instantsearch.js@2.2.0/dist/instantsearch.min.js')
 script(src='/js/bundle.js')

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "markdown-it-attrs": "^1.0.0",
     "metalsmith": "^2.3.0",
     "metalsmith-assets": "^0.1.0",
-    "metalsmith-branch": "0.0.5",
     "metalsmith-copy": "^0.4.0",
     "metalsmith-data-loader": "^1.1.2",
     "metalsmith-headings": "^0.2.0",


### PR DESCRIPTION
1. the livereload-script is moved to partials/scripts as that seems to
be included in more pages (like the landing page)
2. the pug- and consolidate-cache are cleared inbetween runs. we want to
keep the cache within a run though as it massively speeds up things.
3. add hashes for layouts within the revision-plugin to rebuild
everything when a layout changed.
4. `metalsmith-branch` is removed. does not seem to bring any benefit as we ran all files through both pipelines and the processors did the work of filtering our stuff anyway.

# Motivation

you now can edit layouts and see the changes without having to restart the dev environment. layouts and stylesheets/js should livereload now, so we have faster feedback cycles when changing stuff there.