### PR TITLE
backporting changes for helm repo location

### DIFF
--- a/pages/ksphere/konvoy/1.4/reference/addons/index.md
+++ b/pages/ksphere/konvoy/1.4/reference/addons/index.md
@@ -163,7 +163,7 @@ spec:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
     chart: stable/kibana
-    # repo: https://kubernetes-charts.storage.googleapis.com/
+    # repo: https://mesosphere.github.io/charts/
     version: 3.2.5
     values: |
       ---

--- a/pages/ksphere/konvoy/1.5/reference/addons/index.md
+++ b/pages/ksphere/konvoy/1.5/reference/addons/index.md
@@ -163,7 +163,7 @@ spec:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
     chart: stable/kibana
-    # repo: https://kubernetes-charts.storage.googleapis.com/
+    # repo: https://mesosphere.github.io/charts/
     version: 3.2.5
     values: |
       ---


### PR DESCRIPTION
## Jira Ticket
n/a, but described here: https://github.com/mesosphere/konvoy/pull/2337

## Description of changes being made
Backporting changes to the location of the helm repo to change from the one being depracated.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.