### PR TITLE
Typo fixes

### DIFF
--- a/pages/ksphere/konvoy/1.4/install/install-azure/index.md
+++ b/pages/ksphere/konvoy/1.4/install/install-azure/index.md
@@ -36,8 +36,8 @@ This command creates your [Azure Virtual Machines][compute_virtual_machine] inst
 
 Specifically, the `konvoy up` command does the following:
 
-* Provisions three `Standard_DS3_v2` virtual machines as Kubernetes master nodes
-* Provisions six `Standard_DS3_v2` virtual machines as Kubernetes worker nodes
+* Provisions three `Standard_D4S_v3` virtual machines as Kubernetes master nodes
+* Provisions six `Standard_D4S_v3` virtual machines as Kubernetes worker nodes
 * Deploys all of the following default add-ons:
   * Calico
   * Cert-Manager
@@ -71,7 +71,7 @@ The cluster name will be used to tag the provisioned infrastructure and the cont
 To customize the cluster name, run the following command:
 
 ```bash
-konvoy up --cluster-name --provisioner azure <YOUR_SPECIFIED_NAME>
+konvoy up --provisioner azure --cluster-name <YOUR_SPECIFIED_NAME>
 ```
 
 **NOTE:** The cluster name may only contain the following characters: `a-z, 0-9, . - and _`.


### PR DESCRIPTION
Fixed the by default Azure compute vm size which is now Standard_D4S_v3 and fixed a misplaced of  `--cluster-name.`

## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made


## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
