### PR TITLE
Updated DC/OS Metrics Quickstart Formatting: DCOS_OSS-5294

### DIFF
--- a/pages/mesosphere/dcos/1.13/metrics/quickstart/index.md
+++ b/pages/mesosphere/dcos/1.13/metrics/quickstart/index.md
@@ -55,7 +55,6 @@ This page explains how to get started with metrics in DC/OS. A metrics pipeline 
          HOSTNAME       IP                         ID                    
         10.0.0.193  10.0.0.193  7749eada-4974-44f3-aad9-42e2fc6aedaf-S1  
         ```
-
 3.  View metrics.
 
     -   **<a name="container-metrics"></a>Container metrics for a specific task**
@@ -82,7 +81,6 @@ This page explains how to get started with metrics in DC/OS. A metrics pipeline 
         ```
         The output is a combination of container resource utilization and metrics transmitted by the workload. 
         For example:
-
 
         ```bash
         NAME                      VALUE

--- a/pages/mesosphere/dcos/2.0/metrics/quickstart/index.md
+++ b/pages/mesosphere/dcos/2.0/metrics/quickstart/index.md
@@ -83,7 +83,6 @@ This page explains how to get started with metrics in Mesosphere&reg; DC/OS&trad
         The output is a combination of container resource utilization and metrics transmitted by the workload. 
         For example:
 
-
         ```bash
         NAME                      VALUE
         cpus.limit                0.20            

--- a/pages/mesosphere/dcos/2.1/metrics/quickstart/index.md
+++ b/pages/mesosphere/dcos/2.1/metrics/quickstart/index.md
@@ -83,7 +83,6 @@ This page explains how to get started with metrics in DC/OS. A metrics pipeline 
         The output is a combination of container resource utilization and metrics transmitted by the workload. 
         For example:
 
-
         ```bash
         NAME                      VALUE
         cpus.limit                0.20            


### PR DESCRIPTION
## Jira Ticket
DCOS_OSS-5294

## Description of changes being made
1. The formatting was off in `DC/OS Metrics Quickstart Section 3` in versions 1.13, 2.0, 2.1. Reverted back to the 1.12 formatting after double checking no json values had changed. 

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

