### PR TITLE
speed up deployment and setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-ngindox build-api build-development clean reduce-pages
+.PHONY: build-development clean reduce-pages
 
 clean: ## Remove all build folders
 	./scripts/clean.sh
@@ -14,20 +14,9 @@ redirects-replace-old:
 # Build
 #
 
-## Rebuild nginx, swagger, and static content
-build-development: build-api
+## Build static content
+build-development:
 	npm run dev
-
-#
-# Build API
-#
-build-api: build-ngindox
-
-NGINDOX_FILES := $(shell find ./pages -name '*.yaml' | xargs grep -l "ngindox:")
-build-ngindox: $(addprefix ./build-ngindox,$(basename $(NGINDOX_FILES:./pages%=%)))
-build-ngindox/%:
-	@mkdir -p $@
-	@node ./node_modules/ngindox/bin/cli.js ui -c "" -j "" -f "pages/$*.yaml" > "$@/index.html"
 
 #
 # Docker

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-swagger build-ngindox build-api build-development clean reduce-pages
+.PHONY: build-ngindox build-api build-development clean reduce-pages
 
 clean: ## Remove all build folders
 	./scripts/clean.sh
@@ -21,12 +21,7 @@ build-development: build-api
 #
 # Build API
 #
-build-api: build-swagger build-ngindox
-
-SWAGGER_FILES := $(shell find ./pages -name '*.yaml' | xargs grep -l "swagger:")
-build-swagger: $(addprefix ./build-swagger,$(basename $(SWAGGER_FILES:./pages%=%)))
-build-swagger/%:
-	@node ./node_modules/bootprint/bin/bootprint.js openapi "pages/$*.yaml" "$@"
+build-api: build-ngindox
 
 NGINDOX_FILES := $(shell find ./pages -name '*.yaml' | xargs grep -l "ngindox:")
 build-ngindox: $(addprefix ./build-ngindox,$(basename $(NGINDOX_FILES:./pages%=%)))

--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ Content that is kept on other team repos would follow their init, if applicable.
 This must be only done on first time or if a rare site tooling change occurs. Other repos may have other needs, see their Contributing Guide or similar resource for assistance if you will need to build their code.
 `npm install`
 
-### Build the API page sets
-This is necessary anytime a set is changed, or when a new DC/OS version (and there for a new set) is created
-`make --jobs=$(expr $(nproc) - 1) build-api`
-
-This takes some time. It builds the folders `build-ngindox` and `biuld-swagger`.
-
 ### Build a local preview
 This is to ensure setup was successful
 `npm run dev`

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Extra information that the user may wish to know, but not necessary to the basic
 
 ### Removing a border from an image
 
-![Architectural overview](../img/Konvoy-arch-diagram.png){ data-no-border }
+    ![Architectural overview](../img/Konvoy-arch-diagram.png){ data-no-border }
  
 ### Save your edited files!
 

--- a/README.md
+++ b/README.md
@@ -222,8 +222,6 @@ NB: Shortcut is `git pull` when you are on the `staging` branch
 Or, copy/paste the branch name from the PR if there is one open already. Git will track from the remote and set up a new branch locally for you to work on.
 There are often times when you will need to pull and work on someone else's branch even when it isn't a PR yet, you may need to specify `git checkout origin/<branchname>`
 
-
-
 ## Add/Edit content to existing pages
 ### TL;DR Common Gotchas
 1. The docs site uses metalsmith markdown rendering, which is similar to but not exactly github flavored markdown (gfm).
@@ -351,6 +349,10 @@ Extra information that the user may wish to know, but not necessary to the basic
 ### Special - Adding API tables
 :TODO: add info on the API tables and the script to run
 
+### Removing a border from an image
+
+![Architectural overview](../img/Konvoy-arch-diagram.png){ data-no-border }
+ 
 ### Save your edited files!
 
 ## Previewing your work and formatting

--- a/docker/Dockerfile.liveedit
+++ b/docker/Dockerfile.liveedit
@@ -5,7 +5,6 @@ COPY . /dcos-docs-site/
 WORKDIR /dcos-docs-site
 
 RUN npm install
