### PR TITLE
Updated external storage docs for CSI volumes.

### DIFF
--- a/pages/mesosphere/dcos/2.2/deploying-services/marathon-parameters/index.md
+++ b/pages/mesosphere/dcos/2.2/deploying-services/marathon-parameters/index.md
@@ -100,11 +100,12 @@ The container information.
 
 - **volumes** The volumes accessible to the container.
     - **containerPath** The path where your container will read and write data.
-    - **external** An external persistent volume. See [External Persistent Volumes](/mesosphere/dcos/2.2/storage/external-storage/).
-        - **name** Name that your volume driver uses to look up the external volume.
-        - **provider** The storage provider.
-        - **options** Which Docker volume driver to use for storage. The only Docker volume driver supported by DC/OS is [REX-Ray](/mesosphere/dcos/2.2/storage/external-storage/).
-        - **size** The size (in GiB) of the external persistent volume.
+    - **external** An external persistent volume. See [External Storage](/mesosphere/dcos/2.2/storage/external-storage/).
+        - **name** The unique name or ID that your storage provider uses to look up the external volume.
+        - **provider** The storage provider; this could be "dvdi" or "csi".
+        - **options** This specifies the provider-specific options. For a DVDI volume, it will include which Docker volume driver to use for storage. The only Docker volume driver supported by DC/OS is [REX-Ray](/mesosphere/dcos/2.2/storage/external-storage/dvdi/). For a CSI volume, a variety of [other options](mesosphere/dcos/2.2/storage/external-storage/csi/) are possible.
+        - **size** The size (in GiB) of the external persistent volume; only relevant for DVDI volumes.
+        - **pluginName** The name of the CSI plugin which will attach this volume; only relevant for CSI volumes.
     - **hostPath** The host path.
     - **mode** The access mode of the volume, either read-write (`RW`) or read-only (`RO`).
     - **persistent** A local persistent volume. See [Local Persistent Volumes](/mesosphere/dcos/2.2/storage/persistent-volume/).

--- a/pages/mesosphere/dcos/2.2/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/2.2/installing/production/advanced-configuration/configuration-reference/index.md
@@ -770,7 +770,7 @@ The <a href="https://rexray.readthedocs.io/en/v0.9.0/user-guide/config/" target=
             tasks:
               logTimeout: 5m
 
-See the external persistent volumes [documentation](/mesosphere/dcos/{{ model.folder_version }}/storage/external-storage/) for information on how to create your configuration.
+See the DVDI volumes [documentation](/mesosphere/dcos/2.2/storage/external-storage/dvdi/) for information on how to create your configuration.
 
 If the `rexray_config` parameter is provided, its contents are used verbatim for REX-Ray's configuration. This lets you define completely custom REX-Ray configurations which integrate with various [external storage providers]( https://rexray.readthedocs.io/en/v0.9.0/user-guide/storage-providers/). However, if you upgrade your cluster to a version that includes an updated version of REX-Ray, you must ensure that your `rexray_config` parameter is compatible with the newer version of REX-Ray.
 

