### PR TITLE
Changed HAProxy to link to custom CA and external certificates

### DIFF
--- a/pages/mesosphere/dcos/1.10/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/mesosphere/dcos/1.10/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -13,7 +13,7 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
-You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.10/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not currently support adding your own certificates directly into Admin Router.
+You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.10/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not support adding a custom external certificate directly into Admin Router, although it is possible to provide a [custom CA certificate](/mesosphere/dcos/1.10/security/ent/tls-ssl/ca-custom/) as the DC/OS CA.
  
 The HTTP Proxy must perform on-the-fly HTTP request and response header modification because DC/OS is not aware of the custom hostname and port that is being used by user agents to address the HTTP proxy.
 

--- a/pages/mesosphere/dcos/1.11/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/mesosphere/dcos/1.11/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
 
-You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.11/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not currently support adding your own certificates directly into Admin Router.
+You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.11/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not support adding a custom external certificate directly into Admin Router, although it is possible to provide a [custom CA certificate](/mesosphere/dcos/1.11/security/ent/tls-ssl/ca-custom/) as the DC/OS CA.
 
 The HTTP Proxy must perform on-the-fly HTTP request and response header modification, because DC/OS is not aware of the custom hostname and port that is being used by user agents to address the HTTP proxy.
 

--- a/pages/mesosphere/dcos/1.12/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/mesosphere/dcos/1.12/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -11,7 +11,7 @@ enterprise: false
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
 
-You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.12/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not currently support adding your own certificates directly into Admin Router.
+You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.12/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not support adding a custom external certificate directly into Admin Router, although it is possible to provide a [custom CA certificate](/mesosphere/dcos/1.12/security/ent/tls-ssl/ca-custom/) as the DC/OS CA.
 
 The HTTP Proxy must perform on-the-fly HTTP request and response header modification, because DC/OS is not aware of the custom hostname and port that is being used by user agents to address the HTTP proxy.
 

--- a/pages/mesosphere/dcos/1.13/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/mesosphere/dcos/1.13/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -12,7 +12,7 @@ enterprise: false
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
 
-You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.13/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not currently support adding your own certificates directly into Admin Router.
+You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/1.13/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not support adding a custom external certificate directly into Admin Router, although it is possible to provide a [custom CA certificate](/mesosphere/dcos/1.13/security/ent/tls-ssl/ca-custom/) as the DC/OS CA.
 
 The HTTP Proxy must perform on-the-fly HTTP request and response header modification, because DC/OS is not aware of the custom hostname and port that is being used by user agents to address the HTTP proxy.
 

--- a/pages/mesosphere/dcos/2.0/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/mesosphere/dcos/2.0/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -12,7 +12,7 @@ enterprise: false
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
 
-You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/2.0/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not currently support adding your own certificates directly into Admin Router.
+You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/2.0/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not support adding a custom external certificate directly into Admin Router, although it is possible to provide a [custom CA certificate](/mesosphere/dcos/2.0/security/ent/tls-ssl/ca-custom/) as the DC/OS CA.
 
 The HTTP Proxy must perform on-the-fly HTTP request and response header modification, because DC/OS is not aware of the custom hostname and port that is being used by user agents to address the HTTP proxy.
 

--- a/pages/mesosphere/dcos/2.1/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/mesosphere/dcos/2.1/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -12,7 +12,7 @@ enterprise: false
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
 
-You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/2.1/overview/architecture/components/#admin-router). For example, this can be useful if you want to present a custom server certificate to user agents connecting to the cluster via HTTPS. DC/OS does not currently support adding your own certificates directly into Admin Router.
+You can use HAProxy to set up an HTTP proxy in front of the DC/OS [Admin Router](/mesosphere/dcos/2.1/overview/architecture/components/#admin-router). This was previously useful to allow Admin Router to present a custom server certificate to user agents connecting to the cluster via HTTPS. From DC/OS 2.1 this can be achieved more directly using [custom external certificates](/mesosphere/dcos/2.1/security/ent/tls-ssl/ar-custom/).
 
 The HTTP Proxy must perform on-the-fly HTTP request and response header modification, because DC/OS is not aware of the custom hostname and port that is being used by user agents to address the HTTP proxy.
 


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-68894

## Description of changes being made

For 2.0 and earlier, link to custom CA certificates as an alternative approach for HAProxy.

For 2.1, link to custom external certificates as a better approach.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
