### PR TITLE
fix: show centralized monitoring tab in kommander 1.2 docs

### DIFF
--- a/pages/ksphere/kommander/1.2/centralized-monitoring/index.md
+++ b/pages/ksphere/kommander/1.2/centralized-monitoring/index.md
@@ -1,6 +1,5 @@
 ---
 layout: layout.pug
-beta: true
 navigationTitle: Centralized Monitoring
 title: Centralized Monitoring
 menuWeight: 7


### PR DESCRIPTION
## Jira Ticket
N/A

## Description of changes being made

Removes duplicated frontmatter property that was causing the centralized monitoring tab to not show in kommander 1.2 docs

Before (No centralized monitoring tab in sidebar):
<img width="1680" alt="Screen Shot 2020-10-20 at 11 30 29 AM" src="https://user-images.githubusercontent.com/19582796/96630922-8771ad80-12ca-11eb-8705-885dd74915ff.png">

After:
<img width="1680" alt="Screen Shot 2020-10-20 at 11 29 41 AM" src="https://user-images.githubusercontent.com/19582796/96630971-935d6f80-12ca-11eb-8397-7c89a2bec40f.png">


## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.