### PR TITLE
backport helm repo location changes to previous versions of docs

### DIFF
--- a/pages/ksphere/konvoy/1.4/monitoring/index.md
+++ b/pages/ksphere/konvoy/1.4/monitoring/index.md
@@ -426,6 +426,6 @@ When defining the requirements of a Konvoy cluster, you can specify the capacity
 ```
 
 [kube_state_exposed_metrics]: https://github.com/kubernetes/kube-state-metrics/tree/master/docs#exposed-metrics
-[grafana_import_dashboards]: https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards
-[prometheus_rules]: https://github.com/helm/charts/tree/master/stable/prometheus-operator/templates/prometheus/rules
+[grafana_import_dashboards]: https://github.com/mesosphere/charts/tree/master/stable/grafana#import-dashboards
+[prometheus_rules]: https://github.com/mesosphere/charts/tree/master/staging/prometheus-operator/templates/prometheus/rules
 [alertmanager_config]: https://prometheus.io/docs/alerting/configuration/

--- a/pages/ksphere/konvoy/1.4/networking/index.md
+++ b/pages/ksphere/konvoy/1.4/networking/index.md
@@ -321,6 +321,6 @@ Details of these functionalities can be viewed [here][traefik_fn].
 [metallb]: https://metallb.universe.tf/concepts/
 [metallb_config]: https://metallb.universe.tf/configuration/
 [traefik]: https://docs.traefik.io/
-[traefik_chart]: https://github.com/helm/charts/tree/master/stable/traefik
+[traefik_chart]: https://github.com/mesosphere/charts/tree/master/staging/traefik
 [traefik_fn]: https://docs.traefik.io/v1.7/user-guide/kubernetes/
 [&#185;]: https://github.com/danderson/metallb/issues/348#issuecomment-442218138

--- a/pages/ksphere/konvoy/1.4/reference/addons/index.md
+++ b/pages/ksphere/konvoy/1.4/reference/addons/index.md
@@ -145,7 +145,7 @@ metadata:
     appversion.kubeaddons.mesosphere.io/kibana: "6.8.2"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"
-    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/helm/charts/09004fa332094693e2e5fcffe474622ba15491ae/stable/kibana/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/mesosphere/charts/505a69c/stable/kibana/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -178,7 +178,7 @@ The above example is for a helm chart.
 This is expressed using the `chartReference` map.
 The `chart` and `version` keys reference the helm chart name, and version.
 Use the optional `repo` key to point to a custom repository.
-If `repo` is not specified, the [default helm chart](https://github.com/helm/charts/) repo is used.
+If `repo` is not specified, the [default helm chart](https://github.com/mesosphere/charts/) repo is used.
 Override the default chart values using the `values` key.
 Changes made here are merged with the chart's `values.yaml` file when applied using helm.
 

--- a/pages/ksphere/konvoy/1.4/release-notes/index.md
+++ b/pages/ksphere/konvoy/1.4/release-notes/index.md
@@ -1770,6 +1770,6 @@ For information about installing and using Konvoy, see the [Konvoy documentation
 
 For information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
 
-[prometheus-rules]: https://github.com/helm/charts/tree/master/stable/prometheus-operator/templates/prometheus/rules
+[prometheus-rules]: https://github.com/mesosphere/charts/tree/master/staging/prometheus-operator/templates/prometheus/rules
 [konvoy-doc]:https://docs.d2iq.com/ksphere/konvoy
 [kubernetes-doc]:https://kubernetes.io/docs/home/

--- a/pages/ksphere/konvoy/1.4/tutorials/addon-repositories/index.md
+++ b/pages/ksphere/konvoy/1.4/tutorials/addon-repositories/index.md
@@ -201,7 +201,7 @@ metadata:
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "19.2.2-1"
     appversion.kubeaddons.mesosphere.io/cockroachdb: "19.2.2"
-    values.chart.helm.kubeaddons.mesosphere.io/cockroachdb: "https://raw.githubusercontent.com/helm/charts/dfea2ba119be53f0d3f7d70def66e54f9e259768/stable/cockroachdb/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/cockroachdb: "https://raw.githubusercontent.com/cockroachdb/helm-charts/5fa0123/cockroachdb/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/pages/ksphere/konvoy/1.4/tutorials/use-istio/index.md
+++ b/pages/ksphere/konvoy/1.4/tutorials/use-istio/index.md
@@ -22,7 +22,7 @@ Before starting this tutorial, you should verify the following:
 
 - You must have a properly deployed and running cluster. For information about deploying Kubernetes with default settings, see the [Quick start][quickstart].
 
-## Deploy Istio using Helm
+## Deploy Istio
 
 1. Download the latest release of Istio by running the following command:
 
@@ -37,12 +37,14 @@ Before starting this tutorial, you should verify the following:
     export PATH=$PWD/bin:$PATH
     ```
 
-1. Install Istio using Helm by running the following commands:
+1. For this installation, we use the demo configuration profile. It's selected to have a good set of defaults for testing, but there are other profiles for production or performance testing. Install Istio using the following commands:
 
     ```bash
-    helm install install/kubernetes/helm/istio-init --name istio-init --namespace istio-system
-    helm install install/kubernetes/helm/istio --name istio --namespace istio-system
+    istioctl install --set profile=demo
+    kubectl label namespace default istio-injection=enabled
     ```
