### PR TITLE
Skip indexing kubeflow on master (temporary)

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,9 @@
       "mesosphere/dcos/1.14/**",
       "ksphere/dispatch/1.2/**"
     ],
-    "DO_NOT_INDEX": []
+    "DO_NOT_INDEX": [
+      "kubeflow"
+    ]
   },
   "staging": {
     "DO_NOT_BUILD": [


### PR DESCRIPTION
Since kubeflow will be a new product, we need to update algolia and a few places in code to begin indexing. 

This change skips algolia indexing on kubeflow for the time being until we make those changes.