### PR TITLE
fixing template tags for legal notices page on 1.2

### DIFF
--- a/pages/ksphere/kommander/1.2/release-notes/legal-notices/index.md
+++ b/pages/ksphere/kommander/1.2/release-notes/legal-notices/index.md
@@ -2,7 +2,6 @@
 layout: layout.pug
 beta: true
 title: Legal Notices
-beta: true
 menuWeight: 105
 excerpt: List of Third-party trademarks mentioned in the Kommander documentation
 render: mustache


### PR DESCRIPTION
## Jira Ticket
n/a

## Description of changes being made
There's an issue when there are two beta tags in the header part of this markdown file, it makes it look a bit messed up.

So, just making it go from this: 
![Screen Shot 2020-10-27 at 2 11 29 PM](https://user-images.githubusercontent.com/5703649/97350109-565f2300-185e-11eb-9b3c-215555df3ec7.png)

to this: 
![Screen Shot 2020-10-27 at 2 11 15 PM](https://user-images.githubusercontent.com/5703649/97350132-5e1ec780-185e-11eb-9d61-fcac1d73830b.png)

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.