--- a/pages/mesosphere/dcos/2.2/storage/external-storage/csi/index.md
+++ b/pages/mesosphere/dcos/2.2/storage/external-storage/csi/index.md
@@ -1,0 +1,117 @@
+---
+layout: layout.pug
+navigationTitle:  CSI Storage
+title: CSI Storage
+menuWeight: 20
+excerpt: Using CSI volumes with Marathon
+render: mustache
+model: /mesosphere/dcos/2.2/data.yml
+beta: false
+enterprise: false
+---
+
+DC/OS integrates with storage backends that use the Container Storage Interface (CSI) to interact with the cluster orchestrator (DC/OS in this case). This recently-developed standard is gaining wide adoption in the cloud-native ecosystem. If you want a storage solution which will be developed and supported long into the future, it may be wise to choose one with CSI support.
+
+Note that CSI volumes in DC/OS currently must be pre-provisioned before they are used by a service; dynamic provisioning of CSI volumes on demand is not yet supported. If you require dynamic provisioning, we currently recommend that you use [DVDI volumes](/mesosphere/dcos/2.2/storage/dvdi/) in DC/OS.
+ 
+# Creating an application with a CSI volume
+
+## Marathon app definition
+
+You can specify a CSI volume in your [Marathon app definition](/mesosphere/dcos/2.2/deploying-services/creating-services/).
+
+Find below an example task which mounts a pre-provisioned CSI volume; it may be used as a test to verify that your CSI-based storage backend is working correctly. The `cmd` in this app definition appends the output of the `date` command to `test.txt`, reads the file, and then exits. Marathon will repeatedly re-launch the app after it finishes. You will know that the external volume is being used correctly if you see that the logs of successive runs of the application show more and more lines of `date` output; this mean that the same CSI external volume is mounted and written to each time.
+
+```json
+{
+  "id": "csi-volume-test-app",
+  "instances": 1,
+  "cpus": 0.1,
+  "mem": 32,
+  "cmd": "date >> test-csi-volume/test.txt; cat test-csi-volume/test.txt",
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "test-csi-volume",
+        "external": {
+          "provider": "csi",
+          "name": "pre-provisioned-volume-id-001",
+          "pluginName": "csi-plugin-name",
+          "options": { 
+            "accessMode": "MULTI_NODE_MULTI_WRITER",
+            "nodeStageSecret": {
+              "username": "username_secret_001",
+              "password": "password_secret_001"
+            },
+            "nodePublishSecret": {
+              "username": "username_secret_001",
+              "password": "password_secret_001"
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### Volume configuration options
+
+-  `containerPath`: The path where the volume is mounted inside the container.
+-  `external.name`: The unique ID that the CSI volume plugin uses to look up your volume. When your task is staged on an agent, the volume plugin queries the storage service for a volume with this name. If one does not exist, the task will fail to launch.
+-  `external.pluginName`: The name of the CSI plugin which will mount this volume. This is specified in the CSI plugin configuration on the agent; for the Portworx service, this should be `pxd.portworx.com`. For NFS volumes, this should be `nfs.csi.k8s.io`. For other plugins, see the instructions on plugin installation below.
+-  `external.options.accessMode`: The [CSI access mode](https://github.com/container-storage-interface/spec/blob/master/spec.md) to use when mounting the volume. The `XXXX_WRITER` modes will be mounted in read-write, while the `READER_ONLY` modes will be mounted read-only.
+-  `external.options.nodeStageSecret` and `external.options.nodePublishSecret`: The names of secrets in the DC/OS secret store which contain the username/password to use with the storage backend when staging and publishing this volume. "Staging" and "publishing" refer to steps in the CSI volume mounting process.
+-  `external.options.accessType.fsType`: The type of filesystem to be used on this volume, i.e. "xfs", "ext4", etc.
+-  `external.options.accessType.mountFlags`: Flags to be used when mounting the volume on the host.
+-  `external.options.volumeContext`: In some cases, the provisioning of a volume results in the creation of volume context metadata which must be passed as key-value pairs in this field.
+-  Create multiple volumes by adding additional items in the `container.volumes` array.
+-  You cannot change volume parameters after you create the application.
+-  Marathon will not launch apps with external volumes if `upgradeStrategy.minimumHealthCapacity` is greater than 0.5, or if `upgradeStrategy.maximumOverCapacity` does not equal 0.
+
+Some of the options above map directly onto fields in the [`NodeStageVolume`](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodestagevolume) and [`NodePublishVolume`](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodepublishvolume) calls in the [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md); some useful information regarding those parameters can be found in the CSI docs.
+
+## Create an application from the DC/OS UI
+
+1. Click the **Services** tab, then **RUN A SERVICE**.
+1. Click **Volumes** and enter your Volume ID, Plugin Name, and Container Path.
+1. Click **Deploy**.
+
+# Scaling your app
+
+Marathon apps which use CSI volumes can currently only be scaled to a single instance. This constraint will be relaxed in the future.
+
+# Data mobility
+
+If a Marathon application using a CSI volume fails for some reason, Marathon will relaunch that service wherever available resources are found. Since CSI volumes may be attached to any one of the nodes in the cluster running the CSI plugin, Marathon may place it on a different physical host. This is one major advantage of using external storage with your applications: data mobility means that simple, non-distributed stateful applications can tolerate failure with only a short period of downtime.
+
+# Using 3rd party CSI plugins
+
+If you want to use a third party CSI plugin which has not yet integrated with DC/OS, you can do the following to accomplish this:
+
+1. Install the CSI plugin as a Marathon app. To integrate with DC/OS, the CSI plugin must expose a Unix domain socket which DC/OS can connect to in order to make CSI calls. Install the app with a `hostname:UNIQUE` constraint so that only one instance is installed on each node. To make this storage backend available on all nodes, install the plugin on all private agents by setting the number of instances equal to the number of private agents in the cluster.
+
+2. Place a configuration file on each private agent in the folder `/opt/mesosphere/etc/dcos/storage/csi/` which looks like the following:
+
+```json
+{
+  "type": "test.pluginname.com",
+  "endpoints": [
+    {
+      "csi_service": "NODE_SERVICE",
+      "endpoint": "unix:///var/lib/pluginname/csi.sock"
+    }
+  ],
+  "target_path_root": "/var/lib/pluginname/target_root"
+}
+```
+
+The `target_path_root` parameter specifies the root directory, managed by the CSI plugin, where mount targets will be created. Once the app is successfully running on all agents, the plugin is ready for you to use it in DC/OS. The `type` parameter contains the unique name of the CSI plugin which should be passed in the `pluginName` field of the external volume in your Marathon app definitions.
+
+Note that the current implementation of CSI support in DC/OS only makes calls against the [node service](https://github.com/container-storage-interface/spec/blob/master/spec.md#node-service-rpc) of the plugin; this means that any plugins which require calls against the controller service are not currently supported. Support for such plugins is planned in the future.
+
+# Potential issues
+
+* If a task with a CSI volume fails, look in the "Debug" tab of the service's detail view in the DC/OS UI. In the "Last Task Failure" section, look for any CSI errors which may be causing the task to fail to launch.
+* If a CSI plugin is installed on just a subset of the cluster rather than the entire cluster, then node labels must be used on the agents running the plugin. This allows a label constraint to be used on Marathon apps consuming those volumes, ensuring that such an app lands on a capable agent.

--- a/pages/mesosphere/dcos/2.2/storage/external-storage/csi/index.md
+++ b/pages/mesosphere/dcos/2.2/storage/external-storage/csi/index.md
@@ -6,21 +6,21 @@ menuWeight: 20
 excerpt: Using CSI volumes with Marathon
 render: mustache
 model: /mesosphere/dcos/2.2/data.yml
-beta: false
+beta: true
 enterprise: false
 ---
 
-DC/OS integrates with storage backends that use the Container Storage Interface (CSI) to interact with the cluster orchestrator (DC/OS in this case). This recently-developed standard is gaining wide adoption in the cloud-native ecosystem. If you want a storage solution which will be developed and supported long into the future, it may be wise to choose one with CSI support.
+DC/OS integrates with storage backends that use the Container Storage Interface (CSI) to interact with the cluster orchestrator (DC/OS in this case). This recently-developed standard is gaining wide adoption in the cloud-native ecosystem. If you want a storage solution that will be developed and supported long into the future, choose one with CSI support.
 
-Note that CSI volumes in DC/OS currently must be pre-provisioned before they are used by a service; dynamic provisioning of CSI volumes on demand is not yet supported. If you require dynamic provisioning, we currently recommend that you use [DVDI volumes](/mesosphere/dcos/2.2/storage/dvdi/) in DC/OS.
+**Note** Currently, CSI volumes in DC/OS must be pre-provisioned before they are used by a service; dynamic provisioning of CSI volumes on demand is not yet supported. If you require dynamic provisioning, we currently recommend that you use [DVDI volumes](/mesosphere/dcos/2.2/storage/dvdi/) in DC/OS.
  
-# Creating an application with a CSI volume
+# Create an application with a CSI volume
 
 ## Marathon app definition
 
 You can specify a CSI volume in your [Marathon app definition](/mesosphere/dcos/2.2/deploying-services/creating-services/).
 
-Find below an example task which mounts a pre-provisioned CSI volume; it may be used as a test to verify that your CSI-based storage backend is working correctly. The `cmd` in this app definition appends the output of the `date` command to `test.txt`, reads the file, and then exits. Marathon will repeatedly re-launch the app after it finishes. You will know that the external volume is being used correctly if you see that the logs of successive runs of the application show more and more lines of `date` output; this mean that the same CSI external volume is mounted and written to each time.
+Find below an example task which mounts a pre-provisioned CSI volume; it can be used as a test to verify that your CSI-based storage backend is working correctly. The `cmd` in this app definition appends the output of the `date` command to `test.txt`, reads the file, and then exits. Marathon will repeatedly re-launch the app after it finishes. You will know that the external volume is being used correctly if you see that the logs of successive runs of the application show more and more lines of `date` output; this mean that the same CSI external volume is mounted and written to each time.
 
 ```json
 {
@@ -60,7 +60,7 @@ Find below an example task which mounts a pre-provisioned CSI volume; it may be 
 
 -  `containerPath`: The path where the volume is mounted inside the container.
 -  `external.name`: The unique ID that the CSI volume plugin uses to look up your volume. When your task is staged on an agent, the volume plugin queries the storage service for a volume with this name. If one does not exist, the task will fail to launch.
--  `external.pluginName`: The name of the CSI plugin which will mount this volume. This is specified in the CSI plugin configuration on the agent; for the Portworx service, this should be `pxd.portworx.com`. For NFS volumes, this should be `nfs.csi.k8s.io`. For other plugins, see the instructions on plugin installation below.
+-  `external.pluginName`: The name of the CSI plugin that will mount this volume. This is specified in the CSI plugin configuration on the agent; for the Portworx service, this should be `pxd.portworx.com`. For NFS volumes, this should be `nfs.csi.k8s.io`. For other plugins, see the instructions on plugin installation below.
 -  `external.options.accessMode`: The [CSI access mode](https://github.com/container-storage-interface/spec/blob/master/spec.md) to use when mounting the volume. The `XXXX_WRITER` modes will be mounted in read-write, while the `READER_ONLY` modes will be mounted read-only.
 -  `external.options.nodeStageSecret` and `external.options.nodePublishSecret`: The names of secrets in the DC/OS secret store which contain the username/password to use with the storage backend when staging and publishing this volume. "Staging" and "publishing" refer to steps in the CSI volume mounting process.
 -  `external.options.accessType.fsType`: The type of filesystem to be used on this volume, i.e. "xfs", "ext4", etc.
@@ -70,29 +70,31 @@ Find below an example task which mounts a pre-provisioned CSI volume; it may be 
 -  You cannot change volume parameters after you create the application.
 -  Marathon will not launch apps with external volumes if `upgradeStrategy.minimumHealthCapacity` is greater than 0.5, or if `upgradeStrategy.maximumOverCapacity` does not equal 0.
 
-Some of the options above map directly onto fields in the [`NodeStageVolume`](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodestagevolume) and [`NodePublishVolume`](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodepublishvolume) calls in the [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md); some useful information regarding those parameters can be found in the CSI docs.
+Some of the options above map directly into fields in the [`NodeStageVolume`](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodestagevolume) and [`NodePublishVolume`](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodepublishvolume) calls in the [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md); some useful information regarding those parameters can be found in the CSI docs.
 
 ## Create an application from the DC/OS UI
 
-1. Click the **Services** tab, then **RUN A SERVICE**.
-1. Click **Volumes** and enter your Volume ID, Plugin Name, and Container Path.
-1. Click **Deploy**.
+1. Select the **Services** tab, then **RUN A SERVICE**.
+1. Select **Volumes** and enter your Volume ID, Plugin Name, and Container Path.
+1. Select **Deploy**.
 
-# Scaling your app
+# Scale your app
 
-Marathon apps which use CSI volumes can currently only be scaled to a single instance. This constraint will be relaxed in the future.
+Marathon apps that use CSI volumes can currently only be scaled to a single instance. This constraint will be relaxed in the future.
 
 # Data mobility
 
-If a Marathon application using a CSI volume fails for some reason, Marathon will relaunch that service wherever available resources are found. Since CSI volumes may be attached to any one of the nodes in the cluster running the CSI plugin, Marathon may place it on a different physical host. This is one major advantage of using external storage with your applications: data mobility means that simple, non-distributed stateful applications can tolerate failure with only a short period of downtime.
+If a Marathon application using a CSI volume fails, Marathon will relaunch that service wherever available resources are found. Since CSI volumes may be attached to any one of the nodes in the cluster running the CSI plugin, Marathon may place it on a different physical host. This is one major advantage of using external storage with your applications: data mobility means that simple, non-distributed stateful applications can tolerate failure with only a short period of downtime.
 
-# Using 3rd party CSI plugins
+# Use 3rd party CSI plugins
 
-If you want to use a third party CSI plugin which has not yet integrated with DC/OS, you can do the following to accomplish this:
+If you want to use a third party CSI plugin which has not yet integrated with DC/OS, you can do the following:
 
-1. Install the CSI plugin as a Marathon app. To integrate with DC/OS, the CSI plugin must expose a Unix domain socket which DC/OS can connect to in order to make CSI calls. Install the app with a `hostname:UNIQUE` constraint so that only one instance is installed on each node. To make this storage backend available on all nodes, install the plugin on all private agents by setting the number of instances equal to the number of private agents in the cluster.
+1. Install the CSI plugin as a Marathon app. 
 
-2. Place a configuration file on each private agent in the folder `/opt/mesosphere/etc/dcos/storage/csi/` which looks like the following:
+To integrate with DC/OS, the CSI plugin must expose a Unix domain socket which DC/OS can connect to in order to make CSI calls. Install the app with a `hostname:UNIQUE` constraint so that only one instance is installed on each node. To make this storage backend available on all nodes, install the plugin on all private agents by setting the number of instances equal to the number of private agents in the cluster.
+
+2. Place a configuration file that looks like the following on each private agent in the folder `/opt/mesosphere/etc/dcos/storage/csi/`:
 
 ```json
 {

--- a/pages/mesosphere/dcos/2.2/storage/external-storage/dvdi/index.md
+++ b/pages/mesosphere/dcos/2.2/storage/external-storage/dvdi/index.md
@@ -1,0 +1,199 @@
+---
+layout: layout.pug
+navigationTitle:  External Persistent Volumes
+title: External Persistent Volumes
+menuWeight: 20
+excerpt: Using external persistent volumes with Marathon
+render: mustache
+model: /mesosphere/dcos/2.2/data.yml
+beta: false
+enterprise: false
+---
+
+Use external volumes when fault tolerance is crucial for your app. If a host fails, the native Marathon instance reschedules your app on another host, along with its associated data, without user intervention. External volumes also typically offer a larger amount of storage.
+
+Marathon applications normally lose their state when they terminate and are relaunched. In some contexts, for instance, if your application uses MySQL, you’ll want your application to preserve its state. You can use an external storage service, such as Amazon's Elastic Block Store (EBS), to create a persistent volume that follows your application instance.
+
+Note that volume sizes are specified in gibibyte (GiB) units.
+ 
+# Creating an application with an external persistent volume
+
+## Marathon app definition
+
+You can specify an external volume in your [Marathon app definition](/mesosphere/dcos/2.2/deploying-services/creating-services/).
+
+### Using the Universal Container Runtime
+
+The `cmd` in this app definition appends the output of the `date` command to `test.txt`. You will know that the external volume is being used correctly if you see that the logs of successive runs of the application show more and more lines of `date` output.
+
+```json
+{
+  "id": "hello",
+  "instances": 1,
+  "cpus": 0.1,
+  "mem": 32,
+  "cmd": "date >> test-rexray-volume/test.txt; cat test-rexray-volume/test.txt",
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "test-rexray-volume",
+        "external": {
+          "size": 100,
+          "name": "my-test-vol",
+          "provider": "dvdi",
+          "options": { "dvdi/driver": "rexray" }
+          },
+        "mode": "RW"
+      }
+    ]
+  },
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}
+```
+
+#### Volume configuration options
+
+-  `containerPath`: The path where the volume is mounted inside the container. For Mesos external volumes, this must be a single-level path relative to the container; it cannot contain a forward slash (`/`). For more information, see [the REX-Ray documentation on data directories](https://rexray.readthedocs.io/en/v0.9.0/user-guide/config/#data-directories).
+-  `mode`: The access mode of the volume. Currently, `"RW"` is the only possible value and will let your application read from and write to the volume.
+-  `external.size`: The size of the volume in **GiB**.
+-  `external.name`: The name that your volume driver uses to look up your volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is [created implicitly](#implicit-vol). Otherwise, the existing volume is reused.
+-  `external.options["dvdi/driver"]`: which Docker volume driver to use for storage. The only Docker volume driver provided with DC/OS is `rexray`. Learn more about [REX-Ray](https://rexray.readthedocs.io/en/v0.9.0/user-guide/schedulers/).
+-  You can specify additional options with `container.volumes[x].external.options[optionName]`. The dvdi provider for Mesos containers uses `dvdcli`, which offers the following [options](https://github.com/emccode/dvdcli#extra-options). The availability of any option depends on your volume driver.
+-  Create multiple volumes by adding additional items in the `container.volumes` array.
+-  You cannot change volume parameters after you create the application.
+-  Marathon will not launch apps with external volumes if `upgradeStrategy.minimumHealthCapacity` is greater than 0.5, or if `upgradeStrategy.maximumOverCapacity` does not equal 0.
+
+### Using a Docker Engine
+
+Below is a sample app definition that uses a Docker Engine and specifies an external volume. The `cmd` in this app definition appends the output of the `date` command to `test.txt`. You can verify that the external volume is being used correctly if you see that the logs of successive runs of the application show more and more lines of `date` output.
+
+```json
+{
+  "id": "/test-docker",
+  "instances": 1,
+  "cpus": 0.1,
+  "mem": 32,
+  "cmd": "date >> /data/test-rexray-volume/test.txt; cat /data/test-rexray-volume/test.txt",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "alpine:3.1",
+      "network": "HOST",
+      "forcePullImage": true
+    },
+    "volumes": [
+      {
+        "containerPath": "/data/test-rexray-volume",
+        "external": {
+          "name": "my-test-vol",
+          "provider": "dvdi",
+          "options": { "dvdi/driver": "rexray" }
+        },
+        "mode": "RW"
+      }
+    ]
+  },
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}
+```
+
+#### Volume configuration options
+
+* `containerPath` must be absolute.
+*  Only certain versions of Docker are compatible with the REX-Ray volume driver. Refer to the [REX-Ray documentation](https://rexray.readthedocs.io/en/v0.9.0/user-guide/schedulers/#docker-containerizer-with-marathon).
+
+## Create an application from the DC/OS UI
+
+1. Click the **Services** tab, then **RUN A SERVICE**.
+1. If you are using a Docker container, click **Container Settings** and configure your container runtime.
+1. Click **Volumes** and enter your Volume Name and Container Path.
+1. Click **Deploy**.
+
+<a name="implicit-vol"></a>
+
+# Implicit volumes
+
+The default implicit volume size is 16 GiB. If you are using the Universal Container Runtime, you can modify this default for a particular volume by setting `volumes[x].external.size`. You cannot modify this default for a particular volume if you are using the Docker Engine. For both runtimes, however, you can modify the default size for all implicit volumes by modifying the [REX-Ray configuration](https://rexray.readthedocs.io/en/v0.9.0/user-guide/config/).
+
+# Scaling your app
+
+Apps that use external volumes can only be scaled to a single instance because a volume can only attach to a single task at a time.
+
+If you scale your app down to 0 instances, the volume is detached from the agent where it was mounted, but it is not deleted. If you scale your app up again, the data that was associated with it is still be available.
+
+# Using 3rd party Docker volume driver
+
+If you want to use a 3rd party Docker volume driver rather than REX-Ray (e.g., [NetApp Trident](https://github.com/NetApp/trident)), you will need to take the following steps on each agent node (Trident is used as an example in the steps below):
+
+1. Install the volume driver as a Docker plugin.
+    ```
+    $ docker plugin install netapp/trident-plugin:19.10 --alias netapp --grant-all-permissions
+    ```
+
+1. Register the volume driver to Docker plugin directory. Refer to [Docker Plugin API](https://docs.docker.com/engine/extend/plugin_api/#plugin-discovery) to learn how Docker discovers plugins.
+
+    ```
+    $ sudo mkdir -p /etc/docker/plugins/
+    $ sudo bash -c 'echo "unix:///run/docker/plugins/<plugin-id>/netapp.sock" > /etc/docker/plugins/netapp.spec'
+    ```
+
+Now the volume driver is ready for you to use it in DC/OS. When you create an application, you need to set the option `external.options["dvdi/driver"]` to the name of the volume driver (e.g., `netapp`).
+
+# Potential issues
+
+*   You can assign only one task per volume. Your storage provider might have other limitations.
+*   The volumes you create are not automatically cleaned up. If you delete your cluster, you must go to your storage provider and delete the volumes you no longer need. If you're using EBS, find them by searching by the `container.volumes.external.name` that you set in your Marathon app definition. This name corresponds to an EBS volume `Name` tag.
+*   Volumes are namespaced by their storage provider. Choose unique volume names to avoid conflicts.
+*   If you are using Docker, you must use a compatible Docker version. Refer to the [REX-Ray documentation](https://rexray.readthedocs.io/en/v0.9.0/user-guide/schedulers/#docker-containerizer-with-marathon) to learn which versions of Docker are compatible with the REX-Ray volume driver.
+*   Launch time might increase for applications that create volumes implicitly. The amount of the increase depends on several factors which include the size and type of the volume. Your storage provider's method of handling volumes can also influence launch time for implicitly created volumes.
+
+##   EBS specific
+Volumes created on the same AWS account share a namespace. Choose unique volume names to avoid conflicts when multiple clusters are launched under the same account.
+
+EBS volumes are also namespaced by their availability zone (AZ), and an EBS volume [can only be attached to an EC2 instance in the same AZ](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-attaching-volume.html). As a result, attempts to launch a task in an agent running in a different AZ will lead to the creation of a new volume of the same name. If you create a cluster in one AZ, destroy it, be sure to create your cluster in the same AZ if you wish to reuse any external volumes. If a cluster spans multiple AZs, use Marathon constraints to only launch an instance in the same AZ.
+
+REX-Ray by default will fail after 13 EBS volumes are attached. Use the [config option useLargeDeviceRange to extend this limit](https://rexray.readthedocs.io/en/v0.11.0/user-guide/storage-providers/aws/#configuration-notes), which was introduced in RexRay v0.11.4.
+
+EBS volumes present as non-volatile memory express (NVMe) devices on certain newer EC2 instance types. Support for NVMe was only added to RexRay in v0.11.4. You will need to take the following prerequisite steps for RexRay to work with NVMe devices on CentOS (on newer CoreOS AMIs this is unnecessary):
+
+   
+1. Install the NVMe CLI command.
+    
+    ```bash
+    $ yum install -y nvme-cli
+    ```
+
+1. Install the necessary udev rule and helper script. These are taken from the [RexRay user guide](https://github.com/rexray/rexray/blob/362035816046e87f7bc5a6ca745760d09a69a40c/.docs/user-guide/storage-providers/aws.md#nvme-support).
+
+    ```bash
+    $ cat <<EOF > /etc/udev/rules.d/999-aws-ebs-nvme.rules
+    KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/usr/local/bin/ebs-nvme-mapping /dev/%k", SYMLINK+="%c"
+    EOF
+    ```
+1. Create the helper script.
+    ```bash
+    $ cat <<EOF > /usr/local/bin/ebs-nvme-mapping
+    #!/bin/bash
+    #/usr/local/bin/ebs-nvme-mapping
+    vol=$(/usr/sbin/nvme id-ctrl --raw-binary "${1}" | \
+          cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
+    vol=${vol#/dev/}
+    [ -n "${vol}" ] && echo "${vol/xvd/sd} ${vol/sd/xvd}"
+    EOF
+1. Set the file permissions on the scripts and reload the udev rules.      
+    ```bash
+    $ chown root:root /usr/local/bin/ebs-nvme-mapping
+    $ chmod 700 /usr/local/bin/ebs-nvme-mapping
+    $ udevadm control --reload
+    ```
+
+## External volumes   
+
+To troubleshoot external volumes, consult the agent or system logs. If you are using REX-Ray on DC/OS, you can also consult the `systemd` journal for the `dcos-rexray.service` unit logs.

--- a/pages/mesosphere/dcos/2.2/storage/external-storage/dvdi/index.md
+++ b/pages/mesosphere/dcos/2.2/storage/external-storage/dvdi/index.md
@@ -12,17 +12,17 @@ enterprise: false
 
 Use external volumes when fault tolerance is crucial for your app. If a host fails, the native Marathon instance reschedules your app on another host, along with its associated data, without user intervention. External volumes also typically offer a larger amount of storage.
 
-Marathon applications normally lose their state when they terminate and are relaunched. In some contexts, for instance, if your application uses MySQL, you’ll want your application to preserve its state. You can use an external storage service, such as Amazon's Elastic Block Store (EBS), to create a persistent volume that follows your application instance.
+Marathon applications normally lose their state when they terminate and are relaunched. In some contexts, for instance, if your application uses MySQL, you will want your application to preserve its state. You can use an external storage service, such as Amazon's Elastic Block Store (EBS), to create a persistent volume that follows your application instance.
 
-Note that volume sizes are specified in gibibyte (GiB) units.
+**Note** Volume sizes are specified in gibibyte (GiB) units.
  
-# Creating an application with an external persistent volume
+# Create an application with an external persistent volume
 
 ## Marathon app definition
 
 You can specify an external volume in your [Marathon app definition](/mesosphere/dcos/2.2/deploying-services/creating-services/).
 
-### Using the Universal Container Runtime
+### Use the Universal Container Runtime
 
 The `cmd` in this app definition appends the output of the `date` command to `test.txt`. You will know that the external volume is being used correctly if you see that the logs of successive runs of the application show more and more lines of `date` output.
 
@@ -67,7 +67,7 @@ The `cmd` in this app definition appends the output of the `date` command to `te
 -  You cannot change volume parameters after you create the application.
 -  Marathon will not launch apps with external volumes if `upgradeStrategy.minimumHealthCapacity` is greater than 0.5, or if `upgradeStrategy.maximumOverCapacity` does not equal 0.
 
-### Using a Docker Engine
+### Use a Docker engine to specify external volume
 
 Below is a sample app definition that uses a Docker Engine and specifies an external volume. The `cmd` in this app definition appends the output of the `date` command to `test.txt`. You can verify that the external volume is being used correctly if you see that the logs of successive runs of the application show more and more lines of `date` output.
 
@@ -111,10 +111,10 @@ Below is a sample app definition that uses a Docker Engine and specifies an exte
 
 ## Create an application from the DC/OS UI
 
-1. Click the **Services** tab, then **RUN A SERVICE**.
-1. If you are using a Docker container, click **Container Settings** and configure your container runtime.
-1. Click **Volumes** and enter your Volume Name and Container Path.
-1. Click **Deploy**.
+1. Select the **Services** tab, then **RUN A SERVICE**.
+1. If you are using a Docker container, select **Container Settings** and configure your container runtime.
+1. Select **Volumes** and enter your Volume Name and Container Path.
+1. Select **Deploy**.
 
 <a name="implicit-vol"></a>
 
@@ -122,15 +122,15 @@ Below is a sample app definition that uses a Docker Engine and specifies an exte
 
 The default implicit volume size is 16 GiB. If you are using the Universal Container Runtime, you can modify this default for a particular volume by setting `volumes[x].external.size`. You cannot modify this default for a particular volume if you are using the Docker Engine. For both runtimes, however, you can modify the default size for all implicit volumes by modifying the [REX-Ray configuration](https://rexray.readthedocs.io/en/v0.9.0/user-guide/config/).
 
-# Scaling your app
+# Scale your app
 
 Apps that use external volumes can only be scaled to a single instance because a volume can only attach to a single task at a time.
 
 If you scale your app down to 0 instances, the volume is detached from the agent where it was mounted, but it is not deleted. If you scale your app up again, the data that was associated with it is still be available.
 
-# Using 3rd party Docker volume driver
+# Use a 3rd party Docker volume driver
 
-If you want to use a 3rd party Docker volume driver rather than REX-Ray (e.g., [NetApp Trident](https://github.com/NetApp/trident)), you will need to take the following steps on each agent node (Trident is used as an example in the steps below):
+If you want to use a 3rd party Docker volume driver rather than REX-Ray (e.g., [NetApp Trident](https://github.com/NetApp/trident)), take the following steps on each agent node (Trident is used as an example in the steps below):
 
 1. Install the volume driver as a Docker plugin.
     ```
@@ -144,7 +144,7 @@ If you want to use a 3rd party Docker volume driver rather than REX-Ray (e.g., [
     $ sudo bash -c 'echo "unix:///run/docker/plugins/<plugin-id>/netapp.sock" > /etc/docker/plugins/netapp.spec'
     ```
 
-Now the volume driver is ready for you to use it in DC/OS. When you create an application, you need to set the option `external.options["dvdi/driver"]` to the name of the volume driver (e.g., `netapp`).
+Now the volume driver is ready for you to use it in DC/OS. When you create an application, set the option `external.options["dvdi/driver"]` to the name of the volume driver (e.g., `netapp`).
 
 # Potential issues
 
@@ -196,4 +196,4 @@ EBS volumes present as non-volatile memory express (NVMe) devices on certain new
 
 ## External volumes   
 
-To troubleshoot external volumes, consult the agent or system logs. If you are using REX-Ray on DC/OS, you can also consult the `systemd` journal for the `dcos-rexray.service` unit logs.
+To troubleshoot external volumes, see the agent or system logs. If you are using REX-Ray on DC/OS, you can also see the `systemd` journal for the `dcos-rexray.service` unit logs.


### PR DESCRIPTION
## Jira Ticket

[D2IQ-70189](https://jira.d2iq.com/browse/D2IQ-70189)

## Description of changes being made

This PR adds new documentation for the new type of CSI external volumes which we're adding in DC/OS 2.2. It also restructures the external volumes docs by adding a new top-level summary page for external volumes, with two subpages, one each for CSI and DVDI volumes, which are the two types of external volumes we currently offer.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.