### PR TITLE
Fixing Mesos-DNS documentation to avoid customer confusion.

### DIFF
--- a/pages/mesosphere/dcos/1.12/networking/DNS/mesos-dns/index.md
+++ b/pages/mesosphere/dcos/1.12/networking/DNS/mesos-dns/index.md
@@ -21,14 +21,6 @@ Mesos-DNS is designed for reliability and simplicity. It requires little configu
 
 If the Mesos-DNS process fails, `systemd` automatically restarts it. Mesos-DNS then retrieves the latest state from the DC/OS masters and begins serving DNS requests without additional coordination. Mesos-DNS does not require consensus mechanisms, persistent storage, or a replicated log because it does not implement heartbeats, health monitoring, or lifetime management for applications; this functionality is already built in to the DC/OS masters, agents, and services.
 
-You can load balance DNS requests in clusters with large numbers of agents by adding additional master nodes; no additional configuration is necessary.
-
-![Mesos-DNS](/mesosphere/dcos/1.12/img/mesos-dns.png)
-
-Figure 1. Mesos-DNS integration
-
-As shown in the diagram, Mesos-DNS optionally integrates with your existing DNS infrastructure. Mesos-DNS replies directly to lookup requests from agent nodes for applications and services within your DC/OS cluster. If an agent node makes a DNS request for a hostname that is outside your DC/OS cluster, Mesos-DNS queries an external nameserver. External nameservers are only required if DC/OS cluster nodes must resolve hostnames for systems elsewhere on your network or on the Internet.
-
  [1]: https://github.com/mesosphere/mesos-dns
  [2]: http://en.wikipedia.org/wiki/Domain_Name_System
  [3]: https://github.com/mesosphere/marathon

--- a/pages/mesosphere/dcos/1.13/networking/DNS/mesos-dns/index.md
+++ b/pages/mesosphere/dcos/1.13/networking/DNS/mesos-dns/index.md
@@ -22,14 +22,6 @@ Mesos-DNS is designed for reliability and simplicity. It requires little configu
 
 If the Mesos-DNS process fails, `systemd` automatically restarts it. Mesos-DNS then retrieves the latest state from the DC/OS masters and begins serving DNS requests without additional coordination. Mesos-DNS does not require consensus mechanisms, persistent storage, or a replicated log because it does not implement heartbeats, health monitoring, or lifetime management for applications; this functionality is already built into the DC/OS masters, agents, and services.
 
-You can load balance DNS requests in clusters with large numbers of agents by adding additional master nodes; no additional configuration is necessary.
-
-![Mesos-DNS](/mesosphere/dcos/1.13/img/mesos-dns.png)
-
-Figure 1. Mesos-DNS integration
-
-As shown in the diagram, Mesos-DNS optionally integrates with your existing DNS infrastructure. Mesos-DNS replies directly to lookup requests from agent nodes for applications and services within your DC/OS cluster. If an agent node makes a DNS request for a hostname that is outside your DC/OS cluster, Mesos-DNS queries an external nameserver. External nameservers are only required if DC/OS cluster nodes must resolve hostnames for systems elsewhere on your network or on the Internet.
-
  [1]: https://github.com/mesosphere/mesos-dns
  [2]: http://en.wikipedia.org/wiki/Domain_Name_System
  [3]: https://github.com/mesosphere/marathon

--- a/pages/mesosphere/dcos/2.0/networking/DNS/mesos-dns/index.md
+++ b/pages/mesosphere/dcos/2.0/networking/DNS/mesos-dns/index.md
@@ -22,14 +22,6 @@ Mesos-DNS is designed for reliability and simplicity. It requires little configu
 
 If the Mesos-DNS process fails, `systemd` automatically restarts it. Mesos-DNS then retrieves the latest state from the DC/OS masters and begins serving DNS requests without additional coordination. Mesos-DNS does not require consensus mechanisms, persistent storage, or a replicated log because it does not implement heartbeats, health monitoring, or lifetime management for applications; this functionality is already built into the DC/OS masters, agents, and services.
 
