### PR TITLE
Fix build when using dispatch or kommander branch

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,14 +2,14 @@
   "master": {
     "DO_NOT_BUILD": [
       "test/**",
-      "mesosphere/dcos/1.14/**", 
+      "mesosphere/dcos/1.14/**",
       "ksphere/dispatch/1.2/**"
     ],
     "DO_NOT_INDEX": []
   },
   "staging": {
     "DO_NOT_BUILD": [
-      "test/**", 
+      "test/**",
       "ksphere/dispatch/1.2/**"
     ],
     "DO_NOT_INDEX": [
@@ -26,17 +26,6 @@
     "DO_NOT_BUILD": [],
     "DO_NOT_INDEX": []
   },
-  "christina": {
-    "DO_NOT_BUILD": [
-      "mesosphere/dcos/1.7/**",
-      "mesosphere/dcos/1.8/**",
-      "mesosphere/dcos/1.9/**",
-      "mesosphere/dcos/1.10/**",
-      "mesosphere/dcos/1.11/**",
-      "mesosphere/dcos/1.12/**"
-    ],
-    "DO_NOT_INDEX": []
-  },
   "kommander": {
     "DO_NOT_BUILD": [
       "mesosphere/dcos/1.7/**",
@@ -46,7 +35,6 @@
       "mesosphere/dcos/1.11/**",
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2.0/**",
       "mesosphere/dcos/2.1/**"
     ],
     "DO_NOT_INDEX": []
@@ -60,7 +48,6 @@
       "mesosphere/dcos/1.11/**",
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2.0/**",
       "mesosphere/dcos/2.1/**"
     ],
     "DO_NOT_INDEX": []


### PR DESCRIPTION
the layouts are written in a way that requires the latest version of any
given doc to be present during build time. the DO_NOT_BUILD sections
exclude dcos 2.0 since 771142bbdce3c03bbf07cdf5f10b84f01d4c7c81.
unfortunately that version is needed to properly build the docs for the
`dispatch` and `kommander` branches.

i also removed the `christina`-branch as nobody seems to use it.