### PR TITLE
[COPS-6869] adding bit about upgrading prometheus helm conflicts

### DIFF
--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -30,6 +30,27 @@ kubectl -n kube-system delete deployment tiller-deploy
 
 This command shuts down Tiller gracefully and removes all its resources.
 
+## Upgrading Prometheus
+
+If you have the prometheus and prometheusadapter addons enabled and are upgrading those, you will need to take additional steps to ensure they deploy successfully. You will need to delete the addons and then upgrade and deploy them.
+
+Before you begin the upgrade, you can run this command to get delete them:
+
+```bash
+kubectl delete addon prometheus -n kubeaddons
+helm2 delete --purge prometheus-kubeaddons
+```
+
+If you've already ran the upgrade and deploying the prometheus and the prometheusadapter addons have failed, run these commands:
+
+```bash
+kubectl delete addon prometheus -n kubeaddons
+helm2 delete --purge prometheus-kubeaddons
+konvoy deploy addons
+```
+
+The reason for these failures is because there are limitations on the size of large configmaps in the migration of Helm v2 to Helm v3.
+
 ## Related information
 
 For information on related topics or procedures, refer to the following:

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -41,7 +41,7 @@ kubectl delete addon prometheus -n kubeaddons
 helm2 delete --purge prometheus-kubeaddons
 ```
 
-If you've already ran the upgrade and deploying the prometheus and the prometheusadapter addons have failed, run these commands:
+If you've already run the upgrade and deploying the prometheus addon has failed, run these commands:
 
 ```bash
 kubectl delete addon prometheus -n kubeaddons

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -32,7 +32,7 @@ This command shuts down Tiller gracefully and removes all its resources.
 
 ## Upgrading Prometheus
 
-If you have the prometheus addon enabled and are upgrading it, you need to take additional steps to ensure it deploys successfully. You must delete the addon and then upgrade and deploy it.
+If you have the prometheus addon enabled, you must delete the addon before upgrading.
 
 Before you begin the upgrade, run the following command to delete the addon:
 

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -37,8 +37,7 @@ If you have the prometheus addon enabled, you must delete the addon before upgra
 Before you begin the upgrade, run the following command to delete the addon:
 
 ```bash
-kubectl delete addon prometheus -n kubeaddons
-helm2 delete --purge prometheus-kubeaddons
+kubectl delete addon prometheus --namespace kubeaddons --wait
 ```
 
 If you've already run the upgrade and deploying the prometheus addon has failed, run these commands:

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -34,7 +34,7 @@ This command shuts down Tiller gracefully and removes all its resources.
 
 If you have the prometheus and prometheusadapter addons enabled and are upgrading those, you need to take additional steps to ensure they deploy successfully. You must delete the addons and then upgrade and deploy them.
 
-Before you begin the upgrade, you can run this command to get delete them:
+Before you begin the upgrade, run the following command to get delete them:
 
 ```bash
 kubectl delete addon prometheus -n kubeaddons

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -34,7 +34,7 @@ This command shuts down Tiller gracefully and removes all its resources.
 
 If you have the prometheus and prometheusadapter addons enabled and are upgrading those, you need to take additional steps to ensure they deploy successfully. You must delete the addons and then upgrade and deploy them.
 
-Before you begin the upgrade, run the following command to get delete them:
+Before you begin the upgrade, run the following command to delete the addons:
 
 ```bash
 kubectl delete addon prometheus -n kubeaddons

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -49,7 +49,10 @@ helm2 delete --purge prometheus-kubeaddons
 konvoy deploy addons
 ```
 
-These failures happen because there are limitations on the size of large configmaps in the migration of Helm v2 to Helm v3.
+The migration of a helm release from helm v2 to helm v3 adds additional metadata to the release data structure.
+This additional data causes the Prometheus release data to exceed the maximum size of a ConfigMap or Secret.
+Newer versions of the Prometheus chart reduces the amount of data held in this release structure, but the conversion will fail preventing the newer Prometheus chart installation from being reached.
+Removing the oversized data from Kubernetes allows the replacement to continue.
 
 ## Related information
 

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -49,7 +49,7 @@ helm2 delete --purge prometheus-kubeaddons
 konvoy deploy addons
 ```
 
