### PR TITLE
makes markdown links that are in a different domain link out to a new…

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,3 +2,11 @@
 if (typeof feather !== "undefined") {
   feather.replace();
 }
+
+var links = document.links;
+
+for (var i = 0, linksLength = links.length; i < linksLength; i++) {
+   if (links[i].hostname != window.location.hostname) {
+       links[i].target = '_blank';
+   }
+}


### PR DESCRIPTION
## Jira Ticket
N/A

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
So, currently, markdown has no out of the box solution for external links going into a new tab. However, that's the desired functionality that we want. So, I've been replacing different markdown links with a tags so that we can do that. 
But, as @samvantran and @dkoshkin have pointed out, that could lead to future issues when links in the future could turn to dead ones, that would be bad news bears and lead to customer issues. 

SO, we can code this solution for ourselves, and the linting/builds will still check to see if these links work.

This solution was found here: 
https://stackoverflow.com/a/4425214

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
