### PR TITLE
clean up the shortcodes file

### DIFF
--- a/scss/shortcodes/_message.scss
+++ b/scss/shortcodes/_message.scss
@@ -45,31 +45,6 @@
     color: $color-dark;
     background: #89DA71;
   }
-  &--outline {
-    border: 1px solid $color-dark;
-    color: $color-dark;
-    background: transparent;
-  }
-  &--outline-warning {
-    border: 1px solid #F2D98E;
-    color: #F2D98E;
-    background: transparent;
-  }
-  &--outline-error {
-    border: 1px solid #E77975;
-    color: #E77975;
-    background: transparent;
-  }
-  &--outline-info {
-    border: 1px solid;
-    color: #505868;
-    background: transparent;
-  }
-  &--outline-success {
-    border: 1px solid #89DA71;
-    color: #89DA71;
-    background: transparent;
-  }
 }
 .warning-label::before {
   content: "WARNING: ";

--- a/shortcodes/index.js
+++ b/shortcodes/index.js
@@ -5,352 +5,46 @@ const minify = require("html-minifier").minify;
 const NgindoxUi = require("ngindox/lib/ui");
 const Yaml = require("js-yaml");
 
-/**
- * Shortcodes for metalsmith-shortcode-parser
- *
- */
+///////////////////////////////////////////////////////////////////////////////
+//                                  HELPERS                                  //
+///////////////////////////////////////////////////////////////////////////////
+const badge = (style, label) => (buf, { size = "large", type = "block" }) =>
+  buf
+    ? `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--${style}">${label}</span>`
+    : `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--${style}">${label}</span></span>`;
 
-/**
- * Removes any extra whitespace around html tags. Whitespace is a side
- * effect from using es6 template strings.
- * @param {string} html
- */
-const sanitize = (html) => html.replace(/^ +| +$/gm, "");
-
-/**
- * Capitalize for message label (warning, error, etc)
- */
 const capitalize = (string) => string.charAt(0).toUpperCase() + string.slice(1);
 
+const swaggerSVGs = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0"><defs><symbol viewBox="0 0 20 20" id="large-arrow"><path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/></symbol><symbol viewBox="0 0 20 20" id="large-arrow-down"><path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/></symbol></defs></svg>`;
+
+/**
+ * Shortcodes for metalsmith-shortcode-parser
+ */
 const shortcodes = {
-  /**
-   * Icons
-   * @param {string} buf
-   * @param {Object} opts
-   */
-  icon: (buf, opts) =>
-    sanitize(`
-      <i class="icon" data-feather="${opts.glyph}"></i>
-    `),
+  // badges
+  beta: badge("beta", "Beta"),
+  community: badge("community", "Community"),
+  enterprise: badge("enterprise", "Enterprise"),
+  experimental: badge("experimental", "Experimental"),
+  oss: badge("oss", "Open Source"),
+  preview: badge("preview", "Preview"),
 
-  /**
-   * Message
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.type
-   * @param {boolean} opts.fill
-   */
+  button: (buf, { href, color = "purple" }) => {
+    const btn = `<button type="button" class="btn btn--${color} btn--large">${buf.toUpperCase()}</button>`;
+    return href ? `<a href="${href}" target="_blank">${btn}</a>` : btn;
+  },
+
   message: (buf, { type, label = `<strong>${capitalize(type)}: </strong>` }) =>
-    sanitize(`<span class="message message--${type}">${label}${buf}</span>`),
-  /**
-   * Enterprise
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.size
-   * @param {string} opts.type
-   */
-  enterprise: (buf, opts) => {
-    let size = opts.size;
-    let type = opts.type;
-    if (!opts.size) {
-      size = "large";
-    }
-    if (!opts.type) {
-      type = "block";
-    } else if (opts.type === "inline" || opts.type === "inline-block") {
-      type = "inline";
-    }
-    if (buf) {
-      return sanitize(
-        `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--enterprise">Enterprise</span>`
-      );
-    }
-    return sanitize(
-      `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--enterprise">Enterprise</span></span>`
-    );
-  },
+    `<span class="message message--${type}">${label}${buf}</span>`,
 
-  /**
-   * Community
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.size
-   * @param {string} opts.type
-   */
-  community: (buf, opts) => {
-    let size = opts.size;
-    let type = opts.type;
-    if (!opts.size) {
-      size = "large";
-    }
-    if (!opts.type) {
-      type = "block";
-    } else if (opts.type === "inline" || opts.type === "inline-block") {
-      type = "inline";
-    }
-    if (buf) {
-      return sanitize(
-        `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--community">Community</span>`
-      );
-    }
-    return sanitize(
-      `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--community">Community</span></span>`
-    );
-  },
-
-  /**
-   * OSS
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.size
-   * @param {string} opts.type
-   */
-  oss: (buf, opts) => {
-    let size = opts.size;
-    let type = opts.type;
-    if (!opts.size) {
-      size = "large";
-    }
-    if (!opts.type) {
-      type = "block";
-    } else if (opts.type === "inline" || opts.type === "inline-block") {
-      type = "inline";
-    }
-    if (buf) {
-      return sanitize(
-        `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--oss">Open Source</span>`
-      );
-    }
-    return sanitize(
-      `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--oss">Open Source</span></span>`
-    );
-  },
-
-  /**
-   * Beta
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.size
-   * @param {string} opts.type
-   */
-  beta: (buf, opts) => {
-    let size = opts.size;
-    let type = opts.type;
-    if (!opts.size) {
-      size = "large";
-    }
-    if (!opts.type) {
-      type = "block";
-    } else if (opts.type === "inline" || opts.type === "inline-block") {
-      type = "inline";
-    }
-    if (buf) {
-      return sanitize(
-        `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--beta">Beta</span>`
-      );
-    }
-    return sanitize(
-      `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--beta">Beta</span></span>`
-    );
-  },
-  /**
-   * Switch
-   * @param {string} buf
-   * @param {Object} opts
-   */
-  switch: (buf, _opts) =>
-    sanitize(`
-      <div class="switch">
-        <div class="switch__filters">
-        </div>
-        <div class="switch__cases">
-          ${buf}
-        </div>
-      </div>
-    `),
-
-  /**
-   * Preview
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.size
-   * @param {string} opts.type
-   */
-  preview: (buf, opts) => {
-    let size = opts.size;
-    let type = opts.type;
-    if (!opts.size) {
-      size = "large";
-    }
-    if (!opts.type) {
-      type = "block";
-    } else if (opts.type === "inline" || opts.type === "inline-block") {
-      type = "inline";
-    }
-    if (buf) {
-      return sanitize(
-        `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--preview">Preview</span>`
-      );
-    }
-    return sanitize(
-      `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--preview">Preview</span></span>`
-    );
-  },
-
-  /**
-   * Experimental
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.size
-   * @param {string} opts.type
-   */
-  experimental: (buf, opts) => {
-    let size = opts.size;
-    let type = opts.type;
-    if (!opts.size) {
-      size = "large";
-    }
-    if (!opts.type) {
-      type = "block";
-    } else if (opts.type === "inline" || opts.type === "inline-block") {
-      type = "inline";
-    }
-    if (buf) {
-      return sanitize(
-        `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--experimental">Experimental</span>`
-      );
-    }
-    return sanitize(
-      `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--experimental">Experimental</span></span>`
-    );
-  },
-
-  /**
-   * Case
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {Object} opts.filter
-   */
-  case: (buf, opts) => {
-    // If filter is enterprise or oss, will style as pill from badge shortcode
-    // Any other text will default to oss badge styling
-    const badge = `badge--${opts.filter.toLowerCase()}`;
-    return sanitize(`
-      <div class="switch__case-print-badge">
-        <p class="badge badge--shortcode badge--small ${badge}">${opts.filter}</p>
-      </div>
-      <div class="switch__case" data-filter="${opts.filter}">${buf}</div>
-    `);
-  },
-
-  /**
-   * Swagger
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.api
-   */
-  swagger: (buf, opts) => {
-    const swaggerSVGs = `
-      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
-        <defs>
-          <symbol viewBox="0 0 20 20" id="large-arrow">
-            <path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/>
-          </symbol>
-          <symbol viewBox="0 0 20 20" id="large-arrow-down">
-            <path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/>
-          </symbol>
-        </defs>
-      </svg>
-    `;
-    // Else, regular on-demand rendering of SwaggerUI
-    // Output
-    return sanitize(
-      `${swaggerSVGs}<div class="swagger-ui" data-api="${opts.api}" ></div>`
-    );
-  },
-
-  /**
-   * Ngindox
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.api
-   */
   ngindox: (buf, { api }) =>
-    sanitize(
-      NgindoxUi.toHtml(Yaml.safeLoad(fs.readFileSync(`./pages${api}`)), {
-        title: "Routes",
-        legend: true,
-      })
-    ),
+    NgindoxUi.toHtml(Yaml.safeLoad(fs.readFileSync(`./pages${api}`)), {
+      title: "Routes",
+      legend: true,
+    }).replace(/^ +| +$/gm, ""),
 
-  /**
-   * Image
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.src
-   * @param {string} opts.srcset
-   * @param {string} opts.sizes
-   * @param {string} opts.alt
-   * @param {string} opts.type
-   */
-  image: (buf, opts) => {
-    if (opts.srcset && opts.sizes) {
-      return sanitize(`
-        <div class="img__wrapper img__wrapper--${opts.type}"><a href=${opts.src} target="_blank"><img srcset=${opts.srcset} sizes=${opts.sizes} src=${opts.src} alt=${opts.alt} class="img--${opts.type}"></a><p class="img__caption img__caption--${opts.type}">${opts.caption}</p></div>
-      `);
-    }
-
-    return sanitize(`
-      <div class="img__wrapper img__wrapper--${opts.type}"><a href=${opts.src} target="_blank"><img src=${opts.src} alt=${opts.alt} class="img--${opts.type}"></a><p class="img__caption img__caption--${opts.type}">${opts.caption}</p></div>
-    `);
-  },
-
-  /**
-   * Tooltip
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.content
-   */
-  tooltip: (buf, opts) =>
-    sanitize(`
-      <span class="tooltip" data-tooltip data-content="${opts.content}">${buf}</span>
-    `),
-
-  /**
-   * Button
-   * @param {string} buf
-   * @param {Object} opts
-   * @param {string} opts.type
-   * @param {string} opts.size
-   * @param {string} opts.color
-   * @param {string} opts.href
-   */
-  button: (buf, givenOpts) => {
-    const opts = Object.assign({}, givenOpts);
-    if (!opts.color) {
-      opts.color = "purple";
-    }
-    if (!opts.size) {
-      opts.size = "large";
-    }
-    if (!opts.type) {
-      opts.type = "button";
-    }
-    const classes = `btn--${opts.color} btn--${opts.size}`;
-    if (opts.href) {
-      return sanitize(`
-      <a href="${opts.href}" target="_blank"><button type=${
-        opts.type
-      } class="btn ${classes}">${buf.toUpperCase()}</button></a>
-    `);
-    }
-
-    return sanitize(`
-      <button type=${
-        opts.type
-      } class="btn ${classes}">${buf.toUpperCase()}</button>
-    `);
-  },
+  swagger: (buf, { api }) =>
+    `${swaggerSVGs}<div class="swagger-ui" data-api="${api}"></div>`,
 };
 
 module.exports = shortcodes;


### PR DESCRIPTION
while working on #3233 i wanted to use the message-shortcode. it currently is not flexible enough for my use case. then these changes emerged before implementing what i need.

1. because they're not used in the codebase anymore we remove

  * `icon`
  * `switch`
  * `case`
  * `image`
  * `tooltip`

  validated via grepping for `"\[<SHORTCODE>"`.

2. remove `sanitize` as its name should rather had been `trim` and we
don't actually need it when writing our shortcodes differently.
3. add a helper for all those `badge` thingies. we might even introduce a `badge` shortcode that replaces all those later.
4. we remove the `fill` option from `message` as it's not used anywhere and even looks really broken currently.
5. we remove the "inline-block" `type` handling within the badge-helper as that's not used (anymore).
6. we remove `type` and `size` from `button` as those are not used anywhere.

i diffed the output before and after this change (with whitespace off) and did not notice any significant difference. maybe we can automate that in the future via minor adaptions to the sidebar rendering (which seems to spit out items in arbitrary order although they should be sorted) and the CSS (which uses `random` and thus produces different output with every build).