### PR TITLE
Typo: Adding missing permissions on EdgeLB

### DIFF
--- a/pages/mesosphere/dcos/services/edge-lb/1.5/getting-started/installing/index.md
+++ b/pages/mesosphere/dcos/services/edge-lb/1.5/getting-started/installing/index.md
@@ -213,6 +213,8 @@ The secret store is used by Edge-LB to retrieve and install SSL certificates on 
     **Granting specific permissions to the service account**:  If you follow the principle of least-privilege, you should not add the service account principal to the `superusers` group. Instead, you should limit the permissions granted to allow only management of DC/OS packages, Marathon tasks, and Edge-LB pool-related activity. You can grant specific permissions to the service account principal using commands similar to the following:
 
     ```bash
+    dcos security org users grant edge-lb-principal dcos:adminrouter:ops:ca:rw full
+    dcos security org users grant edge-lb-principal dcos:adminrouter:ops:ca:ro full
     dcos security org users grant edge-lb-principal dcos:adminrouter:service:marathon full
     dcos security org users grant edge-lb-principal dcos:adminrouter:package full
     dcos security org users grant edge-lb-principal dcos:adminrouter:service:edgelb full
@@ -227,6 +229,8 @@ The secret store is used by Edge-LB to retrieve and install SSL certificates on 
     dcos security org users grant edge-lb-principal dcos:mesos:master:volume:role full
     dcos security org users grant edge-lb-principal dcos:mesos:master:task:user:root full
     dcos security org users grant edge-lb-principal dcos:mesos:master:task:app_id full
+    dcos security org users grant edge-lb-principal 'dcos:secrets:default:/dcos-edgelb/*' full
+    dcos security org users grant edge-lb-principal 'dcos:secrets:list:default:/dcos-edgelb/*' full
     ```
 
     These sample permissions also enable Edge-LB pool framework schedulers to register with Mesos master nodes and to launch load-balancer tasks. You must also grant the following permission for **each Edge-LB pool** created:


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

**None yet**

## Description of changes being made

I noticed there are a few permissions missing on the latest EdgeLB 1.5 installation instructions. Even worse, it seems they are correctly defined on EdgeLB 1.4 version, so I am not sure why this happened.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
