### PR TITLE
D2IQ-71280: redirects cloud-providers URL to infrastructure-providers

### DIFF
--- a/docker/nginx/redirects-301.map
+++ b/docker/nginx/redirects-301.map
@@ -844,3 +844,4 @@
 ~^/(version-policy/.*)$ /mesosphere/dcos/$1;
 ~^/(search/.*)$ /mesosphere/dcos/$1;
 /ksphere/konvoy/1.5/tutorials/replacing-failed-control-plane-node/(.*) /ksphere/konvoy/1.5/troubleshooting/replace-failed-control-plane-node/(.*);
+/ksphere/kommander/latest/operations/cloud-providers/ /ksphere/kommander/latest/operations/infrastructure-providers/;


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

https://jira.d2iq.com/browse/D2IQ-71280

## Description of changes being made
Redirecting a broken link

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.