### PR TITLE
removing dispatch 1.3 from do not build list

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,6 @@
   "master": {
     "DO_NOT_BUILD": [
       "test/**",
-      "ksphere/dispatch/1.3/**",
       "mesosphere/dcos/2.2/**"
     ],
     "DO_NOT_INDEX": [
@@ -11,7 +10,6 @@
   "staging": {
     "DO_NOT_BUILD": [
       "test/**",
-      "ksphere/dispatch/1.3/**",
       "mesosphere/dcos/2.2/**"
     ],
     "DO_NOT_INDEX": [


### PR DESCRIPTION


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
