### PR TITLE
D2iQ-41078

### DIFF
--- a/layouts/components/content-actions.pug
+++ b/layouts/components/content-actions.pug
@@ -24,7 +24,7 @@ if (!title)
         i.actions__icon(data-feather='share')
         span.actions__text Share
     li.actions__item
-      a.actions__link(href='javascript:window.print()')
+      button.actions__link(onclick='javascript:window.print()')
         i.actions__icon(data-feather='printer')
         span.actions__text Print
     li.actions__item

--- a/scss/components/_actions.scss
+++ b/scss/components/_actions.scss
@@ -18,6 +18,8 @@
     align-items: center;
     color: $color-grey;
     text-decoration: none;
+    background: transparent;
+    border: 0;
     &:hover {
       color: $color-purple-d3;
       & .actions__icon--rss {


### PR DESCRIPTION
this fixes the print-button.

due to some recent changes that add a `target="_blank"` to every
non-internal link, the print button broke.

you'd click it and it would navigate away to an empty page and then try
to print that empty page.

we now replaced the anchor with a button, as buttons don't suffer from
that target-changing we do.


i don't say printing is pretty. but at least we get to see something now again.