### PR TITLE
Fixed configRepository line in cluster.yaml

### DIFF
--- a/pages/ksphere/konvoy/1.4/reference/cluster-configuration/index.md
+++ b/pages/ksphere/konvoy/1.4/reference/cluster-configuration/index.md
@@ -113,7 +113,7 @@ spec:
   nodePools:
   - name: worker
   addons:
-    configRepository: https://github.com/mesosphere/kubernetes-base-addons
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
     configVersion: stable-1.16-1.2.0
     addonsList:
     - name: awsebscsiprovisioner

--- a/pages/ksphere/konvoy/1.4/release-notes/index.md
+++ b/pages/ksphere/konvoy/1.4/release-notes/index.md
@@ -339,7 +339,7 @@ spec:
     calico:
       version: v3.10.1
   addons:
-    configRepository: https://github.com/mesosphere/kubernetes-base-addons
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
     configVersion: stable-1.16.4-2
     addonsList:
     ...

--- a/pages/ksphere/konvoy/1.4/upgrade/upgrade-kubernetes-addons/index.md
+++ b/pages/ksphere/konvoy/1.4/upgrade/upgrade-kubernetes-addons/index.md
@@ -159,7 +159,7 @@ spec:
     calico:
       version: v3.13.3
   addons:
-    configRepository: https://github.com/mesosphere/kubernetes-base-addons
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
     configVersion: stable-1.16-1.2.0
     addonsList:
     ...

--- a/pages/ksphere/konvoy/1.5/reference/cluster-configuration/index.md
+++ b/pages/ksphere/konvoy/1.5/reference/cluster-configuration/index.md
@@ -115,7 +115,7 @@ spec:
   nodePools:
   - name: worker
   addons:
-    configRepository: https://github.com/mesosphere/kubernetes-base-addons
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
     configVersion: testing-2.0.0-5
     addonsList:
     - name: awsebscsiprovisioner

--- a/pages/ksphere/konvoy/1.5/release-notes/index.md
+++ b/pages/ksphere/konvoy/1.5/release-notes/index.md
@@ -792,7 +792,7 @@ spec:
     calico:
       version: v3.10.1
   addons:
-    configRepository: https://github.com/mesosphere/kubernetes-base-addons
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
     configVersion: stable-1.16.4-2
     addonsList:
     ...

--- a/pages/ksphere/konvoy/1.5/upgrade/upgrade-cli/index.md
+++ b/pages/ksphere/konvoy/1.5/upgrade/upgrade-cli/index.md
@@ -109,7 +109,7 @@ spec:
     calico:
       version: v3.10.1
   addons:
-    configRepository: https://github.com/mesosphere/kubernetes-base-addons
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
     configVersion: stable-1.16.4-2
     addonsList:
     ...


### PR DESCRIPTION
## Jira Ticket
Found while working on https://jira.d2iq.com/browse/D2IQ-69280.

## Description of changes being made

Without this, trying to run Konvoy with the given `cluster.yaml` fails with `Error: failed to deploy the cluster: yaml: line 104: did not find expected key`.

## Checklist
- [X] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [X] Test all commands and procedures, if applicable.
- [X] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
