### PR TITLE
Pin pyristent to fix the CI issue.

### DIFF
--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -19,4 +19,8 @@ fi
 GIT_BRANCH=$GIT_BRANCH \
 ALGOLIA_PRIVATE_KEY=$ALGOLIA_PRIVATE_KEY \
 METALSMITH_SKIP_SECTIONS=$METALSMITH_SKIP_SECTIONS \
+
+# pinning a docker-compose dependency
+pip install pip install pyrsistent==0.16.0 
+
 docker-compose build docs


### PR DESCRIPTION
## Jira Ticket

The staging site is not working due to a moving dependency of pyrex.
The error message is

```
Collecting pyrsistent>=0.14.0 (from jsonschema<4,>=2.5.1->docker-compose)
  Downloading https://files.pythonhosted.org/packages/7d/ae/90ddcf28fb8eee5d4990920586d2856342e42faa95f39223f0b9762ef264/pyrsistent-0.17.2.tar.gz (106kB)
pyrsistent requires Python '>=3.5' but the running Python is 2.7.15
```

This is coming from the latest version of pyristent. We are trying to solve this problem by pinning it to an earlier version of pyrsistent.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.