### PR TITLE
convert templates to use pugs class and id notation

### DIFF
--- a/layouts/404.pug
+++ b/layouts/404.pug
@@ -6,28 +6,28 @@ html(lang='en')
   head
     include partials/head.pug
   body
-    div(class='layout')
-      header(class='header' style="position: fixed;")
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
-          img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
-          img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+    .layout
+      header.header(style='position: fixed;')
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
+          img.header__logo--mobile(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ')
+          img.header__logo--desktop(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
         include partials/header/mesosphere-dropdown.pug
         include partials/header/ksphere-dropdown.pug
         include partials/header/header-dropdown.pug
-      div(role='main', class='layout__content')
-        main(class='content content__404')
-          div(class=containerClass)
-            div(class='content__header')
-              div(class='content__header__row')
-                h1(class='content__header-title')!= title
-            article(class='content__article ')
+      .layout__content(role='main')
+        main.content.content__404
+          div
+            .content__header
+              .content__header__row
+                h1.content__header-title
+            article.content__article
               != contents
         include partials/search-results.pug
     include partials/scripts.pug

--- a/layouts/all-products-landing.pug
+++ b/layouts/all-products-landing.pug
@@ -9,18 +9,17 @@ doctype html
 html(lang='en')
   head
     include partials/head.pug
-
-  body(class='landing landing--dcos')
+  body.landing.landing--dcos
     .layout
-      header.header(style="position: fixed;")
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
-          img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
-          img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
+      header.header(style='position: fixed;')
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
+          img.header__logo--mobile(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ')
+          img.header__logo--desktop(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ')
         .header__main
           .header__dropdown
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong D2IQ Documentation
             i(data-feather='chevron-down')
         include partials/header/mesosphere-dropdown.pug
@@ -101,25 +100,24 @@ html(lang='en')
 
         .landing__external
           .landing__external-item
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get Training
-            p(class='landing__external-description') Learn to use and administer D2iQ products in real-time training courses, in person or online, offered by D2iQ.
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get Training
+            p.landing__external-description Learn to use and administer D2iQ products in real-time training courses, in person or online, offered by D2iQ.
           .landing__external-item
-            i(data-feather='users', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://dcos.io/community/') Join the Community
-            p(class='landing__external-description') Join the community to get help via mailing list or Slack.
+            i.landing__external-icon(data-feather='users')
+            h3.landing__external-title
+              a.landing__external-link(href='https://dcos.io/community/') Join the Community
+            p.landing__external-description Join the community to get help via mailing list or Slack.
           .landing__external-item
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
-
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
       footer.landing__footer
         .landing__footer__container
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
           .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy

--- a/layouts/cn-dcos-docs-landing.pug
+++ b/layouts/cn-dcos-docs-landing.pug
@@ -3,61 +3,61 @@
 - var sectionTitle = 'DC/OS 文档'
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(latestPath).children
       if val.menuWeight != -1
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           if val.excerpt
             - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-            p(class='grid-toc__desc')!= displayExcerpt
+            p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               for item in val.children.slice(0, 5)
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 mixin renderGrid()
-  div(class='grid')
-    a(href=latestPath + '/installing', class='grid__item')
-      h3(class='grid__header') Install DC/OS
-      div(class='grid__desc__wrapper')
-        p(class='grid__desc') Installation involves configuring your infrastructure and installing DC/OS bits on top, so the infrastructure provider you choose determines your installation method. Select from development, cloud, and on-premises.
-          span(class='grid__desc__ellipsis') &#8230;Read More
-      div(class="grid__link")
+  .grid
+    a.grid__item(href=latestPath + '/installing')
+      h3.grid__header Install DC/OS
+      .grid__desc__wrapper
+        p.grid__desc Installation involves configuring your infrastructure and installing DC/OS bits on top, so the infrastructure provider you choose determines your installation method. Select from development, cloud, and on-premises.
+          span.grid__desc__ellipsis &#8230;Read More
+      .grid__link
         i(data-feather='arrow-right')
-    a(href='https://support.d2iq.com', class='grid__item')
-      h3(class='grid__header') Need Support?
-      div(class='grid__desc__wrapper')
-        p(class='grid__desc') Subscription pricing for DC/OS is based on the number of nodes (physical or virtual) in your environment. DC/OS subscriptions may include either Premium (24x7) or Standard (9-5) support.
-          span(class='grid__desc__ellipsis') &#8230;Read More
-      div(class="grid__link")
+    a.grid__item(href='https://support.d2iq.com')
+      h3.grid__header Need Support?
+      .grid__desc__wrapper
+        p.grid__desc Subscription pricing for DC/OS is based on the number of nodes (physical or virtual) in your environment. DC/OS subscriptions may include either Premium (24x7) or Standard (9-5) support.
+          span.grid__desc__ellipsis &#8230;Read More
+      .grid__link
         i(data-feather='arrow-right')
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--dcos')
-    div(class='layout')
-      header(class='header')
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+  body.landing.landing--dcos
+    .layout
+      header.header
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
-          nav(class='header__menu')
-            ul(class='header__menu-list')
+          nav.header__menu
+            ul.header__menu-list
               each val, index in hierarchy.find('menus', menus => menus.includes('dcos-cn-header'))
                 - var itemClass = {}
                 - itemClass['header__menu-item'] = true
@@ -66,46 +66,46 @@ html(lang='en')
                   a(href=val.path)!= val.title
         include partials/header/ksphere-dropdown.pug
         include partials/header/localization-dropdown.pug
-        section(class='header__search', role='search')
-          form(class='header__search-form', action='/search/', method='GET')
-            label(class='header__search-label', for='header-search-input')
-              i(class='header__icon', data-feather='search')
-            input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
-      div(class='landing__hero')
-        h1(class='landing__title')!= sectionTitle
-        form(class='landing__search', action='/mesosphere/dcos/search/', method='GET')
-          input(class='landing__search-input', id='landing-search-input', placeholder='Search documentation', tabindex='1', type='text', name='q')
-          button(class='landing__search-button')
+        section.header__search(role='search')
+          form.header__search-form(action='/search/')
+            label.header__search-label(for='header-search-input')
+              i.header__icon(data-feather='search')
+            input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+      .landing__hero
+        h1.landing__title!= sectionTitle
+        form.landing__search(action='/mesosphere/dcos/search/')
+          input.landing__search-input(id='landing-search-input', placeholder='Search documentation', tabindex='1', type='text', name='q')
+          button.landing__search-button
             i(data-feather='search')
 
-      div(class='landing__container')
+      .landing__container
         +renderGridToc()
         +renderGrid()
-        div(class='landing__external')
-          div(class='landing__external-item')
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get DC/OS Training
-            p(class='landing__external-description') Learn to use and administer DC/OS in real-time training courses, in person or online, offered by Mesosphere.
-          div(class='landing__external-item')
-            i(data-feather='users', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://dcos.io/community/') Join the Community
-            p(class='landing__external-description') Join the DC/OS community to get help via mailing list or Slack.
-          div(class='landing__external-item')
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
+        .landing__external
+          .landing__external-item
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get DC/OS Training
+            p.landing__external-description Learn to use and administer DC/OS in real-time training courses, in person or online, offered by Mesosphere.
+          .landing__external-item
+            i.landing__external-icon(data-feather='users')
+            h3.landing__external-title
+              a.landing__external-link(href='https://dcos.io/community/') Join the Community
+            p.landing__external-description Join the DC/OS community to get help via mailing list or Slack.
+          .landing__external-item
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
 
-      footer(class='landing__footer')
-        div(class='landing__footer__container')
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-          div(class='landing__footer__menu')
+      footer.landing__footer
+        .landing__footer__container
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy
-          a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+          a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/cn-service-docs-landing.pug
+++ b/layouts/cn-service-docs-landing.pug
@@ -1,7 +1,7 @@
 - var semverService = /^(v|)[0-9](.*)/
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(`mesosphere/dcos/cn/services`).children
       if val.menuWeight != -1
         if val.children
@@ -11,41 +11,41 @@ mixin renderGridToc()
               - childVal.title = val.title
               - val = childVal
               - break
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-          p(class='grid-toc__desc')!= displayExcerpt
+          p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               for item in val.children.slice(0, 5)
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--services')
-    div(class='layout')
-      div(role='main', class='layout__content')
+  body.landing.landing--services
+    .layout
+      div.layout__content(role='main')
         include partials/header/dcos-cn-header.pug
-        div(class='landing__hero')
-          h1(class='landing__title') DC/OS 服务文档
-        div(class='landing__container')
+        .landing__hero
+          h1.landing__title DC/OS 服务文档
+        .landing__container
           +renderGridToc()
-        footer(class='landing__footer')
-          div(class='landing__footer__container')
-            a(class='landing__footer__logo__link', href='https://d2iq.com/')
-              img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-            div(class='landing__footer__menu')
+        footer.landing__footer
+          .landing__footer__container
+            a.landing__footer__logo__link(href='https://d2iq.com/')
+              img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+            .landing__footer__menu
               a(href='https://d2iq.com/terms/') Terms of Service
               a(href='https://d2iq.com/privacy/') Privacy Policy
-            a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+            a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/components/content-actions.pug
+++ b/layouts/components/content-actions.pug
@@ -17,29 +17,25 @@ if (!title)
 - feedbackPath += '&priority=3'
 - feedbackPath += '&customfield_12300=44' // Sets the team field to Documentation Team
 
-div(class='actions')
-  ul(class='actions__list')
-    li(class='actions__item')
-      a(href='/', class='actions__link addthis_button')
-        i(class='actions__icon', data-feather='share')
-        span(class='actions__text') Share
-    //- li(class='actions__item')
-    //-   a(href=pdfPath, class='actions__link', target="_blank")
-    //-     i(class='actions__icon', data-feather='download')
-    //-     span(class='actions__text') Download
-    li(class='actions__item')
-      a(href='javascript:window.print()', class='actions__link')
-        i(class='actions__icon', data-feather='printer')
-        span(class='actions__text') Print
-    li(class='actions__item')
-      a(href=githubPath, class='actions__link', target="_blank")
-        i(class='actions__icon', data-feather='github')
-        span(class='actions__text') Contribute
-    li(class='actions__item')
-      a(href=slackPath, class='actions__link', target="_blank")
-        i(class='actions__icon', data-feather='slack')
-        span(class='actions__text') Discuss
-    li(class='actions__item')
-      a(href=feedbackPath, class='actions__link', target="_blank")
-        i(class='actions__icon', data-feather='message-square')
-        span(class='actions__text') Feedback
+.actions
+  ul.actions__list
+    li.actions__item
+      a.actions__link.addthis_button(href='/')
+        i.actions__icon(data-feather='share')
+        span.actions__text Share
+    li.actions__item
+      a.actions__link(href='javascript:window.print()')
+        i.actions__icon(data-feather='printer')
+        span.actions__text Print
+    li.actions__item
+      a.actions__link(href=githubPath, target="_blank")
+        i.actions__icon(data-feather='github')
+        span.actions__text Contribute
+    li.actions__item
+      a.actions__link(href=slackPath, target="_blank")
+        i.actions__icon(data-feather='slack')
+        span.actions__text Discuss
+    li.actions__item
+      a.actions__link(href=feedbackPath, target="_blank")
+        i.actions__icon(data-feather='message-square')
+        span.actions__text Feedback

--- a/layouts/components/content-grid.pug
+++ b/layouts/components/content-grid.pug
@@ -1,7 +1,7 @@
 - var pageHierarchy = hierarchy.findByPath(path)
 
 if pageHierarchy.children.length > 0
-  div(class='grid')
+  .grid
     each val, index in pageHierarchy.children
       if typeof val.menuWeight !== 'number' || val.menuWeight == -1
         - continue
@@ -11,11 +11,11 @@ if pageHierarchy.children.length > 0
       - labels = (val.community) ? [...labels, 'COMMUNITY'] : labels
       - labels = (val.beta) ? [...labels, 'BETA'] : labels
       - labels = (val.experimental) ? [...labels, 'EXPERIMENTAL'] : labels
-      a(href=val.path, class='grid__item')
-        div(class='grid__header__wrapper')
-          h3(class='grid__header')!= val.title
+      a.grid__item(href=val.path)
+        .grid__header__wrapper
+          h3.grid__header!= val.title
           if labels.length > 0
-            div(class='grid__label__wrapper')
+            .grid__label__wrapper
               - for (let idx = 0; idx < labels.length; idx++) {
                 - var label = labels[idx]
                 - var labelClass =  {}
@@ -28,8 +28,8 @@ if pageHierarchy.children.length > 0
                 - labelClass['grid__label--experimental'] = label === 'EXPERIMENTAL'
                 h6(class=labelClass)!= label
               - }
-        div(class='grid__desc__wrapper')
-          p(class='grid__desc')!= val.excerpt
-            span(class='grid__desc__ellipsis') &#8230;Read More
+        .grid__desc__wrapper
+          p.grid__desc!= val.excerpt
+            span.grid__desc__ellipsis &#8230;Read More
         div(class="grid__link")
           i(data-feather='arrow-right')

--- a/layouts/conductor-docs-landing.pug
+++ b/layouts/conductor-docs-landing.pug
@@ -2,110 +2,110 @@
 - var sectionTitle = 'Conductor Documentation'
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(`ksphere/conductor/${conductorDocsLatest}`).children
       if val.menuWeight != -1
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           if val.excerpt
             - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-            p(class='grid-toc__desc')!= displayExcerpt
+            p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               for item in val.children.slice(0, 5)
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 mixin renderGrid()
-  div(class='grid')
-    a(href=latestDocs.path + '/installing', class='grid__item')
-      h3(class='grid__header') Install DC/OS
-      div(class='grid__desc__wrapper')
-        p(class='grid__desc') Installation involves configuring your infrastructure and installing DC/OS bits on top, so the infrastructure provider you choose determines your installation method. Select from development, cloud, and on-premises.
-          span(class='grid__desc__ellipsis') &#8230;Read More
-      div(class="grid__link")
+  .grid
+    a.grid__item(href=latestDocs.path + '/installing')
+      h3.grid__header Install DC/OS
+      .grid__desc__wrapper
+        p.grid__desc Installation involves configuring your infrastructure and installing DC/OS bits on top, so the infrastructure provider you choose determines your installation method. Select from development, cloud, and on-premises.
+          span.grid__desc__ellipsis &#8230;Read More
+      .grid__link
         i(data-feather='arrow-right')
-    a(href='https://support.d2iq.com', class='grid__item')
-      h3(class='grid__header') Need Support?
-      div(class='grid__desc__wrapper')
-        p(class='grid__desc') Subscription pricing for DC/OS is based on the number of nodes (physical or virtual) in your environment. DC/OS subscriptions may include either Premium (24x7) or Standard (9-5) support.
-          span(class='grid__desc__ellipsis') &#8230;Read More
-      div(class="grid__link")
+    a.grid__item(href='https://support.d2iq.com')
+      h3.grid__header Need Support?
+      .grid__desc__wrapper
+        p.grid__desc Subscription pricing for DC/OS is based on the number of nodes (physical or virtual) in your environment. DC/OS subscriptions may include either Premium (24x7) or Standard (9-5) support.
+          span.grid__desc__ellipsis &#8230;Read More
+      .grid__link
         i(data-feather='arrow-right')
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--dcos')
-    div(class='layout')
-      header(class='header')
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+  body.landing.landing--dcos
+    .layout
+      header.header
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
-          nav(class='header__menu')
-            ul(class='header__menu-list')
+          nav.header__menu
+            ul.header__menu-list
               each val, index in hierarchy.find('menus', menus => menus.includes('conductor-header'))
                 - var itemClass = {}
                 - itemClass['header__menu-item'] = true
                 - itemClass['header__menu-item--active'] = val.path == '/ksphere/conductor'
                 li(class=itemClass)
                   a(href=val.path)!= val.title
-              li(class='header__menu-item')
+              li.header__menu-item
                 a(href='https://support.d2iq.com') Support
         include partials/header/mesosphere-dropdown.pug
-        section(class='header__search', role='search')
-          form(class='header__search-form', action='/ksphere/conductor/search/', method='GET')
-            label(class='header__search-label', for='header-search-input')
-              i(class='header__icon', data-feather='search')
-            input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+        section.header__search(role='search')
+          form.header__search-form(action='/ksphere/conductor/search/')
+            label.header__search-label(for='header-search-input')
+              i.header__icon(data-feather='search')
+            input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
       include partials/header/header-dropdown.pug
-      div(class='landing__hero')
-        h1(class='landing__title')!= sectionTitle
-        form(class='landing__search', action='/ksphere/conductor/search/', method='GET')
-          input(class='landing__search-input', id='landing-search-input', placeholder='Search Conductor Docs', tabindex='1', type='text', name='q')
-          button(class='landing__search-button')
+      .landing__hero
+        h1.landing__title!= sectionTitle
+        form.landing__search(action='/ksphere/conductor/search/')
+          input.landing__search-input(id='landing-search-input', placeholder='Search Conductor Docs', tabindex='1', type='text', name='q')
+          button.landing__search-button
             i(data-feather='search')
 
-      div(class='landing__container')
+      .landing__container
         +renderGridToc()
-        div(class='landing__external')
-          div(class='landing__external-item')
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get Training
-            p(class='landing__external-description') Learn to use and administer Conductor in real-time training courses, in person or online, offered by D2iQ.
-          div(class='landing__external-item')
-            i(data-feather='users', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://dcos.io/community/') Join the Community
-            p(class='landing__external-description') Join the community to get help via mailing list or Slack.
-          div(class='landing__external-item')
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
+        .landing__external
+          .landing__external-item
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get Training
+            p.landing__external-description Learn to use and administer Conductor in real-time training courses, in person or online, offered by D2iQ.
+          .landing__external-item
+            i.landing__external-icon(data-feather='users')
+            h3.landing__external-title
+              a.landing__external-link(href='https://dcos.io/community/') Join the Community
+            p.landing__external-description Join the community to get help via mailing list or Slack.
+          .landing__external-item
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
 
-      footer(class='landing__footer')
-        div(class='landing__footer__container')
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-          div(class='landing__footer__menu')
+      footer.landing__footer
+        .landing__footer__container
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy
-          a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+          a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/dcos-docs-landing.pug
+++ b/layouts/dcos-docs-landing.pug
@@ -2,41 +2,41 @@
 - var sectionTitle = 'DC/OS Documentation'
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(latestPath).children
       if val.menuWeight != -1
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           if val.excerpt
             - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-            p(class='grid-toc__desc')!= displayExcerpt
+            p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               - var getFive = val.children.slice(0,5)
               - filteredFive = getFive.filter(item => typeof item.menuWeight === 'number')
               for item in filteredFive
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 mixin renderGrid()
-  div(class='grid')
-    a(href=latestPath + '/installing', class='grid__item')
-      h3(class='grid__header') Install DC/OS
-      div(class='grid__desc__wrapper')
-        p(class='grid__desc') Installation involves configuring your infrastructure and installing DC/OS bits on top, so the infrastructure provider you choose determines your installation method. Select from development, cloud, and on-premises.
-          span(class='grid__desc__ellipsis') &#8230;Read More
+  .grid
+    a.grid__item(href=latestPath + '/installing')
+      h3.grid__header Install DC/OS
+      .grid__desc__wrapper
+        p.grid__desc Installation involves configuring your infrastructure and installing DC/OS bits on top, so the infrastructure provider you choose determines your installation method. Select from development, cloud, and on-premises.
+          span.grid__desc__ellipsis &#8230;Read More
       div(class="grid__link")
         i(data-feather='arrow-right')
-    a(href='https://support.d2iq.com', class='grid__item')
-      h3(class='grid__header') Need Support?
-      div(class='grid__desc__wrapper')
-        p(class='grid__desc') Subscription pricing for DC/OS is based on the number of nodes (physical or virtual) in your environment. DC/OS subscriptions may include either Premium (24x7) or Standard (9-5) support.
-          span(class='grid__desc__ellipsis') &#8230;Read More
+    a.grid__item(href='https://support.d2iq.com')
+      h3.grid__header Need Support?
+      .grid__desc__wrapper
+        p.grid__desc Subscription pricing for DC/OS is based on the number of nodes (physical or virtual) in your environment. DC/OS subscriptions may include either Premium (24x7) or Standard (9-5) support.
+          span.grid__desc__ellipsis &#8230;Read More
       div(class="grid__link")
         i(data-feather='arrow-right')
 
@@ -44,72 +44,72 @@ doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--dcos')
-    div(class='layout')
-      header(class='header')
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+  body.landing.landing--dcos
+    .layout
+      header.header
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
-          nav(class='header__menu')
-            ul(class='header__menu-list')
+          nav.header__menu
+            ul.header__menu-list
               each val, index in hierarchy.find('menus', menus => menus.includes('dcos-header'))
                 - var itemClass = {}
                 - itemClass['header__menu-item'] = true
                 - itemClass['header__menu-item--active'] = val.path == '/mesosphere/dcos'
                 li(class=itemClass)
                   a(href=val.path)!= val.title
-              li(class='header__menu-item')
+              li.header__menu-item
                 a(href='https://support.d2iq.com') Support
         include partials/header/ksphere-dropdown.pug
         include partials/header/localization-dropdown.pug
-        section(class='header__search', role='search')
-          form(class='header__search-form', action='/mesosphere/dcos/search/', method='GET')
-            label(class='header__search-label', for='header-search-input')
-              i(class='header__icon', data-feather='search')
-            input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+        section.header__search(role='search')
+          form.header__search-form(action='/mesosphere/dcos/search/')
+            label.header__search-label(for='header-search-input')
+              i.header__icon(data-feather='search')
+            input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
       include partials/header/header-dropdown.pug
-      div(class='landing__hero')
-        h1(class='landing__title')!= sectionTitle
-        form(class='landing__search', action='/mesosphere/dcos/search/', method='GET')
-          input(class='landing__search-input', id='landing-search-input', placeholder='Search DC/OS Docs', tabindex='1', type='text', name='q')
-          button(class='landing__search-button')
+      .landing__hero
+        h1.landing__title!= sectionTitle
+        form.landing__search(action='/mesosphere/dcos/search/')
+          input.landing__search-input(id='landing-search-input', placeholder='Search DC/OS Docs', tabindex='1', type='text', name='q')
+          button.landing__search-button
             i(data-feather='search')
 
-      div(class='landing__container')
+      .landing__container
         +renderGridToc()
         +renderGrid()
-        div(class='landing__external')
-          div(class='landing__external-item')
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get DC/OS Training
-            p(class='landing__external-description') Learn to use and administer DC/OS in real-time training courses, in person or online, offered by Mesosphere.
-          div(class='landing__external-item')
-            i(data-feather='users', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://dcos.io/community/') Join the Community
-            p(class='landing__external-description') Join the DC/OS community to get help via mailing list or Slack.
-          div(class='landing__external-item')
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
+        .landing__external
+          .landing__external-item
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get DC/OS Training
+            p.landing__external-description Learn to use and administer DC/OS in real-time training courses, in person or online, offered by Mesosphere.
+          .landing__external-item
+            i.landing__external-icon(data-feather='users')
+            h3.landing__external-title
+              a.landing__external-link(href='https://dcos.io/community/') Join the Community
+            p.landing__external-description Join the DC/OS community to get help via mailing list or Slack.
+          .landing__external-item
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
 
-      footer(class='landing__footer')
-        div(class='landing__footer__container')
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-          div(class='landing__footer__menu')
+      footer.landing__footer
+        .landing__footer__container
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy
-          a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+          a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/dispatch-docs-landing.pug
+++ b/layouts/dispatch-docs-landing.pug
@@ -2,93 +2,93 @@
 - var sectionTitle = 'Dispatch Documentation'
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(`ksphere/dispatch/${dispatchDocsLatest}`).children
       if val.menuWeight != -1
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           if val.excerpt
             - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-            p(class='grid-toc__desc')!= displayExcerpt
+            p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               for item in val.children.slice(0, 5)
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--dcos')
-    div(class='layout')
-      header(class='header')
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+  body.landing.landing--dcos
+    .layout
+      header.header
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
-          nav(class='header__menu')
-            ul(class='header__menu-list')
+          nav.header__menu
+            ul.header__menu-list
               each val, index in hierarchy.find('menus', menus => menus.includes('dispatch-header'))
                 - var itemClass = {}
                 - itemClass['header__menu-item'] = true
                 - itemClass['header__menu-item--active'] = val.path == '/ksphere/dispatch'
                 li(class=itemClass)
                   a(href=val.path)!= val.title
-              li(class='header__menu-item')
+              li.header__menu-item
                 a(href='https://support.d2iq.com') Support
         include partials/header/mesosphere-dropdown.pug
-        section(class='header__search', role='search')
-          form(class='header__search-form', action='/ksphere/dispatch/search/', method='GET')
-            label(class='header__search-label', for='header-search-input')
-              i(class='header__icon', data-feather='search')
-            input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+        section.header__search(role='search')
+          form.header__search-form(action='/ksphere/dispatch/search/')
+            label.header__search-label(for='header-search-input')
+              i.header__icon(data-feather='search')
+            input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
       include partials/header/header-dropdown.pug
-      div(class='landing__hero')
-        h1(class='landing__title')!= sectionTitle
-        form(class='landing__search', action='/ksphere/dispatch/search/', method='GET')
-          input(class='landing__search-input', id='landing-search-input', placeholder='Search Dispatch Docs', tabindex='1', type='text', name='q')
-          button(class='landing__search-button')
+      .landing__hero
+        h1.landing__title!= sectionTitle
+        form.landing__search(action='/ksphere/dispatch/search/')
+          input.landing__search-input(id='landing-search-input', placeholder='Search Dispatch Docs', tabindex='1', type='text', name='q')
+          button.landing__search-button
             i(data-feather='search')
 
-      div(class='landing__container')
+      .landing__container
         +renderGridToc()
-        div(class='landing__external')
-          div(class='landing__external-item')
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get Training
-            p(class='landing__external-description') Learn to use and administer Dispatch in real-time training courses, in person or online, offered by D2iQ.
-          div(class='landing__external-item')
-            i(data-feather='users', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://dcos.io/community/') Join the Community
-            p(class='landing__external-description') Join the community to get help via mailing list or Slack.
-          div(class='landing__external-item')
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
+        .landing__external
+          .landing__external-item
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get Training
+            p.landing__external-description Learn to use and administer Dispatch in real-time training courses, in person or online, offered by D2iQ.
+          .landing__external-item
+            i.landing__external-icon(data-feather='users')
+            h3.landing__external-title
+              a.landing__external-link(href='https://dcos.io/community/') Join the Community
+            p.landing__external-description Join the community to get help via mailing list or Slack.
+          .landing__external-item
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
 
-      footer(class='landing__footer')
-        div(class='landing__footer__container')
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-          div(class='landing__footer__menu')
+      footer.landing__footer
+        .landing__footer__container
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy
-          a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+          a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/kommander-docs-landing.pug
+++ b/layouts/kommander-docs-landing.pug
@@ -2,88 +2,88 @@
 - var sectionTitle = 'Kommander Documentation'
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(`ksphere/kommander/${kommanderDocsLatest}`).children
       if val.menuWeight != -1
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           if val.excerpt
             - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-            p(class='grid-toc__desc')!= displayExcerpt
+            p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               for item in val.children.slice(0, 5)
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--dcos')
-    div(class='layout')
-      header(class='header')
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+  body.landing.landing--dcos
+    .layout
+      header.header
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
-          nav(class='header__menu')
-            ul(class='header__menu-list')
+          nav.header__menu
+            ul.header__menu-list
               each val, index in hierarchy.find('menus', menus => menus.includes('kommander-header'))
                 - var itemClass = {}
                 - itemClass['header__menu-item'] = true
                 - itemClass['header__menu-item--active'] = val.path == '/ksphere/kommander'
                 li(class=itemClass)
                   a(href=val.path)!= val.title
-              li(class='header__menu-item')
+              li.header__menu-item
                 a(href='https://support.d2iq.com') Support
         include partials/header/ksphere-dropdown.pug
-        section(class='header__search', role='search')
-          form(class='header__search-form', action='/ksphere/kommander/search/', method='GET')
-            label(class='header__search-label', for='header-search-input')
-              i(class='header__icon', data-feather='search')
-            input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+        section.header__search(role='search')
+          form.header__search-form(action='/ksphere/kommander/search/')
+            label.header__search-label(for='header-search-input')
+              i.header__icon(data-feather='search')
+            input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
       include partials/header/header-dropdown.pug
-      div(class='landing__hero')
-        h1(class='landing__title')!= sectionTitle
-        form(class='landing__search', action='/ksphere/kommander/search/', method='GET')
-          input(class='landing__search-input', id='landing-search-input', placeholder='Search Kommander Docs', tabindex='1', type='text', name='q')
-          button(class='landing__search-button')
+      .landing__hero
+        h1.landing__title!= sectionTitle
+        form.landing__search(action='/ksphere/kommander/search/')
+          input.landing__search-input(id='landing-search-input', placeholder='Search Kommander Docs', tabindex='1', type='text', name='q')
+          button.landing__search-button
             i(data-feather='search')
 
-      div(class='landing__container')
+      .landing__container
         +renderGridToc()
-        div(class='landing__external')
-          div(class='landing__external-item')
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get Training
-            p(class='landing__external-description') Learn to use and administer Kommander in real-time training courses, in person or online, offered by D2iQ.
-          div(class='landing__external-item')
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
+        .landing__external
+          .landing__external-item
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get Training
+            p.landing__external-description Learn to use and administer Kommander in real-time training courses, in person or online, offered by D2iQ.
+          .landing__external-item
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
 
-      footer(class='landing__footer')
-        div(class='landing__footer__container')
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-          div(class='landing__footer__menu')
+      footer.landing__footer
+        .landing__footer__container
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy
-          a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+          a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/konvoy-docs-landing.pug
+++ b/layouts/konvoy-docs-landing.pug
@@ -2,93 +2,93 @@
 - var sectionTitle = 'Konvoy Documentation'
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(`ksphere/konvoy/${konvoyDocsLatest}`).children
       if val.menuWeight != -1
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           if val.excerpt
             - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-            p(class='grid-toc__desc')!= displayExcerpt
+            p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               for item in val.children.slice(0, 5)
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--dcos')
-    div(class='layout')
-      header(class='header')
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+  body.landing.landing--dcos
+    .layout
+      header.header
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
-          nav(class='header__menu')
-            ul(class='header__menu-list')
+          nav.header__menu
+            ul.header__menu-list
               each val, index in hierarchy.find('menus', menus => menus.includes('konvoy-header'))
                 - var itemClass = {}
                 - itemClass['header__menu-item'] = true
                 - itemClass['header__menu-item--active'] = val.path == '/ksphere/konvoy'
                 li(class=itemClass)
                   a(href=val.path)!= val.title
-              li(class='header__menu-item')
+              li.header__menu-item
                 a(href='https://support.d2iq.com') Support
         include partials/header/mesosphere-dropdown.pug
-        section(class='header__search', role='search')
-          form(class='header__search-form', action='/ksphere/konvoy/search/', method='GET')
-            label(class='header__search-label', for='header-search-input')
-              i(class='header__icon', data-feather='search')
-            input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+        section.header__search(role='search')
+          form.header__search-form(action='/ksphere/konvoy/search/')
+            label.header__search-label(for='header-search-input')
+              i.header__icon(data-feather='search')
+            input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
       include partials/header/header-dropdown.pug
-      div(class='landing__hero')
-        h1(class='landing__title')!= sectionTitle
-        form(class='landing__search', action='/ksphere/konvoy/search/', method='GET')
-          input(class='landing__search-input', id='landing-search-input', placeholder='Search Konvoy Docs', tabindex='1', type='text', name='q')
-          button(class='landing__search-button')
+      .landing__hero
+        h1.landing__title!= sectionTitle
+        form.landing__search(action='/ksphere/konvoy/search/')
+          input.landing__search-input(id='landing-search-input', placeholder='Search Konvoy Docs', tabindex='1', type='text', name='q')
+          button.landing__search-button
             i(data-feather='search')
 
-      div(class='landing__container')
+      .landing__container
         +renderGridToc()
-        div(class='landing__external')
-          div(class='landing__external-item')
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get Training
-            p(class='landing__external-description') Learn to use and administer Konvoy in real-time training courses, in person or online, offered by D2iQ.
-          div(class='landing__external-item')
-            i(data-feather='users', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://dcos.io/community/') Join the Community
-            p(class='landing__external-description') Join the community to get help via mailing list or Slack.
-          div(class='landing__external-item')
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
+        .landing__external
+          .landing__external-item
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get Training
+            p.landing__external-description Learn to use and administer Konvoy in real-time training courses, in person or online, offered by D2iQ.
+          .landing__external-item
+            i.landing__external-icon(data-feather='users')
+            h3.landing__external-title
+              a.landing__external-link(href='https://dcos.io/community/') Join the Community
+            p.landing__external-description Join the community to get help via mailing list or Slack.
+          .landing__external-item
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
 
-      footer(class='landing__footer')
-        div(class='landing__footer__container')
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-          div(class='landing__footer__menu')
+      footer.landing__footer
+        .landing__footer__container
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy
-          a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+          a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/konvoy-partners-landing.pug
+++ b/layouts/konvoy-partners-landing.pug
@@ -8,34 +8,34 @@
   ]
 
 mixin renderGridInputs()
-  div(class='grid-filters')
-    div(class='grid-filters__controls-div')
-      div(class='grid-filters__select-label-div')
-        label(class='grid-filters__select-label')!= 'CHOOSE A CATEGORY'
-      div(class='custom-select')
-        select(class='grid-filters__category')
-          option(class='grid-filters__category__option' value='view-all')!= 'View All'
+  .grid-filters
+    .grid-filters__controls-div
+      .grid-filters__select-label-div
+        label.grid-filters__select-label!= 'CHOOSE A CATEGORY'
+      .custom-select
+        select.grid-filters__category
+          option.grid-filters__category__option(value='view-all')!= 'View All'
           each category, _ in categories
             - var categoryString = category.toLowerCase().split(' ').join('-')
-            option(class='grid-filters__category__option' value=categoryString)!= category
-    div(class='grid-filters__labels' id="konvoy-labels")
-      div(class='grid-filters__label')
-        input(class='grid-filters__enterprise' type="checkbox" name="enterprise" value="enterprise")
+            option.grid-filters__category__option(value=categoryString)!= category
+    div.grid-filters__labels(id="konvoy-labels")
+      .grid-filters__label
+        input.grid-filters__enterprise(type="checkbox" name="enterprise" value="enterprise")
         label!= 'Include Enterprise'
-      div(class='grid-filters__label')
-        input(class='grid-filters__community' type="checkbox" name="community" value="community")
+      .grid-filters__label
+        input.grid-filters__community(type="checkbox" name="community" value="community")
         label!= 'Include Community'
-      div(class='grid-filters__label')
-        input(class='grid-filters__beta' type="checkbox" name="beta" value="beta")
+      .grid-filters__label
+        input.grid-filters__beta(type="checkbox" name="beta" value="beta")
         label!= 'Include Beta'
 
 mixin renderGridToc()
-  div(class='grid-toc' data-categories=categories.join(','))
+  div.grid-toc(data-categories=categories.join(','))
     each category, _ in categories
       - var categoryString = category.toLowerCase().split(' ').join('-')
       - var categoryClasses = `grid-toc__service-category grid-toc__service-category__${categoryString}`
       div(class=categoryClasses)
-        h1(class='grid-toc__category-header')!= category
+        h1.grid-toc__category-header!= category
         - var categoryServices = []
         each service, _ in hierarchy.findByPath(`ksphere/konvoy/partner-solutions`).children
           if service.menuWeight != -1 && service.category == category
@@ -45,39 +45,39 @@ mixin renderGridToc()
           - var categoryString = category.split(' ').join('-')
           - var serviceItemClasses = `grid-toc__service-item`
           div(class=serviceItemClasses)
-            div(class='grid-toc__title-group')
-              h2(class='grid-toc__title')
+            .grid-toc__title-group
+              h2.grid-toc__title
                 a(href=latestPath)!= service.title
-            p(class='grid-toc__service-desc')!= service.excerpt || 'MISSING'
+            p.grid-toc__service-desc!= service.excerpt || 'MISSING'
             if service.children
-              ul(class='grid-toc__service-list')
+              ul.grid-toc__service-list
                 for version in service.children.slice(0,1)
                   for folder in version.children.slice(0,3)
-                    li(class='grid-toc__service-list-item')
-                      a(href=folder.path, class='grid-toc__link')!= folder.title
+                    li.grid-toc__service-list-item
+                      a.grid-toc__link(href=folder.path)!= folder.title
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--services')
-    div(class='layout')
-      div(role='main', class='layout__content')
+  body.landing.landing--services
+    .layout
+      div.layout__content(role='main')
         - var sectionTitle = 'Konvoy Documentation'
         include partials/header/header.pug
-        div(class='landing__hero')
-          h1(class='landing__title') Konvoy Partner Solutions
-        div(class='landing__container')
+        .landing__hero
+          h1.landing__title Konvoy Partner Solutions
+        .landing__container
           +renderGridInputs()
           +renderGridToc()
-        footer(class='landing__footer')
-          div(class='landing__footer__container')
-            a(class='landing__footer__logo__link', href='https://d2iq.com/')
-              img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-            div(class='landing__footer__menu')
+        footer.landing__footer
+          .landing__footer__container
+            a.landing__footer__logo__link(href='https://d2iq.com/')
+              img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+            .landing__footer__menu
               a(href='https://d2iq.com/terms/') Terms of Service
               a(href='https://d2iq.com/privacy/') Privacy Policy
-            a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+            a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/kudo-kubeflow-docs-landing.pug
+++ b/layouts/kudo-kubeflow-docs-landing.pug
@@ -2,93 +2,93 @@
 - var sectionTitle = 'KUDO Kubeflow Documentation'
 
 mixin renderGridToc()
-  div(class='grid-toc')
+  .grid-toc
     each val, index in hierarchy.findByPath(`ksphere/kubeflow/${kubeflowDocsLatest}`).children
       if val.menuWeight != -1
-        div(class='grid-toc__item')
-          h2(class='grid-toc__title')
+        .grid-toc__item
+          h2.grid-toc__title
             a(href=val.path)!= val.title
           if val.excerpt
             - var displayExcerpt = (val.excerpt.length > 100) ? val.excerpt.substring(0, 100) + '…' : val.excerpt
-            p(class='grid-toc__desc')!= displayExcerpt
+            p.grid-toc__desc!= displayExcerpt
           if val.children
-            ul(class='grid-toc__list')
+            ul.grid-toc__list
               for item in val.children.slice(0, 5)
-                li(class='grid-toc__list-item')
-                  a(href=item.path, class='grid-toc__link')!= item.title
+                li.grid-toc__list-item
+                  a.grid-toc__link(href=item.path)!= item.title
               if val.children.length > 5
-                li(class='grid-toc__list-item')
-                  a(href=val.path, class='grid-toc__link grid-toc__link--all') View All
-                    img(class='grid-toc__link--all__arrow', src='/assets/right-arrow.svg')
+                li.grid-toc__list-item
+                  a.grid-toc__link.grid-toc__link--all(href=val.path) View All
+                    img.grid-toc__link--all__arrow(src='/assets/right-arrow.svg')
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--dcos')
-    div(class='layout')
-      header(class='header')
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+  body.landing.landing--dcos
+    .layout
+      header.header
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
-          nav(class='header__menu')
-            ul(class='header__menu-list')
+          nav.header__menu
+            ul.header__menu-list
               each val, index in hierarchy.find('menus', menus => menus.includes('kubeflow-header'))
                 - var itemClass = {}
                 - itemClass['header__menu-item'] = true
                 - itemClass['header__menu-item--active'] = val.path == '/ksphere/kubeflow'
                 li(class=itemClass)
                   a(href=val.path)!= val.title
-              li(class='header__menu-item')
+              li.header__menu-item
                 a(href='https://support.d2iq.com') Support
         include partials/header/mesosphere-dropdown.pug
-        section(class='header__search', role='search')
-          form(class='header__search-form', action='/ksphere/kubeflow/search/', method='GET')
-            label(class='header__search-label', for='header-search-input')
-              i(class='header__icon', data-feather='search')
-            input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+        section.header__search(role='search')
+          form.header__search-form(action='/ksphere/kubeflow/search/')
+            label.header__search-label(for='header-search-input')
+              i.header__icon(data-feather='search')
+            input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
       include partials/header/header-dropdown.pug
-      div(class='landing__hero')
-        h1(class='landing__title')!= sectionTitle
-        form(class='landing__search', action='/ksphere/kubeflow/search/', method='GET')
-          input(class='landing__search-input', id='landing-search-input', placeholder='Search Kubeflow Docs', tabindex='1', type='text', name='q')
-          button(class='landing__search-button')
+      .landing__hero
+        h1.landing__title!= sectionTitle
+        form.landing__search(action='/ksphere/kubeflow/search/')
+          input.landing__search-input(id='landing-search-input', placeholder='Search Kubeflow Docs', tabindex='1', type='text', name='q')
+          button.landing__search-button
             i(data-feather='search')
 
-      div(class='landing__container')
+      .landing__container
         +renderGridToc()
-        div(class='landing__external')
-          div(class='landing__external-item')
-            i(data-feather='book', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://d2iq.com/training/') Get Training
-            p(class='landing__external-description') Learn to use and administer Kubeflow in real-time training courses, in person or online, offered by D2iQ.
-          div(class='landing__external-item')
-            i(data-feather='users', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='https://dcos.io/community/') Join the Community
-            p(class='landing__external-description') Join the community to get help via mailing list or Slack.
-          div(class='landing__external-item')
-            i(data-feather='slack', class='landing__external-icon')
-            h3(class='landing__external-title')
-              a(class='landing__external-link', href='http://chat.dcos.io/') Find us on Slack
-            p(class='landing__external-description') Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
+        .landing__external
+          .landing__external-item
+            i.landing__external-icon(data-feather='book')
+            h3.landing__external-title
+              a.landing__external-link(href='https://d2iq.com/training/') Get Training
+            p.landing__external-description Learn to use and administer Kubeflow in real-time training courses, in person or online, offered by D2iQ.
+          .landing__external-item
+            i.landing__external-icon(data-feather='users')
+            h3.landing__external-title
+              a.landing__external-link(href='https://dcos.io/community/') Join the Community
+            p.landing__external-description Join the community to get help via mailing list or Slack.
+          .landing__external-item
+            i.landing__external-icon(data-feather='slack')
+            h3.landing__external-title
+              a.landing__external-link(href='http://chat.dcos.io/') Find us on Slack
+            p.landing__external-description Ask questions in the general channel and participate in day 2 ops, networking, packaging, and UX working groups.
 
-      footer(class='landing__footer')
-        div(class='landing__footer__container')
-          a(class='landing__footer__logo__link', href='https://d2iq.com/')
-            img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-          div(class='landing__footer__menu')
+      footer.landing__footer
+        .landing__footer__container
+          a.landing__footer__logo__link(href='https://d2iq.com/')
+            img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+          .landing__footer__menu
             a(href='https://d2iq.com/terms/') Terms of Service
             a(href='https://d2iq.com/privacy/') Privacy Policy
-          a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+          a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug

--- a/layouts/partials/content.pug
+++ b/layouts/partials/content.pug
@@ -1,29 +1,24 @@
-- var pathParts = path.split('/');
-- var gridDisabled = overviewGrid === false
-- var containerClass = headings.length > 0 ? 'content__container content__container--with-sections' : 'content__container'
-
-main(class='content')
-  div(class=containerClass)
-    div(class='content__header')
-      div(class='content__header__row')
-        h1(class='content__header-title')!= title
+main.content
+  .content__container(class={ 'content__container--with-sections': headings.length > 0 })
+    .content__header
+      .content__header__row
+        h1.content__header-title!= title
         if oss
-          p(class='badge badge--content-header badge--oss') OPEN SOURCE
+          p.badge.badge--content-header.badge--oss OPEN SOURCE
         if community
-          p(class='badge badge--content-header badge--community') COMMUNITY
+          p.badge.badge--content-header.badge--community COMMUNITY
         if enterprise
-          p(class='badge badge--content-header badge--enterprise') ENTERPRISE
+          p.badge.badge--content-header.badge--enterprise ENTERPRISE
         if beta
-          p(class='badge badge--content-header badge--beta') BETA
+          p.badge.badge--content-header.badge--beta BETA
         if preview
-          p(class='badge badge--content-header badge--preview') PREVIEW
+          p.badge.badge--content-header.badge--preview PREVIEW
         if experimental
-          p(class='badge badge--content-header badge--experimental') EXPERIMENTAL
+          p.badge.badge--content-header.badge--experimental EXPERIMENTAL
       if excerpt
-        h4(class='content__header-description')!= excerpt
+        h4.content__header-description!= excerpt
       include ../components/content-actions.pug
-    article(class='content__article')
+    article.content__article
       != contents
-      if !gridDisabled
-        include ../components/content-grid.pug
+      include ../components/content-grid.pug
   include ../components/content-sections.pug

--- a/layouts/partials/header/header-dropdown.pug
+++ b/layouts/partials/header/header-dropdown.pug
@@ -34,16 +34,13 @@
       }
     ]
   }]
-div(class='header-dropdown')
-  ul(class='header-dropdown__list')
+.header-dropdown
+  ul.header-dropdown__list
     each sphere in menus
-      li(class='header-dropdown__top-item')
+      li.header-dropdown__top-item
         div(href=sphere.path)!= sphere.title
       each val in sphere.children
-        - var itemClass = {}
-        - itemClass['header-dropdown__item'] = true
-        - itemClass['header-dropdown__item--active'] = (val.path == '/' && semanticVersion.test(paths[0])) || (val.path != '/' && ('/' + path).includes(val.path))
-        li(class=itemClass)
+        li.header-dropdown__item(class={'header-dropdown__item--active':(val.path == '/' && semanticVersion.test(paths[0])) || (val.path != '/' && ('/' + path).includes(val.path)) })
           a(href=val.path)!= val.title
-    li(class='header-dropdown__item')
+    li.header-dropdown__item
         a(href='https://support.d2iq.com') Support

--- a/layouts/partials/header/header.pug
+++ b/layouts/partials/header/header.pug
@@ -2,35 +2,32 @@
 - isItemActive = isItemActive || function(itemPath){ return itemPath === path || itemPath === "/" + path }
 - pages = pages || hierarchy.find('menus', (menus) => menus.includes(`${product}-header`))
 
-header(class='header')
-  a(class='header__drawer')
-    i(class='header__icon', data-feather='menu')
-  a(href='/', class='header__logo')
+header.header
+  a.header__drawer
+    i.header__icon(data-feather='menu')
+  a.header__logo(href='/')
     img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
     img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-  div(class='header__main')
-    div(class='header__dropdown')
-      img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+  .header__main
+    .header__dropdown
+      img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
       strong!= sectionTitle
       i(data-feather='chevron-down')
-    nav(class='header__menu')
-      ul(class='header__menu-list')
+    nav.header__menu
+      ul.header__menu-list
         each val, index in pages
-          - var itemClass = {}
-          - itemClass['header__menu-item'] = true
-          - itemClass['header__menu-item--active'] = isItemActive(val.path)
-          li(class=itemClass)
+          li.header__menu-item(class={'header__menu-item--active':isItemActive(val.path) })
             a(href=val.path)!= val.title
-        li(class='header__menu-item')
+        li.header__menu-item
           a(href='https://support.d2iq.com') Support
   if sphere === 'mesosphere'
     include ksphere-dropdown.pug
     include localization-dropdown.pug
   else
     include mesosphere-dropdown.pug
-  section(class='header__search', role='search')
-    form(class='header__search-form', action=`/${sphere}/${product}/search/`, method='GET')
-      input(class='header__search-input', id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
-      label(class='header__search-label', for='header-search-input')
-        i(class='header__icon', data-feather='search')
+  section.header__search(role='search')
+    form.header__search-form(action=`/${sphere}/${product}/search/`)
+      input.header__search-input(id='header-search-input', tabindex='1', type='text', name='q', placeholder='Search')
+      label.header__search-label(for='header-search-input')
+        i.header__icon(data-feather='search')
 include header-dropdown.pug

--- a/layouts/partials/header/ksphere-dropdown.pug
+++ b/layouts/partials/header/ksphere-dropdown.pug
@@ -25,12 +25,12 @@
   }]
 
 each sphere in ksphereMenu
-  div(class='chooser' id='ks')
-    div(class='chooser-current')
-      a(class='chooser-title')!=sphere.title
+  #ks.chooser
+    .chooser-current
+      a.chooser-title!=sphere.title
       svg(class="chooser-svg" id='kspherer-svg')
         path(class="pointer" d="m 13,6 -5,5 -5,-5 z", fill="#858585")
-    ul(class='chooser-list' id='kspherer-list')
+    ul.chooser-list#kspherer-list
       each section in sphere.children
-        li(class='chooser-list-item')
+        li.chooser-list-item
           a(href=section.path)!= section.title

--- a/layouts/partials/header/localization-dropdown.pug
+++ b/layouts/partials/header/localization-dropdown.pug
@@ -1,15 +1,15 @@
 - var isChinese = paths[2] == 'cn'
 - var enPaths = paths.slice(2)
 
-div(class='chooser' id="localizer")
-  div(class='chooser-current')
-    a(class='chooser-title')!= isChinese ? '中文 (简体)' : 'English'
+.chooser#localizer
+  .chooser-current
+    a.chooser-title!= isChinese ? '中文 (简体)' : 'English'
     svg(class="chooser-svg" id="localizer-svg")
       path(class="pointer" d="m 13,6 -5,5 -5,-5 z", fill="#858585")
-  ul(class='chooser-list' id="localizer-list")
+  ul.chooser-list#localizer-list
     if isChinese
       - var enPath = `/${paths.slice(3).join('/')}`
-      li(class='chooser-list-item')
+      li.chooser-list-item
         - var fullPath = "/mesosphere/dcos".concat(enPath)
         a(href=fullPath) English
     else
@@ -20,6 +20,6 @@ div(class='chooser' id="localizer")
         if hierarchy.checkIfPathExists(currPath)
           - return currPath
         - return findLongestCnPath(inPath.slice(0, inPath.length - 1))
-      li(class='chooser-list-item')
+      li.chooser-list-item
         - var longest = findLongestCnPath(enPaths)
         a(href=longest) 中文 (简体)

--- a/layouts/partials/header/mesosphere-dropdown.pug
+++ b/layouts/partials/header/mesosphere-dropdown.pug
@@ -1,24 +1,23 @@
-- 
+-
   var mesosphereMenu = [{
     "title": "Mesosphere",
     "children": [
       {
-        "title": "DC/OS", 
+        "title": "DC/OS",
         "path":"/mesosphere/dcos"
       }, {
-        "title": "DC/OS Services", 
+        "title": "DC/OS Services",
         "path":"/mesosphere/dcos/services"
       }
     ]
   }]
 each sphere in mesosphereMenu
-  div(class='chooser' id='spherer')
-    div(class='chooser-current')
-      a(class='chooser-title')!=sphere.title
+  #spherer.chooser
+    .chooser-current
+      a.chooser-title!=sphere.title
       svg(class="chooser-svg" id='spherer-svg')
         path(class="pointer" d="m 13,6 -5,5 -5,-5 z", fill="#858585")
-    ul(class='chooser-list' id='spherer-list')
+    ul.chooser-list#spherer-list
       each section in sphere.children
-        li(class='chooser-list-item')
+        li.chooser-list-item
           a(href=section.path)!= section.title
-          

--- a/layouts/partials/search-results.pug
+++ b/layouts/partials/search-results.pug
@@ -1,14 +1,14 @@
-section(class='search')
-  div(id='search-form', class='search__form')
-    input(id='search-input', class='search__form-input', placeholder='Search', value='')
-    button(class='search__form-submit')
-      i(class='search__form-icon', data-feather='search')
-  select(id="template" style="display:none;")
-    option(id="templateOption")
-  div(class='search__filters')
-    div(id='search-section', class='search__filter')
-    div(id='search-version', class='search__filter')
-    div(id='search-type', class='search__filter')
-  div(class='search__results')
-    ul(id='search-results', class='search__results-list')
-  div(id='search-pagination')
+section.search
+  #search-form.search__form
+    input#search-input.search__form-input(placeholder='Search', value='')
+    button.search__form-submit
+      i.search__form-icon(data-feather='search')
+  select#template(style='display:none;')
+    option#templateOption
+  .search__filters
+    #search-section.search__filter
+    #search-version.search__filter
+    #search-type.search__filter
+  .search__results
+    ul#search-results.search__results-list
+  #search-pagination

--- a/layouts/search.pug
+++ b/layouts/search.pug
@@ -5,21 +5,21 @@ html(lang='en')
   head
     include partials/head.pug
   body
-    div(class='layout')
-      header(class='header' style="position: fixed;")
-        a(class='header__drawer')
-          i(class='header__icon', data-feather='menu')
-        a(href='/', class='header__logo')
+    .layout
+      header.header(style="position: fixed;")
+        a.header__drawer
+          i.header__icon(data-feather='menu')
+        a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop
-        div(class='header__main')
-          div(class='header__dropdown')
-            img(class='header__dropdown-icon', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+        .header__main
+          .header__dropdown
+            img.header__dropdown-icon(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
             strong!= sectionTitle
             i(data-feather='chevron-down')
         include partials/header/mesosphere-dropdown.pug
         include partials/header/ksphere-dropdown.pug
       include partials/header/header-dropdown.pug
-      div(role='main', class='layout__content')
+      div.layout__content(role='main')
         include partials/search-results.pug
     include partials/scripts.pug

--- a/layouts/service-docs-landing.pug
+++ b/layouts/service-docs-landing.pug
@@ -17,34 +17,34 @@
   ]
 
 mixin renderGridInputs()
-  div(class='grid-filters')
-    div(class='grid-filters__controls-div')
-      div(class='grid-filters__select-label-div')
-        label(class='grid-filters__select-label')!= 'CHOOSE A CATEGORY'
-      div(class='custom-select')
-        select(class='grid-filters__category')
-          option(class='grid-filters__category__option' value='view-all')!= 'View All'
+  .grid-filters
+    .grid-filters__controls-div
+      .grid-filters__select-label-div
+        label.grid-filters__select-label!= 'CHOOSE A CATEGORY'
+      .custom-select
+        select.grid-filters__category
+          option.grid-filters__category__option(value='view-all')!= 'View All'
           each category, _ in categories
             - var categoryString = category.toLowerCase().split(' ').join('-')
-            option(class='grid-filters__category__option' value=categoryString)!= category
-    div(class='grid-filters__labels')
-      div(class='grid-filters__label')
-        input(class='grid-filters__enterprise' type="checkbox" name="enterprise" value="enterprise")
+            option.grid-filters__category__option(value=categoryString)!= category
+    .grid-filters__labels
+      .grid-filters__label
+        input.grid-filters__enterprise(type="checkbox" name="enterprise" value="enterprise")
         label!= 'Include Enterprise'
-      div(class='grid-filters__label')
-        input(class='grid-filters__community' type="checkbox" name="community" value="community")
+      .grid-filters__label
+        input.grid-filters__community(type="checkbox" name="community" value="community")
         label!= 'Include Community'
-      div(class='grid-filters__label')
-        input(class='grid-filters__beta' type="checkbox" name="beta" value="beta")
+      .grid-filters__label
+        input.grid-filters__beta(type="checkbox" name="beta" value="beta")
         label!= 'Include Beta'
 
 mixin renderGridToc()
-  div(class='grid-toc' data-categories=categories.join(','))
+  .grid-toc(data-categories=categories.join(','))
     each category, _ in categories
       - var categoryString = category.toLowerCase().split(' ').join('-')
       - var categoryClasses = `grid-toc__service-category grid-toc__service-category__${categoryString}`
       div(class=categoryClasses)
-        h1(class='grid-toc__category-header')!= category
+        h1.grid-toc__category-header!= category
         - var categoryServices = []
         each service, _ in hierarchy.findByPath(`mesosphere/dcos/services`).children
           if service.menuWeight != -1 && service.category == category
@@ -60,48 +60,48 @@ mixin renderGridToc()
           if service.community
             - serviceItemClasses += ' grid-toc__community'
           div(class=serviceItemClasses)
-            div(class='grid-toc__title-group')
-              h2(class='grid-toc__title')
+            .grid-toc__title-group
+              h2.grid-toc__title
                 a(href=latestPath)!= service.title
-              ul(class='grid-toc__labels')
+              ul.grid-toc__labels
                 if service.beta
-                  p(class='badge badge--beta') BETA
+                  p.badge.badge--beta BETA
                 if service.enterprise
-                  p(class='badge badge--enterprise') ENTERPRISE
+                  p.badge.badge--enterprise ENTERPRISE
                 if service.community
-                  p(class='badge badge--community') COMMUNITY
-            p(class='grid-toc__service-desc')!= service.excerpt || 'MISSING'
+                  p.badge.badge--community COMMUNITY
+            p.grid-toc__service-desc!= service.excerpt || 'MISSING'
             if service.children
-              ul(class='grid-toc__service-list')
+              ul.grid-toc__service-list
                 for version in service.children.slice(0,1)
                   for folder in version.children.slice(0,3)
-                    li(class='grid-toc__service-list-item')
-                      a(href=folder.path, class='grid-toc__link')!= folder.title
+                    li.grid-toc__service-list-item
+                      a.grid-toc__link(href=folder.path)!= folder.title
 
 doctype html
 html(lang='en')
   head
     include partials/head.pug
-  body(class='landing landing--services')
-    div(class='layout')
-      div(role='main', class='layout__content')
+  body.landing.landing--services
+    .layout
+      div.layout__content(role='main')
         if isChinese
           include partials/header/dcos-cn-header.pug
         else
           include partials/header/dcos-en-header.pug
-        div(class='landing__hero')
-          h1(class='landing__title') DC/OS Service Docs
-        div(class='landing__container')
+        .landing__hero
+          h1.landing__title DC/OS Service Docs
+        .landing__container
           +renderGridInputs()
           +renderGridToc()
-        footer(class='landing__footer')
-          div(class='landing__footer__container')
-            a(class='landing__footer__logo__link', href='https://d2iq.com/')
-              img(class='landing__footer__logo', src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
-            div(class='landing__footer__menu')
+        footer.landing__footer
+          .landing__footer__container
+            a.landing__footer__logo__link(href='https://d2iq.com/')
+              img.landing__footer__logo(src='/assets/D2IQ_Logotype_Color_Positive.png', alt='D2iQ')
+            .landing__footer__menu
               a(href='https://d2iq.com/terms/') Terms of Service
               a(href='https://d2iq.com/privacy/') Privacy Policy
-            a(class='landing__footer__copyright', href='https://d2iq.com/')!= copyright
+            a.landing__footer__copyright(href='https://d2iq.com/')!= copyright
     script(src='https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js')
     script(src='https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js')
     include partials/scripts.pug


### PR DESCRIPTION
piped our layouts through a "pugifier".

```pug
# before
span(class="myClass")
div(class="myClass")


# after (div-elements are considered a default and are thus omitted)
span.myClass
.myClass
```

reasoning: less visual noise makes it easier to work with those
templates.