### PR TITLE
COPS-4997 - fix incorrect script path

### DIFF
--- a/pages/mesosphere/dcos/1.10/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/1.10/tutorials/autoscaling/cpu-memory/index.md
@@ -12,11 +12,11 @@ enterprise: false
 
 
 
-A Python service, `marathon-autoscale.py`, autoscales your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
+A Python service, `marathon-autoscaler.py`, autoscales your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscaler.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
 <table class="table" bgcolor="#FAFAFA"> <tr> <td style="border-left: thin solid; border-top: thin solid; border-bottom: thin solid;border-right: thin solid;"><b>Important:</b> Mesosphere does not support this tutorial, associated scripts, or commands, which are provided without warranty of any kind. The purpose of this tutorial is to demonstrate capabilities, and may not be suited for use in a production environment. Before using a similar solution in your environment, you must adapt, validate, and test.</td> </tr> </table>
 
-Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.
+Periodically, `marathon-autoscaler.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscaler.py` will increase the number of tasks for your Marathon service.
 
 **Prerequisites**
 
@@ -29,9 +29,9 @@ Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory 
 
 # Install the Autoscale App on a Node
 
-SSH to the system where you will run `marathon-autoscale.py` and install it.
+SSH to the system where you will run `marathon-autoscaler.py` and install it.
 
-1.  SSH to the node where you will run `marathon-autoscale.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
+1.  SSH to the node where you will run `marathon-autoscaler.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -56,7 +56,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 1.  Enter this command to run the application:
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     You will be prompted for the following parameters:

--- a/pages/mesosphere/dcos/1.11/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/1.11/tutorials/autoscaling/cpu-memory/index.md
@@ -13,9 +13,9 @@ enterprise: false
 <p class="message--important"><strong>IMPORTANT: </strong>Autoscaling works <strong>only</strong> for DC/OS Open Source or for DC/OS Enterprise in security modes other than "disabled".</p>
 
 
-You can use a Python service, `marathon-autoscale.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
+You can use a Python service, `marathon-autoscaler.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscaler.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
-Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.
+Periodically, `marathon-autoscaler.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscaler.py` will increase the number of tasks for your Marathon service.
 
 **Prerequisites**
 
@@ -28,9 +28,9 @@ Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory 
 
 # Install the Marathon Autoscale app on a node
 
-SSH to the system where you will run `marathon-autoscale.py` and install it.
+SSH to the system where you will run `marathon-autoscaler.py` and install it.
 
-1.  SSH to the node where you will run `marathon-autoscale.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
+1.  SSH to the node where you will run `marathon-autoscaler.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -55,7 +55,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 1.  Enter this command to run the application:
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     You will be prompted for the following parameters:

--- a/pages/mesosphere/dcos/1.12/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/1.12/tutorials/autoscaling/cpu-memory/index.md
@@ -13,9 +13,9 @@ enterprise: false
 #include /mesosphere/dcos/include/tutorial-disclaimer.tmpl
 
 
-You can use a Python service, `marathon-autoscale.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
+You can use a Python service, `marathon-autoscaler.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscaler.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
-Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.
+Periodically, `marathon-autoscaler.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscaler.py` will increase the number of tasks for your Marathon service.
 
 **Prerequisites**
 
@@ -28,9 +28,9 @@ Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory 
 
 # Install the Marathon Autoscale app on a node
 
-SSH to the system where you will run `marathon-autoscale.py` and install it.
+SSH to the system where you will run `marathon-autoscaler.py` and install it.
 
-1.  SSH to the node where you will run `marathon-autoscale.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
+1.  SSH to the node where you will run `marathon-autoscaler.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -55,7 +55,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 1.  Enter this command to run the application:
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     You will be prompted for the following parameters:

--- a/pages/mesosphere/dcos/1.13/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/1.13/tutorials/autoscaling/cpu-memory/index.md
@@ -13,9 +13,9 @@ enterprise: false
 #include /mesosphere/dcos/include/tutorial-disclaimer.tmpl
 
 
-You can use a Python service, `marathon-autoscale.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
+You can use a Python service, `marathon-autoscaler.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscaler.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
-Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.
+Periodically, `marathon-autoscaler.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscaler.py` will increase the number of tasks for your Marathon service.
 
 **Prerequisites**
 
