### PR TITLE
COPS-6402: Add config parameter which avoids the issue

### DIFF
--- a/pages/mesosphere/dcos/1.13/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/1.13/deploying-services/private-docker-registry/index.md
@@ -43,6 +43,7 @@ DC/OS has several parameters which control Docker credentials for all tasks on t
 cluster_docker_credentials = "{}"
 cluster_docker_credentials_enabled = "true"
 cluster_docker_credentials_write_to_etc = "true"
+cluster_docker_credentials_dcos_owned = "false"
 ```
 
 Rather than using a blank configuration, operators can choose to include their full Docker credentials configuration. However, this is not recommended as it leaves sensitive information exposed in DC/OS configuration. Instead, the file `/etc/mesosphere/docker_credentials` can be created prior to DC/OS installation or modified after installation to include the correct configuration and real credentials. The DC/OS agent service must be restarted after making a change to the file: `sudo systemctl restart dcos-mesos-slave` or `sudo systemctl restart dcos-mesos-slave-public`. An empty file or invalid configuration will prevent the agent service from starting.

--- a/pages/mesosphere/dcos/2.0/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/2.0/deploying-services/private-docker-registry/index.md
@@ -43,6 +43,7 @@ DC/OS has several parameters which control Docker credentials for all tasks on t
 cluster_docker_credentials = "{}"
 cluster_docker_credentials_enabled = "true"
 cluster_docker_credentials_write_to_etc = "true"
+cluster_docker_credentials_dcos_owned = "false"
 ```
 
 Rather than using a blank configuration, operators can choose to include their full Docker credentials configuration. However, this is not recommended as it leaves sensitive information exposed in DC/OS configuration. Instead, the file `/etc/mesosphere/docker_credentials` can be created prior to DC/OS installation or modified after installation to include the correct configuration and real credentials. The DC/OS agent service must be restarted after making a change to the file: `sudo systemctl restart dcos-mesos-slave` or `sudo systemctl restart dcos-mesos-slave-public`. An empty file or invalid configuration will prevent the agent service from starting.

--- a/pages/mesosphere/dcos/2.1/deploying-services/private-docker-registry/index.md
+++ b/pages/mesosphere/dcos/2.1/deploying-services/private-docker-registry/index.md
@@ -43,6 +43,7 @@ DC/OS has several parameters which control Docker credentials for all tasks on t
 cluster_docker_credentials = "{}"
 cluster_docker_credentials_enabled = "true"
 cluster_docker_credentials_write_to_etc = "true"
+cluster_docker_credentials_dcos_owned = "false"
 ```
 
 Rather than using a blank configuration, operators can choose to include their full Docker credentials configuration. However, this is not recommended as it leaves sensitive information exposed in DC/OS configuration. Instead, the file `/etc/mesosphere/docker_credentials` can be created prior to DC/OS installation or modified after installation to include the correct configuration and real credentials. The DC/OS agent service must be restarted after making a change to the file: `sudo systemctl restart dcos-mesos-slave` or `sudo systemctl restart dcos-mesos-slave-public`. An empty file or invalid configuration will prevent the agent service from starting.


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/COPS-6402

## Description of changes being made
Adding another parameter to an example which prevents operators from hitting the bug described in the COPS.

This change can be merged any time.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [n/a] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [n/a] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
