### PR TITLE
Point to corresponding Konvoy docs instead of latest

### DIFF
--- a/pages/ksphere/kommander/1.0/install/index.md
+++ b/pages/ksphere/kommander/1.0/install/index.md
@@ -41,7 +41,7 @@ Check version
 konvoy --version
 ```
 
-After you have the newest version of Konvoy, move into the directory in which you would like to test. Note, before beginning, confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
+After you have the newest version of Konvoy installed, move into the directory in which you would like to test. Note, before beginning, confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
 
 Once done, run this command:
 

--- a/pages/ksphere/kommander/1.0/install/index.md
+++ b/pages/ksphere/kommander/1.0/install/index.md
@@ -27,13 +27,13 @@ tar -xf ~/Downloads/konvoy-kommander_darwin.tar.bz2
 
 Copy the Konvoy package files to a directory in your user's `PATH` to ensure you can invoke the konvoy command from any directory.
 
-For example, copy the package to `/usr/local/bin/` by returning to the directory that Kommander was extracted to, and running the following command:
+For example, copy the package to `/usr/local/bin/` by returning to the directory to which Kommander was extracted, and running the following command:
 
 ```
 sudo cp ~/Downloads/darwin/konvoy-kommander/* /usr/local/bin/
 ```
 
-<p class="message--note"><strong>NOTE:</strong> The extracted folder may have a different name (such as `konvoy_dev`, or perhaps it was given a custom directory, or have the version affixed to the end of the directory name).</p>
+<p class="message--note"><strong>NOTE:</strong> The extracted folder may have a different name (such as `konvoy_dev`, or perhaps it was given a custom directory, or may have the version affixed to the end of the directory name).</p>
 
 Check version
 
@@ -41,7 +41,7 @@ Check version
 konvoy --version
 ```
 
-After you have the newest version of Konvoy, move into the directory where you would like to test. Note, you will have to confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
+After you have the newest version of Konvoy, move into the directory in which you would like to test. Note, before beginning, confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
 
 Once done, run this command:
 

--- a/pages/ksphere/kommander/1.0/install/index.md
+++ b/pages/ksphere/kommander/1.0/install/index.md
@@ -10,11 +10,11 @@ Kommander is a tool that provides a command console for deploying, monitoring, a
 
 ### Prerequisites
 
-Currently, installing Kommander also installs Konvoy. Prerequisites and initial requirements for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/latest/quick-start/#prequisites) topic for information.
+Currently, installing Kommander also installs Konvoy. Prerequisites and initial requirements for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/1.4/quick-start/#prequisites) topic for information.
 
 ### Download and Install
 
-To download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/latest/download/) topic for information.
+To download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/1.4/download/) topic for information.
 
 Download the tarball to your local Downloads directory.
 

--- a/pages/ksphere/kommander/1.1/install/index.md
+++ b/pages/ksphere/kommander/1.1/install/index.md
@@ -27,13 +27,13 @@ tar -xf ~/Downloads/konvoy-kommander_darwin.tar.bz2
 
 Copy the Konvoy package files to a directory in your user's `PATH` to ensure you can invoke the konvoy command from any directory.
 
-For example, copy the package to `/usr/local/bin/` by returning to the directory that Kommander was extracted to, and running the following command:
+For example, copy the package to `/usr/local/bin/` by returning to the directory to which Kommander was extracted, and running the following command:
 
 ```
 sudo cp ~/Downloads/darwin/konvoy-kommander/* /usr/local/bin/
 ```
 
-<p class="message--note"><strong>NOTE:</strong> The extracted folder may have a different name (such as `konvoy_dev`, or perhaps it was given a custom directory, or have the version affixed to the end of the directory name).</p>
+<p class="message--note"><strong>NOTE:</strong> The extracted folder may have a different name (such as `konvoy_dev`, or perhaps it was given a custom directory, or may have the version affixed to the end of the directory name).</p>
 
 Check version
 
@@ -41,7 +41,7 @@ Check version
 konvoy --version
 ```
 
-After you have the newest version of Konvoy, move into the directory where you would like to test. Note, you will have to confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
+After you have the newest version of Konvoy installed, move into the directory in which you would like to test. Note, before beginning, confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
 
 Once done, run this command:
 

--- a/pages/ksphere/kommander/1.1/install/index.md
+++ b/pages/ksphere/kommander/1.1/install/index.md
@@ -10,11 +10,11 @@ Kommander is a tool that provides a command console for deploying, monitoring, a
 
 ### Prerequisites
 
-Currently, installing Kommander also installs Konvoy. Prerequisites and initial requirements for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/latest/quick-start/#prequisites) topic for information.
+Currently, installing Kommander also installs Konvoy. Prerequisites and initial requirements for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/1.5/quick-start/#prequisites) topic for information.
 
 ### Download and Install
 
-To download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/latest/download/) topic for information.
+To download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/1.5/download/) topic for information.
 
 Download the tarball to your local Downloads directory.
 

--- a/pages/ksphere/kommander/1.2/install/index.md
+++ b/pages/ksphere/kommander/1.2/install/index.md
@@ -9,18 +9,17 @@ excerpt: Getting started with Kommander
 
 Kommander is a tool that provides a command console for deploying, monitoring, and managing production-ready Kubernetes clusters on an enterprise scale. Kommander supports both Konvoy and non-Konvoy clusters.
 
-### Prerequisites
+# Before you begin
+Prerequisites for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/1.6/quick-start/#prequisites) for information.
 
-Currently, installing Kommander also installs Konvoy. Prerequisites and initial requirements for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/1.6/quick-start/#prequisites) topic for information.
-
-### Download and Install
-
-To download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/1.6/download/) topic for information.
+# Download and Install
+You must download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/1.6/download/) topic for information.
 
 Download the tarball to your local Downloads directory.
 
 For example, if you are installing on MacOS, download the compressed archive to the default `~/Downloads` directory.
-Afterward, extract the tarball to your local system by running the following command (ensure the name of the file that you downloaded, and change konvoy-kommander_darwin.tar.bz2 accordingly):
+Afterward, extract the tarball to your local system by running the following command. 
+**Note** Check the name of the file that you downloaded, and change konvoy-kommander_darwin.tar.bz2 accordingly):
 
 ```
 tar -xf ~/Downloads/konvoy-kommander_darwin.tar.bz2
@@ -50,13 +49,10 @@ Once done, run this command:
 konvoy up
 ```
 
-## Logging In
-
-### Logging in with Username and Password
-
+# Log in with Username and Password
 After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Log in to Konvoy, and look for the "Try Kommander" button. If it's not there, ensure you've installed the Konvoy release that includes Kommander.
 
-To retrieve this information again, you can use the following command:
+To retrieve this information again, use the following command:
 
 ```
 konvoy get ops-portal

--- a/pages/ksphere/kommander/1.2/install/index.md
+++ b/pages/ksphere/kommander/1.2/install/index.md
@@ -11,11 +11,11 @@ Kommander is a tool that provides a command console for deploying, monitoring, a
 
 ### Prerequisites
 
-Currently, installing Kommander also installs Konvoy. Prerequisites and initial requirements for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/latest/quick-start/#prequisites) topic for information.
+Currently, installing Kommander also installs Konvoy. Prerequisites and initial requirements for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/ksphere/konvoy/1.6/quick-start/#prequisites) topic for information.
 
 ### Download and Install
 
-To download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/latest/download/) topic for information.
+To download Konvoy with Kommander, see the [Download Konvoy](https://docs.d2iq.com/ksphere/konvoy/1.6/download/) topic for information.
 
 Download the tarball to your local Downloads directory.
 


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made
My understanding is that intended behavior for kommander docs to link to the corresponding konvoy docs .We had install docs point to latest konvoy docs. It seems like un-intended behavior to me because:
* If i go to an older kommander release (eg 1.0) it points me to konvoy 1.5 docs right now which is not correct for kommander 1.0
* If I go to a 1.2(beta) kommander release it points to konvoy 1.5 since konvoy 1.6 is still in beta but the correct konvoy for this is 1.6

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.