### PR TITLE
fix: improve fault domain example to be a valid script

### DIFF
--- a/pages/mesosphere/dcos/1.13/installing/production/deploying-dcos/installation/index.md
+++ b/pages/mesosphere/dcos/1.13/installing/production/deploying-dcos/installation/index.md
@@ -155,20 +155,25 @@ By default, DC/OS clusters have [fault domain awareness](/mesosphere/dcos/1.13/d
 
 1. Create a fault domain detect script named `fault-domain-detect` to run on each node to detect the node's fault domain. During installation, the output of this script is passed to Mesos.
 
-    We recommend the format for the script output be:
+    We recommend a script like this:
 
-    ```json
-    {
-        "fault_domain": {
-            "region": {
-                "name": "<region-name>"
-            },
-            "zone": {
-                "name": "<zone-name>"
-            }
-        }
-    }
-    ```
+    ```sh
+      #!/bin/sh
+
+      REGION="<enter region name>"
+      ZONE="<enter zone name>"
+
+      echo "{
+          \"fault_domain\": {
+              \"region\": {
+                  \"name\": \"${REGION}\"
+              },
+              \"zone\": {
+                  \"name\": \"${ZONE}\"
+              }
+          }
+      }"
+      ```
 
     We provide [fault domain detect scripts for AWS and Azure nodes](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
 
@@ -469,5 +474,3 @@ You can find information on the next steps listed below:
 [12]: /mesosphere/dcos/1.13/installing/production/deploying-dcos/node-cluster-health-check/
 [10]: /mesosphere/dcos/1.13/installing/troubleshooting/
 [11]: /mesosphere/dcos/1.13/installing/production/uninstalling/
-
-

--- a/pages/mesosphere/dcos/2.0/installing/production/deploying-dcos/installation/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/deploying-dcos/installation/index.md
@@ -155,19 +155,24 @@ By default, DC/OS clusters have [fault domain awareness](/mesosphere/dcos/2.0/de
 
 1. Create a fault domain detect script named `fault-domain-detect` to run on each node to detect the node's fault domain. During installation, the output of this script is passed to Mesos.
 
-    We recommend the format for the script output be:
+    We recommend a script like this:
 
-    ```json
-    {
-        "fault_domain": {
-            "region": {
-                "name": "<region-name>"
+    ```sh
+    #!/bin/sh
+
+    REGION="<enter region name>"
+    ZONE="<enter zone name>"
+
+    echo "{
+        \"fault_domain\": {
+            \"region\": {
+                \"name\": \"${REGION}\"
             },
-            "zone": {
-                "name": "<zone-name>"
+            \"zone\": {
+                \"name\": \"${ZONE}\"
             }
         }
-    }
+    }"
     ```
 
     We provide [fault domain detect scripts for AWS and Azure nodes](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
@@ -430,7 +435,7 @@ At this point your directory structure should resemble:
 
     <p class="message--note"><strong>NOTE: </strong> If you encounter errors such as `Time is marked as bad`, `adjtimex`, or `Time not in sync` in journald, verify that Network Time Protocol (NTP) is enabled on all nodes. For more information, see the <a href="/mesosphere/dcos/2.0/installing/production/system-requirements/ports/">system requirements</a> documentation.</p>
 
-5.  Monitor the DC/OS web interface and wait for it to display at: `http://<master-node-public-ip>/`. 
+5.  Monitor the DC/OS web interface and wait for it to display at: `http://<master-node-public-ip>/`.
 
     <p class="message--note"><strong>NOTE: </strong>This process can take about 10 minutes.</p>
 
@@ -477,5 +482,3 @@ You can find information on the next steps listed below:
 [12]: /mesosphere/dcos/2.0/installing/production/deploying-dcos/node-cluster-health-check/
 [10]: /mesosphere/dcos/2.0/installing/troubleshooting/
 [11]: /mesosphere/dcos/2.0/installing/production/uninstalling/
-
-

--- a/pages/mesosphere/dcos/2.1/installing/production/deploying-dcos/installation/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/deploying-dcos/installation/index.md
@@ -155,20 +155,25 @@ By default, DC/OS clusters have [fault domain awareness](/mesosphere/dcos/2.1/de
 
 1. Create a fault domain detect script named `fault-domain-detect` to run on each node to detect the node's fault domain. During installation, the output of this script is passed to Mesos.
 
-    We recommend the format for the script output be:
+    We recommend a script like this:
 
-    ```json
-    {
-        "fault_domain": {
-            "region": {
-                "name": "<region-name>"
-            },
-            "zone": {
-                "name": "<zone-name>"
-            }
-        }
-    }
-    ```
+    ```sh
+      #!/bin/sh
+
+      REGION="<enter region name>"
+      ZONE="<enter zone name>"
+
+      echo "{
+          \"fault_domain\": {
+              \"region\": {
+                  \"name\": \"${REGION}\"
+              },
+              \"zone\": {
+                  \"name\": \"${ZONE}\"
+              }
+          }
+      }"
+      ```
 
     We provide [fault domain detect scripts for AWS and Azure nodes](https://github.com/dcos/dcos/tree/master/gen/fault-domain-detect). For a cluster that has aws nodes and azure nodes you would combine the two into one script. You can use these as a model for creating a fault domain detect script for an on premises cluster.
 
@@ -430,7 +435,7 @@ At this point your directory structure should resemble:
 
     __Note:__ If you encounter errors such as `Time is marked as bad`, `adjtimex`, or `Time not in sync` in journald, verify that Network Time Protocol (NTP) is enabled on all nodes. For more information, see the [system requirements](/mesosphere/dcos/2.1/installing/production/system-requirements/ports/) documentation.
 
-5.  Monitor the DC/OS web interface and wait for it to display at: `http://<master-node-public-ip>/`. 
+5.  Monitor the DC/OS web interface and wait for it to display at: `http://<master-node-public-ip>/`.
 
     <p class="message--note"><strong>NOTE: </strong>This process can take about 10 minutes.</p>
 
@@ -477,5 +482,3 @@ You can find information on the next steps listed below:
 [12]: /mesosphere/dcos/2.1/installing/production/deploying-dcos/node-cluster-health-check/
 [10]: /mesosphere/dcos/2.1/installing/troubleshooting/
 [11]: /mesosphere/dcos/2.1/installing/production/uninstalling/
-
-


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

[D2IQ-70965](https://jira.d2iq.com/browse/D2IQ-70965) Fault domain detect example in on-prem docs missleading

## Description of changes being made
- Changed the example to be an script instead of just example output of an undefined script


## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
