### PR TITLE
correcting versions on deployed 2.1.1 cluster

### DIFF
--- a/pages/mesosphere/dcos/2.1/release-notes/2.1.1/index.md
+++ b/pages/mesosphere/dcos/2.1/release-notes/2.1.1/index.md
@@ -22,8 +22,8 @@ DC/OS is a distributed operating system that enables you to manage resources, ap
 
 DC/OS 2.1.1 includes the following component versions:
 
-- Apache Mesos 1.9.1-dev
-- Marathon 1.9.136
+- Apache Mesos 1.10.1
+- Marathon 1.10.26
 - DC/OS UI 5.1.7
 - Fluentbit 1.4.6
 


### PR DESCRIPTION
DC/OS UI overview lists these two versions, 
https://jira.d2iq.com/browse/COPS-6329 is indicator that this is not quite correct.

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made


## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Update all links if you are moving a page.
- [x] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.