### PR TITLE
Fix seccomp for 1.13

### DIFF
--- a/pages/mesosphere/dcos/1.13/security/oss/secure-compute-profiles/index.md
+++ b/pages/mesosphere/dcos/1.13/security/oss/secure-compute-profiles/index.md
@@ -14,7 +14,7 @@ Secure computing mode (seccomp) is a Linux kernel feature used to restrict the a
 Seccomp support in DC/OS is based on Mesos 1.8 which [introduces the ability to configure seccomp](http://mesos.apache.org/documentation/latest/isolators/linux-seccomp/) through the UCR containerizer to provide a higher degree of isolation and security to services deployed on DC/OS. The default seccomp profile within DC/OS provides a reasonable default for running containers by disabling more than 300 system calls.
 
 # Enabling and disabling secure computing mode
-By default, DC/OS is installed with secure computing mode enabled. You can opt-out of using seccomp by installing DC/OS with `mesos_seccomp_enabled=false`. Before opting out, however, keep in mind that it is important for the installation of each agent to be consistent with every other agent in the cluster. Deviating from this strategy should only be done by advanced users.
+By default, DC/OS is installed with secure computing mode disabled. You can opt-in of using seccomp by installing DC/OS with `mesos_seccomp_enabled=true`. Before opting in, however, keep in mind that it is important for the installation of each agent to be consistent with every other agent in the cluster. Deviating from this strategy should only be done by advanced users.
 
 If you enable seccomp for a DC/OS cluster, all tasks start under seccomp control using the default seccomp profile unless you explicitly configure tasks to override the default behavior.
 


### PR DESCRIPTION
Seccomp is disabled by default in DC/OS 1.13.x

## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
