### PR TITLE
Rename addons to platform services in kommander docs

### DIFF
--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/attach-eks-cluster/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/attach-eks-cluster/index.md
@@ -128,7 +128,7 @@ This procedure requires the following items and configurations:
 
 1. Select the **Submit** button.
 
-<p class="message--note"><strong>NOTE: </strong>If a cluster has limited resources to deploy all the federated kubeaddons, it will fail to stay attached in the Kommander UI. If this happens, please check if there are any pods that are not getting the resources required.</p>
+<p class="message--note"><strong>NOTE: </strong>If a cluster has limited resources to deploy all the federated platform services, it will fail to stay attached in the Kommander UI. If this happens, please check if there are any pods that are not getting the resources required.</p>
 
 ## Related information
 

--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/federated-platform-services/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/federated-platform-services/index.md
@@ -1,22 +1,22 @@
 ---
 layout: layout.pug
 beta: true
-navigationTitle: Federated Addons
-title: Federated Addons
+navigationTitle: Federated Platform Services
+title: Federated Platform Services
 menuWeight: 5
-excerpt: How federated addons work
+excerpt: How federated platform services work
 ---
 
-## Addons federation
+## Platform services federation
 
-When attaching a cluster, Kommander federates certain addons on the newly attached cluster. To customize the federation of the logging and monitoring stacks, operators can apply labels to the associated `KommanderCluster` resource.
+When attaching a cluster, Kommander federates certain platform services on the newly attached cluster. To customize the federation of the logging and monitoring stacks, operators can apply labels to the associated `KommanderCluster` resource.
 
 On attachment, two factors impact successfully deploying an addon on the attached cluster:
 
 1. Is the attached cluster a Konvoy cluster or not? For example, a cluster deployed using AWS EKS.
 2. Does a label describing the federation of the addon exist and is it defined? If yes, what is its value?
 
-The following tables describe the list of addons and cluster addons that get federated on attachment with their related federation label (if available). Addons that do not have a federation label are federated by default. If the addon description indicates only federated on non-Konvoy clusters, the addon will not get installed into Konvoy clusters, even if its federation label is set to `true`.
+The following tables describe the list of platform services and cluster platform services that get federated on attachment with their related federation label (if available). Platform services that do not have a federation label are federated by default. If the addon description indicates only federated on non-Konvoy clusters, the addon will not get installed into Konvoy clusters, even if its federation label is set to `true`.
 
 Currently, the monitoring stack is federated by default and the logging stack is not. This is why `prometheus` is the only addon federated by default with a federation label to disable it if needed.
 
@@ -24,13 +24,13 @@ Currently, the monitoring stack is federated by default and the logging stack is
 
 #### Use the UI
 
-See [attaching a cluster](/dkp/kommander/latest/clusters/attach-cluster/) for information. You can add labels at the bottom of the attachment form, use the federation labels described in the following tables as keys and the values `true` or `false` if you wish to customize the federation of the addons. The addons that do not have a related federation label cannot get their federation enabled or disabled this way.
+See [attaching a cluster](/dkp/kommander/latest/clusters/attach-cluster/) for information. You can add labels at the bottom of the attachment form, use the federation labels described in the following tables as keys and the values `true` or `false` if you wish to customize the federation of the platform services. The platform services that do not have a related federation label cannot get their federation enabled or disabled this way.
 
 #### Create a new KommanderCluster
 
 If you want to federate a cluster by creating a new `KommanderCluster` object in your Kommander cluster, the federation labels should be set in the field `metadata/labels`.
 
-## Federated addons
+## Federated platform services
 
 | Name                                 | Federated by default | Federation label                                         | Only federated on non-Konvoy clusters |
 | ------------------------------------ | -------------------- | -------------------------------------------------------- | ------------------------------------- |
@@ -47,10 +47,10 @@ If you want to federate a cluster by creating a new `KommanderCluster` object in
 | reloader                             | True                 |                                                          | True                                  |
 | traefik-forward-auth-kommander       | True                 |                                                          | False                                 |
 
