### PR TITLE
Modify custom CA instructions for certificate renewal

### DIFF
--- a/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/ca-custom/index.md
+++ b/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/ca-custom/index.md
@@ -11,7 +11,7 @@ model: /mesosphere/dcos/2.2/data.yml
 <!-- The source repository for this topic is https://github.com/dcos/dcos-docs-site -->
 
 
-Each DC/OS Enterprise cluster has a DC/OS certificate authority (CA). By default the DC/OS CA uses a globally unique root CA certificate generated during the installation of DC/OS. This CA certificate is used to sign certificates for the components of DC/OS such as Admin Router. Instead of using the auto-generated root CA certificate, you can configure DC/OS Enterprise to use a specific CA certificate, either a root CA certificate or an intermediate signing certificate. (See examples [below](#example-use-cases))
+Each DC/OS Enterprise cluster has a DC/OS certificate authority (CA). By default the DC/OS CA uses a globally unique root CA certificate generated during the installation of DC/OS. This CA certificate is used to sign certificates for the components of DC/OS such as Admin Router. Instead of using the default root CA certificate, you can configure DC/OS Enterprise to use a specific CA certificate, either a root CA certificate or an intermediate signing certificate. (See examples [below](#example-use-cases))
 
 Using a custom CA certificate for your DC/OS Enterprise cluster provides several benefits over using the default CA certificate:
 
@@ -29,19 +29,19 @@ Using a custom CA certificate for your DC/OS Enterprise cluster provides several
 # Custom CA certificate support
 - Only RSA and Elliptic Curve (EC) certificates are supported.
 - DC/OS Enterprise 1.9 and earlier do **not** support custom signing certificates.
-- DC/OS Enterprise 2.1.1, 2.1.0, 2.0.0 - 2.0.6, and all versions of DC/OS 1 do **not** support modification (addition, removal, or replacement) of signing certificates in an existing cluster.
+- DC/OS Enterprise 2.1.1, 2.1.0, 2.0.0–2.0.6, and all versions of DC/OS 1 do **not** support modification (addition, removal, or replacement) of signing certificates in an existing cluster.
 - If Calico is enabled in DC/OS Enterprise 2.1 and later, modifying a CA certificate will restart Docker on agent nodes, stopping any workloads running on the agent.
 
 # Glossary 
-- **Signing certificate:** A CA certificate that will be used to issue certificates for DC/OS components such as Admin Router. The custom signing certificate is either an intermediate signing certificate (issued by another CA) or a root CA certificate (self-signed by the custom CA).  The signing certificate must be provided in PEM format (starting with `-----BEGIN CERTIFICATE-----`).
+- **Signing certificate:** A CA certificate that will be used to issue certificates for DC/OS components such as Admin Router. The custom signing certificate is either an intermediate signing certificate (issued by another CA) or a root CA certificate (self-signed by the custom CA). Provide the signing certificate in PEM format (starting with `-----BEGIN CERTIFICATE-----`).
 
-- **Signing key:** The signing key associated with the signing certificate.  The signing key must be provided in unencrypted PKCS 8 format (starting with `-----BEGIN PRIVATE KEY-----`).
+- **Signing key:** The signing key associated with the signing certificate. Provide the signing key in unencrypted PKCS8 format (starting with `-----BEGIN PRIVATE KEY-----`).
 
-- **Signing certificate chain:** The complete CA certification chain required for end-entity certificate verification. It must include the certificates of all parent CAs of the signing certificate up to and including the root CA certificate. If the signing certificate is a root certificate, the chain must be empty. Each certificate must be provided in PEM format (starting with `-----BEGIN CERTIFICATE-----`).
+- **Signing certificate chain:** The complete CA certification chain required for end-entity certificate verification. It must include the certificates of all parent CAs of the signing certificate up to and including the root CA certificate. If the signing certificate is a root certificate, the chain must be empty. Provide the certificates in PEM format (starting with `-----BEGIN CERTIFICATE-----`).
 
-- **Installation directory:** The directory on the bootstrap node where the DC/OS installer resides. It is denoted with `$DCOS_INSTALL_DIR` in this document.
+- **Installation directory:** The directory on the bootstrap node where the DC/OS installer resides. It is denoted by `$DCOS_INSTALL_DIR` in this document.
 
-- **DC/OS configuration file:** The file which contains the DC/OS configuration parameters. The DC/OS configuration file is normally called `config.yaml` and must be present in the `$DCOS_INSTALL_DIR/genconf/` directory on the bootstrap node during the installation. It is used by the DC/OS installer.
+- **DC/OS configuration file:** The file which contains the DC/OS configuration parameters. The DC/OS configuration file is typically called `config.yaml` and must be present in the `$DCOS_INSTALL_DIR/genconf/` directory on the bootstrap node during the installation.
 
 
 # Adding or replacing a custom CA certificate
@@ -88,27 +88,27 @@ then run the command:
 openssl req -config openssl-ca.cnf -newkey rsa:4096 -nodes -keyout dcos-ca.key -x509 -days 1850 -out dcos-ca.crt
 ```
 
-However, you should review the security requirements for your organization to determine a suitable way to create or obtain CA certificates.
+You should review the security requirements for your organization to determine a suitable way to create or obtain CA certificates.
 
 On the bootstrap node copy the files to the `$DCOS_INSTALL_DIR/genconf/` directory.
 
 For security reasons, the installer will not copy the signing key file from the bootstrap node to the master nodes.
-The signing key must be distributed manually to every DC/OS master node **before starting the installation**.
+Manually distribute the signing key to every DC/OS master node **before starting the installation**.
 If you copy the signing key file over the network onto the master nodes, the network channel must be adequately protected.
 
-On each master node create the directory `/var/lib/dcos/pki/tls/CA/private/` owned by the `root` user and with permission mode 0700. Copy the signing key file to `/var/lib/dcos/pki/tls/CA/private/custom_ca.key`.  Ensure that the signing key file is owned by the `root` user and is only accessible to the owner (permission mode 0600).
+On each master node create the directory `/var/lib/dcos/pki/tls/CA/private/` owned by the `root` user and with permission mode 0700. Copy the signing key file to `/var/lib/dcos/pki/tls/CA/private/custom_ca.key`. Ensure that the signing key file is owned by the `root` user and is only accessible to the owner (permission mode 0600).
 
 ## DC/OS Configuration
 
 Add the paths for the signing CA files to the DC/OS configuration file.
 The paths must be relative to `$DCOS_INSTALL_DIR` and hence will always start with `genconf/`.
 
-<p class="message--note"><strong>NOTE: </strong>If Calico is enabled then changing these configuration values for an existing cluster will cause Docker to be restarted on agent nodes. This will terminate running workloads.</p>
+<p class="message--note"><strong>NOTE: </strong>If Calico is enabled then changing these configuration values for an existing cluster will restart Docker on agent nodes. This will terminate running workloads.</p>
 
 ### ca\_certificate\_path
 Path (relative to the `$DCOS_INSTALL_DIR`) to a file containing the signing certificate. For example: `genconf/dcos-ca.crt`. It can be either a self-signed root certificate or an intermediate certificate signed by another certificate authority.
 
-The DC/OS CA will use this certificate for signing end-entity certificates; the subject of this certificate will be the issuer for certificates signed by the DC/OS CA. If not provided the DC/OS cluster generates a unique root certificate during the initial bootstrap phase and uses that as the signing certificate.
+The DC/OS CA will use this certificate for signing end-entity certificates. The subject of this certificate will be the issuer for certificates signed by the DC/OS CA. If not provided the DC/OS cluster generates a unique root certificate during the initial bootstrap phase and uses that as the signing certificate.
 
 ### ca\_certificate\_key\_path
 Path (relative to the `$DCOS_INSTALL_DIR`) to a file containing the signing key. For example: `genconf/dcos-ca.key`.
@@ -120,7 +120,7 @@ This path is required if `ca_certificate_path` is specified.
 ### ca\_certificate\_chain\_path
 Path (relative to the `$DCOS_INSTALL_DIR`) to a file containing the complete CA certification chain required for end-entity certificate verification. For example: `genconf/dcos-ca-chain.pem`.
 
-If `ca_certificate_path` points to a self-signed root certificate this parameter must be omitted.
+If `ca_certificate_path` points to a self-signed root certificate then omit this parameter.
 
 Otherwise `ca_certificate_chain_path` points to a file containing the complete chain of certificates up to a self-signed root certificate, but excluding the signing certificate contained in `ca_certificate_path`. The order is significant: the first certificate must verify the signing certificate in `ca_certificate_path` and each subsequent certificate must verify the preceding certificate.
 
@@ -129,21 +129,21 @@ Otherwise `ca_certificate_chain_path` points to a file containing the complete c
 Proceed with the installation or patch upgrade by running the appropriate `dcos_generate_config.ee.sh` command as described in the [documentation of the Advanced Installer](/mesosphere/dcos/2.2/installing/production). Note that the current working directory when executing `dcos_generate_config.ee.sh` must be the `$DCOS_INSTALL_DIR` directory.
 
 ## Verify installation
-To verify that the DC/OS Enterprise cluster was installed properly with the custom signing certificate, you can access the DC/OS web UI and inspect the certificate to check that the CA has the expected DN.
+To verify that the DC/OS Enterprise cluster was installed with the custom signing certificate, use your browser to access the DC/OS web UI and inspect the certificate and check that the CA has the expected DN.
 
-Programmatically, you can follow these steps:
+Alternatively, you can follow these steps:
 
 Select a master node to test:
 ```bash
 MASTER=172.28.128.21
 ```
 
-You will need the CA certificate.  If necessary, it can be obtained from the master node using:
+You will need the CA certificate. If necessary, retrieve it from the master node using:
 ```bash
 curl -k -v https://${MASTER}/ca/dcos-ca.crt -o dcos-ca.crt
 ```
 
-Obtain the certificate from the web UI and verify it against the CA certificate:
+Retrieve the certificate chain from the web UI and verify it with the CA certificate:
 ```bash
 openssl s_client -verify_ip ${MASTER} -CAfile dcos-ca.crt -connect ${MASTER}:443 | grep -e "s:" -e "i:" -e "return code:"
 ```
@@ -166,7 +166,7 @@ This section describes how the three configuration parameters `ca_certificate_pa
 ## Use case 1: 
 The signing certificate is a self-signed root certificate. The CA does not have a “parent” CA, hence the signing certificate chain is empty.
 
-The following files are present:
+Provide the following files:
 
 - on the bootstrap node:
     - `$DCOS_INSTALL_DIR/genconf/dcos-ca.crt` file containing the signing certificate
@@ -186,7 +186,7 @@ issuer= /C=US/L=Nebraska/O=Example/CN=Integration Test Root CA
 subject= /C=US/L=Nebraska/O=Example/CN=Integration Test Root CA
 ```
 
-Since the signing certificate is a root certificate and the corresponding signing certificate chain is empty, we must omit the `ca_certificate_chain_path` parameter in the DC/OS configuration file. The configuration parameters must be specified as follows in the DC/OS configuration file on the bootstrap node:
+Since the signing certificate is a root certificate and the corresponding signing certificate chain is empty, we must omit the `ca_certificate_chain_path` parameter in the DC/OS configuration file. Specify the configuration parameters as follows in the DC/OS configuration file on the bootstrap node:
 
 ```yaml
 ca_certificate_path: genconf/dcos-ca.crt
@@ -195,12 +195,12 @@ ca_certificate_key_path: genconf/dcos-ca.key
 
 ## Use case 2: 
 
-In this case the signing certificate is an intermediate one, issued directly by a root CA. The signing certificate chain consists of just the root CA certificate. The following files are present:
+In this case the signing certificate is an intermediate one, issued directly by a root CA. The signing certificate chain consists of just the root CA certificate. Provide the following files:
 
 - on the bootstrap node:
     - `$DCOS_INSTALL_DIR/genconf/dcos-ca.crt` file containing the signing certificate in PEM format
     - `$DCOS_INSTALL_DIR/genconf/dcos-ca.key` file containing the signing key
-    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-chain.crt` file containing only the root signing certificate in PEM format
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-chain.crt` file containing the root signing certificate in PEM format
 
 - on the master nodes
     - `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` file containing the signing key
@@ -227,7 +227,7 @@ issuer= /C=US/L=Nebraska/O=Example/CN=Integration Test Root CA
 subject= /C=US/L=Nebraska/O=Example/CN=Integration Test Root CA
 ```
 
-The configuration parameters must be specified similar to the following in the DC/OS configuration file on the bootstrap node:
+Specify the configuration parameters as follows in the DC/OS configuration file on the bootstrap node:
 
 ```yaml
 ca_certificate_path: genconf/dcos-ca.crt
@@ -245,12 +245,12 @@ The signing certificate chain comprises the
 
 in that order.
 
-The following files are present:
+Provide the following files:
 
 - on the bootstrap node:
-    - `$DCOS_INSTALL_DIR/genconf/dcos-ca.crt` file containing the signing certificate in PEM format
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca.crt` file containing the signing certificate
     - `$DCOS_INSTALL_DIR/genconf/dcos-ca.key` file containing the signing key
-    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-chain.crt` file containing the signing certificate chain in PEM format
+    - `$DCOS_INSTALL_DIR/genconf/dcos-ca-chain.crt` file containing the signing certificate chain
 
 - on the master nodes
     - `/var/lib/dcos/pki/tls/CA/private/custom_ca.key` file containing the signing key
@@ -279,7 +279,7 @@ issuer= /C=US/L=Nebraska/O=Example/CN=Integration Test Root CA
 subject= /C=US/L=Nebraska/O=Example/CN=Integration Test Root CA
 ```
 
-The configuration parameters must be specified as follows in the DC/OS configuration file on the bootstrap node:
+Specify the configuration parameters as follows in the DC/OS configuration file on the bootstrap node:
 
 ```yaml
 ca_certificate_path: genconf/dcos-ca.crt


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-71528

## Description of changes being made

Rewrite custom certificate page to add support for certificate renewal.

Although this will also work in the next minor versions of 2.1 and 2.0, I am just changing 2.2 for now to support the beta release. Once we're happy with 2.2 beta results and perhaps closer to minor updates to earlier versions, I will copy this back to 2.1 and 2.0

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.