### PR TITLE
restrict content-width

### DIFF
--- a/scss/base/_content.scss
+++ b/scss/base/_content.scss
@@ -9,6 +9,8 @@ $sections-size: 20%;
     flex-direction: column;
     min-width: 0;
     padding: 40px;
+    max-width: 1000px;
+    margin: 0 auto;
   }
   &__404 {
     margin-bottom: -160px;


### PR DESCRIPTION
on large monitors the main content can look a little off.
this tries to make it look a little better. maybe it's good enough to merge for now.

as no one asked for this, i'd be totally fine with
* closing this PR
* deciding that it looks good enough as it is or 
* starting a more involved process around it.

# before (scaled view)

![before_small](https://user-images.githubusercontent.com/300861/90980118-b3d2ad00-e559-11ea-998e-628b47b1b8e8.gif)

# after

the content now appears centered in the middle, which gives the whole page more structure and prevents images from growing insanely wide.

![after_small](https://user-images.githubusercontent.com/300861/90980121-b7663400-e559-11ea-832e-28c814e21c14.gif)