-## Federated cluster addons
+## Federated cluster platform services
 
 | Name           | Federated by default | Federation label | Only federated on non-Konvoy clusters |
 | -------------- | -------------------- | ---------------- | ------------------------------------- |
 | - cert-manager | True                 |                  | True                                  |
 | - kubecost     | True                 |                  | False                                 |
-| - traefik      | True                 |                  |  True                                 |
+| - traefik      | True                 |                  | True                                  |

--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/federated-platform-services/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/federated-platform-services/index.md
@@ -16,7 +16,7 @@ On attachment, two factors impact successfully deploying an addon on the attache
 1. Is the attached cluster a Konvoy cluster or not? For example, a cluster deployed using AWS EKS.
 2. Does a label describing the federation of the addon exist and is it defined? If yes, what is its value?
 
-The following tables describe the list of platform services and cluster platform services that get federated on attachment with their related federation label (if available). Platform services that do not have a federation label are federated by default. If the addon description indicates only federated on non-Konvoy clusters, the addon will not get installed into Konvoy clusters, even if its federation label is set to `true`.
+The following tables describe the list of platform services and cluster platform services that get federated on attachment with their related federation label (if available). Platform services that do not have a federation label are federated by default. If the platform service description indicates only federated on non-Konvoy clusters, the platform service will not get installed into Konvoy clusters, even if its federation label is set to `true`.
 
 Currently, the monitoring stack is federated by default and the logging stack is not. This is why `prometheus` is the only addon federated by default with a federation label to disable it if needed.
 

--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/federated-platform-services/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/federated-platform-services/index.md
@@ -18,7 +18,7 @@ On attachment, two factors impact successfully deploying an addon on the attache
 
 The following tables describe the list of platform services and cluster platform services that get federated on attachment with their related federation label (if available). Platform services that do not have a federation label are federated by default. If the platform service description indicates only federated on non-Konvoy clusters, the platform service will not get installed into Konvoy clusters, even if its federation label is set to `true`.
 
-Currently, the monitoring stack is federated by default and the logging stack is not. This is why `prometheus` is the only addon federated by default with a federation label to disable it if needed.
+Currently, the monitoring stack is federated by default and the logging stack is not. This is why `prometheus` is the only platform service federated by default with a federation label to disable it if needed.
 
 ### Set federation labels
 

--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
@@ -92,9 +92,9 @@ kubectl --kubeconfig $(pwd)/kommander-cluster-admin-config get all --all-namespa
 
 Using the **Add Cluster** option you can attach an existing Kubernetes or Konvoy cluster directly to Kommander. You can access the multi-cluster management and monitoring benefits Kommander provides while keeping your existing cluster on its current provider and infrastructure.
 
-Selecting the **Attach Cluster** option displays the **Connection Information** dialog box. This dialog box accepts a kubeconfig file, that you can paste, or upload into the field. In the **Context** select list, you can select the intended context or change the display name provided with the config. You can add labels to classify your cluster and select the addons to install.
+Selecting the **Attach Cluster** option displays the **Connection Information** dialog box. This dialog box accepts a kubeconfig file, that you can paste, or upload into the field. In the **Context** select list, you can select the intended context or change the display name provided with the config. You can add labels to classify your cluster and select the platform services to install.
 
-Addons extend the functionality of Kubernetes and allow you to deploy ready-to-use logging and monitoring stacks by federating addons when attaching a cluster to Kommander. For more information, read our documentation about [federated addons](/dkp/kommander/latest/clusters/attach-cluster/federated-addons/).
+Platform services extend the functionality of Kubernetes and allow you to deploy ready-to-use logging and monitoring stacks by federating platform services when attaching a cluster to Kommander. For more information, read our documentation about [federated platform services](/dkp/kommander/latest/clusters/attach-cluster/federated-platform-services/).
 
 ![Add Cluster Connect](/dkp/kommander/1.3/img/add-cluster-connect.png)
 

