### PR TITLE
[DC/OS D2IQ-38763]: remove Parameters key from Docker object in Marathon service section 

### DIFF
--- a/pages/mesosphere/dcos/1.11/deploying-services/creating-services/deploy-docker-app/index.md
+++ b/pages/mesosphere/dcos/1.11/deploying-services/creating-services/deploy-docker-app/index.md
@@ -96,13 +96,7 @@ In this tutorial, you will create a custom Docker image and deploy it to DC/OS.
       "container": {
         "type": "[MESOS | DOCKER]",
         "docker": {
-          "image": "<username>/simple-docker",
-          "parameters": [
-            {
-              "key": "log-driver",
-              "value": "none"
-            }
-          ]
+          "image": "<username>/simple-docker"
         },
         "portMappings": [
           { "hostPort": 80, "containerPort": 80, "protocol": "tcp" }

--- a/pages/mesosphere/dcos/1.12/deploying-services/creating-services/deploy-docker-app/index.md
+++ b/pages/mesosphere/dcos/1.12/deploying-services/creating-services/deploy-docker-app/index.md
@@ -96,13 +96,7 @@ In this tutorial, you will create a custom Docker image and deploy it to DC/OS.
       "container": {
         "type": "[MESOS | DOCKER]",
         "docker": {
-          "image": "<username>/simple-docker",
-          "parameters": [
-            {
-              "key": "log-driver",
-              "value": "none"
-            }
-          ]
+          "image": "<username>/simple-docker"
         },
         "portMappings": [
           { "hostPort": 80, "containerPort": 80, "protocol": "tcp" }

--- a/pages/mesosphere/dcos/1.13/deploying-services/creating-services/deploy-docker-app/index.md
+++ b/pages/mesosphere/dcos/1.13/deploying-services/creating-services/deploy-docker-app/index.md
@@ -96,13 +96,7 @@ In this tutorial, you will create a custom Docker image and deploy it to DC/OS.
       "container": {
         "type": "[MESOS | DOCKER]",
         "docker": {
-          "image": "<username>/simple-docker",
-          "parameters": [
-            {
-              "key": "log-driver",
-              "value": "none"
-            }
-          ]
+          "image": "<username>/simple-docker"
         },
         "portMappings": [
           { "hostPort": 80, "containerPort": 80, "protocol": "tcp" }

--- a/pages/mesosphere/dcos/2.0/deploying-services/creating-services/deploy-docker-app/index.md
+++ b/pages/mesosphere/dcos/2.0/deploying-services/creating-services/deploy-docker-app/index.md
@@ -96,13 +96,7 @@ In this tutorial, you will create a custom Docker image and deploy it to DC/OS.
       "container": {
         "type": "[MESOS | DOCKER]",
         "docker": {
-          "image": "<username>/simple-docker",
-          "parameters": [
-            {
-              "key": "log-driver",
-              "value": "none"
-            }
-          ]
+          "image": "<username>/simple-docker"
         },
         "portMappings": [
           { "hostPort": 80, "containerPort": 80, "protocol": "tcp" }

--- a/pages/mesosphere/dcos/2.1/deploying-services/creating-services/deploy-docker-app/index.md
+++ b/pages/mesosphere/dcos/2.1/deploying-services/creating-services/deploy-docker-app/index.md
@@ -96,13 +96,7 @@ In this tutorial, you will create a custom Docker image and deploy it to DC/OS.
       "container": {
         "type": "[MESOS | DOCKER]",
         "docker": {
-          "image": "<username>/simple-docker",
-          "parameters": [
-            {
-              "key": "log-driver",
-              "value": "none"
-            }
-          ]
+          "image": "<username>/simple-docker"
         },
         "portMappings": [
           { "hostPort": 80, "containerPort": 80, "protocol": "tcp" }


### PR DESCRIPTION
## Jira Ticket
D2IQ-38763: [Deploying Services Docs Bugs] Misleading documentation example in 'Deploying a Docker-based Service'

## Description of changes being made
Removed the Parameters key from  from the Docker object in the Marathon service section of the docs, for versions 2.1, 2.0, 1.13, 1.12, 1.11

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
