### PR TITLE
konvoy: redirect latest to 1.5

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -1,5 +1,5 @@
 ~^/mesosphere/dcos/latest/(.*)$ /mesosphere/dcos/2.1/$1;
-~^/ksphere/konvoy/latest/(.*)$ /ksphere/konvoy/1.4/$1;
+~^/ksphere/konvoy/latest/(.*)$ /ksphere/konvoy/1.5/$1;
 ~^/ksphere/dispatch/latest/(.*)$ /ksphere/dispatch/1.2/$1;
 ~^/ksphere/kommander/latest/(.*)$ /ksphere/kommander/1.1/$1;
 ~^/mesosphere/dcos/services/cassandra/latest/(.*) /mesosphere/dcos/services/cassandra/2.9.0-3.11.6/$1;


### PR DESCRIPTION
Follow up to https://github.com/mesosphere/dcos-docs-site/pull/3095, when CI ran the second time the commit got reverted.