### PR TITLE
Edgelb 1.6.1

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -8,7 +8,7 @@
 ~^/mesosphere/dcos/services/couchbase/latest/(.*) /mesosphere/dcos/services/couchbase/1.0.1-6.0.0/$1;
 ~^/mesosphere/dcos/services/data-science-engine/latest/(.*) /mesosphere/dcos/services/data-science-engine/2.0.0/$1;
 ~^/mesosphere/dcos/services/dse/latest/(.*) /mesosphere/dcos/services/dse/3.2.0-6.7.7/$1;
-~^/mesosphere/dcos/services/edge-lb/latest/(.*) /mesosphere/dcos/services/edge-lb/1.5/$1;
+~^/mesosphere/dcos/services/edge-lb/latest/(.*) /mesosphere/dcos/services/edge-lb/1.6/$1;
 ~^/mesosphere/dcos/services/elastic/latest/(.*) /mesosphere/dcos/services/elastic/3.1.2-7.6.0/$1;
 ~^/mesosphere/dcos/services/hdfs/latest/(.*) /mesosphere/dcos/services/hdfs/2.8.0-3.2.1/$1;
 ~^/mesosphere/dcos/services/jenkins/latest/(.*) /mesosphere/dcos/services/jenkins/3.6.1-2.190.1/$1;

--- a/pages/mesosphere/dcos/services/edge-lb/1.6/getting-started/auto-pools/index.md
+++ b/pages/mesosphere/dcos/services/edge-lb/1.6/getting-started/auto-pools/index.md
@@ -76,6 +76,7 @@ We recommend using the `<group>` field to describe the frontend app, such as `we
 | `edgelb.<group>.backend.protocol` | `HTTP` unless frontend protocol is not `HTTP/HTTPS`, then matches frontend | The backend protocol. |
 | `edgelb.<group>.backend.rewriteHttp.path` | | A `dict` of 1 item mapping the key path on the frontend to the value path on the backend. For example to map `/a` on the frontend to `/` on the backend, set the value to `/a:/` |
 | `edgelb.<group>.backend.rewriteHttp.sticky` | | If the label exists, sticky is enabled with the default options. Any non-whitespace value for the label will be used as the [`customStr`](/mesosphere/dcos/services/edge-lb/1.6/reference/pool-configuration-reference/v2-reference/#poolhaproxybackendrewritehttp) |
+| `edgelb.<group>.backend.endpoint` | | If the label exists, the specified `dict` will be used in place as the endpoint. Useful for specifying an L4LB address and port as the endpoint instead of the container port. All keys from the [api](/mesosphere/dcos/services/edge-lb/1.6/reference/pool-configuration-reference/v2-reference/#poolhaproxybackendserviceendpoint) are support **except** the `check` key as it is impossible to specify a nested `dict` object. |
 
 # Managing Pool Templates
 

--- a/pages/mesosphere/dcos/services/edge-lb/1.6/related-documentation/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/edge-lb/1.6/related-documentation/release-notes/index.md
@@ -9,6 +9,18 @@ enterprise: false
 
 These Edge-LB Release Notes summarize release-specific changes that fix issues or update Edge-LB features for DC/OS&trade; Enterprise clusters.
 
+# DC/OS for Edge-LB Service version 1.6.1 Release Notes
+
+Edge-LB Service version 1.6.0 was released on 26 June 2020.
+
+## New features and capabilities
+
+- Added option to disable AWS meta-data fetching as well as the meta-data endpoint
+- Auto Pool templates now support applications overriding the backend.endpoin dictionary
+- HAProxy is updated to 2.0.15
+- EdgeLB is now built with GO 1.14.4
+
+
 # DC/OS for Edge-LB Service version 1.6.0 Release Notes
 
 Edge-LB Service version 1.6.0 was released on 10 June 2020.

--- a/pages/mesosphere/dcos/services/edge-lb/1.6/tutorials/using-auto-pools/index.md
+++ b/pages/mesosphere/dcos/services/edge-lb/1.6/tutorials/using-auto-pools/index.md
@@ -474,6 +474,57 @@ curl http://34.211.12.88/
 tutorial
 ```
 
+## Backend Endpoint
+
+The endpoint used for the `backend` can be overridden. This is useful to expose a service out via a particular address such as an L4LB VIP:
+
+```json
+{
+  "id": "/auto-pool-tutorial",
+  "labels": {
+      "edgelb.expose": "true",
+      "edgelb.secure.backend.endpoint": "type:ADDRESS|address:myvip.marathon.l4lb.thisdcos.directory|port:8080"
+  },
+  "instances": 1,
+  "portDefinitions": [
+    {
+      "name": "id",
+      "protocol": "tcp",
+      "port": 0
+    }
+  ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/id-server:2.1.0"
+    },
+    "portMappings": [
+      "containerPort": 80,
+      "hostPort": 0,
+      "protocol": "tcp",
+      "name": "id",
+      "labels": {
+        "VIP_0": "/myvip:8080"
+      }
+    ]
+  },
+  "cpus": 0.1,
+  "requirePorts": false,
+  "mem": 32,
+  "cmd": "/start $PORT0 tutorial"
+}
+```
+
+```bash
+dcos marathon app update /auto-pool-tutorial < auto-pool-tutorial.json
+Created deployment 497cbee3-ebdc-4310-8ef3-03175aa52a66
+
+curl http://34.211.12.88/
+tutorial
+```
+
+*NOTE* the `check` key is currently not supported since it is a nested `dict` object.
+
 # Template Management
 
 ## Status

--- a/pages/mesosphere/dcos/services/edge-lb/index.md
+++ b/pages/mesosphere/dcos/services/edge-lb/index.md
@@ -4,7 +4,7 @@ navigationTitle:  Edge-LB
 title: Edge-LB
 menuWeight: 30
 excerpt: 
-enterprise: true
+enterprise: false
 category: Networking
 ---
 One of the most important ways you can manage cluster operations is through efficient load balancing of access requests and workload processing. Load balancing improves the performance, reliability, and network efficiency for web-based properties, applications, databases, and other services by distributing workload across multiple servers. By introducing a load balancer like Edge-LB, you can distribute the traffic for all services that run on a DC/OS Enterprise cluster. 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-69799

## Description of changes being made

* Add EdgeLB v1.6.1 release notes.
* Remove enterprise tag from EdgeLB on services page
* Change 307 map to point to v1.6.1



## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
