### PR TITLE
remove text related to default network policy

### DIFF
--- a/pages/dkp/kommander/1.3/projects/project-network-policies/index.md
+++ b/pages/dkp/kommander/1.3/projects/project-network-policies/index.md
@@ -20,10 +20,6 @@ By default, and to enable fluid communications within and between clusters, all 
 
 A Network Policy's rules define ingress and egress for network communications between pods and across namespaces. Successful traffic control using network policies is bi-directional. You have to configure both the egress policy on the source pod and the ingress policy on the destination pod to enable the traffic. If either end denies the traffic, it will not flow between the pods.
 
-Since the Kubernetes default is to allow all traffic, it's a common practice to create a default "deny all traffic" rule, and then specifically open up some combination of the pods, ports, and applications as needed.
-
-When you first create a Project, Kommander automatically creates a NetworkPolicy that allows traffic originating only within your Project namespace. Pods cannot talk to Pods outside of that namespace, by default. If you want to enable incoming traffic from other namespaces and pods, then you have to create a NetworkPolicy with ingress rules.
-
 Kommander ensures that any network policies that you create in a project get applied to all target clusters in the project.
 
 # Creating Network Policies


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->
D2IQ-74497 related to COPS-6839

## Description of changes being made
Remove text related to default network policy, will be removed in this PR: https://github.com/mesosphere/yakcl/pull/355

DO NOT MERGE until the change is merged into the new konvoy release.

This change is a blocker for the next release.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `staging`, not `master`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.