### PR TITLE
Konvoy is available for more than one public cloud provider (AWS)

### DIFF
--- a/pages/dkp/konvoy/1.4/introduction/index.md
+++ b/pages/dkp/konvoy/1.4/introduction/index.md
@@ -20,11 +20,11 @@ Konvoy provides the following features and functionalities:
 
 - Simplified installation
 
-    Use a simple, single command to install CNCF-certified,high-availability Kubernetes on a public cloud (currently AWS with other cloud providers supported in future releases) or an internal on-prem network.
+    Use a simple, single command to install CNCF-certified,high-availability Kubernetes on a public cloud or an internal on-prem network.
 
 - Infrastructure provisioning
 
-    Provision the cluster infrastructure on cloud provider using Terraform (currently AWS) or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
+    Provision the cluster infrastructure on cloud provider using Terraform or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
 
 - Core addons for networking and storage production-readiness
 

--- a/pages/dkp/konvoy/1.5/introduction/index.md
+++ b/pages/dkp/konvoy/1.5/introduction/index.md
@@ -20,11 +20,11 @@ Konvoy provides the following features and functionalities:
 
 - Simplified installation
 
-    Use a simple, single command to install CNCF-certified, high-availability Kubernetes on a public cloud (currently AWS with other cloud providers supported in future releases) or an internal on-prem network.
+    Use a simple, single command to install CNCF-certified, high-availability Kubernetes on a public cloud or an internal on-prem network.
 
 - Infrastructure provisioning
 
-    Provision the cluster infrastructure on cloud provider using Terraform (currently AWS) or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
+    Provision the cluster infrastructure on cloud provider using Terraform or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
 
 - Core addons for networking and storage production-readiness
 

--- a/pages/dkp/konvoy/1.6/introduction/index.md
+++ b/pages/dkp/konvoy/1.6/introduction/index.md
@@ -21,11 +21,11 @@ Konvoy provides the following features and functionalities:
 
 - Simplified installation
 
-    Use a simple, single command to install CNCF-certified, high-availability Kubernetes on a public cloud (currently AWS with other cloud providers supported in future releases) or an internal on-prem network.
+    Use a simple, single command to install CNCF-certified, high-availability Kubernetes on a public cloud or an internal on-prem network.
 
 - Infrastructure provisioning
 
-    Provision the cluster infrastructure on cloud provider using Terraform (currently AWS) or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
+    Provision the cluster infrastructure on cloud provider using Terraform or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
 
 - Core addons for networking and storage production-readiness
 

--- a/pages/dkp/konvoy/1.7/introduction/index.md
+++ b/pages/dkp/konvoy/1.7/introduction/index.md
@@ -21,11 +21,11 @@ Konvoy provides the following features and functionalities:
 
 - Simplified installation
 
-    Use a simple, single command to install CNCF-certified, high-availability Kubernetes on a public cloud (currently AWS with other cloud providers supported in future releases) or an internal on-prem network.
+    Use a simple, single command to install CNCF-certified, high-availability Kubernetes on a public cloud or an internal on-prem network.
 
 - Infrastructure provisioning
 
-    Provision the cluster infrastructure on cloud provider using Terraform (currently AWS) or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
+    Provision the cluster infrastructure on cloud provider using Terraform or pre-deploy a physical or virtual infrastructure, then deploy using Konvoy.
 
 - Core addons for networking and storage production-readiness
 


### PR DESCRIPTION
This PR fixes the following problem. Konvoy documentation still mentions AWS as the only supported cloud provider for versions 1.7, 1.6, 1.5, and 1.4. At the same time, Konvoy is available for more than one public cloud provider starting at least from v1.4

## Jira Ticket
https://jira.d2iq.com/browse/COPS-6754

## Description of changes being made
Remove mentions of AWS as the only supported cloud provider.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.