### PR TITLE
remove obsolete entries from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,30 +1,13 @@
 {
   "master": {
     "DO_NOT_BUILD": [
-      "test/**",
       "mesosphere/dcos/2.2/**"
-    ],
-    "DO_NOT_INDEX": [
     ]
   },
   "staging": {
     "DO_NOT_BUILD": [
-      "test/**",
       "mesosphere/dcos/2.2/**"
-    ],
-    "DO_NOT_INDEX": [
-      "^cn"
     ]
-  },
-  "develop": {
-    "DO_NOT_BUILD": [],
-    "DO_NOT_INDEX": [
-      "^cn"
-    ]
-  },
-  "local": {
-    "DO_NOT_BUILD": [],
-    "DO_NOT_INDEX": []
   },
   "kommander": {
     "DO_NOT_BUILD": [
@@ -36,35 +19,6 @@
       "mesosphere/dcos/1.12/**",
       "mesosphere/dcos/1.13/**",
       "mesosphere/dcos/2.0/**"
-    ],
-    "DO_NOT_INDEX": []
-  },
-  "dispatch": {
-    "DO_NOT_BUILD": [
-      "mesosphere/dcos/1.7/**",
-      "mesosphere/dcos/1.8/**",
-      "mesosphere/dcos/1.9/**",
-      "mesosphere/dcos/1.10/**",
-      "mesosphere/dcos/1.11/**",
-      "mesosphere/dcos/1.12/**",
-      "mesosphere/dcos/1.13/**",
-      "mesosphere/dcos/2.0/**"
-    ],
-    "DO_NOT_INDEX": []
-  },
-  "alpha": {
-    "DO_NOT_BUILD": [
-      "mesosphere/dcos/1.7/**",
-      "mesosphere/dcos/1.8/**",
-      "mesosphere/dcos/1.9/**",
-      "mesosphere/dcos/1.10/**",
-      "mesosphere/dcos/1.11/**",
-      "mesosphere/dcos/1.12/**"
-    ],
-    "DO_NOT_INDEX": []
-  },
-  "always": {
-    "DO_NOT_BUILD": [],
-    "DO_NOT_INDEX": []
+    ]
   }
 }

--- a/index.js
+++ b/index.js
@@ -48,21 +48,8 @@ const ALGOLIA_PRIVATE_KEY = process.env.ALGOLIA_PRIVATE_KEY;
 const ALGOLIA_INDEX = process.env.ALGOLIA_INDEX;
 const RENDER_PATH_PATTERN = process.env.RENDER_PATH_PATTERN || process.env.RPP;
 
-const branchDoNotIndex = config[GIT_BRANCH]
-  ? config[GIT_BRANCH].DO_NOT_INDEX
-  : [];
-
-const ALGOLIA_SKIP_SECTIONS = branchDoNotIndex
-  ? config.always.DO_NOT_INDEX.concat(branchDoNotIndex)
-  : config.always.DO_NOT_INDEX;
-
-const branchDoNotBuild = config[GIT_BRANCH]
-  ? config[GIT_BRANCH].DO_NOT_BUILD
-  : config.local.DO_NOT_BUILD;
-
-const METALSMITH_SKIP_SECTIONS = config.always.DO_NOT_BUILD.concat(
-  branchDoNotBuild
-);
+const branchCfg = config[GIT_BRANCH] || {};
+const METALSMITH_SKIP_SECTIONS = branchCfg.DO_NOT_BUILD || [];
 
 //
 // Errors
@@ -344,7 +331,6 @@ if (ALGOLIA_UPDATE === "true") {
     algolia({
       projectId: ALGOLIA_PROJECT_ID,
       privateKey: ALGOLIA_PRIVATE_KEY,
-      skipSections: ALGOLIA_SKIP_SECTIONS,
       renderPathPattern: pathPatternRegex,
     })
   );


### PR DESCRIPTION
there seem to be some obsolete branch-configs in `config.json`.

as i think it would be wise to completely get rid of this file in favour of a `draft`-mechanism, we now start by trimming it down.

1. `DO_NOT_INDEX` has no effect currently. things that are not built also won't be indexed.
2. the `develop`- and `alpha`-envs are not used anymore
3. `dispatch` does not have an according branch. IT MIGHT BE that someone specifies dispatch as a docker-arg in some build-process that is now slowed down. if so, they could use the RPP to only build dispatch, which would be even faster.
4. evade the need for `local` and `always` via changes in `index.js`.

--------------

this PR emerged while adding DCOS 2.2.