### PR TITLE
konvoy: Update docs for konvoy release v1.4.4

### DIFF
--- a/pages/ksphere/konvoy/1.4/install/install-airgapped/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-airgapped/index.md
@@ -16,10 +16,10 @@ The topics in this section guide you through the basic steps to prepare your env
 
 Before installing, verify that your environment meets the following basic requirements:
 
-* [Docker Desktop][install_docker] version 18.09.2 or later
+* [Docker][install_docker] version 18.09.2 or later
 
-  You must have Docker Desktop installed on the host where the Konvoy command line interface (CLI) will run.
-  For example, if you are installing Konvoy on your laptop, be sure the laptop has a supported version of Docker Desktop.
+  You must have Docker installed on the host where the Konvoy command line interface (CLI) will run.
+  For example, if you are installing Konvoy on your laptop, be sure the laptop has a supported version of Docker.
 
 * [kubectl][install_kubectl] v1.16.9 or later
 
@@ -334,20 +334,20 @@ spec:
   - configRepository: /opt/konvoy/artifacts/kubernetes-base-addons
     configVersion: stable-1.16-1.2.0
     helmRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.4.3
+      image: mesosphere/konvoy-addons-chart-repo:v1.4.4
     addonsList:
     ...
   - configRepository: /opt/konvoy/artifacts/kubeaddons-dispatch
     configVersion: stable-1.16-1.0.0
     helmRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.4.3
+      image: mesosphere/konvoy-addons-chart-repo:v1.4.4
     addonsList:
     - name: dispatch # Dispatch is currently in Beta
       enabled: false
   - configRepository: /opt/konvoy/artifacts/kubeaddons-kommander
     configVersion: stable-1.16-1.0.1
     helmRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.4.3
+      image: mesosphere/konvoy-addons-chart-repo:v1.4.4
     addonsList:
     - name: kommander
       enabled: false
