### PR TITLE
[op docs] Remove konvoy download instructions from kommander docs

### DIFF
--- a/pages/dkp/kommander/1.3/install/index.md
+++ b/pages/dkp/kommander/1.3/install/index.md
@@ -10,50 +10,22 @@ excerpt: Getting started with Kommander
 Kommander is a tool that provides a command console for deploying, monitoring, and managing production-ready Kubernetes clusters on an enterprise scale. Kommander supports both Konvoy and non-Konvoy clusters.
 
 # Before you begin
-Prerequisites for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/dkp/konvoy/1.6/quick-start/#prequisites) for information.
+Prerequisites for Kommander are the same as those for Konvoy. See the [Konvoy Prerequisites](/dkp/konvoy/1.7/quick-start/#prequisites) for information.
 
 # Download and Install
-You must download Konvoy with Kommander, see the [Download Konvoy](/dkp/konvoy/1.6/download/) topic for information.
-
-Download the tarball to your local Downloads directory.
-
-For example, if you are installing on MacOS, download the compressed archive to the default `~/Downloads` directory.
-Afterward, extract the tarball to your local system by running the following command.
-**Note** Check the name of the file that you downloaded, and change konvoy-kommander_darwin.tar.bz2 accordingly):
-
-```
-tar -xf ~/Downloads/konvoy-kommander_darwin.tar.bz2
-```
-
-Copy the Konvoy package files to a directory in your user's `PATH` to ensure you can invoke the konvoy command from any directory.
-
-For example, copy the package to `/usr/local/bin/` by returning to the directory that Kommander was extracted to, and running the following command:
-
-```
-sudo cp ~/Downloads/darwin/konvoy-kommander/* /usr/local/bin/
-```
-
-<p class="message--note"><strong>NOTE:</strong> The extracted folder may have a different name (such as `konvoy_dev`, or perhaps it was given a custom directory, or have the version affixed to the end of the directory name).</p>
-
-Check version
-
-```
-konvoy --version
-```
-
-After you have the newest version of Konvoy, move into the directory where you would like to test. Note, you will have to confirm your access to your cloud or internal network provider, or you may encounter a message that says `failed to deploy the cluster: error provisioning cluster`.
-
-Once done, run this command:
-
-```
-konvoy up
-```
+Kommander is provided by Konvoy by default as part of [Kubernetes Base Addons](/dkp/konvoy/1.7/addons/). See the [Download Konvoy](/dkp/konvoy/1.7/download/) topic for more information on how to download Konvoy. Once Konvoy is downloaded, see [Installing Konvoy](/dkp/konvoy/1.7/quick-start/#prequisites) for instructions on how to install it. Once Konvoy is installed with the default settings, Kommander is automatically provided on the cluster.
 
 # Log in with Username and Password
-After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Log in to Konvoy, and look for the "Try Kommander" button. If it's not there, ensure you've installed the Konvoy release that includes Kommander.
+After you provision your first Konvoy cluster, your randomly-generated username, password, and a URL to Konvoy are printed to the command-line. Log in to Konvoy, and look for the "Kommander" button in the left sidebar. If it's not there, ensure you've installed the Konvoy release that includes Kommander, and that the Kommander addon is enabled.
 
-To retrieve this information again, use the following command:
+To retrieve the login information again, use the following command:
 
 ```
 konvoy get ops-portal
+```
+
+You can also reach the Kommander UI via this url, given that Kommander is deployed on the cluster:
+
+```
+https://<CLUSTER_URL>/ops/portal/kommander/ui
 ```


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->
https://jira.d2iq.com/browse/D2IQ-62854

## Description of changes being made
Looks like konvoy docs do not include specific details on download instructions, so we should remove them from kommander and just link to the konvoy docs.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.