### PR TITLE
Fix example resource in RBAC doc

### DIFF
--- a/pages/ksphere/konvoy/1.4/security/external-idps/rbac/index.md
+++ b/pages/ksphere/konvoy/1.4/security/external-idps/rbac/index.md
@@ -123,7 +123,7 @@ To grant the user `marry@example.com` administrative access to all operations po
 
 ```shell
 cat << EOF | kubectl apply -f -
- ---
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/pages/ksphere/konvoy/1.5/security/external-idps/rbac/index.md
+++ b/pages/ksphere/konvoy/1.5/security/external-idps/rbac/index.md
@@ -127,7 +127,7 @@ To grant the user `mary@example.com` administrative access to all operations por
 
 ```shell
 cat << EOF | kubectl apply -f -
- ---
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-69607

## Description of changes being made
This fixes an example resource in the RBAC doc. Without this fix, trying to create the resource yields the following error: `error: error parsing STDIN: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context`.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [x] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
