### PR TITLE
feat: document prometheusadapter being federated

### DIFF
--- a/pages/ksphere/kommander/1.2/clusters/attach-cluster/federated-addons/index.md
+++ b/pages/ksphere/kommander/1.2/clusters/attach-cluster/federated-addons/index.md
@@ -41,6 +41,7 @@ If you want to federate a cluster by creating a new `KommanderCluster` object in
 | kube-oidc-proxy-kommander | True | | False |
 | opsportal-addons-kommander-overrides | True | | False |
 | prometheus | True | `kommander.mesosphere.io/federate-prometheus` | True |
+| prometheusadapter | True | `kommander.mesosphere.io/federate-prometheusadapter` | True |
 | reloader | True | | True |
 | traefik-forward-auth-kommander | True | | False |
 

--- a/pages/ksphere/kommander/1.2/clusters/attach-cluster/federated-addons/index.md
+++ b/pages/ksphere/kommander/1.2/clusters/attach-cluster/federated-addons/index.md
@@ -3,28 +3,29 @@ layout: layout.pug
 navigationTitle: Federated Addons
 title: Federated Addons
 menuWeight: 5
+beta: true
 excerpt: How federated addons work
 ---
 
 ## Addons federation
 
-When attaching a cluster, Kommander federates certain addons on the newly attached cluster. To customize the federation of the logging and monitoring stacks, operators may apply labels to the associated `KommanderCluster` resource.
+When attaching a cluster, Kommander federates certain addons on the newly attached cluster. To customize the federation of the logging and monitoring stacks, operators can apply labels to the associated `KommanderCluster` resource.
 
-On attachment, two factors impact if an addon is deployed or not on the attached cluster:
-1. Is the attached cluster a Konvoy cluster or not (e.g. a cluster deployed using AWS EKS)?
-2. Does a label regarding the federation of the addon exist and has it been set? If yes, what is its value?
+On attachment, two factors impact successfully deploying an addon on the attached cluster:
+1. Is the attached cluster a Konvoy cluster or not? For example, a cluster deployed using AWS EKS.
+2. Does a label describing the federation of the addon exist and is it defined? If yes, what is its value?
 
-The tables below describe the list of addons and cluster addons that get federated on attachment with its related federation label (if available). Addons that do not have a federation label are federated by default. If an addon is described as only federated on non-Konvoy clusters, it will not get installed into Konvoy clusters even if its federation label is set to `true`.
+The following tables describe the list of addons and cluster addons that get federated on attachment with their related federation label (if available). Addons that do not have a federation label are federated by default. If the addon description indicates only federated on non-Konvoy clusters, the addon will not get installed into Konvoy clusters, even if its federation label is set to `true`.
 
-Currently, the monitoring stack will be federated by default and the logging stack will not. This is why `prometheus` is the only addon federated by default with a federation label to disable it if needed.
+Currently, the monitoring stack is federated by default and the logging stack is not. This is why `prometheus` is the only addon federated by default with a federation label to disable it if needed.
 
-### Setting federation labels
+### Set federation labels
 
-#### Using the UI
+#### Use the UI
 
-Follow the documentation regarding [attaching a cluster](/ksphere/kommander/latest/clusters/attach-cluster/). You can add labels at the bottom of the attachment form, use the federation labels described in the tables below as keys and the values `true` or `false` if you wish to customize the federation of the addons. The addons that do not have a related federation label cannot get their federation enabled or disabled this way.
+See [attaching a cluster](/ksphere/kommander/latest/clusters/attach-cluster/) for information. You can add labels at the bottom of the attachment form, use the federation labels described in the following tables as keys and the values `true` or `false` if you wish to customize the federation of the addons. The addons that do not have a related federation label cannot get their federation enabled or disabled this way.
 
-#### Creating a new KommanderCluster
+#### Create a new KommanderCluster
 
 If you want to federate a cluster by creating a new `KommanderCluster` object in your Kommander cluster, the federation labels should be set in the field `metadata/labels`.
 


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, please make sure you have a separate ticket for the docs team to track their work to review and merge, even for minor edits. If you need assistance, ask in the #doc-team channel on slack.

[D2IQ-71134](https://jira.d2iq.com/browse/D2IQ-71134)

## Description of changes being made

added prometheusadapter to the list of default federated addons for non-konvoy
clusters. This is to ensure metrics are available in the Kommander GUI.
[PR #176](https://github.com/mesosphere/yakcl/pull/176) makes this
change.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Provide an estimated date for deploying the doc change. Note: Improvements or fixes can be merged ASAP. 
- [ ] Add [redirects](https://github.com/mesosphere/dcos-docs-site/wiki/Redirects) if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/wiki/Contributing) for more information.
