### PR TITLE
Update jenkins auth docs[DO NOT MERGE]

### DIFF
--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/jenkins-auth/index.md
@@ -167,7 +167,7 @@ The contents of the `config.json` file will vary according to your security mode
     "strict-mode": true
   },
   "service": {
-    "name": "/dev/jenkins",
+    "name": "/jenkins/jenkins",
     "user": "nobody"
   }
 }
@@ -181,7 +181,7 @@ The contents of the `config.json` file will vary according to your security mode
     "secret-name": "jenkins/jenkins-secret"
   },
   "service": {
-    "name": "/dev/jenkins",
+    "name": "/jenkins/jenkins",
     "user": "nobody"
   }
 }
@@ -200,7 +200,7 @@ To install the service, complete the following steps.
    dcos package install --options=config.json jenkins
    ```
 
-1. Paste the following path into your browser, replacing `cluster-url` with your actual cluster URL: `https://<cluster-url>/service/dev/jenkins/configure`.
+1. Paste the following path into your browser, replacing `cluster-url` with your actual cluster URL: `https://<cluster-url>/service/jenkins/jenkins/configure`.
 
 1. Scroll to the **Mesos cloud** area.
 


### PR DESCRIPTION
This is more like a issue.  
From the doc:
```
{
  "security": {
    "secret-name": "jenkins/jenkins-secret"
  },
  "service": {
    "name": "/dev/jenkins",
    "user": "nobody"
  }
}
```
But `jenkins/jenkins-secret` cannot be accessed by `/dev/` group.
We can change the service anme to `jenkins/jenkins`, but it's a bit weird...

## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
