### PR TITLE
Add a `latest` redirect for kubeflow.

### DIFF
--- a/docker/nginx/redirects-307.map
+++ b/docker/nginx/redirects-307.map
@@ -3,6 +3,7 @@
 ~^/ksphere/dispatch/latest/(.*)$ /ksphere/dispatch/1.2/$1;
 ~^/ksphere/kommander/latest/(.*)$ /ksphere/kommander/1.1/$1;
 ~^/ksphere/conductor/latest/(.*)$ /ksphere/conductor/1.1/$1;
+~^/ksphere/kubeflow/latest/(.*)$ /ksphere/kubeflow/1.0.1-0.5.0/$1;
 ~^/mesosphere/dcos/services/cassandra/latest/(.*) /mesosphere/dcos/services/cassandra/2.9.0-3.11.6/$1;
 ~^/mesosphere/dcos/services/confluent-kafka/latest/(.*) /mesosphere/dcos/services/confluent-kafka/2.9.0-5.4.0/$1;
 ~^/mesosphere/dcos/services/confluent-zookeeper/latest/(.*) /mesosphere/dcos/services/confluent-zookeeper/2.7.0-5.1.2e/$1;


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-71861

## Description of changes being made

Add a `latest` redirect for kubeflow.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Update all links if you are moving a page.
- [x] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.