### PR TITLE
D2IQ-71207 add a border around images in content

### DIFF
--- a/pages/ksphere/konvoy/1.5/concepts/index.md
+++ b/pages/ksphere/konvoy/1.5/concepts/index.md
@@ -13,7 +13,7 @@ The topics in this section provide a brief overview of the native Kubernetes arc
 
 The following diagram provides a simplified architectural overview to help you visualize the key components of the cluster:
 
-![Architectural overview](../img/Konvoy-arch-diagram.png)
+![Architectural overview](../img/Konvoy-arch-diagram.png){ data-no-border }
 
 Figure 1 - Architectural overview
 

--- a/scss/base/_content.scss
+++ b/scss/base/_content.scss
@@ -5,6 +5,9 @@ $sections-size: 20%;
   margin-top: 70px;
   img {
     border: 1px solid #F0F1F3;
+    &[data-no-border]{
+      border: 0
+    }
   }
   &__container {
     position: relative;

--- a/scss/base/_content.scss
+++ b/scss/base/_content.scss
@@ -3,6 +3,9 @@ $sections-size: 20%;
 .content {
   display: flex;
   margin-top: 70px;
+  img {
+    border: 1px solid #F0F1F3;
+  }
   &__container {
     position: relative;
     display: flex;


### PR DESCRIPTION
we should also start thinking about a max-width for the main content
whilst centering it.
that would be an easy to implement measure that
would make the docs look much better on large monitors.

closes D2IQ-71207

## Screenshot

note that the view has been scaled down on that one, so things might look weird. it's all about displaying the light-grey border around the image in the content section:

<img width="900" alt="Project Platform Services - D2iQ Docs 2020-08-23 15-47-32" src="https://user-images.githubusercontent.com/300861/90979876-2773ba80-e558-11ea-8a5e-76166f21e7d5.png">

