### PR TITLE
just one more img

### DIFF
--- a/pages/ksphere/kommander/1.1.0-beta/clusters/index.md
+++ b/pages/ksphere/kommander/1.1.0-beta/clusters/index.md
@@ -61,7 +61,7 @@ Select an available desired version from the Version dropdown and confirm your a
 
 ## Editing Clusters
 
-![Edit a Cluster Action](/ksphere/kommander/1.1.0beta/img/edit-cluster-action.png)
+![Edit a Cluster Action](/ksphere/kommander/1.1.0-beta/img/edit-cluster-action.png)
 
 ### Editing an Attached cluster
 


### PR DESCRIPTION
## N/A
This just came up when I ran 'npm run dev' - just one more broken img tag.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
Broken img tag got fixed - works local now

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
