### PR TITLE
don't ban crawlers from production

### DIFF
--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -58,7 +58,7 @@ COPY --from=ms-builder /src/build ./
 ADD "$nginx_dir" /etc/nginx/conf.d
 
 # robots
-RUN if [ "${GIT_BRANCH}" != "master" ]; then echo "User-agent: * \nDisallow: /" > /src/build/robots.txt; fi
+# RUN if [ "${GIT_BRANCH}" != "master" ]; then echo "User-agent: * \nDisallow: /" > /src/build/robots.txt; fi
 
 RUN service nginx restart
 


### PR DESCRIPTION
unfortunately the mechanism that has [been "fixed" recently](https://github.com/mesosphere/dcos-docs-site/pull/2922) seemed to
never have worked in the first place. during the build-time for
production `GIT_BRANCH` does not seem to equal "master" and thus we now
have a valid robots.txt on docs.d2iq.com
(https://docs.d2iq.com/robots.txt 😱) which effectively tells google to
not index the docs anymore.

this is a hotfix as to not potentially lose scoring on google. we should follow up
with a fix that properly adds a robot.txt on all non-prod-instances but
NOT on production.

as the `robots.txt`-files we had until a couple days ago were invalid, this change effectively restores the former state.