### PR TITLE
Modify Exhibitor access to support TLS where appropriate

### DIFF
--- a/pages/mesosphere/dcos/1.13/installing/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/1.13/installing/troubleshooting/index.md
@@ -62,52 +62,45 @@ When troubleshooting problems with a DC/OS installation, you should explore the 
    sudo systemctl disable dnsmasq && sudo systemctl stop dnsmasq
    ```
 
-* Verify that Exhibitor is up and running at`http://<MASTER_IP>:8181/exhibitor`. If Exhibitor is not up and running:
+* Verify that Exhibitor is listening on port 8181.
 
-    - [SSH](/mesosphere/dcos/1.13/administering-clusters/sshcluster/) to your master node and enter this command to check the Exhibitor service logs:
+   Run the following command on a master:
+   ```bash
+   curl http://localhost:8181/exhibitor/v1/cluster/status
+   ```
 
-    ```bash
-    journalctl -flu dcos-exhibitor
-    ```
+   If Exhibitor responds, verify that the output of the above command shows the correct number of masters and that all of them have `"description": "serving"` but only one of them has `"isLeader": true`
 
-* Verify that `/tmp` is mounted *without* `noexec`. If it is mounted with `noexec`, Exhibitor will fail to bring up ZooKeeper because Java JNI won't be able to `exec` a file it creates in `/tmp` and you will see multiple `permission denied` errors in the log.
-
-* To repair `/tmp` mounted with `noexec` run the following command:
-
-
-        mount -o remount,exec /tmp
-
-
-* Check the output of `/exhibitor/v1/cluster/status` and verify that it shows the correct number of masters and that all of them are `"serving"` but only one of them is designated as `"isLeader": true`
-
-  For example, [SSH](/mesosphere/dcos/1.13/administering-clusters/sshcluster/) to your master node and enter this command:
-
-
-    curl -fsSL http://localhost:8181/exhibitor/v1/cluster/status | python -m json.tool
-        [
-                {
-                    "code": 3,
-                    "description": "serving",
-                    "hostname": "10.0.6.70",
-                    "isLeader": false
-                },
-                {
-                    "code": 3,
-                    "description": "serving",
-                    "hostname": "10.0.6.69",
-                    "isLeader": false
-                },
-                {
-                    "code": 3,
-                    "description": "serving",
-                    "hostname": "10.0.6.68",
-                    "isLeader": true
-                }
-            ]
+   ```
+   [
+      {
+         "code": 3,
+         "description": "serving",
+         "hostname": "10.0.6.70",
+         "isLeader": false
+      },
+      {
+         "code": 3,
+         "description": "serving",
+         "hostname": "10.0.6.69",
+         "isLeader": false
+      },
+      {
+         "code": 3,
+         "description": "serving",
+         "hostname": "10.0.6.68",
+         "isLeader": true
+      }
+   ]
+   ```
 
 
+   <p class="message--note"><strong>NOTE: </strong>Running this command in multi-master configurations can take up to 15 minutes to complete.</p>
 
-<p class="message--note"><strong>NOTE: </strong>Running this command in multi-master configurations can take up to 10-15 minutes to complete. If it does not complete after 10-15 minutes, you should carefully review the <code>journalctl -flu dcos-exhibitor</code> logs.</p>
+   For any problems, check the Exhibitor logs:
+   ```bash
+   journalctl -flu dcos-exhibitor
+   ```
 
 * Verify whether you can ping the DNS Forwarder (`ready.spartan`). If not, review the DNS Dispatcher service logs: ﻿⁠⁠⁠⁠
 

--- a/pages/mesosphere/dcos/2.0/installing/production/patching/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/patching/index.md
@@ -32,7 +32,6 @@ If patching is performed on a supported OS with all prerequisites fulfilled, the
 - The DC/OS GUI and other higher-level system APIs may be inconsistent or unavailable until all master nodes have been patched. For example, a patched DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been patched. When this occurs:
 
     - The DC/OS GUI may not provide an accurate list of services.
