### PR TITLE
Build DCOS 2.1 docs when branch is `kommander` or `dispatch`.

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,7 +34,7 @@
       "mesosphere/dcos/1.11/**",
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2.1/**"
+      "mesosphere/dcos/2.0/**"
     ],
     "DO_NOT_INDEX": []
   },
@@ -47,7 +47,7 @@
       "mesosphere/dcos/1.11/**",
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2.1/**"
+      "mesosphere/dcos/2.0/**"
     ],
     "DO_NOT_INDEX": []
   },


### PR DESCRIPTION
The latest DCOS docs has been pointed to 2.1, and is required to build kommander or dispatch docs. This patch adjusts the `DO_NOT_BUILD` list accordingly.

## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
