### PR TITLE
fix watching when using RPP on osx

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,8 +361,7 @@ if (process.env.NODE_ENV === "development" && RENDER_PATH_PATTERN) {
   MS.use(
     watch({
       paths: {
-        [`pages/${RENDER_PATH_PATTERN}/*`]: true,
-        [`pages/**/*`]: "layouts/**/*",
+        [`pages/${RENDER_PATH_PATTERN}/*`]: "**/*.{md,tmpl}",
         "layouts/**/*": "**/*",
         "js/**/*": "**/*",
         "scss/**/*": "**/*",


### PR DESCRIPTION
unfortunately the gaze-library uses a mechanism that can only watch so many files (as
it declares the things to watch recursively - which worked back at the
time when node.js supported tail recursion).

we recently tried to be more clever with watching as that helped
massively speeding up the rebuilds in the newly introduced
docker-dev-env (70sec => 10sec). within that docker image node.js 
seems to be configured in a way that allows to recurse that deep.

we go back to the previous behaviour now in order to later find out which 
way to go from here.

we could ditch the metalsmitch-watcher for something as simple as `npx
nodemon ./rebuild-pages` (which should work reasonably fast with our
caching mechanisms), change `metalsmith-watch` to not use recursion or
write a new plugin using something battle tested like chokidar. 
OR we could tell everyone that the docker-way is the only way of running docs 
locally and make it a first-class citizen.