### PR TITLE
Updating dead link in the page.

### DIFF
--- a/pages/dkp/konvoy/1.6/include/enforce-policies-w-gatekeeper.tmpl
+++ b/pages/dkp/konvoy/1.6/include/enforce-policies-w-gatekeeper.tmpl
@@ -73,7 +73,7 @@ Constraints are then used to inform Gatekeeper that the admin wants a Constraint
 Create the privileged pod policy constraint `psp-privileged-container` by running the following command:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/library/pod-security-policy/privileged-containers/constraint.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/constraint.yaml
 ```
 
 #### Test that the constraint is enforced
@@ -81,13 +81,12 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/
 Try to create a privileged pod by running the following command:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/library/pod-security-policy/privileged-containers/example.yaml
-```
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/example_disallowed.yaml
 
 You should see the following output:
 
 ```bash
-Error from server ([denied by psp-privileged-container] Privileged container is not allowed: nginx, securityContext: {"privileged": true}): error when creating "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/library/pod-security-policy/privileged-containers/example.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [denied by psp-privileged-container] Privileged container is not allowed: nginx, securityContext: {"privileged": true}
+Error from server ([denied by psp-privileged-container] Privileged container is not allowed: nginx, securityContext: {"privileged": true}): error when creating "https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/example_disallowed.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [denied by psp-privileged-container] Privileged container is not allowed: nginx, securityContext: {"privileged": true}
 ```
 
 ### Prevent host path volumes
@@ -97,7 +96,7 @@ Error from server ([denied by psp-privileged-container] Privileged container is 
 Create the host path volume policy constraint template `k8spsphostfilesystem` by running the following command:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/library/pod-security-policy/host-filesystem/template.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/host-filesystem/template.yaml
 ```
 
 #### Define the Constraint
@@ -191,7 +190,7 @@ pod/nginx-host-filesystem created
 ```
 
 [gatekeeper]:https://github.com/open-policy-agent/gatekeeper
-[gatekeeper-psp]:https://github.com/open-policy-agent/gatekeeper-library/tree/master/library/pod-security-policy
+[gatekeeper-library]:https://github.com/open-policy-agent/gatekeeper-library/tree/master/library/pod-security-policy
 [opa]:https://github.com/open-policy-agent/opa
 [opa-constraints]:https://github.com/open-policy-agent/frameworks/tree/master/constraint
 [opa-rego]:https://www.openpolicyagent.org/docs/latest/policy-language/


### PR DESCRIPTION
Updating the dead links based on OPA's current structure. They moved the library to a new Github repository https://github.com/open-policy-agent/gatekeeper-library.

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.