### PR TITLE
fix robots-txt

### DIFF
--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -58,7 +58,7 @@ COPY --from=ms-builder /src/build ./
 ADD "$nginx_dir" /etc/nginx/conf.d
 
 # robots
-RUN if [ "${GIT_BRANCH}" != "master" ]; then echo "User-agent: * Disallow: /" > /src/build/robots.txt; fi
+RUN if [ "${GIT_BRANCH}" != "master" ]; then echo "User-agent: * \nDisallow: /" > /src/build/robots.txt; fi
 
 RUN service nginx restart
 


### PR DESCRIPTION
While having a look at an issue that led to the docs not being able to
be built when one specifies a git_branch, i saw that line and wondered
whether it would be able to work.

As per google (https://developers.google.com/search/reference/robots_txt)
it shouldn't, as we need a line separator inbetween statements. A space
is not enough here.

This may mean that our stagings will be indexed by google. Here's
a current instance that won't behave as intended: http://docs-staging.d2iq.com/robots.txt