### PR TITLE
speed up live editing in docker …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,10 @@ docker-liveedit-image:
 
 docker-liveedit:
 	@test -n "$$(docker image ls --quiet $(LIVEEDIT_IMAGE))" || (echo "Image '$(LIVEEDIT_IMAGE)' not found. Did you already run 'make docker-liveedit-image'?"; exit 1)
+	# Note: --mount consistency=delegated for MacOS. See https://docs.docker.com/storage/bind-mounts/#configure-mount-consistency-for-macos.
 	docker run -it --rm \
 	--env RENDER_PATH_PATTERN=$(LIVEEDIT_RENDER_PATH_PATTERN) \
-	--mount type=bind,src=$(LIVEEDIT_PAGES_SRC_ABS_PATH),dst=/dcos-docs-site/pages/$(LIVEEDIT_PAGES_DST_REL_PATH),readonly \
+	--mount type=bind,src=$(LIVEEDIT_PAGES_SRC_ABS_PATH),dst=/dcos-docs-site/pages/$(LIVEEDIT_PAGES_DST_REL_PATH),consistency=delegated,readonly \
 	--publish 127.0.0.1:$(LIVEEDIT_HOST_PORT):3000 \
 	--publish 127.0.0.1:35729:35729 \
 	$(LIVEEDIT_IMAGE)

--- a/index.js
+++ b/index.js
@@ -354,15 +354,15 @@ if (ALGOLIA_UPDATE === "true") {
 // Enable watching
 // The keys represent the files to watch, the values are the files that will
 // be updated. ONLY the files that are being updated will be accessible to
-// during the rebuild. We must include everything at this point or the
-// templates will not be accessible. Need changes to fix this.
+// during the rebuild. We must include the layouts when rerendering a page thus.
 // Can only watch with a RENDER_PATH_PATTERN because there are too many
 // files without it.
 if (process.env.NODE_ENV === "development" && RENDER_PATH_PATTERN) {
   MS.use(
     watch({
       paths: {
-        [`pages/${RENDER_PATH_PATTERN}/*`]: "**/*.{md,tmpl}",
+        [`pages/${RENDER_PATH_PATTERN}/*`]: true,
+        [`pages/**/*`]: "layouts/**/*",
         "layouts/**/*": "**/*",
         "js/**/*": "**/*",
         "scss/**/*": "**/*",


### PR DESCRIPTION
...and on bare metal.

1. the consistency-flag is mostly about optimizing performance on osx. we
trade off file consistency between the docker host and the container for
speed. we actually live dangerously here and say that the container is
authoritative (via "delegated"). this allows the container to perform
everything needed for a live reload way faster though and has never led
to a loss of information in past projects for me.

2. introducing yet another watch-rule for pages. the way the
watch-plugin is implemented limits file access in subsequent
metalsmith-runs to only those files that are on the right side of those
rules. because we need to access the `layouts`-folder whenever we change
a page, we formerly decided to just pump all markdown files
(`**/*.{md,tmpl}`) through the pipeline again. we now try to be more
clever and introduce a rule that always pumps the layout-files through
the pipeline whenever some page changed (unfortunately the plugin does
not seem to have a means to express that more intention-revealing).

  the main benefit here is that the live-reload server does not send ~6k
  events to the browser before that reloads anymore. a process which
  seems to be much slower in a docker-environment.
