### PR TITLE
[D2iQ-70163][DOCS] Jenkins 4.0.0-2.204.6 Release Documentation.

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -11,7 +11,7 @@
 ~^/mesosphere/dcos/services/edge-lb/latest/(.*) /mesosphere/dcos/services/edge-lb/1.6/$1;
 ~^/mesosphere/dcos/services/elastic/latest/(.*) /mesosphere/dcos/services/elastic/3.1.2-7.6.0/$1;
 ~^/mesosphere/dcos/services/hdfs/latest/(.*) /mesosphere/dcos/services/hdfs/2.8.0-3.2.1/$1;
-~^/mesosphere/dcos/services/jenkins/latest/(.*) /mesosphere/dcos/services/jenkins/3.6.1-2.190.1/$1;
+~^/mesosphere/dcos/services/jenkins/latest/(.*) /mesosphere/dcos/services/jenkins/4.0.0-2.204.6/$1;
 ~^/mesosphere/dcos/services/kafka/latest/(.*) /mesosphere/dcos/services/kafka/2.10.0-2.4.0/$1;
 ~^/mesosphere/dcos/services/kubernetes/latest/(.*) /mesosphere/dcos/services/kubernetes/2.6.1-1.17.8/$1;
 ~^/mesosphere/dcos/services/kafka-zookeeper/latest/(.*) /mesosphere/dcos/services/kafka-zookeeper/2.6.0-3.4.14/$1;

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/architecture/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/architecture/index.md
@@ -1,0 +1,33 @@
+---
+layout: layout.pug
+navigationTitle:  Jenkins for DC/OS Service Architecture
+title: Jenkins for DC/OS Service Architecture
+menuWeight: 40
+beta: false
+excerpt: The Jenkins for DC/OS service bundles the Jenkins Automation Server with the Jenkins Mesos Plug-in. 
+featureMaturity:
+enterprise: false
+---
+
+## Overview
+
+The Jenkins for DC/OS service bundles the [Jenkins Automation Server](https://github.com/jenkinsci/jenkins) with the [Jenkins Mesos Plug-in](https://github.com/jenkinsci/mesos-plugin) which lets users dispatch Jenkins jobs on a DC/OS cluster.
+
+Jenkins for DC/OS runs as a root Marathon application inside a Docker container. The default Docker image contains several Jenkins plugins to get you up and running quickly. You can customize the Docker image to match your specific use case.
+
+The Docker container also contains an NGINX reverse proxy that rewrites the URIs into the absolute paths Jenkins requires.
+
+### Container Runtimes
+
+#### Universal Container Runtime (UCR)
+
+By default the Jenkins for DC/OS service uses the [Universal Container Runtime](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/ucr/) (UCR).
+
+#### Docker
+
+Previous version of the Jenkins for DC/OS service used the [Docker Engine](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/docker-containerizer/) as its default containerizer for both the Jenkins Master and the Agents. Users are recommended to use this runtime if they intend to ugprade from existing installations of the Jenkins service.
+
+### Multi-tenancy
+
+The Jenkins for DC/OS service starting with DC/OS 2.0 supports multi-tenancy. Users should familiarize themselves with [Quota](https://docs.d2iq.com/mesosphere/dcos/latest/multi-tenancy/quota-management/) and [Resource Managment Primitives](https://docs.d2iq.com/mesosphere/dcos/latest/multi-tenancy/resource-mgmt-primitives/) in DC/OS.
+In particular, service-accounts in a quota enforced group must be given the correct role permissions for the service to launch and perform its operations.

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install/index.md
@@ -1,0 +1,192 @@
+---
+layout: layout.pug
+navigationTitle:  Customizing your install
+title: Customizing your install
+menuWeight: 20
+beta: false
+excerpt: The Jenkins for DC/OS package accepts a range of custom configuration parameters at install.
+featureMaturity:
+enterprise: false
+---
+# About customizing your installation parameters
+
+The Jenkins for DC/OS package accepts a range of custom configuration parameters at install.
+
+By default, Jenkins for DC/OS uses a `/tmp` directory on the local host to store its configuration and build data. At a minimum, you should change this before going into production. We recommend setting up a shared file system. Alternatively, you can pin to an agent.
+
+We also expect that you'll want to customize the default Docker container to add your own dependencies.
+
+# Using the CLI
+
+## About using the CLI
+
+You can perform a custom installation from either the web interface or the CLI.
+
+## Creating a JSON file
+
+1. Create a new file.
+
+    **Tip:** You might want to choose a pattern like `<package-name>-config.json`.
+    ```bash
+    nano jenkins-config.json
+    ```
+
+1. Use the information in the configuration reference below to build your JSON. This example creates a new Jenkins for DC/OS service named `jenkins-myteam` and uses the NFS share located at `/mnt/nfs/jenkins-data`.
+
+    ```json
+    {
+        "service": {
+            "name": "jenkins-myteam",
+            "storage": {
+                "host-volume": "/mnt/nfs/jenkins_data"
+            }
+        }
+    }
+    ```
+
+    **Tip:** The value of `host-volume` is the base path to a share on a NFS server or other distributed filesystem. The actual path on-disk for this example is `mnt/nfs/jenkins_data/jenkins-myteam`.
+1. From the CLI, pass the custom options file.
+
+    ```bash
+    dcos package install jenkins --options=jenkins-config.json
+    ```
+
+# Configuration reference
+The exact configuration can change between releases of the DC/OS Jenkins Service, the following links describe options available for each release.
+- [Jenkins 4.0.0-2.204.6 Configuration options.](/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/options-compatibility-matrix/)
+- [Jenkins 3.6.1-2.190.1 Configuration options.](https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/J/jenkins/100/config.json)
+- [Jenkins 3.6.0-2.190.1 Configuration options.](https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/J/jenkins/40/config.json)
+- [Jenkins 3.5.4-2.150.1 Configuration options.](https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/J/jenkins/30/config.json)
+- [Jenkins 3.5.3-2.150.1 Configuration options.](https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/J/jenkins/29/config.json)
+- [Jenkins 3.5.2-2.107.2 Configuration options.](https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/J/jenkins/28/config.json)
+
+# Examples
+
+## Create a new instance pinned to a single host
+
+You can also specify an optional `pinned-hostname` constraint. This is useful if you don't have NFS available and need to pin Jenkins to a specific node:
+
+```json
+{
+    "service": {
+        "name": "jenkins-pinned",
+        "storage": {
+            "host-volume": "/var/jenkins_data",
+            "pinned-hostname": "10.0.0.100"
+        }
+    }
+}
+```
+
+## Modify known hosts
+
+With the `known-hosts` option you can specify a space-separated list of hostnames from which to retrieve the SSH public keys. This list will be populated on the Jenkins master when the bootstrap script runs (at container launch time). You must manually ensure that the SSH known hosts list is populated in any Jenkins agent containers.
+```json
+{
+    "service": {
+        "name": "jenkins-private-git",
+    },
+    "jenkins-master": {
+        "known-hosts": "github.com git.apache.org git.example.com"
+    }
+}
+```
+
+## Installing additional Jenkins plugins
+
+With the `additional-plugins` option you can specify a space sperated list of addtional Jenkins plugins to be installed into the Jenkins master. This list will be populated on the Jenkins master when the bootstrap script runs (at container launch time).
+```json
+{
+    "service": {
+        "name": "jenkins-additional-plugins",
+    },
+    "jenkins-master": {
+        "additional-plugins": "gradle:1.34 cvs:2.14 handlebars:1.1.1"
+    }
+}
+```
+
+## Using custom images with pre-installed Jenkins plugins
+
+DC/OS Jenkins service ships with a minimial list of pre-bundled plugins that are officially supported. The [current list can be found at here](https://github.com/mesosphere/dcos-jenkins-service/blob/4.0.0-2.204.6/plugins.conf).
+
+Customers have the option of specifying an image with a custom list of Jenkins plugins they would like to have pre-installed when the Jenkins service starts up.
+This process is diffrent from procedure in [installing additional plugins](#installing-additional-jenkins-plugins) as the plugins in this case are bundled into the container image and aren't downloaded everytime the container gets launched.
+
+### Creating a custom image with bundled Jenkins plugins
+The process below outlines how to create a custom image with bundled jenkins plugins:
+1. Clone the DC/OS Jenkins Github repository
+    ```
+    git clone https://github.com/mesosphere/dcos-jenkins-service.git
+    cd dcos-jenkins-service
+    ```
+1. Modify `plugins.conf` with the list of desired plugins.
+1. Build the docker image. Here we're using `mesosphere/jenkins:custom-image` as the example image tag.
+    ```
+    docker build -t mesosphere/jenkins:custom-image .
+    ```
+1. Push the built image to the respective image repository, we're using the default Dockerhub in this example.
+    ```
+    docker push mesosphere/jenkins:custom-image .
+    ```
+
+### Specifying a custom image at service installation time
+
+Once a image has been created with the desired plugins, the custom image can be specified via the options shown below:
+```json
+{
+    "service": {
+        "name": "jenkins-custom-image",
+        "docker-image": "mesosphere/jenkins:custom-image"
+    }
+}
+```
+
+## Configuring Airgapped clusters
+
+Customers running Jenkins on Airgapped DC/OS clusters should use [Package Registry](/mesosphere/dcos/latest/administering-clusters/package-registry/) to install packages in airgapped environments. Default versions of Jenkins for Package Registry are [available](https://downloads.mesosphere.com/universe/packages/packages.html).
+
+### Configuring Airgapped clusters with custom images.
+
+It is possible to also use a [custom image](#creating-a-custom-image-with-bundled-jenkins-plugins) with Package Registry, the following instructions outline how to create a Jenkins `.dcos` file with a custom image.
+
+1. Install [Package Registry](/mesosphere/dcos/latest/administering-clusters/package-registry/#default-installation)
+1. Clone the DC/OS Universe repository.
+    ```
+    https://github.com/mesosphere/universe.git
+    ```
+1. Create a working directory for Package Registry to build the `.dcos` files.
+    ```
+    mkdir output-directory
+    ```
+1. Copy the desired version of Jenkins, we're using `jenkins` in this example:
+    ```
+    cp -r universe/tree/version-3.x/repo/packages/B/jenkins/0 output-directory/
+    ```
+1. The folder `output-directory` should have the following files:
+    ```
+    config.json
+    marathon.json.mustache
+    package.json
+    resource.json
+    ```
+1. Modify `resource.json` to use the custom docker image.
+    Here we're replacing the default `"mesosphere/jenkins:4.0.0-2.204.6"` with `"mesosphere/jenkins:custom-image"`
+    Modify the `docker` image to point to the desired custom image, the resulting file looks like the following with the above example:
+    ```json
+    {
+        "images": {
+            "icon-small": "https://downloads.mesosphere.com/assets/universe/000/jenkins-icon-small.png",
+            "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/jenkins-icon-medium.png",
+            "icon-large": "https://downloads.mesosphere.com/assets/universe/000/jenkins-icon-large.png"
+        },
+        "assets": {
+            "container": {
+                "docker": {
+                    "jenkins": "mesosphere/jenkins:custom-image"
+                }
+            }
+        }
+    }
+    ```
+1. Complete building the `.dcos` files and uploading them to Package Registry by following the procedure to [build the packages](/mesosphere/dcos/latest/administering-clusters/package-registry/#building-the-packages).

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/index.md
@@ -1,0 +1,17 @@
+---
+layout: layout.pug
+navigationTitle:  Jenkins for DC/OS (Beta)
+title: Jenkins for DC/OS (Beta)
+menuWeight: 60
+beta: false
+excerpt: Run your continuous integration, automated testing, and continuous delivery jobs at scale with Jenkins for DC/OS.
+featureMaturity:
+enterprise: false
+category: Continuous Delivery
+---
+
+Run your continuous integration, automated testing, and continuous delivery jobs at scale with Jenkins for DC/OS. Instead of the static partitions so typical of other Jenkins clusters, Jenkins for DC/OS  can create and destroy agents as demand increases and decreases. With multiple Jenkins masters sharing a single pool of compute resources, you can achieve much more efficient and resilient automations.
+
+Jenkins for DC/OS needs a directory on disk to store its configuration and build data. To get up and running quickly, you can pin it to a single agent and use this to store the data. However, should the agent go down, your data will be lost.
+
+Before going into production, you should set up a single POSIX-compliant file system that each agent mounts using the same path. Some options include NFS, Ceph, HDFS, and iSCSI.

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/jenkins-auth/index.md
@@ -1,0 +1,290 @@
+---
+layout: layout.pug
+navigationTitle:  Provisioning Jenkins for DC/OS
+title: Provisioning Jenkins for DC/OS
+menuWeight: 15
+excerpt: This topic describes when and how to provision Jenkins with a service account.
+beta: false
+featureMaturity:
+enterprise: true
+---
+
+# About provisioning Jenkins with a service account
+
+Whether you can or must provision Jenkins with a service account varies by [security mode](/mesosphere/dcos/latest/security/ent/#security-modes).
+
+- `permissive`: optional
+- `strict`: required
+
+To increase the security of your cluster and conform to the principle of least privilege, we recommend provisioning Jenkins with a service account in `permissive` mode. Otherwise, Marathon and Metronome will act as if Jenkins was provisioned with a service account which has the `superuser` permission.
+
+To set up a service account for Jenkins, complete the following steps.
+
+1. [Create a key pair.](#create-a-keypair)
+1. [Create a service account.](#create-a-service-account)
+1. [Create a service account secret.](#create-an-sa-secret)
+1. [Provision the service account with the necessary permissions.](#give-perms)
+1. [Create a config.json file.](#create-json)
+
+**Requirement:** In `strict` mode, the name of the service account must match the name that the service uses as its `principal`. By default, Jenkins uses `jenkins-principal` as the name of its `principal`. That's the value that we use in the following procedures. Should you modify the default, you must change `jenkins-principal` throughout to match.
+
+**Note:** We will use `jenkins-secret` as the name of the secret, `jenkins-private-key.pem` as the name of the file containing the private key, and `jenkins-public-key.pem` as the name of the file containing the public key. We recommend using these names, as it will make it easier to copy and paste the commands. If you change the names, make sure to modify the commands before issuing them.
+
+**Important:** We store the secret in the `jenkins` path. This protects it from other services, so we do not recommend changing this.
+
+
+# Create a key pair
+
+First, you'll need to generate a 2048-bit RSA public-private key pair. While you can use any tool to accomplish this, the Enterprise DC/OS CLI is the most convenient because it returns the keys in the exact format required.
+
+**Prerequisite:** You must have the [DC/OS CLI installed](/mesosphere/dcos/latest/cli/install/) and the [Enterprise DC/OS CLI installed](/mesosphere/dcos/latest/cli/enterprise-cli/#ent-cli-install).
+
+
+1. Create a public-private key pair and save each value into a separate file within the current directory.
+
+    ```bash
+    dcos security org service-accounts keypair jenkins-private-key.pem jenkins-public-key.pem
+    ```
+
+1. Type `ls` to view the two new files created by the command. You may also want to open the files themselves and verify their contents.
+
+# Create a service account
+
+## About creating a service account
+
+Next, you must create a service account. This section uses the Enterprise DC/OS CLI to accomplish this.
+
+**Prerequisite:** You must have the [DC/OS CLI installed](/mesosphere/dcos/latest/cli/install/), the [Enterprise DC/OS CLI installed](/mesosphere/dcos/latest/cli/enterprise-cli/#ent-cli-install), and be logged in as a superuser via `dcos auth login`.
+
+- Use the following command to create a new service account called `jenkins-principal` with the public key you just generated.
+
+    ```bash
+    dcos security org service-accounts create -p jenkins-public-key.pem -d "Jenkins service account" jenkins-principal
+    ```
+
+- Verify your new service account using the following command.
+
+    ```bash
+    dcos security org service-accounts show jenkins-principal
+    ```
+
+## About creating a service account secret
+
+Next, you need to create a secret associated with the service account that contains the private key.
+
+**Prerequisite:** You must have the [DC/OS CLI installed](/mesosphere/dcos/latest/cli/install/), the [Enterprise DC/OS CLI installed](/mesosphere/dcos/latest/cli/enterprise-cli/#ent-cli-install), and be logged in as a superuser via `dcos auth login`.
+
+- Depending on your security mode, use one of the following commands to create a new secret called `jenkins-secret` in the `jenkins` path. Locating the secret inside the `jenkins` path will ensure that only the Jenkins service can access it. The secret will contain the private key, the name of the service account, and other data.
+
+    **strict:**
+
+    ```bash
+    dcos security secrets create-sa-secret --strict jenkins-private-key.pem jenkins-principal jenkins-secret
+    ```
+
+    **permissive:**
+
+    ```bash
+    dcos security secrets create-sa-secret jenkins-private-key.pem jenkins-principal jenkins-secret
+    ```
+
+- Create a file based secret with the jenkins private key:
+    
+    **Note:** This step is required by the Jenkins master scheduler to authenticate with Mesos.
+    ```bash
+    dcos security secrets create -f ./jenkins-private-key.pem jenkins/private_key
+    ```
+- Ensure the secret was created successfully:
+
+    ```bash
+    dcos security secrets list /
+    ```
+
+- **Optional:** Now that you have stored the private key in the Secret Store, we recommend deleting the private key file from your file system. This will prevent bad actors from using the private key to authenticate to DC/OS. Skip this step if you want to try out [Quota Enforced Multi-Tenant Jenkins](#Quota-enforced-Multi-Tenant-Jenkins)
+
+   ```bash
+   rm -rf jenkins-private-key.pem
+   ```
+
+# Provision the service account with permissions
+
+## About the permissions
+
+The permissions needed vary according to your [security mode](/mesosphere/dcos/latest/security/ent/#security-modes/). In `permissive` mode, the Jenkins service account does not need any permissions. If you plan to upgrade at some point to `strict` mode, we recommending assigning them the permissions needed in `strict` mode to make the upgrade easier. The permissions will not have any effect until the cluster is in `strict` mode. If you plan to remain in `permissive` mode indefinitely, skip to [Create a config.json file](#create-json).
+
+If you are in `strict` mode or want to be ready to upgrade to `strict` mode, continue to the next section.
+
+## Creating and assigning the permissions
+
+The DC/OS Enterprise CLI can be used to rapidly provision the Jenkins service account.  You must also log in via `dcos auth login` as a superuser.
+
+**Note:** Replace `nobody` with the appropriate user for your deployment.
+   ```bash
+   
+    dcos security org users grant jenkins-principal dcos:mesos:master:framework:role:* read
+    dcos security org users grant jenkins-principal dcos:mesos:master:framework:role:* create
+    dcos security org users grant jenkins-principal dcos:mesos:master:reservation:role:* read
+    dcos security org users grant jenkins-principal dcos:mesos:master:reservation:role:* create
+    dcos security org users grant jenkins-principal dcos:mesos:master:volume:role:* read
+    dcos security org users grant jenkins-principal dcos:mesos:master:volume:role:* create
+    
+    dcos security org users grant jenkins-principal dcos:mesos:master:task:user:nobody create
+    dcos security org users grant jenkins-principal dcos:mesos:agent:task:user:nobody create
+
+    dcos security org users grant jenkins-principal dcos:mesos:master:reservation:principal:jenkins-principal delete
+    dcos security org users grant jenkins-principal dcos:mesos:master:volume:principal:jenkins-principal delete
+   ```
+
+# Create a config.json file
+
+The contents of the `config.json` file will vary according to your security mode. We provide two examples below, one for each security mode. Locate the sample appropriate to your security mode, copy the JSON, paste it into a new file, and save it as `config.json`.
+
+`strict` **mode**
+
+```json
+{
+  "service": {
+    "name": "jenkins",
+    "user": "nobody",
+    "security": {
+      "service-account": "jenkins-principal",
+      "secret-name": "jenkins/private_key",
+      "strict-mode": true
+    }
+  }
+}
+```
+
+`permissive` **mode**
+
+```json
+{
+  "service": {
+    "name": "jenkins",
+    "user": "nobody",
+    "security": {
+      "service-account": "jenkins-principal",
+      "secret-name": "jenkins/private_key",
+      "strict-mode": false
+    }
+  }
+}
+```
+
+If you have modified any of the values shown in the previous sections, change the values in the following JSON as appropriate.
+
+
+## Install Jenkins
+
+To install the service, complete the following command.
+
+```bash
+dcos package install --options=config.json jenkins
+```
+---
+# Quota enforced Multi-Tenant Jenkins
+
+The DC/OS Jenkins service starting with DC/OS 2.0 supports multi-tenancy. Users should familiarize themselves with [Quota](/mesosphere/dcos/latest/multi-tenancy/quota-management) and [Resource Managment Primitives](/mesosphere/dcos/latest/multi-tenancy/resource-mgmt-primitives/) in DC/OS.
+
+**Note:** We will use `/dev/jenkins` as the name of the service for the quota enabled multi-tenant examples below.
+- DC/OS 2.0 and later clusters
+`dev` will be the group in which the Jenkins service will be deployed as well as the *role* which the service will use. In `strict` mode, the service will require permissions granted for this `dev` role.
+- DC/OS 1.13 and older clusters
+`dev` will be the group in which the Jenkins service will be deployed. The *role* used by the service can be configured with the default of `*`.  In `strict` mode, the service will require permissions granted for this `*` role.
+
+### Role used by Jenkins Agents
+- DC/OS 2.0 and later clusters - 
+When quota is enforced on the group, the Jenkins agents will inherit the same role as the Jenkins master.
+- DC/OS 1.13 and older clusters - 
+The role used by the Jenkins agents can be configured via `service.roles.jenkins-agent-role` in the configuration options.
+
+
+## Pre-requisites
+1. [Create a Key-Pair](#Create-a-Key-Pair) if you haven't already done so.
+1. [Create a service account](#Create-a-service-account) if you haven't already done so.
+
+
+### Create a file based secret with the jenkins private key:
+
+**Note:** This step is required by the Jenkins master scheduler to authenticate with Mesos.
+
+**Note:** This step creates a key for `dev/jenkins` service.
+
+```bash
+dcos security secrets create -f ./jenkins-private-key.pem dev/jenkins/private_key
+```
+
+## Creating and assigning the permissions
+
+The DC/OS Enterprise CLI can be used to rapidly provision the Jenkins service account.  You must also log in via `dcos auth login` as a superuser.
+
+**Note:** Replace `dev` & `nobody` with the appropriate role and user for your deployment.
+   ```bash
+   
+    dcos security org users grant jenkins-principal dcos:mesos:master:framework:role:dev read
+    dcos security org users grant jenkins-principal dcos:mesos:master:framework:role:dev create
+    dcos security org users grant jenkins-principal dcos:mesos:master:reservation:role:dev read
+    dcos security org users grant jenkins-principal dcos:mesos:master:reservation:role:dev create
+    dcos security org users grant jenkins-principal dcos:mesos:master:volume:role:dev read
+    dcos security org users grant jenkins-principal dcos:mesos:master:volume:role:dev create
+    
+    dcos security org users grant jenkins-principal dcos:mesos:master:task:user:nobody create
+    dcos security org users grant jenkins-principal dcos:mesos:agent:task:user:nobody create
+
+    dcos security org users grant jenkins-principal dcos:mesos:master:reservation:principal:jenkins-principal delete
+    dcos security org users grant jenkins-principal dcos:mesos:master:volume:principal:jenkins-principal delete
+   ```
+
+# Create a config.json file
+
+The contents of the `config.json` file will vary according to your security mode. We provide two examples below, one for each security mode. Locate the sample appropriate to your security mode, copy the JSON, paste it into a new file, and save it as `config.json`.
+
+- **Note**: `roles.jenkins-master-role` must  match the quota role which is `dev` in this example.
+
+`strict` **mode**
+
+```json
+{
+  "service": {
+    "name": "dev/jenkins",
+    "user": "nobody",
+    "roles": {
+      "jenkins-master-role": "dev"
+    },
+    "security": {
+      "service-account": "jenkins-principal",
+      "secret-name": "dev/jenkins/private_key",
+      "strict-mode": true
+    }
+  }
+}
+```
+
+`permissive` **mode**
+
+```json
+{
+  "service": {
+    "name": "dev/jenkins",
+    "user": "nobody",
+    "roles": {
+      "jenkins-master-role": "dev"
+    },
+    "security": {
+      "service-account": "jenkins-principal",
+      "secret-name": "dev/jenkins/private_key",
+      "strict-mode": false
+    }
+  }
+}
+```
+
+## Install Jenkins
+
+To install the service, complete the following command.
+
+```bash
+dcos package install --options=config.json jenkins
+```
+
+Please see the [Jenkins documentation](/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install) for more information about how to use the JSON file to install the service.

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/options-compatibility-matrix/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/options-compatibility-matrix/index.md
@@ -1,0 +1,71 @@
+---
+layout: layout.pug
+navigationTitle: Configuration Options Matrix
+title: Configuration Options Matrix
+menuWeight: 6
+beta: false
+excerpt: Configuration changes in this release of the Jenkins Service
+enterprise: false
+--- 
+
+# Options Compatibility Matrix
+
+## Jenkins Service Related Options
+4.0.0-2.204.6 |    Default   |    3.6.1-2.190.1    |    Default    |    Notes    
+--------------|--------------|---------------------|---------------|-------------
+service.name  | jenkins | service.name | jenkins
+service.user | nobody | service.user | N/A | Changed
+service.marathon-name | marathon | service.marathon-name | marathon
+service.mesos-master | https://leader.mesos:5050 | advanced.mesos-master | zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos | Changed & Relocated
+service.roles.jenkins-master-role | slave_public | roles.jenkins-master-role | slave_public | Relocated
+service.roles.jenkins-agent-role | * | roles.jenkins-agent-role | * | Relocated
+service.security.security-account | "" | N/A | N/A | Added
+service.security.strict-mode | false | security.strict-mode | false | Relocated
+service.security.secret-name | "" | N/A | N/A | Added
+service.containerizer | MESOS | advanced.containerizer | DOCKER | Changed & Relocated
+service.docker-image | "" | advanced.docker-image | "" | Relocated
+service.docker-credentials-uri | "" | advanced.docker-credentials-uri | "" | Relocated
+service.prometheus-endpoint | "v1/metrics/prometheus" | advanced.prometheus-endpoint | "v1/metrics/prometheus" | Relocated
+service.storage.host-volume| "" | storage.host-volume | "" | Relocated
+service.storage.pinned-hostname| "" | storage.pinned-hostname | "" | Relocated
+service.marathon-lb.virtual-host | "" | networking.virtual-host | "" | Relocated
+service.marathon-lb.https-redirect | false | networking.https-redirect | false | Relocated
+---
+## Jenkins Master Related Options
+4.0.0-2.204.6 |    Default   |    3.6.1-2.190.1    |    Default    |    Notes    
+--------------|--------------|---------------------|---------------|-------------
+jenkins-master.cpus | 1.0 | service.cpus | 1.0 | Relocated
+jenkins-master.mem | 4096.0 | service.mem | 4096.0 | Relocated
+jenkins-master.known-hosts | "github.com" | networking.known-hosts | "github.com" | Relocated
+jenkins-master.agent-port | 0 | networking.agent-port | 0 | Relocated
+jenkins-master.jvm-opts | "-Xms1024m -Xmx1024m" | advanced.jvm-opts |  "-Xms1024m -Xmx1024m" | Relocated
+jenkins-master.jenkins-opts | "" | advanced.jenkins-opts |  "" | Relocated
+jenkins-master.additional-plugins | "" | N/A |  N/A | Added
+---
+## Jenkins Agent Related Options
+4.0.0-2.204.6 |    Default   |    3.6.1-2.190.1    |    Default    |    Notes    
+--------------|--------------|---------------------|---------------|-------------
+jenkins-agent.jenkins-agent-user | "nobody" | advanced.jenkins-agent-user | "root" | Changed & Relocated
+---
+### Jenkins Linux Agent Related Options
+4.0.0-2.204.6 |    Default   |    3.6.1-2.190.1    |    Default    |    Notes    
+--------------|--------------|---------------------|---------------|-------------
+jenkins-agent.linux-agent.label | "linux" | N/A | N/A | Added
+jenkins-agent.linux-agent.cpus | 0.1 | N/A | N/A | Added
+jenkins-agent.linux-agent.mem | 512.0 | N/A | N/A | Added
+jenkins-agent.linux-agent.disk | 0.0 | N/A | N/A | Added
+jenkins-agent.linux-agent.max-executors | 1 | N/A | N/A | Added
+jenkins-agent.linux-agent.min-executors | 1 | N/A | N/A | Added
+jenkins-agent.linux-agent.offer-selection-attributes | "" | N/A | N/A | Added
+jenkins-agent.linux-agent.jnlp-args | "-noReconnect" | N/A | N/A | Added
+jenkins-agent.linux-agent.idle-termination-minutes | 3 | N/A | N/A | Added
+jenkins-agent.linux-agent.image | "mesosphere/jenkins-dind:0.9.0" | N/A | N/A | Added
+---
+## Jenkins Health-Check Related Options
+4.0.0-2.204.6 |    Default   |    3.6.1-2.190.1    |    Default    |    Notes    
+--------------|--------------|---------------------|---------------|-------------
+health-checks.grace-period | 30 | health-checks.grace-period | 30 |
+health-checks.interval | 60 | health-checks.interval | 60 |
+health-checks.timeout | 20 | health-checks.timeout | 20 |
+health-checks.max-consecutive-failures | 3 | health-checks.max-consecutive-failures | 3 |
+

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/quickstart/index.md
@@ -1,0 +1,54 @@
+---
+layout: layout.pug
+navigationTitle:  Jenkins for DC/OS Quickstart
+title: Jenkins for DC/OS Quickstart
+menuWeight: 10
+excerpt: Jenkins for DC/OS can be installed using either the web interface or the DC/OS CLI.
+beta: false
+featureMaturity:
+enterprise: false
+---
+# About installing Jenkins for DC/OS
+
+As a package available in the Universe, Jenkins for DC/OS can be installed using either the web interface or the DC/OS CLI. With its sensible defaults, you can get up and running very quickly.
+
+**Important:** The default installation will use a `/tmp` directory on the local host to store configuration and build data. This configuration will not scale to accommodate multiple Jenkins masters. In addition, it will result in the loss of data when the agent goes down. Before going into production, you must perform a [custom install](/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install) and set up either a shared file system (recommended) or pin to a single agent.
+
+# Prerequisites
+
+DC/OS 1.11 or later
+
+**Note:** If you are on an earlier version and would like to try out Jenkins for DC/OS, contact <a href="mailto:support@mesosphere.io">support@mesosphere.io</a>.
+
+# Installing Jenkins for DC/OS
+
+## Using the web interface
+
+
+- Click **Universe**.
+- Click the **Install Package** button for the Jenkins package.
+- To accept the default settings, click **Install Package** on the pop-up. To customize the installation parameters, click **Advanced Installation** instead. Refer to [Customizing your install](/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install) for more information about each option.
+
+## Using the CLI
+
+**Tip:** To install Jenkins using the CLI, you must have the [CLI installed](https://docs.d2iq.com/mesosphere/dcos/latest/cli/install).
+
+From the CLI, type the following command to install Jenkins for DC/OS.
+
+```bash
+dcos package install jenkins
+```
+
+**Note:** You can use the `--options` flag to pass custom configuration parameters. Refer to [Customizing your install](/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install) for more information.
+
+# Verifying your installation
+
+1. You can use either the web interface or the CLI to verify that Jenkins for DC/OS has installed successfully.
+    - From the DC/OS CLI, run the following command to list the installed packages:
+      ```bash
+      dcos package list
+      ```
+
+1. From the web interface, click the **Services** tab and confirm that Jenkins is running at `/#/services`.
+    - Launch your browser and navigate to the Jenkins interface at `http://host-name/service/jenkins`.
+

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/release-notes/index.md
@@ -1,0 +1,33 @@
+---
+layout: layout.pug
+navigationTitle: Jenkins for DC/OS Beta Release Notes
+title: Jenkins for DC/OS Beta Release Notes
+menuWeight: 0
+beta: false
+excerpt: Discover the new features, updates, and known limitations in this release of the Jenkins for DC/OS Service
+enterprise: false
+--- 
+Jenkins 4.0.0-2.204.6 was released on 16, July 2020.
+
+Jenkins 4.0.0-2.204.6
+
+## Improvements
+- Updates to Jenkins version 2.204.6 (LTS)
+- Updates [jenkins-mesos-plugin](https://github.com/jenkinsci/mesos-plugin) to 2.0.0 which is a major overhaul of the plugin.
+    - The jenkins-mesos-plugin has been replatformed on the [Unified Scheduler Iterface (USI)](https://github.com/mesosphere/usi) Library which provides better long-term support and more rapid delivery of Mesos features. The following features are in use:
+        - Mesos v1 API
+        - Offer-suppression
+        - [Universal Container Runtime](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/ucr)
+        - [Multi-Tenancy Features](/mesosphere/dcos/latest/multi-tenancy)
+- Support for configurable Jenkins plugins
+    - Removes previous hardcoded list of bundled plugins.
+    - A list of user desired plugins can be specified at installation time which will be installed into the service before it is started.
+- [Jenkins Configuration as Code (JCasC)](https://github.com/jenkinsci/configuration-as-code-plugin) is bundled by default and is used to configure Jenkins and its plugins.
+
+## Changes from previous 3.x.y releases.
+- Configuration options have changed significantly from the previous releases. See the [options compatiblity matrix](/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/options-compatibility-matrix/) for differences between current and previous releases.
+- [Universal Container Runtime](https://docs.d2iq.com/mesosphere/dcos/latest/deploying-services/containerizers/ucr) (UCR) is now the default containerizer for the Jenkins master.
+- The default user has changed from `root` to `nobody` for both the Jenkins Master and Agents.
+- Agent label `linux` is applied by default.
+
+<!-- This source repo for this topic is located on https://github.com/mesosphere/dcos-jenkins-service -->

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/uninstall/index.md
@@ -1,0 +1,30 @@
+---
+layout: layout.pug
+navigationTitle:  Uninstalling
+title: Uninstalling
+menuWeight: 70
+excerpt: Jenkins for DC/OS can be uninstalled using either the web interface or the CLI. 
+beta: false
+featureMaturity:
+enterprise: false
+---
+# Uninstalling DC/OS Jenkins Service
+
+Jenkins for DC/OS can be uninstalled using either the web interface or the CLI.
+
+**Note:** This process does not delete the data stored on either the pinned agent or the shared file system. You must delete this data manually.
+
+## Using the web interface
+
+1. Select the **Universe** tab.
+1. Selet **Installed** to view your installed services.
+1. Hover over the Jenkins instance that you wish to uninstall. A red **Uninstall** link will appear on the far right.
+1. Select **Uninstall**.
+
+## Using the CLI
+
+From the CLI, you can uninstall with the following command.
+
+```bash
+dcos package uninstall jenkins
+```

--- a/pages/mesosphere/dcos/services/jenkins/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/jenkins-auth/index.md
@@ -9,6 +9,7 @@ excerpt: >
   account.
 featureMaturity:
 enterprise: true
+beta: false
 ---
 
 


### PR DESCRIPTION
## Jira Ticket
[D2iQ-70163](https://jira.d2iq.com/browse/D2IQ-70163)

## Description of changes being made
This PR captures the release of Jenkins 4.0.0-2.204.6
This PR is a minor modification of #2863 which has been reviewed and releaed with the following minor changes:
- Replaced `beta-jenkins` with `jenkins`
- Set `beta` flag to `false` in the headers.
- Updated version to `4.0.0-2.204.6`
- Removed any instances of `windows` as it is deprecated.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [x] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [x] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
