### PR TITLE
Add namespace and namespaced to Vale vocab

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -14,3 +14,5 @@ Kubernetes
 component
 addon
 dcos
+namespace
+namespaced


### PR DESCRIPTION
## Jira Ticket
None.

## Description of changes being made

Created in response to https://github.com/mesosphere/dcos-docs-site/pull/3182/files#annotation_397289461


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [X] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.