### PR TITLE
Removing reference to CoreOS

### DIFF
--- a/pages/mesosphere/dcos/1.13/deploying-services/faq/index.md
+++ b/pages/mesosphere/dcos/1.13/deploying-services/faq/index.md
@@ -62,7 +62,7 @@ For more information, see the installation [documentation](/mesosphere/dcos/1.13
 
 ## What versions of kernel, local OS, Docker Engine, Union Mount are recommended?
 
-We recommend using CoreOS, matched with its correct versions and sensible defaults of Docker, filesystem, and other settings.
+Please see [Version Policy](../../../version-policy) for details.
 
 [1]: /mesosphere/dcos/1.13/networking/load-balancing-vips/
 [2]: /mesosphere/dcos/1.13/networking/

--- a/pages/mesosphere/dcos/2.0/deploying-services/faq/index.md
+++ b/pages/mesosphere/dcos/2.0/deploying-services/faq/index.md
@@ -61,7 +61,7 @@ For more information, see the installation [documentation](/mesosphere/dcos/2.0/
 
 ## What versions of kernel, local OS, Docker Engine, Union Mount are recommended?
 
-We recommend using CoreOS&reg;, matched with its correct versions and sensible defaults of Docker, filesystem, and other settings.
+Please see [Version Policy](../../../version-policy) for details.
 
 [1]: /mesosphere/dcos/2.0/networking/load-balancing-vips/
 [2]: /mesosphere/dcos/2.0/networking/

--- a/pages/mesosphere/dcos/2.1/deploying-services/faq/index.md
+++ b/pages/mesosphere/dcos/2.1/deploying-services/faq/index.md
@@ -62,7 +62,7 @@ For more information, see the installation [documentation](/mesosphere/dcos/2.1/
 
 ## What versions of kernel, local OS, Docker Engine, Union Mount are recommended?
 
-We recommend using CoreOS, matched with its correct versions and sensible defaults of Docker, filesystem, and other settings.
+Please see [Version Policy](../../../version-policy) for details.
 
 [1]: /mesosphere/dcos/2.1/networking/load-balancing-vips/
 [2]: /mesosphere/dcos/2.1/networking/

--- a/pages/mesosphere/dcos/2.2/deploying-services/faq/index.md
+++ b/pages/mesosphere/dcos/2.2/deploying-services/faq/index.md
@@ -62,7 +62,7 @@ For more information, see the installation [documentation](/mesosphere/dcos/2.2/
 
 ## What versions of kernel, local OS, Docker Engine, Union Mount are recommended?
 
-We recommend using CoreOS, matched with its correct versions and sensible defaults of Docker, filesystem, and other settings.
+Please see [Version Policy](../../../version-policy) for details.
 
 [1]: /mesosphere/dcos/2.2/networking/load-balancing-vips/
 [2]: /mesosphere/dcos/2.2/networking/


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/COPS-6615

## Description of changes being made
Removing reference to CoreOS as it is no longer supported. Replace with a link to the version-policy page.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [x] Update all links if you are moving a page.
- [n/a] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.