@@ -28,9 +28,9 @@ Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory 
 
 # Install the Marathon Autoscale app on a node
 
-SSH to the system where you will run `marathon-autoscale.py` and install it.
+SSH to the system where you will run `marathon-autoscaler.py` and install it.
 
-1.  SSH to the node where you will run `marathon-autoscale.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
+1.  SSH to the node where you will run `marathon-autoscaler.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -55,7 +55,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 1.  Enter this command to run the application:
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     You will be prompted for the following parameters:

--- a/pages/mesosphere/dcos/1.9/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/1.9/tutorials/autoscaling/cpu-memory/index.md
@@ -13,11 +13,11 @@ enterprise: false
 <!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
 
 
-A Python service, `marathon-autoscale.py`, autoscales your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
+A Python service, `marathon-autoscaler.py`, autoscales your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscaler.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
 <table class="table" bgcolor="#FAFAFA"> <tr> <td style="border-left: thin solid; border-top: thin solid; border-bottom: thin solid;border-right: thin solid;"><b>Important:</b> Mesosphere does not support this tutorial, associated scripts, or commands, which are provided without warranty of any kind. The purpose of this tutorial is to demonstrate capabilities, and may not be suited for use in a production environment. Before using a similar solution in your environment, you must adapt, validate, and test.</td> </tr> </table>
 
-Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.
+Periodically, `marathon-autoscaler.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscaler.py` will increase the number of tasks for your Marathon service.
 
 **Prerequisites**
 
@@ -30,9 +30,9 @@ Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory 
 
 # Install the Autoscale App on a Node
 
-SSH to the system where you will run `marathon-autoscale.py` and install it.
+SSH to the system where you will run `marathon-autoscaler.py` and install it.
 
-1.  SSH to the node where you will run `marathon-autoscale.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
+1.  SSH to the node where you will run `marathon-autoscaler.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
     
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -57,7 +57,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 1.  Enter this command to run the application:
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     You will be prompted for the following parameters:

--- a/pages/mesosphere/dcos/2.0/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/2.0/tutorials/autoscaling/cpu-memory/index.md
@@ -14,9 +14,9 @@ enterprise: false
 #include /mesosphere/dcos/include/tutorial-disclaimer.tmpl
 
 
-You can use a Python service, `marathon-autoscale.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
+You can use a Python service, `marathon-autoscaler.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscaler.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
-Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.
+Periodically, `marathon-autoscaler.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscaler.py` will increase the number of tasks for your Marathon service.
 
 **Prerequisites**
 
@@ -29,9 +29,9 @@ Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory 
 
 # Install the Marathon Autoscale app on a node
 
-SSH to the system where you will run `marathon-autoscale.py` and install it.
+SSH to the system where you will run `marathon-autoscaler.py` and install it.
 
-1.  SSH to the node where you will run `marathon-autoscale.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
+1.  SSH to the node where you will run `marathon-autoscaler.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -56,7 +56,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 1.  Enter this command to run the application:
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     You will be prompted for the following parameters:

--- a/pages/mesosphere/dcos/2.1/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/2.1/tutorials/autoscaling/cpu-memory/index.md
@@ -14,9 +14,9 @@ enterprise: false
 #include /mesosphere/dcos/include/tutorial-disclaimer.tmpl
 
 
-You can use a Python service, `marathon-autoscale.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscale.py` is intended to demonstrate what is possible when you run your services on DC/OS.
+You can use a Python service, `marathon-autoscaler.py`, to autoscale your Marathon application based on the utilization metrics which Mesos reports. You can run this service from within your DC/OS cluster. `marathon-autoscaler.py` is intended to demonstrate what is possible when you run your services on DC/OS.
 
-Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscale.py` will increase the number of tasks for your Marathon service.
+Periodically, `marathon-autoscaler.py` will monitor the aggregate CPU and memory utilization for all tasks that make up the specified Marathon service. When your threshold is hit, `marathon-autoscaler.py` will increase the number of tasks for your Marathon service.
 
 **Prerequisites**
 
@@ -29,9 +29,9 @@ Periodically, `marathon-autoscale.py` will monitor the aggregate CPU and memory 
 
 # Install the Marathon Autoscale app on a node
 
-SSH to the system where you will run `marathon-autoscale.py` and install it.
+SSH to the system where you will run `marathon-autoscaler.py` and install it.
 
-1.  SSH to the node where you will run `marathon-autoscale.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
+1.  SSH to the node where you will run `marathon-autoscaler.py`, where node ID (`<mesos-id>`) is the node where you want to run the app.
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -56,7 +56,7 @@ SSH to the system where you will run `marathon-autoscale.py` and install it.
 1.  Enter this command to run the application:
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     You will be prompted for the following parameters:

--- a/pages/mesosphere/dcos/cn/1.11/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/cn/1.11/tutorials/autoscaling/cpu-memory/index.md
@@ -10,9 +10,9 @@ enterprise: false
 
 <p class="message--warning"><strong>免责声明：</strong>Mesosphere 不支持本教程、相关脚本或命令，它们不提供任何形式的保证。本教程的目的是为了演示功能，可能不适合在生产环境中使用。在您的环境中使用类似的解决方案之前，您必须进行调整、验证和测试。</p>
 
-您可以使用 Python 服务 `marathon-autoscale.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscale.py` 旨在演示在 DC/OS 上运行服务时可能可以实现的功能。
+您可以使用 Python 服务 `marathon-autoscaler.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscaler.py` 旨在演示在 DC/OS 上运行服务时可能可以实现的功能。
 
-`marathon-autoscale.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscale.py` 将增加您 Marathon 服务的任务数量。
+`marathon-autoscaler.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscaler.py` 将增加您 Marathon 服务的任务数量。
 
 **先决条件**
 
@@ -25,9 +25,9 @@ enterprise: false
 
 # 在节点上安装 Marathon Autoscale 应用程序
 
-通过 SSH 连接到您将运行 `marathon-autoscale.py` 并安装它的系统。
+通过 SSH 连接到您将运行 `marathon-autoscaler.py` 并安装它的系统。
 
-1. 通过 SSH 连接到您将运行的节点 `marathon-autoscale.py`，其中节点 ID (`<mesos-id>`) 是您要运行应用程序的节点。
+1. 通过 SSH 连接到您将运行的节点 `marathon-autoscaler.py`，其中节点 ID (`<mesos-id>`) 是您要运行应用程序的节点。
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -52,7 +52,7 @@ enterprise: false
 1. 输入此命令以运行应用程序：
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
  系统将提示您查看以下参数：

--- a/pages/mesosphere/dcos/cn/1.12/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/cn/1.12/tutorials/autoscaling/cpu-memory/index.md
@@ -13,9 +13,9 @@ enterprise: false
 #include /mesosphere/dcos/cn/include/tutorial-disclaimer.tmpl
 
 
-您可以使用 Python 服务 `marathon-autoscale.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscale.py` 旨在演示在 DC/OS 上运行服务时可能出现的情况。
+您可以使用 Python 服务 `marathon-autoscaler.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscaler.py` 旨在演示在 DC/OS 上运行服务时可能出现的情况。
 
-`marathon-autoscale.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscale.py` 将增加您 Marathon 服务的任务数量。
+`marathon-autoscaler.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscaler.py` 将增加您 Marathon 服务的任务数量。
 
 **先决条件**
 
@@ -28,9 +28,9 @@ enterprise: false
 
 # 在节点上安装 Marathon Autoscale 应用程序
 
-通过 SSH 连接到您将运行 `marathon-autoscale.py` 并安装它的系统。
+通过 SSH 连接到您将运行 `marathon-autoscaler.py` 并安装它的系统。
 
-1. SSH 到您要运行的节点`marathon-autoscale.py`，其中节点 ID（`<mesos-id>`）是您要运行该应用程序的节点。
+1. SSH 到您要运行的节点`marathon-autoscaler.py`，其中节点 ID（`<mesos-id>`）是您要运行该应用程序的节点。
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -55,7 +55,7 @@ enterprise: false
 1. 输入此命令以运行应用程序：
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     系统将提示您查看以下参数：

