### PR TITLE
less redirecting

### DIFF
--- a/layouts/partials/sidebar.pug
+++ b/layouts/partials/sidebar.pug
@@ -17,7 +17,7 @@ mixin renderSidebarNavListItem(item, depth)
       'sidebar__nav__item--parent': hasChildren
     }
   li.sidebar__nav__item(class=itemClassList)
-    a.sidebar__nav__item__container(href=item.path, class=`sidebar__nav__item__container--depth-${depth}`)
+    a.sidebar__nav__item__container(href=item.path + "/", class=`sidebar__nav__item__container--depth-${depth}`)
       if hasChildren
         i.sidebar__nav__icon(data-feather='chevron-right')
       .sidebar__nav__text!= item.navigationTitle || item.title


### PR DESCRIPTION
when having a look at the dev-console on production we notice that no
link in the sidebar has a trailing slash, which lets S3 do a redirect to
the slashed version.

on my connection that makes about half of the total loading time for
small to medium sized pages (mostly all those without images).
let's cut loading times in half!


testing: if the sidebar-links in the preview env work everything should be fine
--------------

![Prerequisites - D2iQ Docs 2020-11-24 12-08-49](https://user-images.githubusercontent.com/300861/100086568-e2f50500-2e4d-11eb-9915-b78c33183feb.png)
