### PR TITLE
kommander: use 1.1 as latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ MS.metadata({
   dcosCNDocsLatest: "2.0",
   dcosDocsLatest: "2.1",
   dispatchDocsLatest: "1.2",
-  kommanderDocsLatest: "1.0",
+  kommanderDocsLatest: "1.1",
   konvoyDocsLatest: "1.5",
   kubeflowDocsLatest: "1.0.1-0.3.1",
 });


### PR DESCRIPTION
Similar change to https://github.com/mesosphere/dcos-docs-site/pull/3103 but for Kommander, use 1.1 links from the landing page.