### PR TITLE
Remove ref to staging from PR template...

### DIFF
--- a/pull_request_template
+++ b/pull_request_template
@@ -9,7 +9,6 @@ Before creating this pull request, make sure you have a separate ticket for the 
 ## Checklist
 - [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
 - [ ] Test all commands and procedures, if applicable.
-- [ ] Create your PR against `staging`, not `master`. 
 - [ ] Update all links if you are moving a page.
 - [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`
 


### PR DESCRIPTION
## Jira Ticket
No ticket...

## Description of changes being made

Remove comment about 'staging' branch from PR template to avoid confusion.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ Haha! ] Create your PR against `staging`, not `master`.  
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> ie `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.