### PR TITLE
nginx: redirect konvoy 1.5 "replace a failed node" URL

### DIFF
--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -843,3 +843,4 @@
 ~^/(cn/.*)$ /mesosphere/dcos/$1;
 ~^/(version-policy/.*)$ /mesosphere/dcos/$1;
 ~^/(search/.*)$ /mesosphere/dcos/$1;
+/ksphere/konvoy/1.5/tutorials/replacing-failed-control-plane-node/(.*) /ksphere/konvoy/1.5/troubleshooting/replace-failed-control-plane-node/(.*);


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-69826

## Description of changes being made
The URL changed in https://github.com/mesosphere/konvoy/pull/1736. Introduce a redirect for users that bookmarked the old URL.


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
