### PR TITLE
konvoy: Update 1.5 docs

### DIFF
--- a/pages/dkp/konvoy/1.5/install/bastion-hosts/index.md
+++ b/pages/dkp/konvoy/1.5/install/bastion-hosts/index.md
@@ -241,7 +241,7 @@ spec:
     bastion: true
     count: 2
     machine:
-      imageID: OpenLogic:CentOS:7.7:7.7.2020042900
+      imageID: OpenLogic:CentOS:7.7:7.7.2020111300
       rootVolumeSize: 40
       rootVolumeType: Standard_LRS
       imagefsVolumeEnabled: false

--- a/pages/dkp/konvoy/1.5/install/install-airgapped/index.md
+++ b/pages/dkp/konvoy/1.5/install/install-airgapped/index.md
@@ -460,20 +460,20 @@ spec:
   - configRepository: /opt/konvoy/artifacts/kubernetes-base-addons
     configVersion: stable-1.17-2.5.0
     addonRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.5.4
+      image: mesosphere/konvoy-addons-chart-repo:v1.5.5
     addonsList:
     ...
   - configRepository: /opt/konvoy/artifacts/kubeaddons-dispatch
     configVersion: stable-1.17-1.2.2
     addonRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.5.4
+      image: mesosphere/konvoy-addons-chart-repo:v1.5.5
     addonsList:
     - name: dispatch # Dispatch is currently in Beta
       enabled: false
   - configRepository: /opt/konvoy/artifacts/kubeaddons-kommander
     configVersion: stable-1.17-1.1.2
     addonRepository:
-      image: mesosphere/konvoy-addons-chart-repo:v1.5.4
+      image: mesosphere/konvoy-addons-chart-repo:v1.5.5
     addonsList:
     - name: kommander
       enabled: false

--- a/pages/dkp/konvoy/1.5/install/install-azure/advanced-provisioning/index.md
+++ b/pages/dkp/konvoy/1.5/install/install-azure/advanced-provisioning/index.md
@@ -50,7 +50,7 @@ spec:
   - name: worker
     count: 6
     machine:
-      imageID: OpenLogic:CentOS:7.7:7.7.2020042900
+      imageID: OpenLogic:CentOS:7.7:7.7.2020111300
       rootVolumeSize: 80
       rootVolumeType: Standard_LRS
       imagefsVolumeEnabled: true
@@ -61,7 +61,7 @@ spec:
     controlPlane: true
     count: 3
     machine:
-      imageID: OpenLogic:CentOS:7.7:7.7.2020042900
+      imageID: OpenLogic:CentOS:7.7:7.7.2020111300
       rootVolumeSize: 80
       rootVolumeType: StandardSSD_LRS
       imagefsVolumeEnabled: true

--- a/pages/dkp/konvoy/1.5/release-notes/index.md
+++ b/pages/dkp/konvoy/1.5/release-notes/index.md
@@ -23,6 +23,26 @@ Rate limiting happens on a per-pull basis regardless of whether the pulled image
 
 For more information on addressing this limit, refer to this [procedure](../operations/manage-docker-hub-rate-limits).
 
+### Version v1.5.5 - Released 12 January 2020
+
+| Kubernetes Support | Version |
+| ------------------ | ------- |
+|**Minimum** | 1.15.4 |
+|**Maximum** | 1.17.x |
+|**Default** | 1.17.16 |
+
+#### Bug Fixes
+
+- Azure: Fix a Terraform template error that prevented `inventory.yaml` files from being created when using `spec.azure.loadbalancer.internal: true`.
+- Azure: Change the default Azure image to `OpenLogic:CentOS:7.7:7.7.2020111300` (CentOS 7.7) because `OpenLogic:CentOS:7.7:7.7.2020042900` is no longer available. See [instructions](../tutorials/update-worker-machines/index.md) on how to replace a node pool.
+- CLI: Wait for an addon to be deleted before printing `[OK]` message. (COPS-6692)
+
+#### Component version changes
+
+- Docker `v19.03.14`
+- Go `1.14.13`
+- Kubernetes `v1.17.16`
+
 ### Version v1.5.4 - Released 9 December 2020
 
 | Kubernetes Support | Version |

--- a/pages/dkp/konvoy/1.5/release-notes/index.md
+++ b/pages/dkp/konvoy/1.5/release-notes/index.md
@@ -23,7 +23,7 @@ Rate limiting happens on a per-pull basis regardless of whether the pulled image
 
 For more information on addressing this limit, refer to this [procedure](../operations/manage-docker-hub-rate-limits).
 