-The migration of a helm release from helm v2 to helm v3 adds additional metadata to the release data structure.
+The migration of a helm release from Helm v2 to Helm v3 adds additional metadata to the release data structure.
 This additional data causes the Prometheus release data to exceed the maximum size of a ConfigMap or Secret.
 Newer versions of the Prometheus chart reduces the amount of data held in this release structure, but the conversion will fail preventing the newer Prometheus chart installation from being reached.
 Removing the oversized data from Kubernetes allows the replacement to continue.

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -34,7 +34,7 @@ This command shuts down Tiller gracefully and removes all its resources.
 
 If you have the prometheus addon enabled and are upgrading it, you need to take additional steps to ensure it deploys successfully. You must delete the addon and then upgrade and deploy it.
 
-Before you begin the upgrade, run the following command to delete the addons:
+Before you begin the upgrade, run the following command to delete the addon:
 
 ```bash
 kubectl delete addon prometheus -n kubeaddons

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -32,7 +32,7 @@ This command shuts down Tiller gracefully and removes all its resources.
 
 ## Upgrading Prometheus
 
-If you have the prometheus and prometheusadapter addons enabled and are upgrading those, you need to take additional steps to ensure they deploy successfully. You must delete the addons and then upgrade and deploy them.
+If you have the prometheus addon enabled and are upgrading it, you need to take additional steps to ensure it deploys successfully. You must delete the addon and then upgrade and deploy it.
 
 Before you begin the upgrade, run the following command to delete the addons:
 

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -40,12 +40,20 @@ Before you begin the upgrade, run the following command to delete the addon:
 kubectl delete addon prometheus --namespace kubeaddons --wait
 ```
 
