### PR TITLE
Fix typos in jenkins docs

### DIFF
--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -176,6 +176,19 @@ To begin installing Jenkins on Konvoy, you must download the `$JENKINS_HOME/jobs
     ```
 
     This command may take awhile. When it is finished, you should have the `jenkins_home/jobs` folder locally.
+  
+1. Download the `$JENKINS_HOME/nodes` directory to your work station:
+
+    ```bash
+    dcos task download <task-id> [<path>]
+    ```
+
+    Example:
+    ```bash
+     dcos task download jenkins.instance-5d5cfb57-365b-11ea-8f22-3ece2a18bc93._app.1 jenkins_home/nodes --target-dir=$(pwd)/jenkins_home
+    ```
+
+    This command may take awhile. When it is finished, you should have the `jenkins_home/nodes` folder locally.  
 
 ## Step 2: Write the directory to new instance of Jenkins
 
@@ -188,10 +201,11 @@ In this step, you will copy the `$JENKINS_HOME/jobs` folder into the running Jen
     ```
 1. Change the namespace, pod name and entry command as needed.
     ```bash
-     kubectl cp ./jenkins_home/jobs/ <POD_ID>:/var/jenkins_home --container jenkins --namespace jenkinsnamespace
+    kubectl cp ./jenkins_home/jobs/ <POD_ID>:/var/jenkins_home --container jenkins --namespace jenkinsnamespace
+    kubectl cp ./jenkins_home/nodes/ <POD_ID>:/var/jenkins_home --container jenkins --namespace jenkinsnamespace
     ```
 
-    These operations can be done even when Jenkins is running. 
+   These operations can be done even when Jenkins is running. 
 
 1. For these changes to take effect, you must go to the Jenkins GUI **Manage Jenkins** page and select **Reload Configuration from Disk** to force Jenkins to reload the configuration from the disk.
 

--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -112,13 +112,26 @@ Your Jenkins instance will deploy.
         --namespace jenkins \
         --name jenkins \
         -f values.yaml \
-        --set master.jenkinsUriPrefix=/jenkins \
-        --set master.ingress.path=/jenkins \
         --set serviceAccount.create=false \
         --set serviceAccount.name=jenkins \
         --set serviceAccountAgent.name=jenkins \
         --repo https://charts.jenkins.io \
-        jenkinsci/jenkins
+        --version 2.6.4 \
+        jenkins
+    ```
+
+1. If you are using helm v3, then following should work (where `--name` flag is not supported and instead the release name is directly supplied):
+
+    ```bash
+    helm install jenkins \
+        --namespace jenkins \
+        -f values.yaml \
+        --set serviceAccount.create=false \
+        --set serviceAccount.name=jenkins \
+        --set serviceAccountAgent.name=jenkins \
+        --repo https://charts.jenkins.io \
+        --version 2.6.4 \
+        jenkins
     ```
 
 # Migrating Jenkins

--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -7,7 +7,7 @@ menuWeight: 70
 category: Workload
 ---
 
-# Installing Jenkins&reg; on Konvoy
+# Install Jenkins&reg; on Konvoy
 
 Install Jenkins in one of the following ways:
 
@@ -27,7 +27,7 @@ You must have a running Konvoy cluster attached to a Kommander instance. If you 
 
 Your Jenkins instance will deploy.
 
-## Installing Jenkins from upstream helm chart
+## Install Jenkins from upstream helm chart
 
 1. Create a namespace for Jenkins 
 
@@ -140,13 +140,13 @@ Your Jenkins instance will deploy.
         jenkins
     ```
 
-# Migrating Jenkins
+# Migrate Jenkins
 
 This section explains how to migrate your workloads from Jenkins on DC/OS to Jenkins on Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>This guide assumes you are moving to a Jenkins instance on Konvoy from a Jenkins instance on DC/OS. For any other migration reference, please refer to the <a href="#references">references</a> at the bottom of this page.</p>
 
-## Step 1: Download the directory
+## Download the directory
 To begin installing Jenkins on Konvoy, you must download the `$JENKINS_HOME/jobs` directory.
 
 1. Make sure the DC/OS Jenkins instance is healthy. Identify the Jenkins task ID by running:
@@ -162,7 +162,7 @@ To begin installing Jenkins on Konvoy, you must download the `$JENKINS_HOME/jobs
     jenkins.instance-5d5cfb57-365b-11ea-8f22-3ece2a18bc93._app.1
     ```
 
-    You may have multiple tasks with the string "jenkins" in their names. Make sure you have the correct task ID by looking at the JSON output as needed (append `--json` to above command).
+    You may have many tasks with the string "jenkins" in their names. Make sure you have the correct task ID by looking at the JSON output as needed (append `--json` to above command).
 
 1. Download the `$JENKINS_HOME/jobs` directory to your work station:
 
@@ -190,7 +190,7 @@ To begin installing Jenkins on Konvoy, you must download the `$JENKINS_HOME/jobs
 
     This command may take awhile. When it is finished, you should have the `jenkins_home/nodes` folder locally.  
 
-## Step 2: Write the directory to new instance of Jenkins
+## Write the directory to new instance of Jenkins
 
 In this step, you will copy the `$JENKINS_HOME/jobs` folder into the running Jenkins pod.
 

--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -176,19 +176,6 @@ To begin installing Jenkins on Konvoy, you must download the `$JENKINS_HOME/jobs
     ```
 
     This command may take awhile. When it is finished, you should have the `jenkins_home/jobs` folder locally.