--- a/pages/mesosphere/dcos/cn/1.13/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/cn/1.13/tutorials/autoscaling/cpu-memory/index.md
@@ -13,9 +13,9 @@ enterprise: false
 #include /mesosphere/dcos/include/tutorial-disclaimer.tmpl
 
 
-您可以使用 Python 服务 `marathon-autoscale.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscale.py` 旨在演示在 DC/OS 上运行服务时可能出现的情况。
+您可以使用 Python 服务 `marathon-autoscaler.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscaler.py` 旨在演示在 DC/OS 上运行服务时可能出现的情况。
 
-`marathon-autoscale.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscale.py` 将增加您 Marathon 服务的任务数量。
+`marathon-autoscaler.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscaler.py` 将增加您 Marathon 服务的任务数量。
 
 **前提条件**
 
@@ -28,9 +28,9 @@ enterprise: false
 
 # 在节点上安装 Marathon Autoscale 应用程序
 
-通过 SSH 连接到您将运行 `marathon-autoscale.py` 并安装它的系统。
+通过 SSH 连接到您将运行 `marathon-autoscaler.py` 并安装它的系统。
 
-1. SSH 到您要运行的节点`marathon-autoscale.py`，其中节点 ID（`<mesos-id>`）是您要运行该应用程序的节点。
+1. SSH 到您要运行的节点`marathon-autoscaler.py`，其中节点 ID（`<mesos-id>`）是您要运行该应用程序的节点。
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -55,7 +55,7 @@ enterprise: false
 1. 输入此命令以运行应用程序：
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     系统将提示您查看以下参数：

--- a/pages/mesosphere/dcos/cn/2.0/tutorials/autoscaling/cpu-memory/index.md
+++ b/pages/mesosphere/dcos/cn/2.0/tutorials/autoscaling/cpu-memory/index.md
@@ -14,9 +14,9 @@ enterprise: false
 #include /mesosphere/dcos/cn/include/tutorial-disclaimer.tmpl
 
 
-您可以使用 Python 服务 `marathon-autoscale.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscale.py` 旨在演示在 DC/OS 上运行服务时可能出现的情况。
+您可以使用 Python 服务 `marathon-autoscaler.py` 根据 Mesos 报告的利用率指标自动扩展您的 Marathon 应用程序。您可以从 DC/OS 群集中运行此服务。`marathon-autoscaler.py` 旨在演示在 DC/OS 上运行服务时可能出现的情况。
 
-`marathon-autoscale.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscale.py` 将增加您 Marathon 服务的任务数量。
+`marathon-autoscaler.py` 将定期监控组成指定 Marathon 服务的所有任务的总 CPU 和内存利用率。达到阈值时，`marathon-autoscaler.py` 将增加您 Marathon 服务的任务数量。
 
 **前提条件**
 
@@ -29,9 +29,9 @@ enterprise: false
 
 # 在节点上安装 Marathon Autoscale 应用程序
 
-通过 SSH 连接到您将运行 `marathon-autoscale.py` 并安装它的系统。
+通过 SSH 连接到您将运行 `marathon-autoscaler.py` 并安装它的系统。
 
-1. SSH 到您要运行的节点`marathon-autoscale.py`，其中节点 ID（`<mesos-id>`）是您要运行该应用程序的节点。
+1. SSH 到您要运行的节点`marathon-autoscaler.py`，其中节点 ID（`<mesos-id>`）是您要运行该应用程序的节点。
 
     ```bash
     dcos node ssh --master-proxy --mesos-id=<mesos-id>
@@ -56,7 +56,7 @@ enterprise: false
 1. 输入此命令以运行应用程序：
 
     ```bash
-    python marathon-autoscale.py
+    python marathon-autoscaler.py
     ```
 
     系统将提示您查看以下参数：


### PR DESCRIPTION
to verify: check out https://github.com/mesosphere/marathon-autoscale/
and see that the script is called `marathon-autoscaler.py` and not
`marathon-autoscale.py`.

closes COPS-4997 (https://jira.d2iq.com/browse/COPS-4997)