+
+<p class="message--note"><strong>NOTE: </strong><a href="https://istio.io/v1.5/docs/setup/install/helm/" target="_blank">Previous documented ways to install Istio with Helm</a> are no longer recommended. This is why we recommend installing Istio here with <code>istioctl</code> instead</p>
 
 ## Deploy a sample application on Istio
 
@@ -74,5 +76,5 @@ The Istio BookInfo sample application is composed of four separate microservices
 
 1. Follow the steps in the Istio [BookInfo Application][istiobook] documentation to understand the different Istio features.
 
-[istiobook]:https://istio.io/docs/examples/bookinfo/
-[quickstart]:../../quick-start/
+[istiobook]: https://istio.io/docs/examples/bookinfo/
+[quickstart]: ../../quick-start/

--- a/pages/ksphere/konvoy/1.5/monitoring/index.md
+++ b/pages/ksphere/konvoy/1.5/monitoring/index.md
@@ -431,6 +431,6 @@ When defining the requirements of a Konvoy cluster, you can specify the capacity
 ```
 
 [kube_state_exposed_metrics]: https://github.com/kubernetes/kube-state-metrics/tree/master/docs#exposed-metrics
-[grafana_import_dashboards]: https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards
-[prometheus_rules]: https://github.com/helm/charts/tree/master/stable/prometheus-operator/templates/prometheus/rules
+[grafana_import_dashboards]: https://github.com/mesosphere/charts/tree/master/stable/grafana#import-dashboards
+[prometheus_rules]: https://github.com/mesosphere/charts/tree/master/staging/prometheus-operator/templates/prometheus/rules
 [alertmanager_config]: https://prometheus.io/docs/alerting/configuration/

--- a/pages/ksphere/konvoy/1.5/networking/index.md
+++ b/pages/ksphere/konvoy/1.5/networking/index.md
@@ -379,6 +379,6 @@ Details of these functionalities can be viewed [here][traefik_fn].
 [metallb]: https://metallb.universe.tf/concepts/
 [metallb_config]: https://metallb.universe.tf/configuration/
 [traefik]: https://docs.traefik.io/
-[traefik_chart]: https://github.com/helm/charts/tree/master/stable/traefik
+[traefik_chart]: https://github.com/mesosphere/charts/tree/master/staging/traefik
 [traefik_fn]: https://docs.traefik.io/v1.7/user-guide/kubernetes/
 [&#185;]: https://github.com/danderson/metallb/issues/348#issuecomment-442218138

--- a/pages/ksphere/konvoy/1.5/reference/addons/index.md
+++ b/pages/ksphere/konvoy/1.5/reference/addons/index.md
@@ -145,7 +145,7 @@ metadata:
     appversion.kubeaddons.mesosphere.io/kibana: "6.8.2"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"
-    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/helm/charts/09004fa332094693e2e5fcffe474622ba15491ae/stable/kibana/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/mesosphere/charts/505a69c/stable/kibana/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -203,4 +203,4 @@ There is no way to override the kudo operator's `params` at this time.
 
 [addon_tutorial]: ../../tutorials/addon-repositories/
 [base_addons_repo]: https://github.com/mesosphere/kubernetes-base-addons
-[helm_charts]: https://github.com/helm/charts/
+[helm_charts]: https://github.com/mesosphere/charts/

--- a/pages/ksphere/konvoy/1.5/release-notes/index.md
+++ b/pages/ksphere/konvoy/1.5/release-notes/index.md
@@ -323,6 +323,6 @@ For information about installing and using Konvoy, see the [Konvoy documentation
 
 For information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
 
-[prometheus-rules]: https://github.com/helm/charts/tree/master/stable/prometheus-operator/templates/prometheus/rules
+[prometheus-rules]: https://github.com/mesosphere/charts/tree/master/staging/prometheus-operator/templates/prometheus/rules
 [konvoy-doc]:https://docs.d2iq.com/ksphere/konvoy
 [kubernetes-doc]:https://kubernetes.io/docs/home/

--- a/pages/ksphere/konvoy/1.5/tutorials/addon-repositories/index.md
+++ b/pages/ksphere/konvoy/1.5/tutorials/addon-repositories/index.md
@@ -202,7 +202,7 @@ metadata:
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "19.2.2-1"
     appversion.kubeaddons.mesosphere.io/cockroachdb: "19.2.2"
-    values.chart.helm.kubeaddons.mesosphere.io/cockroachdb: "https://raw.githubusercontent.com/helm/charts/dfea2ba119be53f0d3f7d70def66e54f9e259768/stable/cockroachdb/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/cockroachdb: "https://raw.githubusercontent.com/cockroachdb/helm-charts/5fa0123/cockroachdb/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0


### PR DESCRIPTION
## Jira Ticket
N/A

## Description of changes being made
There were some previous versions of the docs that will mention charts from helm repos that are set to be archived.

Also made some minor changes to the istio install that works more readily.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.