### PR TITLE
mark mitigated entries and add an according filter

### DIFF
--- a/scss/base/_content.scss
+++ b/scss/base/_content.scss
@@ -14,6 +14,7 @@ $sections-size: 20%;
     flex-direction: column;
     min-width: 0;
     padding: 40px;
+    width: 100%;
   }
   &__404 {
     margin-bottom: -160px;

--- a/scss/components/_cve-table.scss
+++ b/scss/components/_cve-table.scss
@@ -8,7 +8,7 @@
 
   @media screen and (min-width: 1200px) {
     grid-template-areas:
-      ". filter pagination"
+      "filter filter pagination"
       "main main main"
       ". . perPage";
     grid-template-columns: 1fr 3fr 1fr;
@@ -25,6 +25,10 @@
   }
 }
 
+.muted {
+  background-color: #f3f4f5;
+}
+
 .cve-pagination {
   align-self: center;
   text-align: right;
@@ -36,6 +40,7 @@
     text-align: center;
     padding: 1px 0 3px 0px;
     border: 1px solid #DADDE2;
+    border-radius: .25rem;
   }
   span {
     padding: 0 .5em;
@@ -78,22 +83,37 @@
 }
 
 .cve-filter {
-  display: flex;
   grid-area: filter;
   align-self: center;
-  justify-self: center;
+  // justify-self: center;
   margin-bottom: 1rem;
   cursor: pointer;
+  > * {
+    border-radius: .25em;
+    border: 1px solid #DADDE2;
+    margin-bottom: .5rem;
+  }
+  @media screen and (min-width: 480px) {
+    display: flex;
+    > * {
+      display: flex;
+      margin-bottom: 0;
+      margin-right: 1rem;
+      > * + * { border-left: 1px solid #DADDE2; }
+    }
+  }
 }
 .cve-filter-button {
   display: flex;
   align-items: center;
-  border: 1px solid #DADDE2;
   margin-left: -1px;
   color: #76797E;
   font-weight: 600;
   padding: .5rem;
-  &.active { box-shadow: #7D58FF inset 0px -1px; }
+  &.active { box-shadow: #7D58FF inset 2px 0; }
+  @media screen and (min-width: 480px) {
+    &.active { box-shadow: #7D58FF inset 0 -1px; }
+  }
   svg {
     width: 20px;
   }
@@ -128,10 +148,11 @@
     position: absolute;
     text-align: center;
     visibility: hidden;
-    max-width: 300px;
+    max-width: 250px;
     left: 50%;
     transform: translateX(-50%);
     z-index: 1;
+    width: max-content;
 
     &::after {
       border-color: #221944 transparent transparent transparent;
@@ -143,6 +164,16 @@
       position: absolute;
       top: 100%;
     }
+    &.tip-bottom {
+      bottom: auto;
+      top: 100%;
+      &::after {
+        top: auto;
+        bottom: 100%;
+        border-color:  transparent transparent #221944 transparent;
+      }
+    }
   }
+
   &:hover .tip { visibility: visible; }
 }


### PR DESCRIPTION
this lets customers see the difference between mitigated and non-mitigated issues.

things done and looking for more opiniones/suggestions:

- grey out the background of a mitigated CVE
- strikethrough the severity when the CVE is mitigated
- add a tooltip to this striked severity: **"Mitigated - see Addtional Explanation"**
- add a filter-button right to the severity-filters to hide mitigated CVEs. it's filtering by default, so one has to click it to see all the CVEs of the export.
- move filters to the left, so we can fit one more button easily above the table
- adapted responsiveness (so it does not look rubbish on mobile devices)


we might want to run this by the UX-department as i feel like that
eye-button is rather not intention-revealing at first sight.

# have a look here:

https://user-images.githubusercontent.com/300861/108495520-2cb48680-72a9-11eb-88fc-91646c1052c6.mp4

