### PR TITLE
updating repos for helm charts to be on upstream repos

### DIFF
--- a/pages/ksphere/kommander/1.0/centralized-monitoring/index.md
+++ b/pages/ksphere/kommander/1.0/centralized-monitoring/index.md
@@ -147,7 +147,7 @@ You can define additional [Prometheus alerting rules][alerting_rules] on the Kom
     ```
 
 [thanos_query]: https://thanos.io/components/query.md/
-[grafana_import_dashboards]: https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards
+[grafana_import_dashboards]: https://github.com/mesosphere/charts/tree/master/stable/grafana#import-dashboards
 [karma_docs]: https://github.com/prymitive/karma
 [alerting_rules]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
 [kubefed_status_docs]: https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#propagation-status

--- a/pages/ksphere/kommander/1.1/centralized-monitoring/index.md
+++ b/pages/ksphere/kommander/1.1/centralized-monitoring/index.md
@@ -161,7 +161,7 @@ You can define additional [Prometheus alerting rules][alerting_rules] on the Kom
    ```
 
 [thanos_query]: https://thanos.io/components/query.md/
-[grafana_import_dashboards]: https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards
+[grafana_import_dashboards]: https://github.com/mesosphere/charts/tree/master/stable/grafana#import-dashboards
 [karma_docs]: https://github.com/prymitive/karma
 [alerting_rules]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
 [kubefed_status_docs]: https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#propagation-status

--- a/pages/ksphere/kommander/1.1/projects/platform-services/index.md
+++ b/pages/ksphere/kommander/1.1/projects/platform-services/index.md
@@ -68,7 +68,7 @@ spec:
         catalog.kubeaddons.mesosphere.io/addon-revision: 1.9.4-1
         catalog.kubeaddons.mesosphere.io/origin-repository: https://github.com/mesosphere/kubeaddons-enterprise
         catalog.kubeaddons.mesosphere.io/origin-repository-version: master
-        values.chart.helm.kubeaddons.mesosphere.io/jenkins: https://raw.githubusercontent.com/helm/charts/master/stable/jenkins/values.yaml
+        values.chart.helm.kubeaddons.mesosphere.io/jenkins: https://raw.githubusercontent.com/jenkinsci/helm-charts/main/charts/jenkins/values.yaml
       labels:
         kubeaddons.mesosphere.io/name: jenkins
       name: jenkins

--- a/pages/ksphere/kommander/1.2/centralized-monitoring/index.md
+++ b/pages/ksphere/kommander/1.2/centralized-monitoring/index.md
@@ -161,7 +161,7 @@ You can define additional [Prometheus alerting rules][alerting_rules] on the Kom
    ```
 
 [thanos_query]: https://thanos.io/components/query.md/
-[grafana_import_dashboards]: https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards
+[grafana_import_dashboards]: https://github.com/mesosphere/charts/tree/master/stable/grafana#import-dashboards
 [karma_docs]: https://github.com/prymitive/karma
 [alerting_rules]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
 [kubefed_status_docs]: https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#propagation-status

--- a/pages/ksphere/kommander/1.2/projects/platform-services/index.md
+++ b/pages/ksphere/kommander/1.2/projects/platform-services/index.md
@@ -69,7 +69,7 @@ spec:
         catalog.kubeaddons.mesosphere.io/addon-revision: 1.9.4-1
         catalog.kubeaddons.mesosphere.io/origin-repository: https://github.com/mesosphere/kubeaddons-enterprise
         catalog.kubeaddons.mesosphere.io/origin-repository-version: master
-        values.chart.helm.kubeaddons.mesosphere.io/jenkins: https://raw.githubusercontent.com/helm/charts/master/stable/jenkins/values.yaml
+        values.chart.helm.kubeaddons.mesosphere.io/jenkins: https://raw.githubusercontent.com/jenkinsci/helm-charts/main/charts/jenkins/values.yaml
       labels:
         kubeaddons.mesosphere.io/name: jenkins
       name: jenkins


### PR DESCRIPTION
## Jira Ticket
N/A

<!-- Link to DOCS work ticket -->

## Description of changes being made
Updating repos of helm charts to be upstream repos

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.