-    - For multi-master configurations, after one master has finished patching, you can monitor the health of the remaining masters from the Exhibitor UI on port 8181.
 - A patched DC/OS Marathon leader cannot connect to a non-secure (not patched) leading Mesos master. The DC/OS UI cannot be trusted until all masters are patched. There are multiple Marathon scheduler instances and multiple Mesos masters, each being patched, and the Marathon leader may not be the Mesos leader.
 - Task history in the Mesos UI will not persist through the patch.
 - DC/OS Enterprise downloads can be found [here](https://support.mesosphere.com/hc/en-us/articles/213198586-Mesosphere-Enterprise-DC-OS-Downloads). [enterprise type="inline" size="small" /]
@@ -201,32 +200,43 @@ Proceed with patching every master node one at a time in any order using the fol
     0
     ```
 
-1.  Validate the patch:
+1.  Validate the patch by running the following commands on the master node:
 
-    1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green).
+    1.  Monitor Exhibitor and wait for it to converge.
 
-        <p class="message--note"><strong>NOTE: </strong>If you are patching from permissive to strict mode, this URL will be "https://...".</p>
+        On DC/OS Enterprise clusters with a static master list use the command:
+        ```bash
+        sudo curl --cacert /var/lib/dcos/exhibitor-tls-artifacts/root-cert.pem --cert /var/lib/dcos/exhibitor-tls-artifacts/client-cert.pem --key /var/lib/dcos/exhibitor-tls-artifacts/client-key.pem https://localhost:8181/exhibitor/v1/cluster/status
+        ```
 
+        On other clusters use the command:
+        ```bash
+        curl http://localhost:8181/exhibitor/v1/cluster/status
+        ```
+
+        Wait until the response shows that all hosts have `"description":"serving"`.
     1.  Wait until the `dcos-mesos-master` unit is up and running.
-    1.  Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
+    1.  Verify that `curl http://localhost:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
 
         <p class="message--note"><strong>NOTE: </strong>If you are patching from permissive to strict mode, this URL will be "curl https://..." and you will need a JWT for access. </p>
         [enterprise type="inline" size="small" /]
 
     1.  Verify that `/opt/mesosphere/bin/mesos-master --version` indicates that the patched master is running the version of Mesos specified in the [release notes](/mesosphere/dcos/2.0/release-notes/), for example `1.5.1`.
-1.  Verify that the number of under-replicated ranges has dropped to zero as the IAM database is replicated to the new master. This can be done by running the following command and confirming that the last column on the right shows only zeros.
+    1.  Verify that the number of under-replicated ranges in CockroachDB has dropped to zero as the IAM database is replicated to the new master. Run the following command and confirm that the `ranges_underreplicated` column shows only zeros.
     ```bash
-        sudo /opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/bouncer --host=$(/opt/mesosphere/bin/detect_ip)
-        +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
-        | id |       address       | build  |     updated_at      |     started_at      | replicas_leaders | replicas_leaseholders | ranges | ranges_unavailable | ranges_underreplicated |
-        +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
-        |  1 | 172.31.7.32:26257   | v1.1.4 | 2018-03-08 13:56:10 | 2018-02-28 20:11:00 |              195 |                   194 |    195 |                  0 |                      0 |
-        |  2 | 172.31.10.48:26257  | v1.1.4 | 2018-03-08 13:56:05 | 2018-03-05 13:33:45 |              200 |                   199 |    200 |                  0 |                      0 |
-        |  3 | 172.31.23.132:26257 | v1.1.4 | 2018-03-08 13:56:01 | 2018-02-28 20:18:41 |              187 |                   187 |    187 |                  0 |                      0 |
-        +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
+    sudo /opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/bouncer --host=$(/opt/mesosphere/bin/detect_ip)
+    ```
+    ```
+    +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
+    | id |       address       | build  |     updated_at      |     started_at      | replicas_leaders | replicas_leaseholders | ranges | ranges_unavailable | ranges_underreplicated |
+    +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
+    |  1 | 172.31.7.32:26257   | v1.1.4 | 2018-03-08 13:56:10 | 2018-02-28 20:11:00 |              195 |                   194 |    195 |                  0 |                      0 |
+    |  2 | 172.31.10.48:26257  | v1.1.4 | 2018-03-08 13:56:05 | 2018-03-05 13:33:45 |              200 |                   199 |    200 |                  0 |                      0 |
+    |  3 | 172.31.23.132:26257 | v1.1.4 | 2018-03-08 13:56:01 | 2018-02-28 20:18:41 |              187 |                   187 |    187 |                  0 |                      0 |
+    +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
     ```
 
-    If the `ranges_underreplicated` column lists any non-zero values, wait a minute and rerun the command. The values will converge to zero once all data is safely replicated.
+    If the `ranges_underreplicated` column lists any non-zero values, wait a minute and rerun the command. The values will converge to zero after all data is safely replicated.
 
 1.  Go to the DC/OS Agents [procedure](#agents) to complete your installation.
 

--- a/pages/mesosphere/dcos/2.0/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/system-requirements/ports/index.md
@@ -47,14 +47,14 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
-| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 3888  | ZooKeeper | `dcos-exhibitor.service` | master | master |
+| 2888  | ZooKeeper | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |
 | 8101  | DC/OS Identity and Access Manager | `dcos-bouncer.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` | localhost | localhost |
-| 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
+| 8181  | Exhibitor | `dcos-exhibitor.service` | agent/master | master |
 | 8200  | Vault | `dcos-vault.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 8201  | Vault HA | `dcos-vault.service` | master| master [enterprise type="inline" size="small" /] |
 | 8443  | Marathon SSL | `dcos-marathon.service` | agent/master | master |

--- a/pages/mesosphere/dcos/2.0/installing/production/upgrading/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/upgrading/index.md
@@ -28,7 +28,6 @@ If upgrading is performed on a supported OS with all prerequisites fulfilled, th
 - The DC/OS GUI and other higher-level system APIs may be inconsistent or unavailable until all master nodes have been upgraded.
   When this occurs:
    * The DC/OS GUI may not provide an accurate list of services.
-   * For multi-master configurations, after one master has finished upgrading, you can monitor the health of the remaining masters from the Exhibitor UI on port 8181.
 - An upgraded DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been upgraded. The DC/OS UI cannot be trusted until all masters are upgraded. There are multiple Marathon scheduler instances and multiple Mesos masters, each being upgraded, and the Marathon leader may not be the Mesos leader.
 - Task history in the Mesos UI will not persist through the upgrade.
 
@@ -223,24 +222,34 @@ Proceed with upgrading every master node one at a time in any order using the fo
     0
     ```
 
-1.  Validate the upgrade:
+1.  Validate the upgrade by running the following commands on the master node:
 
-    1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green).
+    1.  Monitor Exhibitor and wait for it to converge.
 
-        <p class="message--note"><strong>NOTE: </strong>If you are upgrading from permissive to strict mode, this URL will be "https://...".</p>
+        On DC/OS Enterprise clusters with a static master list use the command:
+        ```bash
+        sudo curl --cacert /var/lib/dcos/exhibitor-tls-artifacts/root-cert.pem --cert /var/lib/dcos/exhibitor-tls-artifacts/client-cert.pem --key /var/lib/dcos/exhibitor-tls-artifacts/client-key.pem https://localhost:8181/exhibitor/v1/cluster/status
+        ```
 
+        On other clusters use the command:
+        ```bash
+        curl http://localhost:8181/exhibitor/v1/cluster/status
+        ```
+
+        Wait until the response shows that all hosts have `"description":"serving"`.
     1.  Wait until the `dcos-mesos-master` unit is up and running.
-    1.  Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
+    1.  Verify that `curl http://localhost:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
 
         <p class="message--note"><strong>NOTE: </strong>If you are upgrading from permissive to strict mode, this URL will be <code>curl https://...</code> and you will need a JWT for access. </p>
         [enterprise type="inline" size="small" /]
 
     1.  Verify that `/opt/mesosphere/bin/mesos-master --version` indicates that the upgraded master is running the version of Mesos specified in the [release notes](/mesosphere/dcos/2.0/release-notes/), for example `1.5.1`.
 
-	1.  Verify that the number of under-replicated ranges has dropped to zero as the IAM database is replicated to the new master. Run the following command and confirm that the `ranges_underreplicated` column shows only zeros.
-
+    1.  Verify that the number of under-replicated ranges in CockroachDB has dropped to zero as the IAM database is replicated to the new master. Run the following command and confirm that the `ranges_underreplicated` column shows only zeros.
     ```bash
     sudo /opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/bouncer --host=$(/opt/mesosphere/bin/detect_ip)
+    ```
+    ```
     +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
     | id |       address       | build  |     updated_at      |     started_at      | replicas_leaders | replicas_leaseholders | ranges | ranges_unavailable | ranges_underreplicated |
     +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
@@ -249,7 +258,7 @@ Proceed with upgrading every master node one at a time in any order using the fo
     |  3 | 172.31.23.132:26257 | v1.1.4 | 2018-03-08 13:56:01 | 2018-02-28 20:18:41 |              187 |                   187 |    187 |                  0 |                      0 |
     +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
     ```
-		
+
     If the `ranges_underreplicated` column lists any non-zero values, wait a minute and rerun the command. The values will converge to zero after all data is safely replicated.
 
 1.  Go to the DC/OS Agents [procedure](#agents) to complete your installation.

--- a/pages/mesosphere/dcos/2.0/installing/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/troubleshooting/index.md
@@ -32,6 +32,7 @@ You must have working DNS resolvers, specified in your [config.yaml](/mesosphere
 
 When troubleshooting problems with a DC/OS installation, you should explore the components in this sequence:
 
+ 1. Time synchronization
  1. Exhibitor
  1. Apache&reg; Mesos&reg; master
  1. Mesos DNS
@@ -42,15 +43,17 @@ When troubleshooting problems with a DC/OS installation, you should explore the 
 
  Be sure to verify that all services are up and healthy on the masters before verifying the agents.
 
- ### NTP
+*  Network Time Protocol (NTP) must be enabled on all nodes for clock synchronization. By default, during DC/OS startup you will receive an error if this is not enabled. You can verify that NTP is enabled by running one of these commands, depending on your OS and configuration:
 
- Network Time Protocol (NTP) must be enabled on all nodes for clock synchronization. By default, during DC/OS startup you will receive an error if this is not enabled. You can verify that NTP is enabled by running one of these commands, depending on your OS and configuration:
-
-```bash
-ntptime
-adjtimex -p
-timedatectl
-```
+    ```bash
+    ntptime
+    ```
+    ```bash
+    adjtimex -p
+    ```
+    ```bash
+    timedatectl
+    ```
 
 * Ensure that firewalls and any other connection-filtering mechanisms are not interfering with cluster component communications. TCP, UDP, and ICMP must be permitted.
 
@@ -61,53 +64,50 @@ timedatectl
    sudo systemctl disable dnsmasq && sudo systemctl stop dnsmasq
    ```
 
-* Verify that Exhibitor is up and running at`http://<MASTER_IP>:8181/exhibitor`. If Exhibitor is not up and running:
+* Verify that Exhibitor is listening on port 8181.
 
-    - [SSH](/mesosphere/dcos/2.0/administering-clusters/sshcluster/) to your master node and enter this command to check the Exhibitor service logs:
+   On DC/OS Enterprise clusters with a static master list run the following command on a master:
+   ```bash
+   sudo curl --cacert /var/lib/dcos/exhibitor-tls-artifacts/root-cert.pem --cert /var/lib/dcos/exhibitor-tls-artifacts/client-cert.pem --key /var/lib/dcos/exhibitor-tls-artifacts/client-key.pem https://localhost:8181/exhibitor/v1/cluster/status
+   ```
 
-    ```bash
-    journalctl -flu dcos-exhibitor
-    ```
+   On other clusters run the following command on a master:
+   ```bash
+   curl http://localhost:8181/exhibitor/v1/cluster/status
+   ```
 
-* Verify that `/tmp` is mounted *without* `noexec`. If it is mounted with `noexec`, Exhibitor will fail to bring up ZooKeeper&trade; because Java JNI won't be able to `exec` a file it creates in `/tmp` and you will see multiple `permission denied` errors in the log.
+   If Exhibitor responds, verify that the output of the above command shows the correct number of masters and that all of them have `"description": "serving"` but only one of them has `"isLeader": true`
 
-* To repair `/tmp` mounted with `noexec` run the following command:
-
-    ```bash
-    mount -o remount,exec /tmp
-    ```
-
-
-* Check the output of `/exhibitor/v1/cluster/status` and verify that it shows the correct number of masters and that all of them are `"serving"` but only one of them is designated as `"isLeader": true`
-
-  For example, [SSH](/mesosphere/dcos/2.0/administering-clusters/sshcluster/) to your master node and enter this command:
-
-    ```json
-    curl -fsSL http://localhost:8181/exhibitor/v1/cluster/status | python -m json.tool
-    [
-            {
-                "code": 3,
-                "description": "serving",
-                "hostname": "10.0.6.70",
-                "isLeader": false
-            },
-            {
-                "code": 3,
-                "description": "serving",
-                "hostname": "10.0.6.69",
-                "isLeader": false
-            },
-            {
-                "code": 3,
-                "description": "serving",
-                "hostname": "10.0.6.68",
-                "isLeader": true
-            }
-        ]
-    ```
+   ```
+   [
+      {
+         "code": 3,
+         "description": "serving",
+         "hostname": "10.0.6.70",
+         "isLeader": false
+      },
+      {
+         "code": 3,
+         "description": "serving",
+         "hostname": "10.0.6.69",
+         "isLeader": false
+      },
+      {
+         "code": 3,
+         "description": "serving",
+         "hostname": "10.0.6.68",
+         "isLeader": true
+      }
+   ]
+   ```
 
 
-<p class="message--note"><strong>NOTE: </strong>Running this command in multi-master configurations can take up to 10-15 minutes to complete. If it does not complete after 10-15 minutes, you should carefully review the <code>journalctl -flu dcos-exhibitor</code> logs.</p>
+   <p class="message--note"><strong>NOTE: </strong>Running this command in multi-master configurations can take up to 15 minutes to complete.</p>
+
+   For any problems, check the Exhibitor logs:
+   ```bash
+   journalctl -flu dcos-exhibitor
+   ```
 
 * Verify whether you can ping the DNS Forwarder (`ready.spartan`). If not, review the DNS Dispatcher service logs: ﻿⁠⁠⁠⁠
 

--- a/pages/mesosphere/dcos/2.0/security/ent/tls-ssl/exhibitor/index.md
+++ b/pages/mesosphere/dcos/2.0/security/ent/tls-ssl/exhibitor/index.md
@@ -9,7 +9,7 @@ enterprise: true
 
 # Verifying that Exhibitor is secured 
 
-Starting with DC/OS 2.0, Exhibitor is secured by default in most circumstances. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
+Starting with DC/OS 2.0, Exhibitor is secured by default in static master clusters. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
 ```bash
 
     curl -LI \

--- a/pages/mesosphere/dcos/2.1/installing/production/system-requirements/ports/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/system-requirements/ports/index.md
@@ -47,14 +47,14 @@ DC/OS allocates additional ports to services running on top of DC/OS. These port
 | 80    | Admin Router Master (HTTP) | `dcos-adminrouter.service` |public IP| master |
 | 443   | Admin Router Master (HTTPS) | `dcos-adminrouter.service`|public IP| master |
 | 2181  | ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
-| 3888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
-| 2888  | Exhibitor, or ZooKeeper and Exhibitor | `dcos-exhibitor.service` | master | master |
+| 3888  | ZooKeeper | `dcos-exhibitor.service` | master | master |
+| 2888  | ZooKeeper | `dcos-exhibitor.service` | master | master |
 | 5050  | Mesos Master | `dcos-mesos-master.service` | agent/master | master |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` | localhost| localhost(master) |
 | 8080  | Marathon | `dcos-marathon.service` | agent/master | master |
 | 8101  | DC/OS Identity and Access Manager | `dcos-bouncer.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` | localhost | localhost |
-| 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` | agent/master | master |
+| 8181  | Exhibitor | `dcos-exhibitor.service` | agent/master | master |
 | 8200  | Vault | `dcos-vault.service` | localhost| localhost(master) [enterprise type="inline" size="small" /] |
 | 8201  | Vault HA | `dcos-vault.service` | master| master [enterprise type="inline" size="small" /] |
 | 8443  | Marathon SSL | `dcos-marathon.service` | agent/master | master |

--- a/pages/mesosphere/dcos/2.1/installing/production/upgrading/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/upgrading/index.md
@@ -28,7 +28,6 @@ If upgrading is performed on a supported OS with all prerequisites fulfilled, th
 - The DC/OS GUI and other higher-level system APIs may be inconsistent or unavailable until all master nodes have been upgraded.
   When this occurs:
    * The DC/OS GUI may not provide an accurate list of services.
-   * For multi-master configurations, after one master has finished upgrading, you can monitor the health of the remaining masters from the Exhibitor UI on port 8181.
 - An upgraded DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been upgraded. The DC/OS UI cannot be trusted until all masters are upgraded. There are multiple Marathon scheduler instances and multiple Mesos masters, each being upgraded, and the Marathon leader may not be the Mesos leader.
 - Task history in the Mesos UI will not persist through the upgrade.
 
@@ -185,35 +184,46 @@ Start the upgraded nodes and wait for them to join the master.
 
 The leader should be still on the old node that has not been upgraded. Let's upgrade that one as well. Shut it down and upgrade it as described above. If all went fine the leader should have switched to one of the new nodes.
 
-1.  Validate the upgrade:
+Validate the upgrade by running the following commands on the master node:
 
-    1.  Monitor Exhibitor and wait for it to converge at `http://<master-ip>:8181/exhibitor/v1/ui/index.html`. Confirm that the master rejoins the ZooKeeper quorum successfully (the status indicator will turn green).
+1.  Monitor Exhibitor and wait for it to converge.
 
-        <p class="message--note"><strong>NOTE: </strong>If you are upgrading from permissive to strict mode, this URL will be "https://...".</p>
-
-    1.  Wait until the `dcos-mesos-master` unit is up and running.
-    1.  Verify that `curl http://<dcos_master_private_ip>:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
-
-        <p class="message--note"><strong>NOTE: </strong>If you are upgrading from permissive to strict mode, this URL will be <code>curl https://...</code> and you will need a JWT for access. </p>
-        [enterprise type="inline" size="small" /]
-
-    1.  Verify that `/opt/mesosphere/bin/mesos-master --version` indicates that the upgraded master is running the version of Mesos specified in the [release notes](/mesosphere/dcos/2.1/release-notes/), for example `1.5.1`.
-
-	1.  Verify that the number of under-replicated ranges has dropped to zero as the IAM database is replicated to the new master. Run the following command and confirm that the `ranges_underreplicated` column shows only zeros.
+    On DC/OS Enterprise clusters with a static master list use the command:
     ```bash
-    sudo /opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/bouncer --host=$(/opt/mesosphere/bin/detect_ip)
-    +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
-    | id |       address       | build  |     updated_at      |     started_at      | replicas_leaders | replicas_leaseholders | ranges | ranges_unavailable | ranges_underreplicated |
-    +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
-    |  1 | 172.31.7.32:26257   | v1.1.4 | 2018-03-08 13:56:10 | 2018-02-28 20:11:00 |              195 |                   194 |    195 |                  0 |                      0 |
-    |  2 | 172.31.10.48:26257  | v1.1.4 | 2018-03-08 13:56:05 | 2018-03-05 13:33:45 |              200 |                   199 |    200 |                  0 |                      0 |
-    |  3 | 172.31.23.132:26257 | v1.1.4 | 2018-03-08 13:56:01 | 2018-02-28 20:18:41 |              187 |                   187 |    187 |                  0 |                      0 |
-    +----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
+    sudo curl --cacert /var/lib/dcos/exhibitor-tls-artifacts/root-cert.pem --cert /var/lib/dcos/exhibitor-tls-artifacts/client-cert.pem --key /var/lib/dcos/exhibitor-tls-artifacts/client-key.pem https://localhost:8181/exhibitor/v1/cluster/status
     ```
-		
-    If the `ranges_underreplicated` column lists any non-zero values, wait a minute and rerun the command. The values will converge to zero after all data is safely replicated.
 
-1.  Go to the DC/OS Agents [procedure](#agents) to complete your installation.
+    On other clusters use the command:
+    ```bash
+    curl http://localhost:8181/exhibitor/v1/cluster/status
+    ```
+
+    Wait until the response shows that all hosts have `"description":"serving"`.
+1.  Wait until the `dcos-mesos-master` unit is up and running.
+1.  Verify that `curl http://localhost:5050/metrics/snapshot` has the metric `registrar/log/recovered` with a value of `1`.
+
+    <p class="message--note"><strong>NOTE: </strong>If you are upgrading from permissive to strict mode, this URL will be <code>curl https://...</code> and you will need a JWT for access. </p>
+    [enterprise type="inline" size="small" /]
+
+1.  Verify that `/opt/mesosphere/bin/mesos-master --version` indicates that the upgraded master is running the version of Mesos specified in the [release notes](/mesosphere/dcos/2.1/release-notes/), for example `1.5.1`.
+
+1.  Verify that the number of under-replicated ranges in CockroachDB has dropped to zero as the IAM database is replicated to the new master. Run the following command and confirm that the `ranges_underreplicated` column shows only zeros.
+```bash
+sudo /opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/bouncer --host=$(/opt/mesosphere/bin/detect_ip)
+```
+```
++----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
+| id |       address       | build  |     updated_at      |     started_at      | replicas_leaders | replicas_leaseholders | ranges | ranges_unavailable | ranges_underreplicated |
++----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
+|  1 | 172.31.7.32:26257   | v1.1.4 | 2018-03-08 13:56:10 | 2018-02-28 20:11:00 |              195 |                   194 |    195 |                  0 |                      0 |
+|  2 | 172.31.10.48:26257  | v1.1.4 | 2018-03-08 13:56:05 | 2018-03-05 13:33:45 |              200 |                   199 |    200 |                  0 |                      0 |
+|  3 | 172.31.23.132:26257 | v1.1.4 | 2018-03-08 13:56:01 | 2018-02-28 20:18:41 |              187 |                   187 |    187 |                  0 |                      0 |
++----+---------------------+--------+---------------------+---------------------+------------------+-----------------------+--------+--------------------+------------------------+
+```
+
+If the `ranges_underreplicated` column lists any non-zero values, wait a minute and rerun the command. The values will converge to zero after all data is safely replicated.
+
+Go to the DC/OS Agents [procedure](#agents) to complete your installation.
 
 ### <a name="agents"></a>DC/OS Agents
 

--- a/pages/mesosphere/dcos/2.1/security/ent/tls-ssl/exhibitor/index.md
+++ b/pages/mesosphere/dcos/2.1/security/ent/tls-ssl/exhibitor/index.md
@@ -9,7 +9,7 @@ enterprise: true
 
 # Verifying that Exhibitor is secured 
 
-Starting with DC/OS 2.0, Exhibitor is secured by default in most circumstances. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
+Starting with DC/OS 2.0, Exhibitor is secured by default in static master clusters. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
 
 
     curl -LI \


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-68867

## Description of changes being made

Provide a way to contact Exhibitor when its endpoint has TLS enabled. https://jira.d2iq.com/browse/D2IQ-67335

Remove restriction on `/tmp` being `noexec`. https://jira.d2iq.com/browse/D2IQ-47741

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
