### PR TITLE
mesos-calico: clarify labeling for Docker vs UCR

### DIFF
--- a/pages/mesosphere/dcos/2.1/networking/SDN/calico/index.md
+++ b/pages/mesosphere/dcos/2.1/networking/SDN/calico/index.md
@@ -42,7 +42,7 @@ NAME
 The `DC/OS Calico CLI` requires gRPC port to be open and accessible from outside of the cluster on the current leader.
 
 
-## DC/OS network configuration reference 
+## DC/OS network configuration reference
 
 | Parameter | Description |
 |-----------|-------------|
@@ -130,12 +130,16 @@ limitations on network policy we have in DC/OS:
 
 * Calico network policy is a namespaced resource, but for now, we support only `default` namespace in DC/OS, and all the namespaced Calico resources should be defined under `default` namespace.
 * Calico network policy takes effect only on Calico networking containers, which means labels set on non-Calico networking containers like `hostnetwork`, `dcos` and `bridge` will not count in Calico network policy.
-* Labels work for network policy must be set in `NetworkInfo.Labels` in Mesos, and for Marathon, they should be in `networks.[].labels`, for example:
+* UCR containers: Labels for network policy MUST be set in `NetworkInfo.Labels` for Mesos, and for Marathon, they should be in `networks.[].labels`, for example:
 
 ```json
 {
   "id": "/client",
   "instances": 1,
+  "container": {
+    "type": "MESOS",
+    ...
+  },
    ...
   "networks": [
     {
@@ -146,6 +150,32 @@ limitations on network policy we have in DC/OS:
       }
     }
   ],
+  ...
+}
+```
+
+* Docker Containers: Labels for network policy MUST be set in `container.docker.paramaters` and prefixed with `org.projectcalico.label`, for example:
+
++```json
+{
+  "id": "/client",
+  "instances": 1,
+  "container": {
+    "type": "Docker",
+    "docker": {
+      "parameters": [
+        {
+          "key": "label",
+          "value": "org.projectcalico.label.role=client"
+        },
+        {
+          "key": "label",
+          "value": "org.projectcalico.label.public=yes"
+        }
+      ]
+    },
+    ...
+  },
   ...
 }
 ```

--- a/pages/mesosphere/dcos/2.2/networking/SDN/calico/index.md
+++ b/pages/mesosphere/dcos/2.2/networking/SDN/calico/index.md
@@ -130,12 +130,16 @@ limitations on network policy we have in DC/OS:
 
 * Calico network policy is a namespaced resource, but for now, we support only `default` namespace in DC/OS, and all the namespaced Calico resources should be defined under `default` namespace.
 * Calico network policy takes effect only on Calico networking containers, which means labels set on non-Calico networking containers like `hostnetwork`, `dcos` and `bridge` will not count in Calico network policy.
-* Labels work for network policy MUST be set in `NetworkInfo.Labels` in Mesos, and for Marathon, they should be in `networks.[].labels`, for example:
+* UCR containers: Labels for network policy MUST be set in `NetworkInfo.Labels` for Mesos, and for Marathon, they should be in `networks.[].labels`, for example:
 
 ```json
 {
   "id": "/client",
   "instances": 1,
+  "container": {
+    "type": "MESOS",
+    ...
+  },
    ...
   "networks": [
     {
@@ -146,6 +150,32 @@ limitations on network policy we have in DC/OS:
       }
     }
   ],
+  ...
+}
+```
+
+* Docker Containers: Labels for network policy MUST be set in `container.docker.paramaters` and prefixed with `org.projectcalico.label`, for example:
+
+```json
+{
+  "id": "/client",
+  "instances": 1,
+  "container": {
+    "type": "Docker",
+    "docker": {
+      "parameters": [
+        {
+          "key": "label",
+          "value": "org.projectcalico.label.role=client"
+        },
+        {
+          "key": "label",
+          "value": "org.projectcalico.label.public=yes"
+        }
+      ]
+    },
+    ...
+  },
   ...
 }
 ```


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-6328

## Description of changes being made

The docker isolator does not parse and forward networkinfo labels, so customers must set the labels explicitly in the docker parameters.


## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.