-You can load balance DNS requests in clusters with large numbers of agents by adding additional master nodes; no additional configuration is necessary.
-
-![Mesos-DNS](/mesosphere/dcos/2.0/img/mesos-dns.png)
-
-Figure 1. Mesos-DNS integration
-
-As shown in the diagram, Mesos-DNS optionally integrates with your existing DNS infrastructure. Mesos-DNS replies directly to lookup requests from agent nodes for applications and services within your DC/OS cluster. If an agent node makes a DNS request for a hostname that is outside your DC/OS cluster, Mesos-DNS queries an external nameserver. External nameservers are only required if DC/OS cluster nodes must resolve hostnames for systems elsewhere on your network or on the Internet.
-
  [1]: https://github.com/mesosphere/mesos-dns
  [2]: http://en.wikipedia.org/wiki/Domain_Name_System
  [3]: https://github.com/mesosphere/marathon

--- a/pages/mesosphere/dcos/2.1/networking/DNS/mesos-dns/index.md
+++ b/pages/mesosphere/dcos/2.1/networking/DNS/mesos-dns/index.md
@@ -22,14 +22,6 @@ Mesos-DNS is designed for reliability and simplicity. It requires little configu
 
 If the Mesos-DNS process fails, `systemd` automatically restarts it. Mesos-DNS then retrieves the latest state from the DC/OS masters and begins serving DNS requests without additional coordination. Mesos-DNS does not require consensus mechanisms, persistent storage, or a replicated log because it does not implement heartbeats, health monitoring, or lifetime management for applications; this functionality is already built into the DC/OS masters, agents, and services.
 
-You can load balance DNS requests in clusters with large numbers of agents by adding additional master nodes; no additional configuration is necessary.
-
-![Mesos-DNS](/mesosphere/dcos/2.1/img/mesos-dns.png)
-
-Figure 1. Mesos-DNS integration
-
-As shown in the diagram, Mesos-DNS optionally integrates with your existing DNS infrastructure. Mesos-DNS replies directly to lookup requests from agent nodes for applications and services within your DC/OS cluster. If an agent node makes a DNS request for a hostname that is outside your DC/OS cluster, Mesos-DNS queries an external nameserver. External nameservers are only required if DC/OS cluster nodes must resolve hostnames for systems elsewhere on your network or on the Internet.
-
  [1]: https://github.com/mesosphere/mesos-dns
  [2]: http://en.wikipedia.org/wiki/Domain_Name_System
  [3]: https://github.com/mesosphere/marathon

--- a/pages/mesosphere/dcos/2.2/networking/DNS/mesos-dns/index.md
+++ b/pages/mesosphere/dcos/2.2/networking/DNS/mesos-dns/index.md
@@ -22,14 +22,6 @@ Mesos-DNS is designed for reliability and simplicity. It requires little configu
 
 If the Mesos-DNS process fails, `systemd` automatically restarts it. Mesos-DNS then retrieves the latest state from the DC/OS masters and begins serving DNS requests without additional coordination. Mesos-DNS does not require consensus mechanisms, persistent storage, or a replicated log because it does not implement heartbeats, health monitoring, or lifetime management for applications; this functionality is already built into the DC/OS masters, agents, and services.
 
-You can load balance DNS requests in clusters with large numbers of agents by adding additional master nodes; no additional configuration is necessary.
-
-![Mesos-DNS](/mesosphere/dcos/2.2/img/mesos-dns.png)
-
-Figure 1. Mesos-DNS integration
-
-As shown in the diagram, Mesos-DNS optionally integrates with your existing DNS infrastructure. Mesos-DNS replies directly to lookup requests from agent nodes for applications and services within your DC/OS cluster. If an agent node makes a DNS request for a hostname that is outside your DC/OS cluster, Mesos-DNS queries an external nameserver. External nameservers are only required if DC/OS cluster nodes must resolve hostnames for systems elsewhere on your network or on the Internet.
-
  [1]: https://github.com/mesosphere/mesos-dns
  [2]: http://en.wikipedia.org/wiki/Domain_Name_System
  [3]: https://github.com/mesosphere/marathon


### PR DESCRIPTION
## Jira Ticket
As of 1.10 (or 1.11??), MesosDNS is never sent any requests for domains other than .mesos.  So it will never forward any requests to outside cluster addresses because it is never sent any. 
The current diagram confuses customers and results in support tickets, so the purpose of this PR is to avoid customer confusion.

[COPS-6583](https://jira.d2iq.com/browse/COPS-6583)

## Description of changes being made


## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.12, 1.13, 2.0, 2.1, 2.2).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.