### PR TITLE
Line Highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,30 @@ $ openssl x509 -hash -noout -in ca.crt
 
 For the same usability as removing the shell prompt, always separate input blocks from output blocks so that users can copy the commands.
 
+### Adding line highlights
+
+You can highlight lines in a code block by adding a `data-line` attribute:
+
+    ```json {data-line=2-5}
+    {
+      "id": "my-job",
+      "description": "A job that sleeps",
+      "run": {
+        "cmd": "sleep 1000",
+        "cpus": 0.01,
+        "mem": 32,
+        "disk": 0
+      }
+    }
+    ```
+
+You can highlight any combination of single lines and ranges. Some examples:
+
+* `1` - highlight line 1.
+* `2-5` - highlight the range 2 to 5.
+* `1,3` - highlight the lines 1 and 3.
+* `1-3,42` - highlight lines 1 to 3 and 42.
+
 ### Adding mustache variables
 Version numbers, product names and other commonly used items can be added in as variables to increase text reusability.
 

--- a/js/code-container.js
+++ b/js/code-container.js
@@ -1,8 +1,315 @@
 function wrapCodeBlocks() {
   $("pre").each((index, elem) => {
     $(elem).wrapAll('<div class="code-container" />');
+    $(elem).attr("data-line", $(elem).find("code").attr("data-line"));
+    $(elem).attr("data-range", $(elem).find("code").attr("data-range"));
     elem.classList.add("language-*");
   });
 }
 
 wrapCodeBlocks();
