### PR TITLE
change "config.yaml" to "cluster.yaml"

### DIFF
--- a/pages/ksphere/kubeflow/1.0.1-0.5.0/install/air-gapped/index.md
+++ b/pages/ksphere/kubeflow/1.0.1-0.5.0/install/air-gapped/index.md
@@ -22,7 +22,7 @@ The installation steps for KUDO for Kubeflow on an air-gapped cluster are as fol
 
 * Place the Konvoy add-ons Docker tar file in the images folder, re-tag it, and push it to a private registry. Regarding the private bootstrap Docker registry configuration, please see the corresponding [Konvoy docs](https://docs.d2iq.com/ksphere/konvoy/1.5/install/install-airgapped/#configure-the-image-registry) for more details.
 
-* Modify the Konvoy `config.yaml` to ensure a local Helm repository is used, ensuring all add-on repos' images are `mesosphere/konvoy-addons-chart-repo:kfa-1.5.2-stable-1.17-0.4.3`. For instance,
+* Modify the Konvoy `cluster.yaml` to ensure a local Helm repository is used, ensuring all add-on repos' images are `mesosphere/konvoy-addons-chart-repo:kfa-1.5.2-stable-1.17-0.4.3`. For instance,
 	```yaml
     - configRepository: https://github.com/mesosphere/kubeaddons-kubeflow
       configVersion: stable-1.17-0.4.3


### PR DESCRIPTION
AFAIK, there is no "config.yaml" associated with a Konvoy cluster?

Renamed to "cluster.yaml" to avoid end user confusion.

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.