### PR TITLE
konvoy: move addons page

### DIFF
--- a/pages/ksphere/konvoy/1.5/addons/index.md
+++ b/pages/ksphere/konvoy/1.5/addons/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Kubernetes Base Addons
 title: Kubernetes Base Addons
-menuWeight: 0
+menuWeight: 6
 excerpt: What are Kubernetes Base Addons
 enterprise: false
 ---

--- a/pages/ksphere/konvoy/1.5/logging/fluentbit/index.md
+++ b/pages/ksphere/konvoy/1.5/logging/fluentbit/index.md
@@ -17,6 +17,6 @@ enterprise: false
 
 For information on related topics or procedures, refer to the following:
 
-- [Logging](../../logging)
-- [Resource Recommendations](../../logging/recommendations)
+- [Logging](../logging)
+- [Resource Recommendations](../recommendations)
 - [Disable Audit Log Collection](../../tutorials/disable-audit-logs)


### PR DESCRIPTION
Move the KBA page to after logging and monitoring, instead of the first one in the list.

![image](https://user-images.githubusercontent.com/4969231/88010770-8615c680-caca-11ea-9257-ed4a3a52a181.png)
