### PR TITLE
Fix missing redirect for Beta-Kafka

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -30,3 +30,4 @@
 ~^/mesosphere/dcos/cn/services/kubernetes/latest/(.*) /mesosphere/dcos/cn/services/kubernetes/1.2.1-1.10.6/$1;
 ~^/mesosphere/dcos/services/hive-metastore/latest/(.*) /mesosphere/dcos/services/hive-metastore/1.2.0-3.0.0/$1;
 ~^/mesosphere/dcos/services/beta-jenkins/latest/(.*) /mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/$1;
+~^/mesosphere/dcos/services/beta-kafka/latest/(.*) /mesosphere/dcos/services/beta-kafka/2.10.0-2.4.0-beta/$1;


### PR DESCRIPTION
## Jira Ticket
[D2IQ-64208](https://jira.d2iq.com/browse/D2IQ-64208)

## Description of changes being made
Fix missing redirect for Beta-Kafka which was mistakenly removed from [this commit](https://github.com/mesosphere/dcos-docs-site/commit/869238020ec69fc0586e62f578f1985277817a81).

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
