### PR TITLE
Remove section for unsupported operation of changing service account creds

### DIFF
--- a/pages/mesosphere/dcos/1.13/security/oss/user-account-management/service-accounts/index.md
+++ b/pages/mesosphere/dcos/1.13/security/oss/user-account-management/service-accounts/index.md
@@ -57,19 +57,6 @@ To list all configured service accounts using the DC/OS [Identity and Access Man
 curl -i -X GET "http://<host-ip>/acs/api/v1/users?type=service" -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
 ```
 
-# Change a service account public key
-
-## Using the IAM API
-
-**Prerequisite:**
-- [DC/OS Authentication token](/mesosphere/dcos/1.13/security/oss/authentication/authentication-token/) exported into the environment as `TOKEN`.
-
-To change a service account's public key using the DC/OS [Identity and Access Management (IAM) API](/mesosphere/dcos/1.13/security/oss/iam-api/) provide a new public key in the `public-key.pem` file. Then replace `<uid>` in the following command and execute it:
-
-```bash
-curl -i -X PATCH http://<host-ip>/acs/api/v1/users/<uid> -d '{"public_key": "'"$(sed ':a;N;$!ba;s/\n/\\n/g' public-key.pem)"'"}' -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
-```
-
 # Remove a service account
 
 ## Using the IAM API

--- a/pages/mesosphere/dcos/2.0/security/oss/user-account-management/service-accounts/index.md
+++ b/pages/mesosphere/dcos/2.0/security/oss/user-account-management/service-accounts/index.md
@@ -57,19 +57,6 @@ To list all configured service accounts using the DC/OS [Identity and Access Man
 curl -i -X GET "http://<host-ip>/acs/api/v1/users?type=service" -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
 ```
 
-# Change a service account public key
-
-## Using the IAM API
-
-**Prerequisite:**
-- [DC/OS Authentication token](/mesosphere/dcos/2.0/security/oss/authentication/authentication-token/) exported into the environment as `TOKEN`.
-
-To change a service account's public key using the DC/OS [Identity and Access Management (IAM) API](/mesosphere/dcos/2.0/security/oss/iam-api/) provide a new public key in the `public-key.pem` file. Then replace `<uid>` in the following command and execute it:
-
-```bash
-curl -i -X PATCH http://<host-ip>/acs/api/v1/users/<uid> -d '{"public_key": "'"$(sed ':a;N;$!ba;s/\n/\\n/g' public-key.pem)"'"}' -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
-```
-
 # Remove a service account
 
 ## Using the IAM API

--- a/pages/mesosphere/dcos/2.1/security/oss/user-account-management/service-accounts/index.md
+++ b/pages/mesosphere/dcos/2.1/security/oss/user-account-management/service-accounts/index.md
@@ -57,19 +57,6 @@ To list all configured service accounts using the DC/OS [Identity and Access Man
 curl -i -X GET "http://<host-ip>/acs/api/v1/users?type=service" -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
 ```
 
-# Change a service account public key
-
-## Using the IAM API
-
-**Prerequisite:**
-- [DC/OS Authentication token](/mesosphere/dcos/2.1/security/oss/authentication/authentication-token/) exported into the environment as `TOKEN`.
-
-To change a service account's public key using the DC/OS [Identity and Access Management (IAM) API](/mesosphere/dcos/2.1/security/oss/iam-api/) provide a new public key in the `public-key.pem` file. Then replace `<uid>` in the following command and execute it:
-
-```bash
-curl -i -X PATCH http://<host-ip>/acs/api/v1/users/<uid> -d '{"public_key": "'"$(sed ':a;N;$!ba;s/\n/\\n/g' public-key.pem)"'"}' -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
-```
-
 # Remove a service account
 
 ## Using the IAM API

--- a/pages/mesosphere/dcos/2.2/security/oss/user-account-management/service-accounts/index.md
+++ b/pages/mesosphere/dcos/2.2/security/oss/user-account-management/service-accounts/index.md
@@ -57,19 +57,6 @@ To list all configured service accounts using the DC/OS [Identity and Access Man
 curl -i -X GET "http://<host-ip>/acs/api/v1/users?type=service" -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
 ```
 
-# Change a service account public key
-
-## Using the IAM API
-
-**Prerequisite:**
-- [DC/OS Authentication token](/mesosphere/dcos/2.2/security/oss/authentication/authentication-token/) exported into the environment as `TOKEN`.
-
-To change a service account's public key using the DC/OS [Identity and Access Management (IAM) API](/mesosphere/dcos/2.2/security/oss/iam-api/) provide a new public key in the `public-key.pem` file. Then replace `<uid>` in the following command and execute it:
-
-```bash
-curl -i -X PATCH http://<host-ip>/acs/api/v1/users/<uid> -d '{"public_key": "'"$(sed ':a;N;$!ba;s/\n/\\n/g' public-key.pem)"'"}' -H 'Content-Type: application/json' -H "Authorization: token=$TOKEN"
-```
-
 # Remove a service account
 
 ## Using the IAM API


### PR DESCRIPTION

## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-73137

## Description of changes being made
Remove section that describes an unsupported operation (changing service account credentials).

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.