-  
-1. Download the `$JENKINS_HOME/nodes` directory to your work station:
-
-    ```bash
-    dcos task download <task-id> [<path>]
-    ```
-
-    Example:
-    ```bash
-     dcos task download jenkins.instance-5d5cfb57-365b-11ea-8f22-3ece2a18bc93._app.1 jenkins_home/nodes --target-dir=$(pwd)/jenkins_home
-    ```
-
-    This command may take awhile. When it is finished, you should have the `jenkins_home/nodes` folder locally.  
 
 ## Write the directory to new instance of Jenkins
 
@@ -202,7 +189,6 @@ In this step, you will copy the `$JENKINS_HOME/jobs` folder into the running Jen
 1. Change the namespace, pod name and entry command as needed.
     ```bash
     kubectl cp ./jenkins_home/jobs/ <POD_ID>:/var/jenkins_home --container jenkins --namespace jenkinsnamespace
-    kubectl cp ./jenkins_home/nodes/ <POD_ID>:/var/jenkins_home --container jenkins --namespace jenkinsnamespace
     ```
 
    These operations can be done even when Jenkins is running. 

--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -85,7 +85,13 @@ Your Jenkins instance will deploy.
     ```yaml
     master:
       useSecurity: false
-      installPlugins: ["prometheus:2.0.6","kubernetes:1.18.2","workflow-job:2.39","workflow-aggregator:2.6","credentials-binding:1.23","git:4.4.2"]
+      installPlugins:
+        - prometheus:2.0.6
+        - kubernetes:1.18.2
+        - workflow-job:2.39
+        - workflow-aggregator:2.6
+        - credentials-binding:1.23
+        - git:4.4.2
       csrf:
         defaultCrumbIssuer:
           enabled: false
@@ -94,8 +100,8 @@ Your Jenkins instance will deploy.
         enabled: true
         serviceMonitorNamespace: "kubeaddons"
         serviceMonitorAdditionalLabels:
-        app: jenkins
-        release: prometheus-kubeaddons
+          app: jenkins
+          release: prometheus-kubeaddons
       serviceType: "LoadBalancer"
       jenkinsUriPrefix: "/jenkins"
       ingress:
@@ -120,7 +126,7 @@ Your Jenkins instance will deploy.
         jenkins
     ```
 
-1. If you are using helm v3, then following should work (where `--name` flag is not supported and instead the release name is directly supplied):
+1. If you are using helm v3, install the chart with the following command (note: the `--name` flag is no longer supported and instead the release name is directly supplied):
 
     ```bash
     helm install jenkins \

--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -85,7 +85,7 @@ Your Jenkins instance will deploy.
     ```yaml
     master:
       useSecurity: false
-      installPlugins: ["prometheus:2.0.6","kubernetes:1.18.2","workflow-job:2.33","workflow-aggregator:2.6","credentials-binding:1.19","git:3.11.0"] 
+      installPlugins: ["prometheus:2.0.6","kubernetes:1.18.2","workflow-job:2.39","workflow-aggregator:2.6","credentials-binding:1.23","git:4.4.2"]
       csrf:
         defaultCrumbIssuer:
           enabled: false

--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -90,19 +90,19 @@ Your Jenkins instance will deploy.
         defaultCrumbIssuer:
           enabled: false
           proxyCompatability: false
-    prometheus:
-      enabled: true
-      serviceMonitorNamespace: "kubeaddons"
-      serviceMonitorAdditionalLabels:
-      app: jenkins
-      release: prometheus-kubeaddons
-    serviceType: "LoadBalancer"
-    jenkinsUriPrefix: "/jenkins"
-    ingress:
-      enabled: true
-      path: /jenkins
-      annotations:
-        kubernetes.io/ingress.class: traefik
+      prometheus:
+        enabled: true
+        serviceMonitorNamespace: "kubeaddons"
+        serviceMonitorAdditionalLabels:
+        app: jenkins
+        release: prometheus-kubeaddons
+      serviceType: "LoadBalancer"
+      jenkinsUriPrefix: "/jenkins"
+      ingress:
+        enabled: true
+        path: /jenkins
+        annotations:
+          kubernetes.io/ingress.class: traefik
     ```
 
 1. Install helm chart with the service credentials and `values.yaml` created above. (For using helm v2)
@@ -117,7 +117,8 @@ Your Jenkins instance will deploy.
         --set serviceAccount.create=false \
         --set serviceAccount.name=jenkins \
         --set serviceAccountAgent.name=jenkins \
-        stable/jenkins
+        --repo https://charts.jenkins.io \
+        jenkinsci/jenkins
     ```
 
 # Migrating Jenkins

--- a/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
+++ b/pages/ksphere/konvoy/partner-solutions/jenkins/index.md
@@ -29,6 +29,8 @@ Your Jenkins instance will deploy.
 
 ## Install Jenkins from upstream helm chart
 
+The following instructions would work for both helm v2 and v3. If using helm v2, ensure tiller is setup correctly with right perms to be able to install charts into target namespace. Refer [https://v2.helm.sh/docs/rbac/](https://v2.helm.sh/docs/rbac/) for setting up Tiller with correct perms.
+
 1. Create a namespace for Jenkins 
 
     ```bash


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made

Jenkins docs had some (more!) indentation errors which are fixed by this PR. Also, update docs to move to new jenkins chart repo at `jenkinsci/helm-charts` instead of the default helm repo.

For [COPS-6503](https://jira.d2iq.com/browse/COPS-6503)

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Update all links if you are moving a page.
- [x] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.