### PR TITLE
COPS-6126: Fixing invalid reference links in ksphere docs

### DIFF
--- a/pages/ksphere/kommander/1.0/clusters/creating-konvoy-cluster-azure/index.md
+++ b/pages/ksphere/kommander/1.0/clusters/creating-konvoy-cluster-azure/index.md
@@ -31,3 +31,4 @@ Now select the preconfigured [Azure Cloud Provider](/ksphere/kommander/latest/op
 - **Add Labels**: By default, your cluster has some suggested labels that reflect the cloud provider provisioning. For example, in Azure your cluster may be labelled with the datacenter region as well as `provider: azure`. Cluster labels are matched to the selectors created for projects. Changing a cluster label may add or remove the cluster from projects.
 
 [azure-regions]: https://azure.microsoft.com/en-us/global-infrastructure/regions/
+[azure_tags]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources

--- a/pages/ksphere/kommander/1.1.0-beta/clusters/creating-konvoy-cluster-azure/index.md
+++ b/pages/ksphere/kommander/1.1.0-beta/clusters/creating-konvoy-cluster-azure/index.md
@@ -31,3 +31,4 @@ Now select the preconfigured [Azure Cloud Provider](/ksphere/kommander/latest/op
 - **Add Labels**: By default, your cluster has some suggested labels that reflect the cloud provider provisioning. For example, in Azure your cluster may be labelled with the datacenter region as well as `provider: azure`. Cluster labels are matched to the selectors created for projects. Changing a cluster label may add or remove the cluster from projects.
 
 [azure-regions]: https://azure.microsoft.com/en-us/global-infrastructure/regions/
+[azure_tags]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources

--- a/pages/ksphere/konvoy/1.4/install/install-airgapped/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-airgapped/index.md
@@ -492,7 +492,7 @@ Specifically, the `konvoy up` command does the following:
   * [Elasticsearch][elasticsearch] (including [Elasticsearch exporter][elasticsearch_exporter]) to enable scalable, high-performance logging pipeline.
   * [Kibana][kibana] to support data visualization for content indexed by Elasticsearch.
   * [Fluent Bit][fluentbit] to collect and collate logs from different sources and send logged messages to multiple destinations.
-  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][promethsus_adapter]) to collect and evaluate metrics for monitoring and alerting.
+  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][prometheus_adapter]) to collect and evaluate metrics for monitoring and alerting.
   * [Traefik][traefik] to route [layer 7][osi] traffic as a reverse proxy and load balancer.
   * [Kubernetes dashboard][kubernetes_dashboard] to provide a general-purpose web-based user interface for the Kubernetes cluster.
   * Operations portal to centralize access to addon dashboards.
@@ -574,3 +574,4 @@ When the `konvoy up` completes its setup operations, the following files are gen
 [static_lvp]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [selinux-rpm]: http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm
 [containerd_mirrors]: https://github.com/containerd/cri/blob/master/docs/registry.md#configure-registry-endpoint
+[cluster_configuration]: ../../reference/cluster-configuration/

--- a/pages/ksphere/konvoy/1.4/install/install-dev/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-dev/index.md
@@ -159,3 +159,5 @@ docker exec -ti konvoy-control-plane-0 /bin/bash
 [pv]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 [terraform_docker]: https://www.terraform.io/docs/providers/docker/index.html
 [ops_portal]: ../../operations/accessing-the-cluster/
+[install_docker]: https://www.docker.com/products/docker-desktop
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/pages/ksphere/konvoy/1.4/install/install-onprem/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-onprem/index.md
@@ -516,7 +516,7 @@ Specifically, the `konvoy up` command does the following:
   * [Elasticsearch][elasticsearch] (including [Elasticsearch exporter][elasticsearch_exporter]) to enable scalable, high-performance logging pipeline.
   * [Kibana][kibana] to support data visualization for content indexed by Elasticsearch.
   * [Fluent Bit][fluentbit] to collect and collate logs from different sources and send logged messages to multiple destinations.
-  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][promethsus_adapter]) to collect and evaluate metrics for monitoring and alerting.
+  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][prometheus_adapter]) to collect and evaluate metrics for monitoring and alerting.
   * [Traefik][traefik] to route [layer 7][osi] traffic as a reverse proxy and load balancer.
   * [Kubernetes dashboard][kubernetes_dashboard] to provide a general-purpose web-based user interface for the Kubernetes cluster.
   * Operations portal to centralize access to addon dashboards.
@@ -625,3 +625,4 @@ When the `konvoy up` completes its setup operations, the following files are gen
 [kubeaddons_kommander_repo]: https://github.com/mesosphere/kubeaddons-kommander
 [kubeaddons_dispatch_repo]: https://github.com/mesosphere/kubeaddons-dispatch
 [selinux-rpm]: http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm
+[cluster_configuration]: ../../reference/cluster-configuration/

--- a/pages/ksphere/konvoy/1.4/install/ssh-configuration/index.md
+++ b/pages/ksphere/konvoy/1.4/install/ssh-configuration/index.md
@@ -96,3 +96,4 @@ spec:
 [ansible]: https://www.ansible.com
 [ansible_inventory]: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
 [ansible_wait_for]: https://docs.ansible.com/ansible/latest/modules/wait_for_module.html
+[ansible_wait_for_connection]: https://docs.ansible.com/ansible/latest/modules/wait_for_connection_module.html

--- a/pages/ksphere/konvoy/1.4/quick-start/index.md
+++ b/pages/ksphere/konvoy/1.4/quick-start/index.md
@@ -90,7 +90,7 @@ Before starting the Konvoy installation, you should verify the following:
         - [Elasticsearch][elasticsearch] (including [Elasticsearch exporter][elasticsearch_exporter]) to enable scalable, high-performance logging pipeline.
         - [Kibana][kibana] to support data visualization for content indexed by Elasticsearch.
         - [Fluent Bit][fluentbit] to collect and collate logs from different sources and send logged messages to multiple destinations.
-        - [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][promethsus_adapter]) to collect and evaluate metrics for monitoring and alerting.
+        - [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][prometheus_adapter]) to collect and evaluate metrics for monitoring and alerting.
         - [Traefik][traefik] to route [layer 7][osi] traffic as a reverse proxy and load balancer.
         - [Kubernetes dashboard][kubernetes_dashboard] to provide a general-purpose web-based user interface for the Kubernetes cluster.
         - Operations portal to centralize access to addon dashboards.

--- a/pages/ksphere/konvoy/1.4/reference/cluster-configuration/index.md
+++ b/pages/ksphere/konvoy/1.4/reference/cluster-configuration/index.md
@@ -578,10 +578,12 @@ Properties of an `addon` object.
 [aws_vpc_endpoints]: https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html
 [aws_elb]: https://aws.amazon.com/elasticloadbalancing/
 [nvidia]: https://docs.nvidia.com/datacenter/kubernetes/kubernetes-upstream/index.html
-[azure_imageiD]: https://azure.microsoft.com/en-in/blog/vm-image-blog-post/
+[azure_imageid]: https://azure.microsoft.com/en-in/blog/vm-image-blog-post/
 [azure_location]: https://azure.microsoft.com/en-us/global-infrastructure/locations/
 [azure_vnet]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview
 [azure_loadbalancer]: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview
 [availability_set]: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/manage-availability
 [azure_tags]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources
 [azure_volume_types]: https://docs.microsoft.com/en-us/rest/api/compute/disks/createorupdate#diskstorageaccounttypes
+[azure_subnet_ids]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview
+[azure_instance_types]: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes

--- a/pages/ksphere/konvoy/1.4/storage/index.md
+++ b/pages/ksphere/konvoy/1.4/storage/index.md
@@ -308,3 +308,5 @@ spec:
 [local_persistent_volume]: https://kubernetes.io/docs/concepts/storage/volumes/#local
 [static_lvp]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [reclaim_policy]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming
+[persistent_volume]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+[#storage-class]: #storage-classes-and-dynamic-volume-provisioning

--- a/pages/ksphere/konvoy/1.4/tutorials/deploy-sample-app/index.md
+++ b/pages/ksphere/konvoy/1.4/tutorials/deploy-sample-app/index.md
@@ -80,3 +80,5 @@ To deploy the sample application:
     ```
 
     This command destroys the Kubernetes cluster and the infrastructure it runs on.
+
+[guestbook]: https://kubernetes.io/docs/tutorials/stateless-application/guestbook/

--- a/pages/ksphere/konvoy/1.5.0-beta/install/install-airgapped/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/install/install-airgapped/index.md
@@ -489,7 +489,7 @@ Specifically, the `konvoy up` command does the following:
   * [Elasticsearch][elasticsearch] (including [Elasticsearch exporter][elasticsearch_exporter]) to enable scalable, high-performance logging pipeline.
   * [Kibana][kibana] to support data visualization for content indexed by Elasticsearch.
   * [Fluent Bit][fluentbit] to collect and collate logs from different sources and send logged messages to multiple destinations.
-  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][promethsus_adapter]) to collect and evaluate metrics for monitoring and alerting.
+  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][prometheus_adapter]) to collect and evaluate metrics for monitoring and alerting.
   * [Traefik][traefik] to route [layer 7][osi] traffic as a reverse proxy and load balancer.
   * [Kubernetes dashboard][kubernetes_dashboard] to provide a general-purpose web-based user interface for the Kubernetes cluster.
   * Operations portal to centralize access to addon dashboards.
@@ -571,3 +571,4 @@ When the `konvoy up` completes its setup operations, the following files are gen
 [static_lvp]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [selinux-rpm]: http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm
 [containerd_mirrors]: https://github.com/containerd/cri/blob/master/docs/registry.md#configure-registry-endpoint
+[cluster_configuration]: ../../reference/cluster-configuration/

--- a/pages/ksphere/konvoy/1.5.0-beta/install/install-dev/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/install/install-dev/index.md
@@ -159,3 +159,5 @@ docker exec -ti konvoy-control-plane-0 /bin/bash
 [pv]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 [terraform_docker]: https://www.terraform.io/docs/providers/docker/index.html
 [ops_portal]: ../../operations/accessing-the-cluster/
+[install_docker]: https://www.docker.com/products/docker-desktop
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/pages/ksphere/konvoy/1.5.0-beta/install/install-onprem/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/install/install-onprem/index.md
@@ -516,7 +516,7 @@ Specifically, the `konvoy up` command does the following:
   * [Elasticsearch][elasticsearch] (including [Elasticsearch exporter][elasticsearch_exporter]) to enable scalable, high-performance logging pipeline.
   * [Kibana][kibana] to support data visualization for content indexed by Elasticsearch.
   * [Fluent Bit][fluentbit] to collect and collate logs from different sources and send logged messages to multiple destinations.
-  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][promethsus_adapter]) to collect and evaluate metrics for monitoring and alerting.
+  * [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][prometheus_adapter]) to collect and evaluate metrics for monitoring and alerting.
   * [Traefik][traefik] to route [layer 7][osi] traffic as a reverse proxy and load balancer.
   * [Kubernetes dashboard][kubernetes_dashboard] to provide a general-purpose web-based user interface for the Kubernetes cluster.
   * Operations portal to centralize access to addon dashboards.
@@ -625,3 +625,4 @@ When the `konvoy up` completes its setup operations, the following files are gen
 [kubeaddons_kommander_repo]: https://github.com/mesosphere/kubeaddons-kommander
 [kubeaddons_dispatch_repo]: https://github.com/mesosphere/kubeaddons-dispatch
 [selinux-rpm]: http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm
+[cluster_configuration]: ../../reference/cluster-configuration/

--- a/pages/ksphere/konvoy/1.5.0-beta/install/ssh-configuration/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/install/ssh-configuration/index.md
@@ -96,3 +96,4 @@ spec:
 [ansible]: https://www.ansible.com
 [ansible_inventory]: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
 [ansible_wait_for]: https://docs.ansible.com/ansible/latest/modules/wait_for_module.html
+[ansible_wait_for_connection]: https://docs.ansible.com/ansible/latest/modules/wait_for_connection_module.html

--- a/pages/ksphere/konvoy/1.5.0-beta/quick-start/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/quick-start/index.md
@@ -90,7 +90,7 @@ Before starting the Konvoy installation, you should verify the following:
         - [Elasticsearch][elasticsearch] (including [Elasticsearch exporter][elasticsearch_exporter]) to enable scalable, high-performance logging pipeline.
         - [Kibana][kibana] to support data visualization for content indexed by Elasticsearch.
         - [Fluent Bit][fluentbit] to collect and collate logs from different sources and send logged messages to multiple destinations.
-        - [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][promethsus_adapter]) to collect and evaluate metrics for monitoring and alerting.
+        - [Prometheus operator][prometheus_operator] (including [Grafana][grafana] AlertManager and [Prometheus Adaptor][prometheus_adapter]) to collect and evaluate metrics for monitoring and alerting.
         - [Traefik][traefik] to route [layer 7][osi] traffic as a reverse proxy and load balancer.
         - [Kubernetes dashboard][kubernetes_dashboard] to provide a general-purpose web-based user interface for the Kubernetes cluster.
         - Operations portal to centralize access to addon dashboards.

--- a/pages/ksphere/konvoy/1.5.0-beta/storage/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/storage/index.md
@@ -308,3 +308,5 @@ spec:
 [local_persistent_volume]: https://kubernetes.io/docs/concepts/storage/volumes/#local
 [static_lvp]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [reclaim_policy]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming
+[persistent_volume]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+[#storage-class]: #storage-classes-and-dynamic-volume-provisioning

--- a/pages/ksphere/konvoy/1.5.0-beta/tutorials/deploy-sample-app/index.md
+++ b/pages/ksphere/konvoy/1.5.0-beta/tutorials/deploy-sample-app/index.md
@@ -80,3 +80,5 @@ To deploy the sample application:
     ```
 
     This command destroys the Kubernetes cluster and the infrastructure it runs on.
+
+[guestbook]: https://kubernetes.io/docs/tutorials/stateless-application/guestbook/


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/COPS-6126

## Description of changes being made
A number of reference links are broken. Adding the missing references to fix that. This change can be merged any time.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.