### PR TITLE
Update KBA release notes with missing fix

### DIFF
--- a/pages/dkp/konvoy/1.7/release-notes/kubernetes-base-addon/index.md
+++ b/pages/dkp/konvoy/1.7/release-notes/kubernetes-base-addon/index.md
@@ -43,6 +43,7 @@ February 10, 2020
 
 -   Velero
     - Upgrade Velero to 1.5.2 and minio 8.0.8. Users can now use the official velero client, where before users needed to use a patched velero client.
+    - Upgrade kubeaddons-addon-initializer init container to v0.4.3. This fixes the issue that was making it impossible to use a custom S3Url in Velero.
 
 December 19, 2020
 


### PR DESCRIPTION
## Jira Ticket
This follows a comment on https://jira.d2iq.com/browse/COPS-6675 : https://jira.d2iq.com/browse/COPS-6675?focusedCommentId=358663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-358663

The release notes on GitHub have been updated as well.

## Description of changes being made


## Checklist
- [X] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [X] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.