-RUN make build-api
 
 ENTRYPOINT [ "npm", "run", "dev" ]
 

--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -18,7 +18,6 @@ ADD . /src/
 
 RUN npm install
 
-RUN make --jobs=$(expr $(nproc) - 1) build-api
 RUN \
 GIT_BRANCH=$git_branch \
 ALGOLIA_UPDATE=$algolia_update \

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-preset-env": "^1.7.0",
-    "bootprint": "^1.0.0",
-    "bootprint-openapi": "^1.1.0",
     "browser-sync": "^2.18.12",
     "cheerio": "^1.0.0-rc.2",
     "css-loader": "^0.28.4",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -6,6 +6,5 @@
 #
 
 rm -rf "./build"
-rm -rf "./build-swagger"
 rm -rf "./build-ngindox"
 rm -f ".revision"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -6,5 +6,4 @@
 #
 
 rm -rf "./build"
-rm -rf "./build-ngindox"
 rm -f ".revision"

--- a/shortcodes/index.js
+++ b/shortcodes/index.js
@@ -2,6 +2,8 @@ const fs = require("fs");
 const path = require("path");
 const cheerio = require("cheerio");
 const minify = require("html-minifier").minify;
+const NgindoxUi = require("ngindox/lib/ui");
+const Yaml = require("js-yaml");
 
 /**
  * Shortcodes for metalsmith-shortcode-parser
@@ -288,37 +290,13 @@ const shortcodes = {
    * @param {Object} opts
    * @param {string} opts.api
    */
-  ngindox: (buf, opts) => {
-    // Check if exists
-    const configFilePath = path.join("./pages", opts.api);
-    const configFileExists = fs.existsSync(configFilePath);
-
-    if (!configFileExists) {
-      throw new Error(`Ngindox config file does not exist ${configFilePath}`);
-    }
-
-    const buildFileDir = opts.api.replace(".yaml", "");
-    const buildFilePath = path.join(
-      "./build-ngindox",
-      buildFileDir,
-      "index.html"
-    );
-    const buildFileExists = fs.existsSync(buildFilePath);
-
-    if (!buildFileExists) {
-      throw new Error(`Ngindox build file does not exist ${buildFilePath}`);
-    }
-
-    // Read file
-    const contents = fs.readFileSync(buildFilePath, { encoding: "utf-8" });
-
-    // Hide from headings
-    const $ = cheerio.load(contents);
-    $("h1, h2, h3").each((el) => $(el).attr("data-hide", true));
-
-    // Output
-    return sanitize($.html());
-  },
+  ngindox: (buf, { api }) =>
+    sanitize(
+      NgindoxUi.toHtml(Yaml.safeLoad(fs.readFileSync(`./pages${api}`)), {
+        title: "Routes",
+        legend: true,
+      })
+    ),
 
   /**
    * Image


### PR DESCRIPTION
I think this is a pretty impactful one. Here are the commit messages: 

## don't build dedicated swagger-docs

why? because they were only ever rendered to be included in PDFs.
so currently we're waiting like 10 minutes on every deployment (and on
every dev's machine that's setup to render docs) for no good reason.

if we want to build PDFs in the futue, we'd most likely do so by using
puppeteer or wkhtml2pdf, so even then this output is of no use.

## get rid of `make build-api` completely

we now compile ngindox-content on the fly, as the compiler seems to be
pretty darn fast. this way we can get rid of the whole "prebuild" step
and can start right at `npm run dev`. 

-----

imagine deploying or setting up a new dev-env in the future 😻 

# Testing

if you see that the includes work as they did before, everything should be fine!

* [prod ngindox](https://docs.d2iq.com/mesosphere/dcos/2.1/api/agent-routes ) / [local ngindox](http://localhost:3000/mesosphere/dcos/2.1/api/agent-routes ) (remember to checkout this branch and run `npm run dev` before clicking the local links)
* [prod swagger](https://docs.d2iq.com/mesosphere/dcos/2.1/gui/updating-gui/#updating-the-gui-via-the-api) / [local swagger](https://docs.d2iq.com/mesosphere/dcos/2.1/gui/updating-gui/#updating-the-gui-via-the-api)