### PR TITLE
Fix: Kommander installation example nit removal.

### DIFF
--- a/pages/ksphere/kommander/1.0/install/index.md
+++ b/pages/ksphere/kommander/1.0/install/index.md
@@ -30,7 +30,7 @@ Copy the Konvoy package files to a directory in your user's `PATH` to ensure you
 For example, copy the package to `/usr/local/bin/` by returning to the directory that Kommander was extracted to, and running the following command:
 
 ```
-sudo cp ~/Downloads/darwin/konvoy-kommander.tar.bz2/* /usr/local/bin/
+sudo cp ~/Downloads/darwin/konvoy-kommander/* /usr/local/bin/
 ```
 
 <p class="message--note"><strong>NOTE:</strong> The extracted folder may have a different name (such as `konvoy_dev`, or perhaps it was given a custom directory, or have the version affixed to the end of the directory name).</p>

--- a/pages/ksphere/kommander/1.1.0-beta/install/index.md
+++ b/pages/ksphere/kommander/1.1.0-beta/install/index.md
@@ -30,7 +30,7 @@ Copy the Konvoy package files to a directory in your user's `PATH` to ensure you
 For example, copy the package to `/usr/local/bin/` by returning to the directory that Kommander was extracted to, and running the following command:
 
 ```
-sudo cp ~/Downloads/darwin/konvoy-kommander.tar.bz2/* /usr/local/bin/
+sudo cp ~/Downloads/darwin/konvoy-kommander/* /usr/local/bin/
 ```
 
 <p class="message--note"><strong>NOTE:</strong> The extracted folder may have a different name (such as `konvoy_dev`, or perhaps it was given a custom directory, or have the version affixed to the end of the directory name).</p>


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
The install page was suggesting that a folder, when having been extracted from an archive was completely named like the tarball -- but commonly "tar" and "gz"/"bz2"/... are removed.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