+
+(function () {
+  if (
+    typeof self === "undefined" ||
+    !self.Prism ||
+    !self.document ||
+    !document.querySelector
+  ) {
+    return;
+  }
+
+  /**
+   * @param {string} selector
+   * @param {ParentNode} [container]
+   * @returns {HTMLElement[]}
+   */
+  function $$(selector, container) {
+    return Array.prototype.slice.call(
+      (container || document).querySelectorAll(selector)
+    );
+  }
+
+  /**
+   * Returns whether the given element has the given class.
+   *
+   * @param {Element} element
+   * @param {string} className
+   * @returns {boolean}
+   */
+  function hasClass(element, className) {
+    className = " " + className + " ";
+    return (
+      (" " + element.className + " ")
+        .replace(/[\n\t]/g, " ")
+        .indexOf(className) > -1
+    );
+  }
+
+  /**
+   * Calls the given function.
+   *
+   * @param {() => any} func
+   * @returns {void}
+   */
+  function callFunction(func) {
+    func();
+  }
+
+  // Some browsers round the line-height, others don't.
+  // We need to test for it to position the elements properly.
+  var isLineHeightRounded = (function () {
+    var res;
+    return function () {
+      if (typeof res === "undefined") {
+        var d = document.createElement("div");
+        d.style.fontSize = "13px";
+        d.style.lineHeight = "1.5";
+        d.style.padding = "0";
+        d.style.border = "0";
+        d.innerHTML = "&nbsp;<br />&nbsp;";
+        document.body.appendChild(d);
+        // Browsers that round the line-height should have offsetHeight === 38
+        // The others should have 39.
+        res = d.offsetHeight === 38;
+        document.body.removeChild(d);
+      }
+      return res;
+    };
+  })();
+
+  /**
+   * Highlights the lines of the given pre.
+   *
+   * This function is split into a DOM measuring and mutate phase to improve performance.
+   * The returned function mutates the DOM when called.
+   *
+   * @param {HTMLElement} pre
+   * @param {string} [lines]
+   * @param {string} [classes='']
+   * @returns {() => void}
+   */
+  function highlightLines(pre, lines, classes) {
+    lines = typeof lines === "string" ? lines : pre.getAttribute("data-line");
+
+    var ranges = lines.replace(/\s+/g, "").split(",").filter(Boolean);
+    var offset = +pre.getAttribute("data-line-offset") || 0;
+
+    var parseMethod = isLineHeightRounded() ? parseInt : parseFloat;
+    var lineHeight = parseMethod(getComputedStyle(pre).lineHeight);
+    var hasLineNumbers = hasClass(pre, "line-numbers");
+    var parentElement = hasLineNumbers ? pre : pre.querySelector("code") || pre;
+    var mutateActions = /** @type {(() => void)[]} */ ([]);
+
+    ranges.forEach(function (currentRange) {
+      var range = currentRange.split("-");
+
+      var start = +range[0];
+      var end = +range[1] || start;
+
+      /** @type {HTMLElement} */
+      var line =
+        pre.querySelector(
+          '.line-highlight[data-range="' + currentRange + '"]'
+        ) || document.createElement("div");
+
+      mutateActions.push(function () {
+        line.setAttribute("aria-hidden", "true");
+        line.setAttribute("data-range", currentRange);
+        line.className = (classes || "") + " line-highlight";
+      });
+
+      // if the line-numbers plugin is enabled, then there is no reason for this plugin to display the line numbers
+      if (hasLineNumbers && Prism.plugins.lineNumbers) {
+        var startNode = Prism.plugins.lineNumbers.getLine(pre, start);
+        var endNode = Prism.plugins.lineNumbers.getLine(pre, end);
+
+        if (startNode) {
+          var top = startNode.offsetTop + "px";
+          mutateActions.push(function () {
+            line.style.top = top;
+          });
+        }
+
+        if (endNode) {
+          var height =
+            endNode.offsetTop -
+            startNode.offsetTop +
+            endNode.offsetHeight +
+            "px";
+          mutateActions.push(function () {
+            line.style.height = height;
+          });
+        }
+      } else {
+        mutateActions.push(function () {
+          line.setAttribute("data-start", start);
+
+          if (end > start) {
+            line.setAttribute("data-end", end);
+          }
+
+          line.style.top = (start - offset - 1) * lineHeight + "px";
+
+          line.textContent = new Array(end - start + 2).join(" \n");
+        });
+      }
+
+      mutateActions.push(function () {
+        // allow this to play nicely with the line-numbers plugin
+        // need to attack to pre as when line-numbers is enabled, the code tag is relatively which screws up the positioning
+        parentElement.appendChild(line);
+      });
+    });
+
+    var id = pre.id;
+    if (hasLineNumbers && id) {
+      // This implements linkable line numbers. Linkable line numbers use Line Highlight to create a link to a
+      // specific line. For this to work, the pre element has to:
+      //  1) have line numbers,
+      //  2) have the `linkable-line-numbers` class or an ascendant that has that class, and
+      //  3) have an id.
+
+      var linkableLineNumbersClass = "linkable-line-numbers";
+      var linkableLineNumbers = false;
+      var node = pre;
+      while (node) {
+        if (hasClass(node, linkableLineNumbersClass)) {
+          linkableLineNumbers = true;
+          break;
+        }
+        node = node.parentElement;
+      }
+
+      if (linkableLineNumbers) {
+        if (!hasClass(pre, linkableLineNumbersClass)) {
+          // add class to pre
+          mutateActions.push(function () {
+            pre.className = (
+              pre.className +
+              " " +
+              linkableLineNumbersClass
+            ).trim();
+          });
+        }
+
+        var start = parseInt(pre.getAttribute("data-start") || "1");
+
+        // iterate all line number spans
+        $$(".line-numbers-rows > span", pre).forEach(function (lineSpan, i) {
+          var lineNumber = i + start;
+          lineSpan.onclick = function () {
+            var hash = id + "." + lineNumber;
+
+            // this will prevent scrolling since the span is obviously in view
+            scrollIntoView = false;
+            location.hash = hash;
+            setTimeout(function () {
+              scrollIntoView = true;
+            }, 1);
+          };
+        });
+      }
+    }
+
+    return function () {
+      mutateActions.forEach(callFunction);
+    };
+  }
+
+  var scrollIntoView = true;
+  function applyHash() {
+    var hash = location.hash.slice(1);
+
+    // Remove pre-existing temporary lines
+    $$(".temporary.line-highlight").forEach(function (line) {
+      line.parentNode.removeChild(line);
+    });
+
+    var range = (hash.match(/\.([\d,-]+)$/) || [, ""])[1];
+
+    if (!range || document.getElementById(hash)) {
+      return;
+    }
+
+    var id = hash.slice(0, hash.lastIndexOf(".")),
+      pre = document.getElementById(id);
+
+    if (!pre) {
+      return;
+    }
+
+    if (!pre.hasAttribute("data-line")) {
+      pre.setAttribute("data-line", "");
+    }
+
+    var mutateDom = highlightLines(pre, range, "temporary ");
+    mutateDom();
+
+    if (scrollIntoView) {
+      document.querySelector(".temporary.line-highlight").scrollIntoView();
+    }
+  }
+
+  var fakeTimer = 0; // Hack to limit the number of times applyHash() runs
+
+  Prism.hooks.add("before-sanity-check", function (env) {
+    var pre = env.element.parentNode;
+    var lines = pre && pre.getAttribute("data-line");
+
+    if (!pre || !lines || !/pre/i.test(pre.nodeName)) {
+      return;
+    }
+
+    /*
+     * Cleanup for other plugins (e.g. autoloader).
+     *
+     * Sometimes <code> blocks are highlighted multiple times. It is necessary
+     * to cleanup any left-over tags, because the whitespace inside of the <div>
+     * tags change the content of the <code> tag.
+     */
+    var num = 0;
+    $$(".line-highlight", pre).forEach(function (line) {
+      num += line.textContent.length;
+      line.parentNode.removeChild(line);
+    });
+    // Remove extra whitespace
+    if (num && /^( \n)+$/.test(env.code.slice(-num))) {
+      env.code = env.code.slice(0, -num);
+    }
+  });
+
+  Prism.hooks.add("complete", function completeHook(env) {
+    var pre = env.element.parentNode;
+    var lines = pre && pre.getAttribute("data-line");
+
+    if (!pre || !lines || !/pre/i.test(pre.nodeName)) {
+      return;
+    }
+
+    clearTimeout(fakeTimer);
+
+    var hasLineNumbers = Prism.plugins.lineNumbers;
+    var isLineNumbersLoaded = env.plugins && env.plugins.lineNumbers;
+
+    if (
+      hasClass(pre, "line-numbers") &&
+      hasLineNumbers &&
+      !isLineNumbersLoaded
+    ) {
+      Prism.hooks.add("line-numbers", completeHook);
+    } else {
+      var mutateDom = highlightLines(pre, lines);
+      mutateDom();
+      fakeTimer = setTimeout(applyHash, 1);
+    }
+  });
+
+  window.addEventListener("hashchange", applyHash);
+  window.addEventListener("resize", function () {
+    var actions = $$("pre[data-line]").map(function (pre) {
+      return highlightLines(pre);
+    });
+    actions.forEach(callFunction);
+  });
+})();

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jstransformer-mustache": "^0.1.1",
     "markdown-it": "^8.4.0",
     "markdown-it-anchor": "^4.0.0",
