### PR TITLE
decrease build size

### DIFF
--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -1,24 +1,11 @@
 const sidebarDropdown = document.querySelector(".sidebar__dropdown");
-const sidebarDropdownList = document.querySelector(".sidebar__dropdown__list");
-let sidebarItems = document.querySelectorAll(".sidebar__nav__item--parent");
-sidebarItems = [...sidebarItems];
+const sidebarDropdownList = document.querySelector(".sidebar__dropdown ul");
 
 if (sidebarDropdown && sidebarDropdownList) {
   document.addEventListener("click", detectClick);
   sidebarDropdown.addEventListener("click", toggleDropdown);
 }
 
-if (sidebarItems.length) {
-  sidebarItems.forEach((menu) => {
-    const caret = menu.querySelector("svg");
-    if (caret) caret.addEventListener("click", toggleMenu);
-  });
-}
-
-/**
- *
- *
- */
 function toggleDropdown() {
   if (!sidebarDropdown.classList.contains("sidebar__dropdown--active")) {
     sidebarDropdown.classList.add("sidebar__dropdown--active");
@@ -27,32 +14,11 @@ function toggleDropdown() {
   }
 }
 
-/**
- *
- *
- */
 function detectClick(event) {
   if (
     sidebarDropdown.classList.contains("sidebar__dropdown--active") &&
     !sidebarDropdown.contains(event.target)
   ) {
     sidebarDropdown.classList.remove("sidebar__dropdown--active");
-  }
-}
-
-/**
- *
- *
- */
-function toggleMenu(event) {
-  event.stopPropagation();
-  event.preventDefault();
-  const childMenu = this.parentNode.parentNode.nextSibling;
-  if (!childMenu.classList.contains("sidebar__nav__list--active")) {
-    childMenu.classList.add("sidebar__nav__list--active");
-    this.style.transform = "rotate(90deg)";
-  } else {
-    childMenu.classList.remove("sidebar__nav__list--active");
-    this.style.transform = "rotate(0)";
   }
 }

--- a/layouts/partials/head.pug
+++ b/layouts/partials/head.pug
@@ -35,10 +35,6 @@ link(href='https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,500,
 
 script(src='https://unpkg.com/feather-icons/dist/feather.min.js')
 if env != 'development'
-  <!-- Ethnio Activation Code -->
-  <!-- script(type='text/javascript', language='javascript', src='//ethn.io/74286.js', async='true', charset='utf-8') -->
-
-if env != 'development'
   script.
     window.analytics||(window.analytics=[]),window.analytics.methods=["identify","track","trackLink","trackForm","trackClick","trackSubmit","page","pageview","ab","alias","ready","group","on","once","off"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var method=window.analytics.methods[i];window.analytics[method]=window.analytics.factory(method)}window.analytics.load=function(t){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)},window.analytics.SNIPPET_VERSION="2.0.8",
     window.analytics.load("7sgtwqvuai");

--- a/layouts/partials/sidebar.pug
+++ b/layouts/partials/sidebar.pug
@@ -11,18 +11,13 @@ mixin renderSidebarNavListItem(item, depth)
   -
     var hasChildren = !!item.children.length
     var onPath = currentPath.includes(item.path)
-    var itemClassList = {
-      'sidebar__nav__item--active': onPath,
-      'sidebar__nav__item--active-on': currentPath == item.path,
-      'sidebar__nav__item--parent': hasChildren
-    }
-  li.sidebar__nav__item(class=itemClassList)
-    a.sidebar__nav__item__container(href=item.path + "/", class=`sidebar__nav__item__container--depth-${depth}`)
+  li(class={'active': onPath, 'active-on': currentPath == item.path})
+    a(href=item.path + "/", class=`d${depth}`)
       if hasChildren
-        i.sidebar__nav__icon(data-feather='chevron-right')
-      .sidebar__nav__text!= item.navigationTitle || item.title
-  if(hasChildren)
-    ul.sidebar__nav__list(class={'sidebar__nav__list--active': onPath})
+        i(data-feather='chevron-right')
+      != item.navigationTitle || item.title
+  if(hasChildren && onPath)
+    ul
       each val, index in item.children.filter(inMenu)
         +renderSidebarNavListItem(val, depth + 1)
 
@@ -31,20 +26,20 @@ mixin renderSidebarNavListItem(item, depth)
     header.sidebar__header
       .sidebar__dropdown
         if productVersions.length > 1
-          ul.sidebar__dropdown__list
+          ul
             each val, index in productVersions
               if val.navigationTitle || val.title
-                li.sidebar__dropdown__item
-                  a.sidebar__dropdown__link(href=hierarchy.findLongestExisting(path.replace(`${productPath}${versionFragment}`, val.path)))!= val.navigationTitle || val.title
-        .sidebar__dropdown__toggle
-          p.sidebar__dropdown__text
-            span.sidebar__dropdown__text__title!= productName
-            span.sidebar__dropdown__text__version!= ' ' + version
+                li
+                  a(href=hierarchy.findLongestExisting(path.replace(`${productPath}${versionFragment}`, val.path)))!= val.navigationTitle || val.title
+        .toggle
+          p
+            span.title!= productName
+            span.version!= ' ' + version
           if productVersions.length > 1
-            i.sidebar__dropdown__icon(data-feather='chevron-down')
+            i(data-feather='chevron-down')
 
-    nav.sidebar__nav(role='navigation')
-      ul.sidebar__nav__list.sidebar__nav__list--active
+    nav.sidebar_nav(role='navigation')
+      ul
         each val, index in hierarchy.findByPath(`${productPath}${versionFragment}`).children.filter(inMenu)
           +renderSidebarNavListItem(val, 0)
 

--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -11,7 +11,7 @@
   &__dropdown {
     position: relative;
     width: 100%;
-    &__toggle {
+    .toggle {
       display: flex;
       justify-content: space-between;
       align-items: center;
@@ -19,31 +19,30 @@
       padding: 0 2rem;
       font-weight: 500;
       user-select: none;
+      cursor: pointer;
     }
-    &__text {
+    p {
       width: calc(100% - 20px);
       padding: 0;
       margin: 0;
       display: inline;
       overflow: hidden;
-      &__title {
-        color: $color-light;
+      color: $color-light;
+      font-size: 16px;
+      .title {
         opacity: 0.7;
-        font-size: 16px;
       }
-      &__version {
-        color: $color-light;
+      .version {
         white-space: nowrap;
-        font-size: 16px;
       }
     }
-    &__icon {
+    svg {
       width: 20px;
       height: 20px;
       color: $color-light;
       transition: all 0.3s ease-in-out;
     }
-    &__list {
+    ul {
       position: absolute;
       top: 70px;
       margin: 0;
@@ -56,17 +55,14 @@
       visibility: hidden;
       box-shadow: inset 0 40px 40px -40px rgba(0, 0, 0, 0.1), 0 20px 20px rgba(0, 0, 0, 0.1);
       overflow: hidden;
-      + .sidebar__dropdown__toggle {
-        cursor: pointer;
-      }
     }
-    &__item {
+    li {
       color: $color-light;
       &:not(:last-of-type) {
         border-bottom: 1px rgba($color-purple, 0.2) solid;
       }
     }
-    &__link {
+    a {
       display: block;
       padding: 1rem 2rem;
       font-size: 0.9rem;
@@ -80,98 +76,14 @@
     }
     &--active {
       background: $color-purple-d3;
-      & .sidebar__dropdown__list {
+      & ul {
           height: auto;
           visibility: visible;
           opacity: 1;
           z-index: 1;
       }
-      & .sidebar__dropdown__icon {
+      & svg {
         transform: rotate(180deg);
-      }
-    }
-  }
-  &__nav {
-    &::-webkit-scrollbar {
-      width: 0px;
-      background: transparent;
-    }
-    flex: 1;
-    padding-top: 1rem;
-    overflow-y: scroll;
-    font-size: 1rem;
-    color: rgba(255, 255, 255, 0.6);
-    a {
-      color: rgba(255, 255, 255, 0.6);
-    }
-    &__list {
-      display: none;
-      margin: 0;
-      padding: 0;
-      list-style-type: none;
-      &--active {
-        display: block;
-      }
-    }
-    &__icon {
-      width: 20px;
-      height: 20px;
-      margin: -1px 3px 0 -23px;
-      color: rgba(255, 255, 255, 0.6);
-      user-select: none;
-    }
-    &__text {
-      font-weight: 400;
-      color: rgba(255, 255, 255, 0.6);
-    }
-    &__item {
-      position: relative;
-      margin-bottom: 0.5rem;
-      line-height: 1;
-      &__container {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        padding: 0.25rem 2rem;
-        line-height: 1.25;
-        text-decoration: none;
-        &--depth-0 {
-          padding-left: calc(1rem * 2 + 23px);
-        }
-        &--depth-1 {
-          padding-left: calc(1rem * 3 + 23px);
-        }
-        &--depth-2 {
-          padding-left: calc(1rem * 4 + 23px);
-        }
-        &--depth-3 {
-          padding-left: calc(1rem * 5 + 23px);
-        }
-        &--depth-4 {
-          padding-left: calc(1rem * 6 + 23px);
-        }
-        &--depth-5 {
-          padding-left: calc(1rem * 7 + 23px);
-        }
-      }
-      &--active {
-        > .sidebar__nav__item__container .sidebar__nav__text {
-          color: $color-light;
-          font-weight: bolder;
-        }
-        > .sidebar__nav__item__container .sidebar__nav__icon {
-          color: $color-light;
-          transform: rotate(90deg);
-        }
-      }
-      &--active-on {
-        background: $color-purple-d3;
-        > .sidebar__nav__item__container .sidebar__nav__text {
-          color: $color-light;
-        }
-        > .sidebar__nav__item__container .sidebar__nav__icon {
-          color: $color-light;
-        }
       }
     }
   }
@@ -197,26 +109,73 @@
       text-decoration: none;
     }
   }
+}
+
+
+// we're not using BEM for the sidebar as it otherwise increases our build-size a lot.
+.sidebar_nav {
+  &::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+  }
+  flex: 1;
+  padding-top: 1rem;
+  overflow-y: scroll;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.6);
+  a {
+    color: inherit;
+  }
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+  svg {
+    width: 20px;
+    height: 20px;
+    margin: -1px 3px 0 -23px;
+    user-select: none;
+  }
+  // item
+  li {
+    position: relative;
+    margin-bottom: 0.5rem;
+    line-height: 1;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.6);
+    // container
+    a {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      padding: 0.25rem 2rem;
+      line-height: 1.25;
+      text-decoration: none;
+      &.d0 { padding-left: calc(1rem * 2 + 23px); }
+      &.d1 { padding-left: calc(1rem * 3 + 23px); }
+      &.d2 { padding-left: calc(1rem * 4 + 23px); }
+      &.d3 { padding-left: calc(1rem * 5 + 23px); }
+      &.d4 { padding-left: calc(1rem * 6 + 23px); }
+      &.d5 { padding-left: calc(1rem * 7 + 23px); }
+    }
+    &.active {
+      color: $color-light;
+      font-weight: bolder;
+      svg { transform: rotate(90deg); }
+    }
+    &.active-on {
+      background: $color-purple-d3;
+      color: $color-light;
+    }
+  }
   @include md {
-    &__nav {
-      // font-size: 14px;
-      &__icon {
-        &:hover {
-          opacity: 0.3;
-        }
-      }
-      &__item {
-        line-height: 1.25rem;
-        margin-bottom: 0;
-        &:hover {
-          background: $color-purple-d3;
-          > .sidebar__nav__item__container .sidebar__nav__text {
-            color: $color-light;
-          }
-          > .sidebar__nav__item__container .sidebar__nav__icon {
-            color: $color-light;
-          }
-        }
+    li {
+      line-height: 1.25rem;
+      margin-bottom: 0;
+      &:hover {
+        background: $color-purple-d3;
+        color: $color-light;
       }
     }
   }


### PR DESCRIPTION
a lot of the markup on our pages belong to the sidebar, as we always
render all entries and each of those has really long classnames attached
to it.

`du -sm` tells us `1482MB` before and `903MB` after this change.
if we take into account that images weight in at `749MB` (and thus are our next
target), we get a html-size reduction of about 80% (from `733MB` to `154MB`).   
the size of e.g. `mesosphere/dcos/2.2/release-notes/2.2.1/` went from 160KB to 15KB.

benefits: 

* upload to S3 is faster (we should see deployments that scratch the 4 minute mark regularly with this)
* metalsmith's layouts-step takes less time (faster deployment, faster dev-cycle)
* ~40% less spend on S3 
* potentially better SEO-score due to improved load times


the change itself is twofold:

1. don't render nested children that would be invisible
2. don't use BEM for sidebar-CSS as the long class names are the culprit here.

## testing

* it's mainly about the sidebar-navigation or "TOC". so if that still works as expected, we're good.

⚠️ TRADEOFF: we can't click the carets anymore to dynamically open a navigation item with children on the same page. instead the associated site will open (with the now open sub-menu). if you think that drawback in UX outweighs the gains described above, please let me know.

----------------

btw sorry for putting up a non-related PR when we have issues in JIRA to be solved - but this kind of tiny and straightforward improvement fits into a few waiting cycles i encounter in the migration-work i'm currently doing while not requiring much overhead due to a context switch. 