### PR TITLE
COPS-6601: "Zones and Regions" page missing Enterprise tag

### DIFF
--- a/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuring-zones-regions/index.md
+++ b/pages/mesosphere/dcos/1.13/installing/production/advanced-configuration/configuring-zones-regions/index.md
@@ -6,6 +6,7 @@ menuWeight: 15
 excerpt: Using the high-availability features in DC/OS
 render: mustache
 model: /mesosphere/dcos/1.13/data.yml
+enterprise: true
 ---
 
 This topic discusses the high availability (HA) features in DC/OS and best practices for building HA applications on DC/OS.

--- a/pages/mesosphere/dcos/2.0/installing/production/advanced-configuration/configuring-zones-regions/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/advanced-configuration/configuring-zones-regions/index.md
@@ -6,6 +6,7 @@ menuWeight: 15
 excerpt: Using the high-availability features in DC/OS
 render: mustache
 model: /mesosphere/dcos/2.0/data.yml
+enterprise: true
 ---
 
 This topic discusses the high availability (HA) features in DC/OS and best practices for building HA applications on DC/OS.

--- a/pages/mesosphere/dcos/2.1/installing/production/advanced-configuration/configuring-zones-regions/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/advanced-configuration/configuring-zones-regions/index.md
@@ -6,6 +6,7 @@ menuWeight: 15
 excerpt: Using the high-availability features in DC/OS
 render: mustache
 model: /mesosphere/dcos/2.1/data.yml
+enterprise: true
 ---
 
 This topic discusses the high availability (HA) features in DC/OS and best practices for building HA applications on DC/OS.

--- a/pages/mesosphere/dcos/2.2/installing/production/advanced-configuration/configuring-zones-regions/index.md
+++ b/pages/mesosphere/dcos/2.2/installing/production/advanced-configuration/configuring-zones-regions/index.md
@@ -6,6 +6,7 @@ menuWeight: 15
 excerpt: Using the high-availability features in DC/OS
 render: mustache
 model: /mesosphere/dcos/2.2/data.yml
+enterprise: true
 ---
 
 This topic discusses the high availability (HA) features in DC/OS and best practices for building HA applications on DC/OS.


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/COPS-6601

## Description of changes being made
Adding the "Enterprise" tag to a page which describes an enterprise-only feature.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Update all links if you are moving a page.
- [n/a] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.