-    "markdown-it-attrs": "^1.0.0",
+    "markdown-it-attrs": "^1.2.1",
     "metalsmith": "^2.3.0",
     "metalsmith-assets": "^0.1.0",
     "metalsmith-copy": "^0.4.0",

--- a/scss/vendor/_prism.scss
+++ b/scss/vendor/_prism.scss
@@ -179,3 +179,42 @@
 	 color: inherit;
 	 text-decoration: none;
  }
+
+//////////////////////////////////////////////////////////////////////////////
+//                          LINE HIGHLIGHTING PLUGIN                        //
+//////////////////////////////////////////////////////////////////////////////
+pre[data-line] {
+	position: relative;
+	padding: 1em 0 1em 3em;
+}
+
+.line-highlight {
+	position: absolute;
+	left: 0;
+	right: 0;
+	padding: inherit 0;
+	margin-top: 1em; /* Same as .prism’s padding-top */
+
+	background: rgba(125, 88, 255, 0.1);
+  background: linear-gradient(to right, rgba(125, 88, 255, 0.15) 70%, rgba(125, 88, 255, 0));
+
+	pointer-events: none;
+
+	line-height: inherit;
+	white-space: pre;
+}
+
+.line-numbers .line-highlight:before,
+.line-numbers .line-highlight:after {
+	content: none;
+}
+
+pre[id].linkable-line-numbers span.line-numbers-rows {
+	pointer-events: all;
+}
+pre[id].linkable-line-numbers span.line-numbers-rows > span:before {
+	cursor: pointer;
+}
+pre[id].linkable-line-numbers span.line-numbers-rows > span:hover:before {
+	background-color: rgba(128, 128, 128, .2);
+}


### PR DESCRIPTION
@russurquhart1 recently asked whether we could add asciidoctor to our stack. it turned out that the most-wanted feature was line-highlighting.


![Job Examples - D2iQ Docs 2020-08-24 11-42-16](https://user-images.githubusercontent.com/300861/91029345-ee425580-e5fe-11ea-945e-c7ee272bb59d.png)

to have a look or play around with that yourself:

the `data-line` attribute can take the following values:

* `1` - highlight line 1.
* `1-3` - highlight the range 1 to 3.
* `1,3` - highlight the lines 1 and 3.
* `1-3,42` - highlight lines 1 to 3 and 42.