### PR TITLE
allow to set RPP for `npm run build`

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ const neededToBuildMainMenu = [
   "ksphere/conductor/index.md",
   `ksphere/conductor/${MS._metadata.conductorDocsLatest}/index.md`,
 ];
-if (process.env.NODE_ENV === "development" && RENDER_PATH_PATTERN) {
+if (RENDER_PATH_PATTERN) {
   MS.use((files, _, done) => {
     Object.keys(files)
       .filter(


### PR DESCRIPTION
we formerly made sure that an `RPP` could only be used in
development-mode. that restriction seems to be cumbersome for other
teams as they'd like to have a fast build (and not a fast dev-mode).
see
https://github.com/mesosphere/dispatch/pull/746#issuecomment-683142668

we have pretty solid control over how we deploy to production so it looks like it's worth removing this safety-measure in exchange for those (way!) faster builds.