### PR TITLE
Update redirects-307.map

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -1,4 +1,4 @@
-~^/mesosphere/dcos/latest/(.*)$ /mesosphere/dcos/2.1.0/$1;
+~^/mesosphere/dcos/latest/(.*)$ /mesosphere/dcos/2.1/$1;
 ~^/ksphere/konvoy/latest/(.*)$ /ksphere/konvoy/1.4/$1;
 ~^/ksphere/dispatch/latest/(.*)$ /ksphere/dispatch/1.2/$1;
 ~^/ksphere/kommander/latest/(.*)$ /ksphere/kommander/1.0/$1;


### PR DESCRIPTION
Rishabh noticed that the links ("start tutorial") on https://dcos.io/learning/ appear to be broken.


```
button
https://docs.d2iq.com/mesosphere/dcos/latest/tutorials/dcos-101/

broken redirect
https://docs.d2iq.com/mesosphere/dcos/2.1.0/tutorials/dcos-101/

actual URL
https://docs.d2iq.com/mesosphere/dcos/2.1/tutorials/dcos-101/
```

not 100% sure whether the proposed changes are a proper fix, as the opposite change (from `2.1` to `2.1.0`) seems to be intended: https://github.com/mesosphere/dcos-docs-site/commit/b8315f86f96fc081de460071cb75cfb5162534a2#diff-ffadabb9049686535404014ce18e6a3b 

although the [history](https://github.com/mesosphere/dcos-docs-site/commits/staging/docker/nginx/redirects-307.map) suggests that the redirect always was in a `X.Y` format before and never included the patch-version...