### PR TITLE
remove addThis

### DIFF
--- a/js/actions.js
+++ b/js/actions.js
@@ -1,8 +1,0 @@
-window.addEventListener("load", () => {
-  if (window.addthis) {
-    window.addthis_config = {
-      ui_disable: true,
-    };
-    addthis.init();
-  }
-});

--- a/js/main.js
+++ b/js/main.js
@@ -10,7 +10,6 @@ require("./sidebar-drawer.js");
 require("./header.js");
 require("./header-dropdown.js");
 require("./search.js");
-require("./actions.js");
 require("./sections.js");
 require("./switch.js");
 require("./image.js");

--- a/layouts/components/content-actions.pug
+++ b/layouts/components/content-actions.pug
@@ -20,10 +20,6 @@ if (!title)
 .actions
   ul.actions__list
     li.actions__item
-      a.actions__link.addthis_button(href='/')
-        i.actions__icon(data-feather='share')
-        span.actions__text Share
-    li.actions__item
       button.actions__link(onclick='javascript:window.print()')
         i.actions__icon(data-feather='printer')
         span.actions__text Print

--- a/layouts/partials/scripts.pug
+++ b/layouts/partials/scripts.pug
@@ -2,8 +2,6 @@ script(src='/assets/js/jquery-3.2.1.js')
 script(src='/assets/js/clipboard.js')
 script(src='/assets/js/prism.js')
 
-if env == 'production'
-  script(src='//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-59c6dc5017f3462f', async)
 if env == 'development'
   script(src='//localhost:35729/livereload.js', async)
 


### PR DESCRIPTION
addThis is a service that makes for a great share-button.
unfortunately they add 9 script files in total that weight in at ~1MB
and they add a click handler that catches clicks on internal and
external links which makes for a noticeable delay in changing pages.

as we guess that this button is not used very often, we remove it for
now. if we ever want to have share functionality, that's pretty easy
(and also stable by now) to add for the major platforms even without
using a service.

--------

obviously today is docs-performance-day...