### PR TITLE
Remove steps related to manual provisioning of root certificate for attached clusters

### DIFF
--- a/pages/ksphere/kommander/1.1.0-beta/clusters/attach-cluster/index.md
+++ b/pages/ksphere/kommander/1.1.0-beta/clusters/attach-cluster/index.md
@@ -95,45 +95,4 @@ Selecting the **Attach Cluster** option displays the **Connection Information** 
 
 ## Accessing your managed clusters using your Kommander administrator credentials
 
-To enable Single Sign-On (SSO), for accessing the Kubernetes API across connected clusters with Kommander administrator credentials, a Certificate Authority (CA) must be created as a secret first. The following script creates a CA including the CA certificate and a private key. The `kubectl` command then creates this CA, using the current context, under the name `kubernetes-root-ca` into the namespace `cert-manager` which is created if it does not already exist.
-
-```bash
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-KEY_SIZE=4096
-PRIV_KEY_FILE=root-ca-private-key.pem
-CA_CERT_FILE=root-ca-certificate.pem
-
-case "$(uname -s)" in
-  Linux*)  base64Options="-w0";;
-  Darwin*) base64Options="-b 0";;
-esac
-echo ${base64Options}
-
-if [ ! -f $PRIV_KEY_FILE ]; then
-    openssl genrsa -out $PRIV_KEY_FILE $KEY_SIZE
-fi
-
-if [ ! -f $CA_CERT_FILE ]; then
-    openssl req -x509 -new -nodes -key $PRIV_KEY_FILE -sha256 -days 1825 -out $CA_CERT_FILE
-fi
-
-kubectl create namespace cert-manager || true
-
-cat <<EOF | kubectl apply -f -
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubernetes-root-ca
-  namespace: cert-manager
-type: kubernetes.io/tls
-data:
-  tls.crt: $(base64 ${base64Options} < ${CA_CERT_FILE})
-  tls.key: $(base64 ${base64Options} < ${PRIV_KEY_FILE})
-EOF
-```
-
-After the CA secret has been created successfully, a custom kubeconfig can be retrieved by visiting the `/token` endpoint on the Kommander cluster domain. Selecting the attached cluster name displays the instructions to assemble a kubeconfig for accessing its Kubernetes API.
+After the cluster has been attached successfully, a custom kubeconfig can be retrieved by visiting the `/token` endpoint on the Kommander cluster domain. Selecting the attached cluster name displays the instructions to assemble a kubeconfig for accessing its Kubernetes API.


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-65608 `Remove unnecessary steps from "attach cluster" documentation.`

## Description of changes being made

The part that is being removed has been automated via https://jira.d2iq.com/browse/D2IQ-65077 and will be available in the next version of Kommander (1.1).

PR can be merged imediatelly, the change is already merged.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
