### PR TITLE
Remove horizontal scrollbar

### DIFF
--- a/scss/base/_global.scss
+++ b/scss/base/_global.scss
@@ -1,7 +1,3 @@
-html {
-  width: 100vw;
-}
-
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
TL;DR: We have a horizontal scrollbar on most pages. This PR removes those.

there seems to be no need to set the width of a block element to the
full viewport width. even more so as the drawback is that every device
that's not in "touch mode" (try not using your macs trackpad but an
external mouse) will have a horizontal scrollbar because 100vw does not
account for the vertical scrollbar.

<img width="1410" alt="Introducing Konvoy - D2iQ Docs 2020-05-10 05-20-48" src="https://user-images.githubusercontent.com/300861/81490134-90bc1000-927e-11ea-9bcd-44f4d5b38e04.png">

<img width="1679" alt="D2iQ Docs 2020-05-10 05-25-51" src="https://user-images.githubusercontent.com/300861/81490142-bcd79100-927e-11ea-80d8-ce9c82aefecd.png">
