### PR TITLE
Remove kubecost 3hr wait time from centralized cost monitoring docs

### DIFF
--- a/pages/ksphere/kommander/1.1/centralized-cost-monitoring/index.md
+++ b/pages/ksphere/kommander/1.1/centralized-cost-monitoring/index.md
@@ -18,8 +18,6 @@ The Kommander cluster collects cost metrics remotely, using Thanos, from each ma
 https://<CLUSTER_URL>/ops/portal/kommander/kubecost/frontend/detail.html#&agg=cluster
 ```
 
-<p class="message--note"><strong>NOTE: </strong>It takes at least 3 hours for each managed cluster to generate sufficient cost data to be aggregated and presented in the UI.</p>
-
 To identify clusters in Kubecost, managed clusters are distinguished by a monitoring ID.
 The monitoring ID corresponds to the kube-system namespace UID of the cluster.
 To find a cluster's monitoring ID, go to the **Clusters** tab on the Kommander UI in the relevant workspace:


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-70685
<!-- Link to DOCS work ticket for reviewing and merging this PR -->

## Description of changes being made
Minor change to remove a note that cost data takes 3hr to show up (it is now 5min - essentially immediately)

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