--- a/pages/dkp/kommander/1.3/clusters/index.md
+++ b/pages/dkp/kommander/1.3/clusters/index.md
@@ -181,8 +181,8 @@ data:
 ```
 
 | Key | Description | Required |
-| :--- | :--- | :---: | 
-| metadata . labels . "d2iq.io/addon" | The addon name (id) | X |
+| :--- | :--- | :---: |
+| metadata . labels . "d2iq.io/addon" | The platform service name (id) | X |
 | data . name | The display name used to describe the service and shown on the Card in the GUI. | X |
 | data . dashboardLink | The link to the service. This can be an absolute link "https://www.d2iq.com" or a relative link "/ops/portal". If a relative link is used, the link will be built using the cluster's path as the base of the URL to the service. | X |
 | data . docsLink | Link to documentation about the service, this is displayed on the service card, but omitted if not present. | |

--- a/pages/dkp/kommander/1.3/install-airgapped/index.md
+++ b/pages/dkp/kommander/1.3/install-airgapped/index.md
@@ -27,7 +27,7 @@ Before installing, make sure your environment has the following basic requiremen
   cluster:
   - both management and attached clusters must connect to the Docker registry
   - management cluster must connect to the attached cluster's API server
-  - management cluster must connect to load balancers created by some addons. For example, Thanos, part of the Prometheus addon, connects to those load balancers.
+  - management cluster must connect to load balancers created by some platform services. For example, Thanos, part of the Prometheus platform service, connects to those load balancers.
 
 - all the prerequisites in [air gapped Konvoy installation][air-gap-before-you-begin] in case of Konvoy clusters.
 

--- a/pages/dkp/kommander/1.3/projects/platform-services/index.md
+++ b/pages/dkp/kommander/1.3/projects/platform-services/index.md
@@ -11,7 +11,7 @@ Kommander can also deploy services from a catalog of current cloud native servic
 
 ![Project Catalog](/dkp/kommander/1.3/img/project-catalog.png)
 
-Kommander can be extended with the AddonRepository resource that point to git repositories containing application addons. For example, the kubeaddons-enterprise repo contains addons such as Jenkins and Kafka with specific settings for each service. Addons can be composed using either Helm V2 charts or KUDO operators.
+Kommander can be extended with the AddonRepository resource that point to git repositories containing application platform services. For example, the kubeaddons-enterprise repo contains platform services such as Jenkins and Kafka with specific settings for each service. Platform services can be composed using either Helm V2 charts or KUDO operators.
 
 Example AddonRepository resource to add a new repository to your catalog:
 
@@ -27,26 +27,26 @@ spec:
   url: https://github.com/mesosphere/kubeaddons-enterprise
 ```
 
-To deploy an addon:
+To deploy a platform service:
 
 1. Select **Workspace** > **Project**
-2. Select **View Catalog** to browse the available addons from your configured repositories.
-3. Select your desired addon.
+2. Select **View Catalog** to browse the available platform services from your configured repositories.
+3. Select your desired platform service.
 4. Select the version you'd like to deploy from the version drop-down, and then select Deploy.
 