-If you've already run the upgrade and deploying the prometheus addon has failed, run these commands:
+If you've **already run the upgrade and deploying the prometheus addon has failed**, run this command:
 
 ```bash
-kubectl delete addon prometheus -n kubeaddons
 helm2 delete --purge prometheus-kubeaddons
-konvoy deploy addons
+```
+
+This assumes helm2 CLI has been installed. If it hasn't, you will need to install it.
+If you've already ran the Konvoy upgrade, the Addon resource has been updated.
+After you've deleted this old Helm data from the above command and the failing helm release has been removed, kubeaddons can successfully reconcile the Addon.
+
+If you want to verify the status of your prometheus addon state, you can monitor that with the following:
+
+```bash
+kubectl --namespace kubeaddons get addon prometheus --watch
 ```
 
 The migration of a helm release from Helm v2 to Helm v3 adds additional metadata to the release data structure.

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -49,7 +49,7 @@ helm2 delete --purge prometheus-kubeaddons
 konvoy deploy addons
 ```
 
-The reason for these failures is because there are limitations on the size of large configmaps in the migration of Helm v2 to Helm v3.
+These failures happen because there are limitations on the size of large configmaps in the migration of Helm v2 to Helm v3.
 
 ## Related information
 

--- a/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
+++ b/pages/dkp/konvoy/1.6/addons/helmv2-to-v3-migration/index.md
@@ -32,7 +32,7 @@ This command shuts down Tiller gracefully and removes all its resources.
 
 ## Upgrading Prometheus
 
-If you have the prometheus and prometheusadapter addons enabled and are upgrading those, you will need to take additional steps to ensure they deploy successfully. You will need to delete the addons and then upgrade and deploy them.
+If you have the prometheus and prometheusadapter addons enabled and are upgrading those, you need to take additional steps to ensure they deploy successfully. You must delete the addons and then upgrade and deploy them.
 
 Before you begin the upgrade, you can run this command to get delete them:
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to Helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
 For more information, see <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 ### Supported versions

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
@@ -87,8 +87,6 @@ Add links to previous release notes
 
 <!-- Add links to external documentation as needed -->
 
-For information about installing and using Konvoy, see the [Konvoy documentation][konvoy-doc].
-
 For information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
 
 [konvoy-doc]: ../../index.md

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
@@ -20,7 +20,8 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+For more information, see <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 ### Supported versions
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 ### Supported versions
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.1/index.md
@@ -20,6 +20,8 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+
 ### Supported versions
 
 | Kubernetes Support | Version |

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
@@ -30,7 +30,7 @@ This release provides new features and enhancements to improve the user experien
 
 ### Known Issues
 
-There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to Helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
 For more information, see [Helm v2 to v3 migration](../../addons/helmv2-to-v3-migration/)
 
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 ### Supported versions
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
@@ -30,7 +30,8 @@ This release provides new features and enhancements to improve the user experien
 
 ### Known Issues
 
-When upgrading from 1.5.x to 1.6.2, there are some limitations due to the Helm v2 to Helm v3 migration of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more information, see [Helm v2 to v3 migration](../../addons/helmv2-to-v3-migration/)
+There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+For more information, see [Helm v2 to v3 migration](../../addons/helmv2-to-v3-migration/)
 
 
 ### New features and capabilities

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
@@ -20,8 +20,6 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
-
 ### Supported versions
 
 | Kubernetes Support | Version |
@@ -29,6 +27,11 @@ This release provides new features and enhancements to improve the user experien
 |**Minimum** | 1.16.x |
 |**Maximum** | 1.18.x |
 |**Default** | 1.18.13 |
+
+### Known Issues
+
+When upgrading from 1.5.x to 1.6.2, there are some limitations due to the Helm v2 to Helm v3 migration of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more information, see [Helm v2 to v3 migration](../../addons/helmv2-to-v3-migration/)
+
 
 ### New features and capabilities
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6.2/index.md
@@ -20,6 +20,8 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+
 ### Supported versions
 
 | Kubernetes Support | Version |

--- a/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to Helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
 For more information, see <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 ### Supported versions

--- a/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
@@ -20,7 +20,8 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+For more information, see <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 ### Supported versions
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
@@ -20,7 +20,7 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 ### Supported versions
 

--- a/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
+++ b/pages/dkp/konvoy/1.6/release-notes/1.6/index.md
@@ -20,6 +20,8 @@ enterprise: false
 
 This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy.
 
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+
 ### Supported versions
 
 | Kubernetes Support | Version |

--- a/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
@@ -87,7 +87,8 @@ It is recommended to upgrade to the newest supported version of Containerd, set 
 
 The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.18-3.3.0`.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+For more information, see <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.18-1.2.1`.
 

--- a/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
@@ -87,6 +87,8 @@ It is recommended to upgrade to the newest supported version of Containerd, set 
 
 The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.18-3.3.0`.
 
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+
 If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.18-1.2.1`.
 
 The version of Konvoy is now `v1.6.2`, set `spec.version: v1.6.2`.

--- a/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
@@ -87,7 +87,7 @@ It is recommended to upgrade to the newest supported version of Containerd, set 
 
 The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.18-3.3.0`.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy these addons. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.2: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large configmaps to smaller restricted secrets for Prometheus and the need to delete and redeploy this addon. For more, see our page on <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.18-1.2.1`.
 

--- a/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.6/upgrade/upgrade-cli/index.md
@@ -87,7 +87,7 @@ It is recommended to upgrade to the newest supported version of Containerd, set 
 
 The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.18-3.3.0`.
 
-<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
+<p class="message--note"><strong>NOTE: </strong>A note on upgrading from 1.5.x to 1.6.1: There are some limitations upgrading to this Konvoy version due to the migration of Helm v2 to Helm v3 of large ConfigMaps to Helm v3 Secrets for Prometheus and the need to delete and redeploy this addon.
 For more information, see <a href="../../addons/helmv2-to-v3-migration/">Helm v2 to v3 migration</a>.</p>
 
 If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.18-1.2.1`.


### PR DESCRIPTION
## Jira Ticket
[COPS-6869](https://jira.d2iq.com/browse/COPS-6869)

## Description of changes being made
Adding a note about if there is an issue with prometheus failing due to size of configmaps

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.