### PR TITLE
COPS-6728: kommander limit range docs

### DIFF
--- a/pages/dkp/kommander/1.2/projects/project-quotas-limit-range/index.md
+++ b/pages/dkp/kommander/1.2/projects/project-quotas-limit-range/index.md
@@ -84,17 +84,17 @@ spec:
       - type: "Pod"
         max:
           cpu: 500m
-          mem: 50Gi
+          memory: 50Gi
         min:
           cpu: 100m
-          mem: 10Gi
+          memory: 10Gi
       - type: "Container"
         max:
           cpu: 2
-          mem: 100Mi
+          memory: 100Mi
         min:
           cpu: 1
-          mem: 10Mi
+          memory: 10Mi
       - type: "PersistentVolumeClaim"
         max:
           storage: 3Gi

--- a/pages/dkp/kommander/1.3/projects/project-quotas-limit-range/index.md
+++ b/pages/dkp/kommander/1.3/projects/project-quotas-limit-range/index.md
@@ -84,17 +84,17 @@ spec:
       - type: "Pod"
         max:
           cpu: 500m
-          mem: 50Gi
+          memory: 50Gi
         min:
           cpu: 100m
-          mem: 10Gi
+          memory: 10Gi
       - type: "Container"
         max:
           cpu: 2
-          mem: 100Mi
+          memory: 100Mi
         min:
           cpu: 1
-          mem: 10Mi
+          memory: 10Mi
       - type: "PersistentVolumeClaim"
         max:
           storage: 3Gi


### PR DESCRIPTION
Part of resolution for COPS-6728

## Jira Ticket
https://jira.d2iq.com/browse/COPS-6728

## Description of changes being made
Fixes limit range docs

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.