### PR TITLE
Improve instructions for Exhibitor TLS on upgrade

### DIFF
--- a/pages/mesosphere/dcos/2.0/administering-clusters/replacing-a-master-node/index.md
+++ b/pages/mesosphere/dcos/2.0/administering-clusters/replacing-a-master-node/index.md
@@ -22,7 +22,7 @@ You can replace a master node in an existing DC/OS&trade; cluster. You should ke
 
     For more information about backing up the DC/OS identity and access management CockroachDB database, see [How do I backup the IAM database?](/mesosphere/dcos/2.0/installing/installation-faq/#iam-backup)
 
-1. Back up /var/lib/dcos/exhibitor-tls-artifacts if it exists.
+1. [enterprise type="inline" size="small" /] Back up the Exhibitor TLS artifacts in `/var/lib/dcos/exhibitor-tls-artifacts` if it exists.
 
     ```bash
     tar czf exhibitor-tls-artifacts.tar.gz /var/lib/dcos/exhibitor-tls-artifacts
@@ -36,13 +36,17 @@ You can replace a master node in an existing DC/OS&trade; cluster. You should ke
     If you have configured **static master discovery** in your `config.yaml` file (`master_discovery: static`):
     - Verify that the new server has the same internal IP address as the old master node.
     - Verify that the old server is completely unreachable from the cluster.
-    - Copy exhibitor-tls-artifacts.tar.gz to the new master node.
+    - [enterprise type="inline" size="small" /] If the Exhibitor TLS artifacts existed on the old master node, then copy `exhibitor-tls-artifacts.tar.gz` to the new master node.
         ```bash
         scp exhibitor-tls-artifacts.tar.gz root@<new-master-host>:/root
         ```
-    - Extract the archive on the master
+        Extract the archive on the master
         ```bash
         tar xzf /root/exhibitor-tls-artifacts.tar.gz -C /
+        ```
+    - [enterprise type="inline" size="small" /] If the Exhibitor TLS artifacts did not exist on the old master node, then ensure Exhibitor TLS is disabled in the `config.yaml` file:
+        ```yaml
+        exhibitor_tls_required: false
         ```
     - Install the new master as you would normally.
     

--- a/pages/mesosphere/dcos/2.0/installing/production/upgrading/index.md
+++ b/pages/mesosphere/dcos/2.0/installing/production/upgrading/index.md
@@ -29,6 +29,7 @@ If upgrading is performed on a supported OS with all prerequisites fulfilled, th
    * The DC/OS GUI may not provide an accurate list of services.
 - An upgraded DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been upgraded. The DC/OS UI cannot be trusted until all masters are upgraded. There are multiple Marathon scheduler instances and multiple Mesos masters, each being upgraded, and the Marathon leader may not be the Mesos leader.
 - Task history in the Mesos UI will not persist through the upgrade.
+- DC/OS 2.0 added TLS for Exhibitor.  Exhibitor TLS is automatically enabled for static master clusters during installation of DC/OS 2.0 or later. It is not enabled during an upgrade from DC/OS 1.13 or earlier.  Once the cluster has been upgraded to DC/OS 2.0 or later, [Exhibitor can be manually configured to use TLS](/mesosphere/dcos/2.0/security/ent/tls-ssl/exhibitor).  [enterprise type="inline" size="small" /]
 
 ## Supported upgrade paths
 The following tables list the supported upgrade paths for DC/OS 2.0.

--- a/pages/mesosphere/dcos/2.0/security/ent/tls-ssl/exhibitor/index.md
+++ b/pages/mesosphere/dcos/2.0/security/ent/tls-ssl/exhibitor/index.md
@@ -9,22 +9,27 @@ enterprise: true
 
 # Verifying that Exhibitor is secured 
 
-Starting with DC/OS 2.0, Exhibitor is secured by default in static master clusters. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
-```bash
+Starting with DC/OS 2.0, Exhibitor is secured by default during installation of static master clusters. It is not secured if DC/OS was upgraded from DC/OS 1.13 or earlier. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
+
 
     curl -LI \
         --cacert /var/lib/dcos/exhibitor-tls-artifacts/root-cert.pem \
         --cert /var/lib/dcos/exhibitor-tls-artifacts/client-cert.pem \
         --key /var/lib/dcos/exhibitor-tls-artifacts/client-key.pem \
         https://localhost:8181/exhibitor/v1/ui/index.html
-```
 
 If you see the following, Exhibitor has been secured on your cluster:
-```bash
+
     HTTP/1.1 200 OK
     Content-Type: text/html
     Content-Length: 0
     Server: Jetty(1.5.6-SNAPSHOT)
+
+If Exhibitor is not secured, you can follow the next section to manually secure Exhibitor.
+
+If you do not want to add TLS security to Exhibitor, we recommend that you add the following configuration to your cluster `config.yaml` file:
+```yaml
+exhibitor_tls_required: false
 ```
 
 # Securing Exhibitor

--- a/pages/mesosphere/dcos/2.1/administering-clusters/replacing-a-master-node/index.md
+++ b/pages/mesosphere/dcos/2.1/administering-clusters/replacing-a-master-node/index.md
@@ -22,7 +22,7 @@ You can replace a master node in an existing DC/OS cluster. You should keep in m
 
     For more information about backing up the DC/OS identity and access management CockroachDB database, see [How do I backup the IAM database?](/mesosphere/dcos/2.1/installing/installation-faq/#iam-backup)
 
-1. Back up /var/lib/dcos/exhibitor-tls-artifacts if it exists.
+1. [enterprise type="inline" size="small" /] Back up the Exhibitor TLS artifacts in `/var/lib/dcos/exhibitor-tls-artifacts` if it exists.
 
     ```bash
     tar czf exhibitor-tls-artifacts.tar.gz /var/lib/dcos/exhibitor-tls-artifacts
@@ -36,13 +36,17 @@ You can replace a master node in an existing DC/OS cluster. You should keep in m
     If you have configured **static master discovery** in your `config.yaml` file (`master_discovery: static`):
     - Verify that the new server has the same internal IP address as the old master node.
     - Verify that the old server is completely unreachable from the cluster.
-    - Copy exhibitor-tls-artifacts.tar.gz to the new master node.
+    - [enterprise type="inline" size="small" /] If the Exhibitor TLS artifacts existed on the old master node, then copy `exhibitor-tls-artifacts.tar.gz` to the new master node.
         ```bash
         scp exhibitor-tls-artifacts.tar.gz root@<new-master-host>:/root
         ```
-    - Extract the archive on the master
+        Extract the archive on the master
         ```bash
         tar xzf /root/exhibitor-tls-artifacts.tar.gz -C /
+        ```
+    - [enterprise type="inline" size="small" /] If the Exhibitor TLS artifacts did not exist on the old master node, then ensure Exhibitor TLS is disabled in the `config.yaml` file:
+        ```yaml
+        exhibitor_tls_required: false
         ```
     - Install the new master as you would normally.
     

--- a/pages/mesosphere/dcos/2.1/installing/production/upgrading/index.md
+++ b/pages/mesosphere/dcos/2.1/installing/production/upgrading/index.md
@@ -29,6 +29,7 @@ If upgrading is performed on a supported OS with all prerequisites fulfilled, th
    * The DC/OS GUI may not provide an accurate list of services.
 - An upgraded DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been upgraded. The DC/OS UI cannot be trusted until all masters are upgraded. There are multiple Marathon scheduler instances and multiple Mesos masters, each being upgraded, and the Marathon leader may not be the Mesos leader.
 - Task history in the Mesos UI will not persist through the upgrade.
+- DC/OS 2.0 added TLS for Exhibitor.  Exhibitor TLS is automatically enabled for static master clusters during installation of DC/OS 2.0 or later. It is not enabled during an upgrade from DC/OS 1.13 or earlier.  Once the cluster has been upgraded to DC/OS 2.0 or later, [Exhibitor can be manually configured to use TLS](/mesosphere/dcos/2.1/security/ent/tls-ssl/exhibitor).  [enterprise type="inline" size="small" /]
 
 ## Supported upgrade paths
 The following tables list the supported upgrade paths for DC/OS 2.1.

--- a/pages/mesosphere/dcos/2.1/security/ent/tls-ssl/exhibitor/index.md
+++ b/pages/mesosphere/dcos/2.1/security/ent/tls-ssl/exhibitor/index.md
@@ -9,7 +9,7 @@ enterprise: true
 
 # Verifying that Exhibitor is secured 
 
-Starting with DC/OS 2.0, Exhibitor is secured by default in static master clusters. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
+Starting with DC/OS 2.0, Exhibitor is secured by default during installation of static master clusters. It is not secured if DC/OS was upgraded from DC/OS 1.13 or earlier. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
 
 
     curl -LI \
@@ -24,6 +24,13 @@ If you see the following, Exhibitor has been secured on your cluster:
     Content-Type: text/html
     Content-Length: 0
     Server: Jetty(1.5.6-SNAPSHOT)
+
+If Exhibitor is not secured, you can follow the next section to manually secure Exhibitor.
+
+If you do not want to add TLS security to Exhibitor, we recommend that you add the following configuration to your cluster `config.yaml` file:
+```yaml
+exhibitor_tls_required: false
+```
 
 # Securing Exhibitor
 

--- a/pages/mesosphere/dcos/2.2/administering-clusters/replacing-a-master-node/index.md
+++ b/pages/mesosphere/dcos/2.2/administering-clusters/replacing-a-master-node/index.md
@@ -22,7 +22,7 @@ You can replace a master node in an existing DC/OS cluster. You should keep in m
 
     For more information about backing up the DC/OS identity and access management CockroachDB database, see [How do I backup the IAM database?](/mesosphere/dcos/2.2/installing/installation-faq/#iam-backup)
 
-1. Back up /var/lib/dcos/exhibitor-tls-artifacts if it exists.
+1. [enterprise type="inline" size="small" /] Back up the Exhibitor TLS artifacts in `/var/lib/dcos/exhibitor-tls-artifacts` if it exists.
 
     ```bash
     tar czf exhibitor-tls-artifacts.tar.gz /var/lib/dcos/exhibitor-tls-artifacts
@@ -36,13 +36,17 @@ You can replace a master node in an existing DC/OS cluster. You should keep in m
     If you have configured **static master discovery** in your `config.yaml` file (`master_discovery: static`):
     - Verify that the new server has the same internal IP address as the old master node.
     - Verify that the old server is completely unreachable from the cluster.
-    - Copy exhibitor-tls-artifacts.tar.gz to the new master node.
+    - [enterprise type="inline" size="small" /] If the Exhibitor TLS artifacts existed on the old master node, then copy `exhibitor-tls-artifacts.tar.gz` to the new master node.
         ```bash
         scp exhibitor-tls-artifacts.tar.gz root@<new-master-host>:/root
         ```
-    - Extract the archive on the master
+        Extract the archive on the master
         ```bash
         tar xzf /root/exhibitor-tls-artifacts.tar.gz -C /
+        ```
+    - [enterprise type="inline" size="small" /] If the Exhibitor TLS artifacts did not exist on the old master node, then ensure Exhibitor TLS is disabled in the `config.yaml` file:
+        ```yaml
+        exhibitor_tls_required: false
         ```
     - Install the new master as you would normally.
     

--- a/pages/mesosphere/dcos/2.2/installing/production/upgrading/index.md
+++ b/pages/mesosphere/dcos/2.2/installing/production/upgrading/index.md
@@ -29,6 +29,7 @@ If upgrading is performed on a supported OS with all prerequisites fulfilled, th
    * The DC/OS GUI may not provide an accurate list of services.
 - An upgraded DC/OS Marathon leader cannot connect to the leading Mesos master until it has also been upgraded. The DC/OS UI cannot be trusted until all masters are upgraded. There are multiple Marathon scheduler instances and multiple Mesos masters, each being upgraded, and the Marathon leader may not be the Mesos leader.
 - Task history in the Mesos UI will not persist through the upgrade.
+- DC/OS 2.0 added TLS for Exhibitor.  Exhibitor TLS is automatically enabled for static master clusters during installation of DC/OS 2.0 or later. It is not enabled during an upgrade from DC/OS 1.13 or earlier.  Once the cluster has been upgraded to DC/OS 2.0 or later, [Exhibitor can be manually configured to use TLS](/mesosphere/dcos/2.0/security/ent/tls-ssl/exhibitor).  [enterprise type="inline" size="small" /]
 
 ## Supported upgrade paths
 The following tables list the supported upgrade paths for DC/OS 2.1.

--- a/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/exhibitor/index.md
+++ b/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/exhibitor/index.md
@@ -9,7 +9,7 @@ enterprise: true
 
 # Verifying that Exhibitor is secured 
 
-Starting with DC/OS 2.0, Exhibitor is secured by default in static master clusters. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
+Starting with DC/OS 2.0, Exhibitor is secured by default during installation of static master clusters. It is not secured if DC/OS was upgraded from DC/OS 1.13 or earlier. To verify that Exhibitor is secured on your cluster, run the following command on one of your master nodes: 
 
 
     curl -LI \
@@ -24,6 +24,13 @@ If you see the following, Exhibitor has been secured on your cluster:
     Content-Type: text/html
     Content-Length: 0
     Server: Jetty(1.5.6-SNAPSHOT)
+
+If Exhibitor is not secured, you can follow the next section to manually secure Exhibitor.
+
+If you do not want to add TLS security to Exhibitor, we recommend that you add the following configuration to your cluster `config.yaml` file:
+```yaml
+exhibitor_tls_required: false
+```
 
 # Securing Exhibitor
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-72618

## Description of changes being made

Clarify what happens with Exhibitor TLS when upgrading from DC/OS pre-2.0.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.