@@ -539,7 +539,7 @@ When the `konvoy up` completes its setup operations, the following files are gen
 
 [kubectl]: ../../operations/accessing-the-cluster#using-kubectl
 [kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-[install_docker]: https://www.docker.com/products/docker-desktop
+[install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [ansible]: https://www.ansible.com
 [persistent_volume]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/

--- a/pages/ksphere/konvoy/1.4/install/install-aws/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-aws/index.md
@@ -14,7 +14,7 @@ This section guides you through the basic steps to prepare your environment and 
 ## Prerequisites
 
 * The [aws][install_aws] command line utility
-* [Docker Desktop][install_docker] _version 18.09.2 or newer_
+* [Docker][install_docker] _version 18.09.2 or newer_
 * [kubectl][install_kubectl] _v1.16.9 or newer_ (for interacting with the running cluster)
 * A valid AWS account with [credentials configured][aws_credentials].
   You must be authorized to create the following resources in the AWS account:
@@ -249,7 +249,7 @@ When the `konvoy up` completes its setup operations, the following files are gen
 
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 [install_aws]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
-[install_docker]: https://www.docker.com/products/docker-desktop
+[install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [prerequisites]: #prerequisites
 [cluster_configuration]: ../../reference/cluster-configuration

--- a/pages/ksphere/konvoy/1.4/install/install-azure/advanced-provisioning/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-azure/advanced-provisioning/index.md
@@ -14,7 +14,7 @@ The topics in this section describe advanced provisioning and configuration opti
 # Customize region and availability zones
 
 Konvoy supports provisioning hosts across fault and update domains in an Azure location.
-For instance, the following configuration will instruct Konvoy to provision hosts across the three fault and update domains in `westus` location.
+For instance, the following configuration will instruct Konvoy to provision hosts across the three fault and update domains in `eastus2` location.
 
 ```yaml
 kind: ClusterProvisioner
@@ -24,7 +24,7 @@ metadata:
 spec:
   provider: azure
   azure:
-    location: westus
+    location: eastus2
     availabilitySet:
       faultDomainCount: 3
       updateDomainCount: 3
@@ -42,7 +42,7 @@ metadata:
 spec:
   provider: azure
   azure:
-    location: westus
+    location: eastus2
     availabilitySet:
       faultDomainCount: 3
       updateDomainCount: 3
@@ -162,7 +162,7 @@ metadata:
 spec:
   provider: azure
   azure:
-    location: westus
+    location: eastus2
     vnet:
       name: existing-vnet
       resourceGroup: existing-resource-group
@@ -185,7 +185,7 @@ metadata:
 spec:
   provider: azure
   azure:
-    location: westus
+    location: eastus2
     vnet:
       name: existing-vnet
       resourceGroup: existing-resource-group
@@ -234,7 +234,7 @@ apiVersion: konvoy.mesosphere.io/v1beta1
 spec:
   provider: azure
   azure:
-    location: westus
+    location: eastus2
     vnet:
       name: existing-vnet
       resourceGroup: existing-resource-group

--- a/pages/ksphere/konvoy/1.4/install/install-azure/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-azure/index.md
@@ -14,7 +14,7 @@ This section guides you through the basic steps to prepare your environment and 
 ## Prerequisites
 
 * The [azure][install_az] command line utility
-* [Docker Desktop][install_docker] _version 18.09.2 or newer_
+* [Docker][install_docker] _version 18.09.2 or newer_
 * [kubectl][install_kubectl] _v1.16.9 or newer_ (for interacting with the running cluster)
 * A valid Azure account with [credentials configured][az_login].
   You need to be authorized as a `Contributor` in your Azure account and need the be able to assign roles to a user.
@@ -144,7 +144,7 @@ When the `konvoy up` completes its setup operations, the following files are gen
 
 [az_login]: https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest
 [install_az]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
-[install_docker]: https://www.docker.com/products/docker-desktop
+[install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [prerequisites]: #prerequisites
 [cluster_configuration]: ../../reference/cluster-configuration/

--- a/pages/ksphere/konvoy/1.4/install/install-dev/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-dev/index.md
@@ -16,7 +16,7 @@ This is very useful for development and end-to-end testing with Konvoy.
 
 Before starting the development machine installation, you should verify the following:
 
-* [Docker Desktop][install_docker] version 18.09.2 or later
+* [Docker][install_docker] version 18.09.2 or later
 * [kubectl][install_kubectl] v1.16.9 or later (for interacting with the running cluster)
 * Docker is configured with the following minimum requirements for CPU, memory, and disk:
   * 4 CPUs
@@ -159,5 +159,5 @@ docker exec -ti konvoy-control-plane-0 /bin/bash
 [pv]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 [terraform_docker]: https://www.terraform.io/docs/providers/docker/index.html
 [ops_portal]: ../../operations/accessing-the-cluster/
-[install_docker]: https://www.docker.com/products/docker-desktop
+[install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/pages/ksphere/konvoy/1.4/install/install-onprem/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-onprem/index.md
@@ -15,7 +15,7 @@ The topics in this section guide you through the basic steps to prepare your env
 
 Before installing, verify that your environment meets the following basic requirements:
 
-* [Docker Desktop][install_docker] version 18.09.2 or later. You must have Docker Desktop installed on the host where the Konvoy command line interface (CLI) will run. For example, if you are installing Konvoy on your laptop computer, be sure the laptop has a supported version of Docker Desktop.
+* [Docker][install_docker] version 18.09.2 or later. You must have Docker installed on the host where the Konvoy command line interface (CLI) will run. For example, if you are installing Konvoy on your laptop computer, be sure the laptop has a supported version of Docker.
 
 * [kubectl][install_kubectl] v1.16.9 or later. You must have `kubectl` installed on the host, where the Konvoy command line interface (CLI) runs, to enable interaction with the running cluster.
 
@@ -588,7 +588,7 @@ When the `konvoy up` completes its setup operations, the following files are gen
 
 [kubectl]: ../../operations/accessing-the-cluster#using-kubectl
 [kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-[install_docker]: https://www.docker.com/products/docker-desktop
+[install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [ansible]: https://www.ansible.com
 [persistent_volume]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/

--- a/pages/ksphere/konvoy/1.4/install/install-secured/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-secured/index.md
@@ -13,7 +13,7 @@ enterprise: false
 
 Before installing, ensure that your environment has the following basic requirements:
 
-* [Docker Desktop][install_docker] version 18.09.2 or later
+* [Docker][install_docker] version 18.09.2 or later
 
   You must have Docker Desktop installed on the host where the Konvoy command line interface (CLI) will run.
   For example, if you are installing Konvoy on your laptop, be sure the laptop has a supported version of Docker Desktop.
@@ -78,7 +78,7 @@ spec:
 
 [kubectl]: ../../operations/accessing-the-cluster#using-kubectl
 [kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-[install_docker]: https://www.docker.com/products/docker-desktop
+[install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [ansible]: https://www.ansible.com
 [persistent_volume]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/

--- a/pages/ksphere/konvoy/1.4/install/install-secured/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-secured/index.md
@@ -1,0 +1,116 @@
+---
+layout: layout.pug
+navigationTitle: Install on secured machines
+title: Install on secured machines
+menuWeight: 37
+excerpt: Install on secured machines
+enterprise: false
+---
+
+<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
+
+# Before you begin
+
+Before installing, ensure that your environment has the following basic requirements:
+
+* [Docker Desktop][install_docker] version 18.09.2 or later
+
+  You must have Docker Desktop installed on the host where the Konvoy command line interface (CLI) will run.
+  For example, if you are installing Konvoy on your laptop, be sure the laptop has a supported version of Docker Desktop.
+
+* [kubectl][install_kubectl] v1.16.9 or later
+
+  To enable interaction with the running cluster, you must have `kubectl` installed on the host where the Konvoy command line interface (CLI) will run.
+
+* The `konvoy_air_gapped.tar.bz2` that contains the required artifacts to perform an air-gapped installation.
+
+## Control plane nodes
+
+* You should have at least three control plane nodes.
+
+* Each control plane node should have at least:
+  * 4 cores
+  * 16 GiB memory
+  * 80 GiB of free space in the root partition, and the root partition must be less than 85% full.
+
+## Worker nodes
+
+* You should have at least four worker nodes.
+
+  The specific number of worker nodes required for your environment varies depending on the cluster workload and size of the nodes.
+
+* Each worker node should have at least:
+  * 8 cores
+  * 32 GiB memory
+  * 80 GiB of free space in the root partition and the root partition must be less than 85% full.
+
+* If you plan to use **local volume provisioning** to provide [persistent volumes][persistent_volume] for the workloads, you must mount at least three volumes to `/mnt/disks/` mount point on each node.
+  Each volume must have **at least** 55 GiB of capacity if the default addon configurations are used.
+
+## Operating system and services for all nodes
+
+For all hosts that are part of the cluster -- except the **deploy host** -- you should verify the following configuration requirements:
+
+* Firewalld is disabled.
+* Containerd is uninstalled.
+* Docker-ce is uninstalled.
+* Swap is disabled.
+
+## Installation
+
+On highly secured clusters you may need to modify the `cluster.yaml` file with additional options.
+See the sample file below for possible changes that may be applied in your cluster.
+
+## Kubernetes CVE Patches
+
+At times, CVEs may be discovered in the Kubernetes codebase. Based on the severity and the impact of a specific CVE, you may want to temporarily use alternative docker images for the core Kubernetes components instead of the default `k8s.gcr.io` repository.
+To do so, set the `version` and `imageRepository` as describe below.
+The repository `docker.io/mesosphere` will contain patched images with a suffix of `+d2iq.1`, `+d2iq.2`, etc.
+
+```yaml
+kind: ClusterConfiguration
+apiVersion: konvoy.mesosphere.io/v1beta1
+spec:
+  kubernetes:
+    version: 1.16.9+d2iq.2
+    imageRepository: docker.io/mesosphere
+```
+
+[kubectl]: ../../operations/accessing-the-cluster#using-kubectl
+[kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+[install_docker]: https://www.docker.com/products/docker-desktop
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[ansible]: https://www.ansible.com
+[persistent_volume]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+[ansible_inventory]: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
+[ansible_group]: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#inventory-basics-hosts-and-groups
+[keepalived]: https://www.keepalived.org/
+[vrrp]: https://en.wikipedia.org/wiki/Virtual_Router_Redundancy_Protocol
+[kubernetes_service]: https://kubernetes.io/docs/concepts/services-networking/service/
+[metallb]: https://metallb.universe.tf
+[ops_portal]: ../../operations/accessing-the-cluster#using-the-operations-portal
+[local_persistent_volume]: https://kubernetes.io/docs/concepts/storage/volumes/#local
+[static_pv_provisioner]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
+[static_pv_provisioner_operations]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/master/docs/operations.md
+[calico]: https://www.projectcalico.org/
+[coredns]: https://coredns.io/
+[aws_ebs_csi]: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
+[elasticsearch]: https://www.elastic.co/products/elastic-stack
+[elasticsearch_exporter]: https://www.elastic.co/guide/en/elasticsearch/reference/7.2/es-monitoring-exporters.html
+[helm]: https://helm.sh/
+[kibana]: https://www.elastic.co/products/kibana
+[fluentbit]: https://fluentbit.io/
+[prometheus_operator]: https://prometheus.io/
+[grafana]: https://grafana.com/
+[prometheus_adapter]: https://github.com/DirectXMan12/k8s-prometheus-adapter
+[traefik]: https://traefik.io/
+[osi]: https://en.wikipedia.org/wiki/OSI_model
+[kubernetes_dashboard]: https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/
+[velero]: https://velero.io/
+[dex]: https://github.com/dexidp/dex
+[dex_k8s_authenticator]: https://github.com/mesosphere/dex-k8s-authenticator
+[traefik_foward_auth]: https://github.com/thomseddon/traefik-forward-auth
+[static_lvp]: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
+[selinux-rpm]: http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-3.el7.noarch.rpm
+[containerd_mirrors]: https://github.com/containerd/cri/blob/master/docs/registry.md#configure-registry-endpoint
+[ubi_image]: https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image

--- a/pages/ksphere/konvoy/1.4/operations/managing-nodes/index.md
+++ b/pages/ksphere/konvoy/1.4/operations/managing-nodes/index.md
@@ -17,7 +17,7 @@ enterprise: false
 If your cluster was provisioned manually, please follow the steps in <a href="#adding-nodes-to-an-on-premise-cluster">Adding Nodes to an On-Premise Cluster</a>.</p>
 
 <p class="message--note"><strong>NOTE: </strong> This process should only be applied to healthy clusters.
-If you are attempting to recover from a node failure, please see <a href="../../troubleshooting/replace-a-failed-node">Recovering from Node Failure</a> instead.</p>
+If you are attempting to recover from a node failure, please see <a href="../troubleshooting/replace-a-failed-node">Recovering from Node Failure</a> instead.</p>
 
 After the initial provisioning of a cluster, the same `konvoy` tools can be used to add nodes.
 

--- a/pages/ksphere/konvoy/1.4/quick-start/index.md
+++ b/pages/ksphere/konvoy/1.4/quick-start/index.md
@@ -24,7 +24,7 @@ Before starting the Konvoy installation, you should verify the following:
 
 -   You have a Linux or MacOS computer with a supported version of the operating system.
 -   You have the [aws][install_aws] command-line utility if you are installing on an AWS cloud instance.
--   You have [Docker Desktop][install_docker] version 18.09.2 or later.
+-   You have [Docker][install_docker] version 18.09.2 or later.
 -   You have [kubectl][install_kubectl] v1.16.9 or later for interacting with the running cluster.
 -   You have a valid AWS account with [credentials configured][aws_credentials].
     You must be authorized to create the following resources in the AWS account:
@@ -50,7 +50,7 @@ Before starting the Konvoy installation, you should verify the following:
 1.  Check the Kubernetes client version. Many important Kubernetes functions **do not work** if your client is outdated. You can verify that the version of `kubectl` you have installed is supported by running the following command:
 
     ```bash
-    kubectl version --short=true`
+    kubectl version --short=true
     ```
 
 1.  Download and extract the Konvoy package. You will need to download and extract the Konvoy package tarball. There are a couple of ways to get the tarball:
@@ -210,7 +210,7 @@ For more details, see the following topics:
 - [Troubleshooting](../troubleshooting/)
 
 [cncf]: https://www.cncf.io
-[install_docker]: https://www.docker.com/products/docker-desktop
+[install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 [install_aws]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html

--- a/pages/ksphere/konvoy/1.4/reference/cluster-configuration/index.md
+++ b/pages/ksphere/konvoy/1.4/reference/cluster-configuration/index.md
@@ -256,7 +256,7 @@ spec:
 
 | Parameter               | Description                                                                      | Default               |
 | ----------------------- | -------------------------------------------------------------------------------- | --------------------- |
-| `azure.location`            | [Azure location][azure_location] where your cluster is hosted                            |  `westus`          |
+| `azure.location`            | [Azure location][azure_location] where your cluster is hosted                            |  `eastus2`          |
 | `azure.availabilitySet` | [Azure availability sets][availability_set] Availability set define grouping capability for isolating VMs from each other     | `N/A`        |
 | `azure.tags`              | Additional [Azure tags][azure_tags] for the resources provisioned through the Konvoy CLI | `[owner: <username>]` |
 | `aws.vnet`               | [Azure VNET][azure_vnet] to use when deploying a cluster                   | N/A                   |  
@@ -367,6 +367,7 @@ The default value of this entire object is `omitted`.
 | Parameter                      | Description                                                 | Default                 |
 | ------------------------------ | ----------------------------------------------------------- | ----------------------- |
 | `kubernetes.version`           | Specifies the version of Kubernetes to deploy.  | `1.16.9`                |
+| `imageRepository`              | The imageRepository to pull the control-plane images from. | `k8s.gcr.io`) |
 | `kubernetes.controlPlane`      | Specifies the object that defines control plane configuration.       | See [spec.kubernetes.controlPlane](#speckubernetescontrolplane) |
 | `kubernetes.networking`        | Specifies the object that defines cluster networking.          | See [spec.kubernetes.networking](#speckubernetesnetworking) |
 | `kubernetes.cloudProvider`     | Specifies the object that defines which cloud-provider to enable.    | See [spec.kubernetes.clouldProvider](#speckubernetescloudprovider)  |

--- a/pages/ksphere/konvoy/1.4/release-notes/index.md
+++ b/pages/ksphere/konvoy/1.4/release-notes/index.md
@@ -15,6 +15,28 @@ enterprise: false
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. For new customers, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download Konvoy.</p>
 
+### Version v1.4.4 - Released 28 May 2020
+
+| Kubernetes Support | Version |
+| ------------------ | ------- |
+|**Minimum** | 1.15.4 |
+|**Maximum** | 1.16.x |
+|**Default** | 1.16.9 |
+
+#### Improvements
+
+-   Change the default Azure region for new clusters to `eastus2` to improve stability.
+-   New `cluster.yaml` option `spec.kubernetes.imageRepository` to allow for pulling control-plane images from an alternative repository instead of the default `k8s.gcr.io`.
+
+    ```text
+    kind: ClusterConfiguration
+    apiVersion: konvoy.mesosphere.io/v1beta1
+    spec:
+      kubernetes:
+        version: 1.16.9+d2iq.2
+        imageRepository: docker.io/mesosphere
+    ```
+
 ### Version v1.4.3 - Released 12 May 2020
 
 | Kubernetes Support | Version |


### PR DESCRIPTION
Minor docs for `v1.4.4`.
Majority of the install-secured doc was a copy paste of what was there already.