-### Version v1.5.5 - Released 12 January 2020
+### Version v1.5.5 - Released 12 January 2021
 
 | Kubernetes Support | Version |
 | ------------------ | ------- |

--- a/pages/dkp/konvoy/1.5/version-support/index.md
+++ b/pages/dkp/konvoy/1.5/version-support/index.md
@@ -1,0 +1,68 @@
+---
+layout: layout.pug
+navigationTitle: Version Support Policy
+title: Version Support Policy
+menuWeight: 280
+excerpt: Supported version policy for Konvoy
+beta: true
+enterprise: false
+---
+
+D2iQ&reg; supports N-2 of the latest `MAJOR.MINOR` version of Konvoy&reg;. For example, if the current version of Konvoy is version 1.5, then D2iQ supports all patch versions of Konvoy 1.5, 1.4, and 1.3.
+
+When the 1.6.0 version releases, support continues for 1.5, and 1.4. Support for Konvoy version 1.3.x expires. Users should upgrade their Konvoy clusters with every new release to stay up-to-date with the latest features and bug fixes.
+
+You can read more about our official support policy in [D2iQ Support and Maintenance Terms](https://d2iq.com/legal/support-terms).
+
+## Supported Kubernetes versions
+
+Each Konvoy release supports a range of Kubernetes versions. The [Release Notes](../release-notes) describe these versions.
+
+For example, Konvoy 1.5.0 supports:
+
+| Kubernetes Support | Version |
+| ------------------ | ------- |
+|**Minimum** | 1.15.4 |
+|**Maximum** | 1.18.13 |
+|**Default** | 1.18.13 |
+
+## Supported operating systems
+
+Details for supported operating systems on Konvoy can be found in [Supported Operating Systems](../install/supported-operating-systems).
+
+## Supported Kubernetes-Base-Addons (KBA) versions
+
+Konvoy support for KBA depends on the Kubernetes version it deploys with. Every KBA release has the supported Kubernetes version in its tag.
+
+For example, KBA version `stable-1.17-2.1.1` is made up of:
+
+```text
+<release_channel>-<kubernetes_version>-<kba_version>
+```
+
+This means this set of addons can deploy on any 1.17 Kubernetes cluster, regardless of the distribution. The support policy for KBA on Konvoy follows the same support policy for [Kubernetes versions](#supported-kubernetes-versions). You can find more details for KBA under [Kubernetes Base Addons](../addons).
+
+### Experimental Status
+"Experimental" means software, features, functionality, sample configurations, or other speculative content that is still under exploration, development, or testing by D2iQ. Experimental components carry no guarantee of eventual release as GA and therefore must not be used in Production Environments. Experimental components qualify for limited, Severity 4 support only and may be discontinued at any time, with or without notice.
+
+Since Experimental components are not intended for Production Environment use, D2iQ cannot assume any responsibility for errors occurring during their use in Production. We can offer only these services in a commercially-reasonable manner, based on the availability of relevant subject matter experts (SMEs):
+
+- General operational guidance for the Experimental component.
+- Identifying and diagnosing of errors in configuration or implementation, if possible.
+- Advice on preventing and recovering from failures and troubleshooting, as available.
+
+Support for Experimental components is provided on a Standard level, Severity 4 basis only.
+
+## Supported Kommander Versions
+
+The following chart identifies which version of Konvoy supports which version of Kommander.
+
+| Konvoy Version | Kommander Version |
+| -------------- | ----------------- |
+| 1.5.x | 1.1.x |
+| 1.4.x | 1.0.x |
+
+Konvoy and Kommander release `MAJOR.MINOR` versions together and are compatible with each other for that version set. This means, Kommander 1.1, and all of its patch versions (e.g. 1.1.0, 1.1.1), can deploy successfully on any version of Konvoy 1.5. Mixing minor versions is prohibited and the following is not supported:
+
+- You cannot deploy Kommander 1.1.x on Konvoy 1.4.x
+- You cannot deploy Kommander 1.0.x on Konvoy 1.3.x


### PR DESCRIPTION
Release docs for Konvoy v1.5.5.
https://jira.d2iq.com/browse/D2IQ-73794

Release needed for https://jira.d2iq.com/browse/D2IQ-73767