### PR TITLE
fix: account for cluster CA being empty

### DIFF
--- a/pages/dkp/kommander/1.0/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.0/clusters/attach-cluster/index.md
@@ -49,7 +49,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ index .cluster "certificate-authority-data" }}{{end}}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 

--- a/pages/dkp/kommander/1.0/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.0/clusters/attach-cluster/index.md
@@ -49,7 +49,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}"{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}"{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 

--- a/pages/dkp/kommander/1.1/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.1/clusters/attach-cluster/index.md
@@ -50,7 +50,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}"{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}"{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 

--- a/pages/dkp/kommander/1.1/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.1/clusters/attach-cluster/index.md
@@ -50,7 +50,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ index .cluster "certificate-authority-data" }}{{end}}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 

--- a/pages/dkp/kommander/1.2/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.2/clusters/attach-cluster/index.md
@@ -51,7 +51,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}"{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}"{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 

--- a/pages/dkp/kommander/1.2/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.2/clusters/attach-cluster/index.md
@@ -51,7 +51,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ index .cluster "certificate-authority-data" }}{{end}}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 

--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
@@ -31,7 +31,7 @@ Next, configure the new service account for `cluster-admin` permissions:
 
 ```shell
 cat << EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kommander-cluster-admin

--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
@@ -53,7 +53,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}"{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}"{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 

--- a/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.3/clusters/attach-cluster/index.md
@@ -53,7 +53,7 @@ export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-clu
 export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
 export CURRENT_CONTEXT=$(kubectl config current-context)
 export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ index .cluster "certificate-authority-data" }}{{end}}{{ end }}')
+export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}{{ end }}{{ end }}')
 export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
 ```
 


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made
In some kubeconfigs the cluster-certificate-authority-data field of a
cluster might not exist, causing 'CLUSTER_CA' to be set to '<no
value>'. With this patch, it is set to the empty string.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.