### PR TITLE
Split certificate renewal into setting and renewing sections

### DIFF
--- a/pages/mesosphere/dcos/2.2/installing/production/advanced-configuration/configuration-reference/index.md
+++ b/pages/mesosphere/dcos/2.2/installing/production/advanced-configuration/configuration-reference/index.md
@@ -108,15 +108,16 @@ This page contains the configuration parameters for both DC/OS Enterprise and DC
 | [adminrouter_x_frame_options](#adminrouter-x-frame-options)    | Set the `X-Frame-Options` header value for the DC/OS UI. Default is set to `DENY` |
 | [auth_cookie_secure_flag](#auth-cookie-secure-flag-enterprise)    | Indicates whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. [enterprise type="inline" size="small" /] |
 | [bouncer_expiration_auth_token_days](#bouncer-expiration-auth-token-days-enterprise) | Sets the auth token time-to-live (TTL) for Identity and Access Management. [enterprise type="inline" size="small" /]|
-| [ca_certificate_path](#ca-certificate-path-enterprise)                   | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
-| [ca_certificate_key_path](#ca-certificate-key-path-enterprise)           | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
-| [ca_certificate_chain_path](#ca-certificate-chain-path-enterprise)       | Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
+| [ca_certificate_path](#ca-certificate-path-enterprise)                   | Use this to set a custom CA certificate. See [Configuring a Certificate Authority](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom) for details. [enterprise type="inline" size="small" /] |
+| [ca_certificate_key_path](#ca-certificate-key-path-enterprise)           | Use this to set a custom CA certificate. See [Configuring a Certificate Authority](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom) for details. [enterprise type="inline" size="small" /] |
+| [ca_certificate_chain_path](#ca-certificate-chain-path-enterprise)       | Use this to set a custom CA certificate. See [Configuring a Certificate Authority](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom) for details. [enterprise type="inline" size="small" /] |
+| [ca_truststore_path](#ca-truststore-path-enterprise)       | Use this to set additional CA certificates to be trusted within the cluster. See [Configuring a Certificate Authority](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom) for details. [enterprise type="inline" size="small" /] |
 | [exhibitor_tls_required](#exhibitor-tls-required-enterprise)             | When `true` DC/OS will fail to launch when Exhibitor TLS initialization fails [enterprise type="inline" size="small" /]  |
 | [exhibitor_bootstrap_ca_url](#exhibitor-bootstrap-ca-url-enterprise)     | Specify a custom CA service URL for exhibitor TLS bootstrapping. This is an advanced option and should only be used when performing non-standard installations [enterprise type="inline" size="small" /]  |
-| [external_certificate_path](#external-certificate-path-enterprise)                   | Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
-| [external_certificate_key_path](#external-certificate-key-path-enterprise)           | Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
-| [external_certificate_servernames](#external-certificate-servernames-enterprise)       | Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
-| [external_certificate_validation_disable](#external-certificate-validation-disable-enterprise)       | Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference. [enterprise type="inline" size="small" /] |
+| [external_certificate_path](#external-certificate-path-enterprise)                   | Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details. [enterprise type="inline" size="small" /] |
+| [external_certificate_key_path](#external-certificate-key-path-enterprise)           | Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details. [enterprise type="inline" size="small" /] |
+| [external_certificate_servernames](#external-certificate-servernames-enterprise)       | Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details. [enterprise type="inline" size="small" /] |
+| [external_certificate_validation_disable](#external-certificate-validation-disable-enterprise)       | Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details. [enterprise type="inline" size="small" /] |
 | [license_key_contents](#license-key-contents-enterprise)    | Optional override parameter to provide the license key contents directly in the config.yaml. If this parameter is specified, any key saved to `genconf/license.txt` will be ignored. [enterprise type="inline" size="small" /]  |
 | [iam_ldap_sync_interval](#iam-ldap-sync-interval-enterprise) | Interval in seconds between LDAP synchronization operations. [enterprise type="inline" size="small" /] |
 | [permissions_cache_ttl_seconds](#permissions-cache-ttl-seconds-enterprise)   | The maximum number of seconds for permission changes to propagate through the entire system. [enterprise type="inline" size="small" /] |
@@ -255,15 +256,19 @@ For more information, see the [security](/mesosphere/dcos/{{ model.folder_versio
 
 ### ca_certificate_path   [enterprise type="inline" size="small" /]              
 
-Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) documentation for a detailed configuration parameter reference.
+Use this to set a custom CA certificate. See [Configuring a Certificate Authority](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom) documentation for details.
 
 ### ca_certificate_key_path  [enterprise type="inline" size="small" /]       
 
-Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) documentation for a detailed configuration parameter reference.
+Use this to set a custom CA certificate. See [Configuring a Certificate Authority](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom) documentation for details.
 
 ### ca_certificate_chain_path  [enterprise type="inline" size="small" /]
 
-Use this to set up a custom CA certificate. See [using a Custom CA Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom#configuration-parameter-reference) documentation for a detailed configuration parameter reference.
+Use this to set a custom CA certificate. See [Configuring a Certificate Authority](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ca-custom) documentation for details.
+
+### ca_truststore_path  [enterprise type="inline" size="small" /]
+
+Use this to set additional trusted CA certificates.
 
 ### exhibitor_tls_required [enterprise type="inline" size="small" /]
 
@@ -275,19 +280,19 @@ Optional parameter used for generating the TLS artifacts for the automated Exhib
 
 ### external_certificate_path [enterprise type="inline" size="small" /]
 
-Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference.
+Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details.
 
 ### external_certificate_key_path [enterprise type="inline" size="small" /]
 
-Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference.
+Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details.
 
 ### external_certificate_servernames [enterprise type="inline" size="small" /]
 
-Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference.
+Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details.
 
 ### external_certificate_validation_disable [enterprise type="inline" size="small" /]
 
-Use this to set up a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) page for a detailed configuration parameter reference.
+Use this to set a custom external certificate. See [Configuring a Custom External Certificate](/mesosphere/dcos/{{ model.folder_version }}/security/ent/tls-ssl/ar-custom/#configuration-parameter-reference) for details.
 
 ### calico_network_cidr
 

--- a/pages/mesosphere/dcos/2.2/installing/production/deploying-dcos/configuration/examples/index.md
+++ b/pages/mesosphere/dcos/2.2/installing/production/deploying-dcos/configuration/examples/index.md
@@ -79,6 +79,12 @@ exhibitor_storage_backend: zookeeper
 exhibitor_zk_hosts: `<list-of-ip-port>`
 exhibitor_zk_path: <filepath-to-data>
 exhibitor_storage_backend: aws_s3
+external_certificate_path: <path-to-certificate>
+external_certificate_key_path: <path-to-private-key>
+external_certificate_servernames:
+  - hostname
+  - hostname
+external_certificate_validation_disable: <true|false>
 aws_access_key_id: <key-id>
 aws_region: <bucket-region>
 aws_secret_access_key: <secret-access-key>

--- a/pages/mesosphere/dcos/2.2/installing/production/deploying-dcos/opt-out/index.md
+++ b/pages/mesosphere/dcos/2.2/installing/production/deploying-dcos/opt-out/index.md
@@ -4,6 +4,7 @@ navigationTitle:  Opt-Out
 excerpt: Disabling authentication and telemetry for your cluster
 title: Opt-Out
 model: /mesosphere/dcos/2.2/data.yml
+render: mustache
 menuWeight: 20
 ---
 

--- a/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/ca-custom/index.md
+++ b/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/ca-custom/index.md
@@ -144,7 +144,7 @@ On each master node:
 
 # Changing the CA Certificate in an existing cluster
 
-To replace the CA certificate (for example, if it is expiring or compromised), perform the following procedure consisting of three patch upgrades.  This procedure ensures that the cluster stays healthy during the certificate replacement.  If Calico is enabled (the default setting), then workloads may be stopped.
+To replace the CA certificate (for example, if it is expiring or compromised), perform the following procedure consisting of three patch upgrades.  Three patch upgrades are required to ensure that the cluster stays healthy during the certificate replacement.  If Calico is enabled (the default setting), then workloads may be stopped.
 
 ## Add new CA certificate to truststore
 

--- a/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/exhibitor/index.md
+++ b/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/exhibitor/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Securing Exhibitor with mutual TLS
 title: Securing Exhibitor with mutual TLS
-menuWeight: 500
+menuWeight: 450
 excerpt: Securing DC/OS with a TLS enabled Exhibitor ensemble
 enterprise: true
 ---

--- a/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/haproxy-adminrouter/index.md
+++ b/pages/mesosphere/dcos/2.2/security/ent/tls-ssl/haproxy-adminrouter/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle:  Configuring HAProxy in Front of Admin Router
 title: Configuring HAProxy in Front of Admin Router
-menuWeight: 6
+menuWeight: 450
 excerpt: Using the HAProxy to set up an HTTP proxy for the DC/OS Admin Router
 render: mustache
 model: /mesosphere/dcos/2.2/data.yml


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-71896

## Description of changes being made

Separate the description of custom CA's being added to an initial installation and being changed in an existing installation.

The instructions for an existing installation are more complicated as they require 3 patch upgrades.

There is a new configuration variable (`ca_truststore_path`) which is required to set two trusted CA's during the changeover.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.