### PR TITLE
use the "real" export

### DIFF
--- a/js/cve.js
+++ b/js/cve.js
@@ -220,6 +220,8 @@ const shield = (color) => (
 ///////////////////////////////////////////////////////////////////////////////
 //                                    APP                                    //
 ///////////////////////////////////////////////////////////////////////////////
+const reportURL =
+  "https://konvoy-staging-devx-cac8-cve-reporter.s3-us-west-2.amazonaws.com/vulnerability_report_latest.json";
 const App = () => {
   React.useEffect(() => {
     // we have a lot of entries in the list that only differ in `resource_purl`.
@@ -228,7 +230,7 @@ const App = () => {
       Object.values(groupBy(cves, (c) => c.vulnerability_name)).map((group) => {
         return { ...group[0], purls: group.map((c) => c.resource_purl) };
       });
-    fetch("/assets/konvoy_cves.json")
+    fetch(reportURL)
       .then((r) => r.json())
       .then((cves) => onUpdate({ cves })); //: foldPurlsByVulnName(cves) }));
   }, []);


### PR DESCRIPTION
the CVE-export is now directly pulled from its S3-bucket, so changes
will automatically propagate.
note that we set the caching-headers on the export to 24h.

# testing

testing this is rather complicated. i suggest merging this to staging and then trying to access the table on https://docs-staging.d2iq.com/dkp/security-updates/ to see that there's an XHR-request pulling the data. i tested this upfront with some js-trickery for `https://docs.d2iq.com` and `https://docs-staging.d2iq.com`.