### PR TITLE
adding beta in dropdown nav for kommander 1.4 and 2.0

### DIFF
--- a/pages/dkp/kommander/1.4/index.md
+++ b/pages/dkp/kommander/1.4/index.md
@@ -1,8 +1,8 @@
 ---
 layout: layout.pug
 beta: true
-navigationTitle: Kommander 1.4
-title: Kommander 1.4
+navigationTitle: Kommander 1.4 beta
+title: Kommander 1.4 beta
 version: 1.4
 featureMaturity:
 category: K-Sphere

--- a/pages/dkp/kommander/2.0/index.md
+++ b/pages/dkp/kommander/2.0/index.md
@@ -1,8 +1,8 @@
 ---
 layout: layout.pug
 beta: true
-navigationTitle: Kommander 2.0
-title: Kommander 2.0
+navigationTitle: Kommander 2.0 beta
+title: Kommander 2.0 beta
 version: 2.0
 featureMaturity:
 enterprise: false


### PR DESCRIPTION
## Jira Ticket
n/a

## Description of changes being made
Updating the dropdown nav menu titles so it accurately says they're beta.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.