### PR TITLE
Drop 2-click benefit from Kaptain

### DIFF
--- a/pages/dkp/kaptain/1.2.0-1.0.0/introducing/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/introducing/index.md
@@ -21,4 +21,3 @@ If you want to learn more, please read our [blog post for Kaptain](https://d2iq.
  |
 | Train, tune, and deploy from a Jupyter notebook   | No context switching or credentials and CLI tools on individuals' laptops    |
 | Enterprise-grade security controls and profiles   | Multi-tenancy? No problem!                                      |
-| Two-click installation from Kommander             | Faster ROI. Focus on what's important: data science             |


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-74551

## Description of changes being made
Drop the "2-click installation from Kommander" benefit from Kaptain as it's bogus.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [X] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.