### PR TITLE
remove a troublesome line break

### DIFF
--- a/layouts/partials/head.pug
+++ b/layouts/partials/head.pug
@@ -48,6 +48,5 @@ if env != 'development'
   script.
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-PBJ84KX');


### PR DESCRIPTION
TL;DR: nothing changes. just prevents errors for folks that use an automatic formatter.

------------------------

if you run prettier - the prevalent formatter of the JS ecosystem - it will remove the trailing `=` in this snippet:

```diff
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src
```

this is troublesome as only the next line contains the right-hand side of the assignment, which is needed for google tag manager to work.

i think prettier is fooled by the special pug element we're using here (note the trailing `.` on the surrounding `script.` element. 

so let's prevent this from accidentally happening `=` [again](https://github.com/mesosphere/dcos-docs-site/pull/3315/commits/dafcd30e77eae41633347da44809889761afe7c7#diff-38a443e525e99139456132adee32f65346783a1a1c6249ac62cff03d2f30b054L51-R51). thanks @cneth for catching this!