-For all addons, you must provide a display name and an ID. The ID will be automatically generated based on what is entered for the display name, unless or until you edit the ID directly. The ID must be compliant with [Kubernetes DNS subdomain name validation rules](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
+For all platform services, you must provide a display name and an ID. The ID will be automatically generated based on what is entered for the display name, unless or until you edit the ID directly. The ID must be compliant with [Kubernetes DNS subdomain name validation rules](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
 
 Optionally, you can customize the helm chart values or KUDO parameters of a service before deploying it.
 
-For Helm-based addons, specify the chart values in a YAML editor:
+For Helm-based platform services, specify the chart values in a YAML editor:
 
 ![Deploy Helm Platform Service](/dkp/kommander/1.3/img/project-catalog-deploy-helm.png)
 
-For KUDO-based addons, fill out the form fields supported by that addon's parameters schema:
+For KUDO-based platform services, fill out the form fields supported by that platform service's parameters schema:
 
 ![Deploy KUDO Platform Service](/dkp/kommander/1.3/img/project-catalog-deploy-kudo.png)
 
-After an addon is deployed in a project, the service is installed to all clusters in that project.
+After a platform service is deployed in a project, the service is installed to all clusters in that project.
 
 Since a project Platform Service is simply a Kubernetes FederatedAddon, it can also be created using kubectl:
 
@@ -167,6 +167,6 @@ status:
 
 The Konvoy Addon Controller is then responsible for deploying the application.
 
-After the addon is deployed, the addon may be upgraded to a newer version. The only versions shown are compatible with the clusters in that project.
+After the platform service is deployed, the platform service may be upgraded to a newer version. The only versions shown are compatible with the clusters in that project.
 
-![Project addon edit form](/dkp/kommander/1.3/img/project-catalog-addon-edit.png)
+![Project platform service edit form](/dkp/kommander/1.3/img/project-catalog-addon-edit.png)

--- a/pages/dkp/kommander/1.3/security/distributed-authnz/index.md
+++ b/pages/dkp/kommander/1.3/security/distributed-authnz/index.md
@@ -15,13 +15,13 @@ Kommander is part of a Konvoy cluster installation. Konvoy comes with a pre-conf
 
 The operational portal admin credentials are stored as a secret. They never leave the boundary of the Kommander cluster and are never shared to any other cluster.
 
-The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other Konvoy components use the id token as an authentication proof. User identity to the Kubernetes API server is provided by the [`kube-oidc-proxy`][kube_oidc_proxy] Addon that reads the identity from an id token. Web requests to operations portal access are authenticated by the [traefik forward auth][traefik_forward_auth] Addon.
+The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other Konvoy components use the id token as an authentication proof. User identity to the Kubernetes API server is provided by the [`kube-oidc-proxy`][kube_oidc_proxy] platform service that reads the identity from an id token. Web requests to operations portal access are authenticated by the [traefik forward auth][traefik_forward_auth] platform service.
 
 A user identity is shared across a Kommander cluster and all other provisioned clusters.
 
 ### Kommander provisioned clusters
 
-A newly provisioned cluster gets federated `kube-oidc-proxy`, `dex-k8s-authenticator`, and `traefik-forward-auth` Addons. These Addons are configured to accept Kommander cluster Dex issued id tokens.
+A newly provisioned cluster gets federated `kube-oidc-proxy`, `dex-k8s-authenticator`, and `traefik-forward-auth` platform services. These platform services are configured to accept Kommander cluster Dex issued id tokens.
 
 When the `traefik-forward-auth` is used as a [Traefik ingress authenticator][traefik_ingress] it checks if the user identity was issued by the Kommander cluster Dex service. An anonymous user is redirected to the Kommander cluster Dex service to authenticate and confirm their identity.
 

--- a/pages/dkp/kommander/1.3/tutorials/duplicating-cluster/index.md
+++ b/pages/dkp/kommander/1.3/tutorials/duplicating-cluster/index.md
@@ -4,7 +4,7 @@ beta: true
 navigationTitle: Duplicate a Production Cluster
 title: Duplicate a Production Cluster
 menuWeight: 1
-excerpt: Create a second cluster in another region and duplicate all the addons and configuration
+excerpt: Create a second cluster in another region and duplicate all the platform services and configuration
 ---
 
 In this tutorial you will learn how to create a second production cluster for your E-Commerce team. For example: to have a fallback or to migrate to a different cloud provider.


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->
https://jira.d2iq.com/browse/D2IQ-73666
docs review ticket: https://jira.d2iq.com/browse/D2IQ-73669

## Description of changes being made
We are renaming "addons" to "platform services" across Kommander UI and docs for kommander 1.3. Konvoy rename will happen later with konvoy/kommander unification work.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.