### PR TITLE
adding note about metrics-server to pages/ksphere/kommander/1.2/clust…

### DIFF
--- a/pages/ksphere/kommander/1.2/clusters/attach-cluster/attach-eks-cluster/index.md
+++ b/pages/ksphere/kommander/1.2/clusters/attach-cluster/attach-eks-cluster/index.md
@@ -18,7 +18,7 @@ This procedure requires the following items and configurations:
 - Konvoy v1.5.0 or above, [installed and configured](/ksphere/konvoy/1.5/install/) for your Amazon EKS cluster, on your machine.
 - Kommander v1.2.0 or above, [installed and configured](/ksphere/kommander/1.2/install/) on your machine.
 
-<p class="message--note"><strong>NOTE: </strong>This procedure assumes you have an existing and spun up Amazon EKS cluster(s) with administrative privileges. Refer to the Amazon <a href="https://aws.amazon.com/eks/" target="_blank">EKS</a> for setup and configuration information. </p>
+<p class="message--note"><strong>NOTE: </strong>This procedure assumes you have an existing and spun up Amazon EKS cluster(s) with administrative privileges. Refer to the Amazon <a href="https://aws.amazon.com/eks/" target="_blank">EKS</a> for setup and configuration information.</p>
 
 ## Attach Amazon EKS Clusters to Kommander
 
@@ -33,25 +33,6 @@ This procedure requires the following items and configurations:
 
    ```bash
    kubectl get no
-   ```
-
-1. The metrics Kommander displays on its cluster view do not come from Prometheus. They come from the Kubernetes metrics API. You must expose this API using a [metrics server][k8s-metrics-server] to make it available. To do that, you must [deploy the metrics server][deploy-metrics-server], otherwise the EKS cluster may fail to stay attached. To deploy the server, run the following command:
-
-   ```bash
-   kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
-   ```
-
-1. Verify the `metrics-server` deployment is running the desired number of pods with the following command:
-
-   ```bash
-   kubectl get deployment metrics-server -n kube-system
-   ```
-
-1. The output will look something like:
-
-   ```bash
-   NAME             READY   UP-TO-DATE   AVAILABLE   AGE
-   metrics-server   1/1     1            1           6m
    ```
 
 1. Create a service account for Kommander on your EKS cluster.
@@ -147,6 +128,8 @@ This procedure requires the following items and configurations:
 
 1. Select the **Submit** button.
 
+<p class="message--note"><strong>NOTE: </strong>If a cluster has limited resources to deploy all the federated kubeaddons, it will fail to stay attached in the Kommander UI. If this happens, please check if there are any pods that are not getting the resources required.</p>
+
 ## Related information
 
 For information on related topics or procedures, refer to the following:
@@ -159,6 +142,4 @@ For information on related topics or procedures, refer to the following:
 
 - [Working with Kommander Clusters](/ksphere/kommander/1.2/clusters/)
 
-[deploy-metrics-server]: https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html
 [eks]: https://aws.amazon.com/eks/
-[k8s-metrics-server]: https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/#the-metrics-api

--- a/pages/ksphere/kommander/1.2/clusters/attach-cluster/attach-eks-cluster/index.md
+++ b/pages/ksphere/kommander/1.2/clusters/attach-cluster/attach-eks-cluster/index.md
@@ -35,6 +35,25 @@ This procedure requires the following items and configurations:
    kubectl get no
    ```
 
+1. The metrics that Kommander displays on its cluster view don't come from Prometheus. Rather they come from the Kubernetes metrics API. In order for this API to be available, it must be exposed by a [metrics server][k8s-metrics-server]. In order to do that, you must [deploy the metrics server][deploy-metrics-server], otherwise the EKS cluster may fail to stay attached. To deploy the server, run the following command:
+
+   ```bash
+   kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
+   ```
+
+1. Verify the `metrics-server` deployment is running the desired number of pods with the following command:
+
+   ```bash
+   kubectl get deployment metrics-server -n kube-system
+   ```
+
+1. The output will look something like:
+
+   ```bash
+   NAME             READY   UP-TO-DATE   AVAILABLE   AGE
+   metrics-server   1/1     1            1           6m
+   ```
+
 1. Create a service account for Kommander on your EKS cluster.
 
    ```bash
@@ -140,4 +159,6 @@ For information on related topics or procedures, refer to the following:
 
 - [Working with Kommander Clusters](/ksphere/kommander/1.2/clusters/)
 
+[deploy-metrics-server]: https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html
 [eks]: https://aws.amazon.com/eks/
+[k8s-metrics-server]: https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/#the-metrics-api

--- a/pages/ksphere/kommander/1.2/clusters/attach-cluster/attach-eks-cluster/index.md
+++ b/pages/ksphere/kommander/1.2/clusters/attach-cluster/attach-eks-cluster/index.md
@@ -35,7 +35,7 @@ This procedure requires the following items and configurations:
    kubectl get no
    ```
 
-1. The metrics that Kommander displays on its cluster view don't come from Prometheus. Rather they come from the Kubernetes metrics API. In order for this API to be available, it must be exposed by a [metrics server][k8s-metrics-server]. In order to do that, you must [deploy the metrics server][deploy-metrics-server], otherwise the EKS cluster may fail to stay attached. To deploy the server, run the following command:
+1. The metrics Kommander displays on its cluster view do not come from Prometheus. They come from the Kubernetes metrics API. You must expose this API using a [metrics server][k8s-metrics-server] to make it available. To do that, you must [deploy the metrics server][deploy-metrics-server], otherwise the EKS cluster may fail to stay attached. To deploy the server, run the following command:
 
    ```bash
    kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml


### PR DESCRIPTION
…ers/attach-cluster/attach-eks-cluster/index.md

## Jira Ticket
n/a

## Description of changes being made
adding note about ensuring metrics-server is enabled when attaching eks cluster

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.