### PR TITLE
only lint markdown files and ignore shortcodes

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -1,4 +1,5 @@
 D2iQ
+COPS
 Mesos
 Chronos
 DC/OS
@@ -10,3 +11,4 @@ Conductor
 KUDO
 Kubeflow
 Kubernetes
+component

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,10 +1,5 @@
 name: Linting
-on:
-  push:
-    branches-ignore:
-      - master
-      - staging
-  pull_request:
+on: [ pull_request ]
 
 jobs:
   prose:
@@ -22,8 +17,12 @@ jobs:
       uses: trilom/file-changes-action@a6ca26c14274c33b15e6499323aac178af06ad4b
       with:
         prNumber: ${{ steps.findPr.outputs.pr }}
+    - id: changed_files
+      run: |
+        files=$(cat $HOME/files.json | jq -c '[ .[] | select(endswith(".md")), "pages/index.md" ]')
+        echo "::set-output name=files::$files"
     - uses: errata-ai/vale-action@75a4db25a0833de205ab750af4b4ed36e24280ec
       with:
-        files: ${{ steps.file_changes.outputs.files }}
+        files: ${{ steps.changed_files.outputs.files }}
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.vale.ini
+++ b/.vale.ini
@@ -10,6 +10,6 @@ MinAlertLevel = suggestion
 # Define the exceptions to use in *all* `BasedOnStyles`.
 Vocab = Docs
 
-[*]
-# List of styles to load
+[*.md]
 BasedOnStyles = Vale, write-good, Microsoft, ttd-light, proselint
+TokenIgnores = (\[.*?\].*?\[\/\w+\])   # ignore shortcodes

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,7 +1,7 @@
 ---
 layout: all-products-landing.pug
-navigationTitle: D2IQ Documentation
-title: D2IQ Documentation
+navigationTitle: D2iQ Documentation
+title: D2iQ Documentation
 featureMaturity:
 enterprise: false
 menuWeight: 0


### PR DESCRIPTION
... as well as the term `COPS`.

had a look at https://github.com/mesosphere/dcos-docs-site/pull/3153 and and fixed the most urgent misconfigurations, so that the warnings and suggestions start to seem mostly meaningful (for that PR).