### PR TITLE
chore: remove obsolete frontmatter-entries

### DIFF
--- a/pages/dkp/conductor/1.0/index.md
+++ b/pages/dkp/conductor/1.0/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Welcome to Conductor 1.0
 title: Welcome to Conductor 1.0
 beta: false
-category: K-Sphere
 menuWeight: 15
 ---
 

--- a/pages/dkp/conductor/1.1/index.md
+++ b/pages/dkp/conductor/1.1/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Welcome to Conductor 1.1
 title: Welcome to Conductor 1.1
 beta: false
-category: K-Sphere
 menuWeight: 10
 ---
 

--- a/pages/dkp/dispatch/1.0/index.md
+++ b/pages/dkp/dispatch/1.0/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Welcome to Dispatch 1.0
 title: Welcome to Dispatch 1.0
 beta: false
-category: K-Sphere
 menuWeight: 10
 ---
 

--- a/pages/dkp/dispatch/1.1/deployment/tutorials/deploy-application-to-multiple-environments/index.md
+++ b/pages/dkp/dispatch/1.1/deployment/tutorials/deploy-application-to-multiple-environments/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploy an application to multiple clusters
 navigationTitle: Deploy an application to multiple clusters
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to deploy different versions of an application to staging and production environments.
 ---

--- a/pages/dkp/dispatch/1.1/deployment/tutorials/deploy-to-multiple-production-clusters/index.md
+++ b/pages/dkp/dispatch/1.1/deployment/tutorials/deploy-to-multiple-production-clusters/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploy an application to multiple production clusters
 navigationTitle: Deploy an application to multiple production clusters
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to deploy an application to multiple production clusters.
 ---

--- a/pages/dkp/dispatch/1.1/deployment/tutorials/index.md
+++ b/pages/dkp/dispatch/1.1/deployment/tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Tutorials
 title: Tutorials
 beta: false
-category: K-Sphere
 menuWeight: 40
 ---
 

--- a/pages/dkp/dispatch/1.1/deployment/tutorials/trust-self-signed-tls-certificates/index.md
+++ b/pages/dkp/dispatch/1.1/deployment/tutorials/trust-self-signed-tls-certificates/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configure ArgoCD to trust TLS certificates issued by a custom CA
 navigationTitle: Configure ArgoCD to trust TLS certificates issued by a custom CA
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial configures ArgoCD to trust TLS certificates issued by a custom TLS certificates authority (CA).
 ---

--- a/pages/dkp/dispatch/1.1/index.md
+++ b/pages/dkp/dispatch/1.1/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Welcome to Dispatch 1.1
 title: Welcome to Dispatch 1.1
 beta: false
-category: K-Sphere
 menuWeight: 5
 ---
 

--- a/pages/dkp/dispatch/1.1/pipeline-configuration/tutorials/index.md
+++ b/pages/dkp/dispatch/1.1/pipeline-configuration/tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Tutorials
 title: Tutorials
 beta: false
-category: K-Sphere
 menuWeight: 0
 ---
 

--- a/pages/dkp/dispatch/1.1/pipeline-configuration/tutorials/triggering-pipelines-using-chatops/index.md
+++ b/pages/dkp/dispatch/1.1/pipeline-configuration/tutorials/triggering-pipelines-using-chatops/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Running pipelines from ChatOps Commands
 navigationTitle: Running pipelines from ChatOps Commands
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to trigger pipelines from Github comments
 ---

--- a/pages/dkp/dispatch/1.2/index.md
+++ b/pages/dkp/dispatch/1.2/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Welcome to Dispatch 1.2
 title: Welcome to Dispatch 1.2
 beta: false
-category: K-Sphere
 menuWeight: 2
 excerpt: Dispatch provides a declarative CI/CD platform for rapidly deploying Cloud Native applications and enabling enterprises to rapidly build, test and manage applications' lifecycle using GitOps processes.
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/deploy-application-to-multiple-environments/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/deploy-application-to-multiple-environments/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploy an application to multiple clusters
 navigationTitle: Deploy an application to multiple clusters
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to deploy different versions of an application to staging and production environments.
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/deploy-to-multiple-production-clusters/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/deploy-to-multiple-production-clusters/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploy an application to multiple production clusters
 navigationTitle: Deploy an application to multiple production clusters
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to deploy an application to multiple production clusters.
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Continuous Deployment
 title: Continuous Deployment
 beta: false
-category: K-Sphere
 menuWeight: 20
 excerpt: Tutorials for implementing Continuous Deployment for your application.
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/storing-dispatch-secrets-with-gitops/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/storing-dispatch-secrets-with-gitops/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Store secrets in GitOps Repository using SealedSecrets
 navigationTitle: Store secrets in a GitOps Repository using SealedSecrets
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: Securely managing secrets in a GitOps workflow using SealedSecrets
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/trust-self-signed-tls-certificates/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/trust-self-signed-tls-certificates/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configure ArgoCD to trust TLS certificates issued by a custom CA
 navigationTitle: Configure ArgoCD to trust TLS certificates issued by a custom CA
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial configures ArgoCD to trust TLS certificates issued by a custom TLS certificates authority (CA).
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/using-argocd-cli/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/cd_tutorials/using-argocd-cli/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configure the ArgoCD CLI with Dispatch
 navigationTitle: Configure the ArgoCD CLI with Dispatch
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to use the ArgoCD CLI to operate the instance of ArgoCD that is bundled with Dispatch.
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/configuring-cron-triggers/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/configuring-cron-triggers/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring Cron Triggers
 navigationTitle: Configure Cron Based Triggers
 beta: false
-category: K-Sphere
 menuWeight: 60
 excerpt: Schedule CI pipeline runs using cron expressions
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/import-tasks-from-dispatchfile/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/import-tasks-from-dispatchfile/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Importing tasks into a Dispatchfile
 navigationTitle: Import tasks into a Dispatchfile
 beta: false
-category: K-Sphere
 menuWeight: 30
 excerpt: This tutorial describes how to import tasks from another Dispatchfile
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Continuous Integration
 title: Continuous Integration
 beta: false
-category: K-Sphere
 menuWeight: 10
 ---
 

--- a/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/local-runner/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/local-runner/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Run pipelines locally
 navigationTitle: Running pipelines locally
 beta: false
-category: K-Sphere
 menuWeight: 70
 excerpt: This tutorial describes how to trigger pipelines locally
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/triggering-pipelines-using-chatops/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/ci_tutorials/triggering-pipelines-using-chatops/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Running pipelines from ChatOps Commands
 navigationTitle: Run pipelines from ChatOps Commands
 beta: false
-category: K-Sphere
 menuWeight: 90
 excerpt: This tutorial describes how to trigger pipelines from Github comments
 ---

--- a/pages/dkp/dispatch/1.2/tutorials/index.md
+++ b/pages/dkp/dispatch/1.2/tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Tutorials
 title: Tutorials
 beta: false
-category: K-Sphere
 menuWeight: 60
 excerpt: Easy to follow tutorials for learning and implementing Dispatch's features. 
 ---

--- a/pages/dkp/dispatch/1.3/index.md
+++ b/pages/dkp/dispatch/1.3/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Welcome to Dispatch 1.3
 title: Welcome to Dispatch 1.3
 beta: false
-category: K-Sphere
 menuWeight: 1
 excerpt: Dispatch provides a declarative CI/CD platform for rapidly deploying Cloud Native applications and enabling enterprises to rapidly build, test and manage applications' lifecycle using GitOps processes.
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/deploy-application-to-multiple-environments/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/deploy-application-to-multiple-environments/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploy an application to multiple clusters
 navigationTitle: Deploy an application to multiple clusters
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to deploy different versions of an application to staging and production environments.
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/deploy-to-multiple-production-clusters/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/deploy-to-multiple-production-clusters/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploy an application to multiple production clusters
 navigationTitle: Deploy an application to multiple production clusters
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to deploy an application to multiple production clusters.
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Continuous Deployment
 title: Continuous Deployment
 beta: false
-category: K-Sphere
 menuWeight: 20
 excerpt: Tutorials for implementing Continuous Deployment for your application.
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/storing-dispatch-secrets-with-gitops/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/storing-dispatch-secrets-with-gitops/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Store secrets in GitOps Repository using SealedSecrets
 navigationTitle: Store secrets in a GitOps Repository using SealedSecrets
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: Securely managing secrets in a GitOps workflow using SealedSecrets
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/trust-self-signed-tls-certificates/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/trust-self-signed-tls-certificates/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configure ArgoCD to trust TLS certificates issued by a custom CA
 navigationTitle: Configure ArgoCD to trust TLS certificates issued by a custom CA
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial configures ArgoCD to trust TLS certificates issued by a custom TLS certificates authority (CA).
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/using-argocd-cli/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/cd_tutorials/using-argocd-cli/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configure the ArgoCD CLI with Dispatch
 navigationTitle: Configure the ArgoCD CLI with Dispatch
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial describes how to use the ArgoCD CLI to operate the instance of ArgoCD that is bundled with Dispatch.
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/configuring-cron-triggers/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/configuring-cron-triggers/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring Cron Triggers
 navigationTitle: Configure Cron Based Triggers
 beta: false
-category: K-Sphere
 menuWeight: 60
 excerpt: Schedule CI pipeline runs using cron expressions
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/import-tasks-from-dispatchfile/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/import-tasks-from-dispatchfile/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Importing tasks into a Dispatchfile
 navigationTitle: Import tasks into a Dispatchfile
 beta: false
-category: K-Sphere
 menuWeight: 30
 excerpt: This tutorial describes how to import tasks from another Dispatchfile
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Continuous Integration
 title: Continuous Integration
 beta: false
-category: K-Sphere
 menuWeight: 10
 ---
 

--- a/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/local-runner/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/local-runner/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Run pipelines locally
 navigationTitle: Running pipelines locally
 beta: false
-category: K-Sphere
 menuWeight: 70
 excerpt: This tutorial describes how to trigger pipelines locally
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/triggering-pipelines-using-chatops/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/ci_tutorials/triggering-pipelines-using-chatops/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Running pipelines from ChatOps Commands
 navigationTitle: Run pipelines from ChatOps Commands
 beta: false
-category: K-Sphere
 menuWeight: 90
 excerpt: This tutorial describes how to trigger pipelines from Github comments
 ---

--- a/pages/dkp/dispatch/1.3/tutorials/index.md
+++ b/pages/dkp/dispatch/1.3/tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Tutorials
 title: Tutorials
 beta: false
-category: K-Sphere
 menuWeight: 60
 excerpt: Easy to follow tutorials for learning and implementing Dispatch's features. 
 ---

--- a/pages/dkp/dispatch/1.4/index.md
+++ b/pages/dkp/dispatch/1.4/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Welcome to Dispatch 1.4
 title: Welcome to Dispatch 1.4
 beta: false
-category: K-Sphere
 menuWeight: 0
 excerpt: Dispatch provides a declarative CI/CD platform for rapidly deploying Cloud Native applications and enabling enterprises to rapidly build, test and manage applications' lifecycle using GitOps processes.
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/fluxcd-federated/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/fluxcd-federated/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploying with FluxCD to multiple clusters
 navigationTitle: Deploying with FluxCD to multiple clusters
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial demonstrates how to setup a GitOps application using FluxCD and federation using Kommander.
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/fluxcd/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/fluxcd/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Deploying with FluxCD
 navigationTitle: Deploying with FluxCD
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial demonstrates how to setup a GitOps application using FluxCD.
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Continuous Deployment
 title: Continuous Deployment
 beta: false
-category: K-Sphere
 menuWeight: 20
 excerpt: Tutorials for implementing Continuous Deployment for your application.
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/storing-dispatch-secrets-with-gitops/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/cd_tutorials/storing-dispatch-secrets-with-gitops/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Store secrets in GitOps Repository using SealedSecrets
 navigationTitle: Store secrets in a GitOps Repository using SealedSecrets
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: Securely managing secrets in a GitOps workflow using SealedSecrets
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/configuring-cron-triggers/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/configuring-cron-triggers/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring Cron Triggers
 navigationTitle: Configure Cron Based Triggers
 beta: false
-category: K-Sphere
 menuWeight: 60
 excerpt: Schedule CI pipeline runs using cron expressions
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/import-tasks-from-dispatchfile/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/import-tasks-from-dispatchfile/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Importing tasks into a Dispatchfile
 navigationTitle: Import tasks into a Dispatchfile
 beta: false
-category: K-Sphere
 menuWeight: 30
 excerpt: This tutorial describes how to import tasks from another Dispatchfile
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Continuous Integration
 title: Continuous Integration
 beta: false
-category: K-Sphere
 menuWeight: 10
 ---
 

--- a/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/kind/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/kind/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Using Kind with Dispatch
 navigationTitle: Using Kind with Dispatch
 beta: false
-category: K-Sphere
 menuWeight: 105
 excerpt: This tutorial demonstrates how to use a Kind cluster in Dispatch.
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/local-runner/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/local-runner/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Run pipelines locally
 navigationTitle: Running pipelines locally
 beta: false
-category: K-Sphere
 menuWeight: 70
 excerpt: This tutorial describes how to trigger pipelines locally
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/triggering-pipelines-using-chatops/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/ci_tutorials/triggering-pipelines-using-chatops/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Running pipelines from ChatOps Commands
 navigationTitle: Run pipelines from ChatOps Commands
 beta: false
-category: K-Sphere
 menuWeight: 90
 excerpt: This tutorial describes how to trigger pipelines from Github comments
 ---

--- a/pages/dkp/dispatch/1.4/tutorials/index.md
+++ b/pages/dkp/dispatch/1.4/tutorials/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Tutorials
 title: Tutorials
 beta: false
-category: K-Sphere
 menuWeight: 60
 excerpt: Easy to follow tutorials for learning and implementing Dispatch's features. 
 ---

--- a/pages/dkp/index.md
+++ b/pages/dkp/index.md
@@ -2,7 +2,6 @@
 layout: konvoy-docs-landing.pug
 navigationTitle: D2iQ Kubernetes Platform
 title: D2iQ Kubernetes Platform
-featureMaturity:
 menus: ['landing-header']
 menuWeight: 5
 ---

--- a/pages/dkp/kommander/1.0/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.0/backup-and-restore/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Back up and restore
 title: Back up and restore
 excerpt: Back up and restore Kommander data and the Konvoy cluster
-category: K-Sphere
 menuWeight: 11
 ---
 

--- a/pages/dkp/kommander/1.0/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.0/backup-and-restore/index.md
@@ -2,7 +2,6 @@
 layout: layout.pug
 navigationTitle: Back up and restore
 title: Back up and restore
-featureMaturity:
 excerpt: Back up and restore Kommander data and the Konvoy cluster
 category: K-Sphere
 menuWeight: 11

--- a/pages/dkp/kommander/1.0/index.md
+++ b/pages/dkp/kommander/1.0/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Kommander 1.0
 title: Kommander 1.0
 version: 1.0
-featureMaturity:
 category: K-Sphere
 menuWeight: 0
 ---

--- a/pages/dkp/kommander/1.0/index.md
+++ b/pages/dkp/kommander/1.0/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Kommander 1.0
 title: Kommander 1.0
 version: 1.0
-category: K-Sphere
 menuWeight: 0
 ---
 

--- a/pages/dkp/kommander/1.0/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.0/introducing-kommander/index.md
@@ -2,7 +2,6 @@
 layout: layout.pug
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
-featureMaturity:
 excerpt: Deploy and manage Kubernetes on an enterprise scale
 category: K-Sphere
 menuWeight: 2

--- a/pages/dkp/kommander/1.0/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.0/introducing-kommander/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
 excerpt: Deploy and manage Kubernetes on an enterprise scale
-category: K-Sphere
 menuWeight: 2
 ---
 

--- a/pages/dkp/kommander/1.0/uninstall/index.md
+++ b/pages/dkp/kommander/1.0/uninstall/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Uninstall
 title: Uninstall
 excerpt: Remove Kommander and related infrastructure
-category: K-Sphere
 menuWeight: 10
 ---
 

--- a/pages/dkp/kommander/1.0/uninstall/index.md
+++ b/pages/dkp/kommander/1.0/uninstall/index.md
@@ -2,7 +2,6 @@
 layout: layout.pug
 navigationTitle: Uninstall
 title: Uninstall
-featureMaturity:
 excerpt: Remove Kommander and related infrastructure
 category: K-Sphere
 menuWeight: 10

--- a/pages/dkp/kommander/1.1/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.1/backup-and-restore/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Back up and restore
 title: Back up and restore
 excerpt: Back up and restore Kommander data and the Konvoy cluster
-category: K-Sphere
 menuWeight: 11
 ---
 

--- a/pages/dkp/kommander/1.1/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.1/backup-and-restore/index.md
@@ -2,7 +2,6 @@
 layout: layout.pug
 navigationTitle: Back up and restore
 title: Back up and restore
-featureMaturity:
 excerpt: Back up and restore Kommander data and the Konvoy cluster
 category: K-Sphere
 menuWeight: 11

--- a/pages/dkp/kommander/1.1/index.md
+++ b/pages/dkp/kommander/1.1/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Kommander 1.1
 title: Kommander 1.1
 version: 1.1 Beta
-featureMaturity:
 category: K-Sphere
 menuWeight: 0
 ---

--- a/pages/dkp/kommander/1.1/index.md
+++ b/pages/dkp/kommander/1.1/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Kommander 1.1
 title: Kommander 1.1
 version: 1.1 Beta
-category: K-Sphere
 menuWeight: 0
 ---
 

--- a/pages/dkp/kommander/1.1/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.1/introducing-kommander/index.md
@@ -2,7 +2,6 @@
 layout: layout.pug
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
-featureMaturity:
 excerpt: Deploy and manage Kubernetes on an enterprise scale
 category: K-Sphere
 menuWeight: 2

--- a/pages/dkp/kommander/1.1/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.1/introducing-kommander/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
 excerpt: Deploy and manage Kubernetes on an enterprise scale
-category: K-Sphere
 menuWeight: 2
 ---
 

--- a/pages/dkp/kommander/1.1/uninstall/index.md
+++ b/pages/dkp/kommander/1.1/uninstall/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 navigationTitle: Uninstall
 title: Uninstall
 excerpt: Remove Kommander and related infrastructure
-category: K-Sphere
 menuWeight: 10
 ---
 

--- a/pages/dkp/kommander/1.1/uninstall/index.md
+++ b/pages/dkp/kommander/1.1/uninstall/index.md
@@ -2,7 +2,6 @@
 layout: layout.pug
 navigationTitle: Uninstall
 title: Uninstall
-featureMaturity:
 excerpt: Remove Kommander and related infrastructure
 category: K-Sphere
 menuWeight: 10

--- a/pages/dkp/kommander/1.2/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.2/backup-and-restore/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: false
 navigationTitle: Back up and restore
 title: Back up and restore
-featureMaturity:
 excerpt: Back up and restore Kommander data and the Konvoy cluster
 category: K-Sphere
 menuWeight: 14

--- a/pages/dkp/kommander/1.2/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.2/backup-and-restore/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Back up and restore
 title: Back up and restore
 excerpt: Back up and restore Kommander data and the Konvoy cluster
-category: K-Sphere
 menuWeight: 14
 ---
 

--- a/pages/dkp/kommander/1.2/index.md
+++ b/pages/dkp/kommander/1.2/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Kommander 1.2
 title: Kommander 1.2
 version: 1.2 Beta
-category: K-Sphere
 menuWeight: 0
 ---
 

--- a/pages/dkp/kommander/1.2/index.md
+++ b/pages/dkp/kommander/1.2/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Kommander 1.2
 title: Kommander 1.2
 version: 1.2 Beta
-featureMaturity:
 category: K-Sphere
 menuWeight: 0
 ---

--- a/pages/dkp/kommander/1.2/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.2/introducing-kommander/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
 excerpt: Deploy and manage Kubernetes on an enterprise scale
-category: K-Sphere
 menuWeight: 2
 ---
 

--- a/pages/dkp/kommander/1.2/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.2/introducing-kommander/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: false
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
-featureMaturity:
 excerpt: Deploy and manage Kubernetes on an enterprise scale
 category: K-Sphere
 menuWeight: 2

--- a/pages/dkp/kommander/1.2/uninstall/index.md
+++ b/pages/dkp/kommander/1.2/uninstall/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Uninstall
 title: Uninstall
 excerpt: Remove Kommander and related infrastructure
-category: K-Sphere
 menuWeight: 13
 ---
 

--- a/pages/dkp/kommander/1.2/uninstall/index.md
+++ b/pages/dkp/kommander/1.2/uninstall/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: false
 navigationTitle: Uninstall
 title: Uninstall
-featureMaturity:
 excerpt: Remove Kommander and related infrastructure
 category: K-Sphere
 menuWeight: 13

--- a/pages/dkp/kommander/1.3/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.3/backup-and-restore/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: false
 navigationTitle: Back up and restore
 title: Back up and restore
-featureMaturity:
 excerpt: Back up and restore Kommander data and the Konvoy cluster
 category: K-Sphere
 menuWeight: 14

--- a/pages/dkp/kommander/1.3/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.3/backup-and-restore/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Back up and restore
 title: Back up and restore
 excerpt: Back up and restore Kommander data and the Konvoy cluster
-category: K-Sphere
 menuWeight: 14
 ---
 

--- a/pages/dkp/kommander/1.3/index.md
+++ b/pages/dkp/kommander/1.3/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Kommander 1.3
 title: Kommander 1.3
 version: 1.3
-featureMaturity:
 category: K-Sphere
 menuWeight: 0
 ---

--- a/pages/dkp/kommander/1.3/index.md
+++ b/pages/dkp/kommander/1.3/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Kommander 1.3
 title: Kommander 1.3
 version: 1.3
-category: K-Sphere
 menuWeight: 0
 ---
 

--- a/pages/dkp/kommander/1.3/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.3/introducing-kommander/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
 excerpt: Deploy and manage Kubernetes on an enterprise scale
-category: K-Sphere
 menuWeight: 2
 ---
 

--- a/pages/dkp/kommander/1.3/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.3/introducing-kommander/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: false
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
-featureMaturity:
 excerpt: Deploy and manage Kubernetes on an enterprise scale
 category: K-Sphere
 menuWeight: 2

--- a/pages/dkp/kommander/1.3/uninstall/index.md
+++ b/pages/dkp/kommander/1.3/uninstall/index.md
@@ -4,7 +4,6 @@ beta: false
 navigationTitle: Uninstall
 title: Uninstall
 excerpt: Remove Kommander and related infrastructure
-category: K-Sphere
 menuWeight: 13
 ---
 

--- a/pages/dkp/kommander/1.3/uninstall/index.md
+++ b/pages/dkp/kommander/1.3/uninstall/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: false
 navigationTitle: Uninstall
 title: Uninstall
-featureMaturity:
 excerpt: Remove Kommander and related infrastructure
 category: K-Sphere
 menuWeight: 13

--- a/pages/dkp/kommander/1.4/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.4/backup-and-restore/index.md
@@ -4,7 +4,6 @@ beta: true
 navigationTitle: Back up and restore
 title: Back up and restore
 excerpt: Back up and restore Kommander data and the Konvoy cluster
-category: K-Sphere
 menuWeight: 14
 ---
 

--- a/pages/dkp/kommander/1.4/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.4/backup-and-restore/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: true
 navigationTitle: Back up and restore
 title: Back up and restore
-featureMaturity:
 excerpt: Back up and restore Kommander data and the Konvoy cluster
 category: K-Sphere
 menuWeight: 14

--- a/pages/dkp/kommander/1.4/index.md
+++ b/pages/dkp/kommander/1.4/index.md
@@ -4,7 +4,6 @@ beta: true
 navigationTitle: Kommander 1.4 beta
 title: Kommander 1.4 beta
 version: 1.4
-category: K-Sphere
 menuWeight: 0
 ---
 

--- a/pages/dkp/kommander/1.4/index.md
+++ b/pages/dkp/kommander/1.4/index.md
@@ -4,7 +4,6 @@ beta: true
 navigationTitle: Kommander 1.4 beta
 title: Kommander 1.4 beta
 version: 1.4
-featureMaturity:
 category: K-Sphere
 menuWeight: 0
 ---

--- a/pages/dkp/kommander/1.4/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.4/introducing-kommander/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: true
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
-featureMaturity:
 excerpt: Deploy and manage Kubernetes on an enterprise scale
 category: K-Sphere
 menuWeight: 2

--- a/pages/dkp/kommander/1.4/introducing-kommander/index.md
+++ b/pages/dkp/kommander/1.4/introducing-kommander/index.md
@@ -4,7 +4,6 @@ beta: true
 navigationTitle: Introducing Kommander
 title: Introducing Kommander
 excerpt: Deploy and manage Kubernetes on an enterprise scale
-category: K-Sphere
 menuWeight: 2
 ---
 

--- a/pages/dkp/kommander/1.4/uninstall/index.md
+++ b/pages/dkp/kommander/1.4/uninstall/index.md
@@ -4,7 +4,6 @@ beta: true
 navigationTitle: Uninstall
 title: Uninstall
 excerpt: Remove Kommander and related infrastructure
-category: K-Sphere
 menuWeight: 13
 ---
 

--- a/pages/dkp/kommander/1.4/uninstall/index.md
+++ b/pages/dkp/kommander/1.4/uninstall/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 beta: true
 navigationTitle: Uninstall
 title: Uninstall
-featureMaturity:
 excerpt: Remove Kommander and related infrastructure
 category: K-Sphere
 menuWeight: 13

--- a/pages/index.md
+++ b/pages/index.md
@@ -2,7 +2,6 @@
 layout: all-products-landing.pug
 navigationTitle: D2iQ Documentation
 title: D2iQ Documentation
-featureMaturity:
 enterprise: false
 menuWeight: 0
 ---

--- a/pages/mesosphere/dcos/cn/services/cassandra/2.3.0-3.0.16/cass-auth/index.md
+++ b/pages/mesosphere/dcos/cn/services/cassandra/2.3.0-3.0.16/cass-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: 为 Cassandra 配置 DC/OS Access 
 menuWeight: 270
 excerpt: 为 2.3.0-3.0.16 之前的版本配置 DC/OS Access
-featureMaturity:
 model: /mesosphere/dcos/cn/services/cassandra/data.yml
 render: mustache
 enterprise: true

--- a/pages/mesosphere/dcos/cn/services/cassandra/index.md
+++ b/pages/mesosphere/dcos/cn/services/cassandra/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Cassandra
 title: Cassandra
 menuWeight: 1
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/hdfs/2.2.0-2.6.0-cdh5.11.0/hdfs-auth/index.md
+++ b/pages/mesosphere/dcos/cn/services/hdfs/2.2.0-2.6.0-cdh5.11.0/hdfs-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: 为 HDFS 配置 DC/OS Access 
 menuWeight: 550
 excerpt: 在 2.1.0-2.6.0-cdh5.11.0 和更早版本中为 HDFS 配置 DC/OS Access
-featureMaturity:
 enterprise: true
 model: /mesosphere/dcos/cn/services/hdfs/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/cn/services/kafka/2.3.0-1.1.0/kafka-auth/index.md
+++ b/pages/mesosphere/dcos/cn/services/kafka/2.3.0-1.1.0/kafka-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: 为  Kafka 配置 DC/OS Access
 menuWeight: 660
 excerpt: 配置 DC/OS Access 
-featureMaturity:
 enterprise: true
 model: /mesosphere/dcos/cn/services/kafka/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/alerting-overview/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/alerting-overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: 警报概述
 title: 警报概述
 menuWeight: 25
 excerpt: DC/OS Prometheus 警报概述
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/prometheus-federation/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/prometheus-federation/index.md
@@ -4,7 +4,6 @@ navigationTitle: DC/OS Prometheus 联合
 title: DC/OS Prometheus 联合
 menuWeight: 35
 excerpt: 为 Prometheus 配置 Federation
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/remote-storage/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/remote-storage/index.md
@@ -4,7 +4,6 @@ navigationTitle: 远程存储
 title: Impx DB 上的 Prometheus 远程存储
 menuWeight: 40
 excerpt: 将 Prometheus 与远程存储 ImpxDB 集成
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/service-discovery/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/service-discovery/index.md
@@ -4,7 +4,6 @@ navigationTitle: 服务发现
 title: 服务发现配置选项
 menuWeight: 45
 excerpt: 服务发现
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/visualization/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/configuration/visualization/index.md
@@ -4,7 +4,6 @@ navigationTitle: 可视化
 title: Grafana 和 Prometheus Expression 浏览器
 menuWeight: 45
 excerpt: DC/OS Prometheus Expression 浏览器
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus 0.1.1-2.3.2
 title: Prometheus 0.1.1-2.3.2
 menuWeight: 50
 excerpt: DC/OS Prometheus 服务是一项自动化服务，可轻松部署和管理 Mesosphere DC/OS 上的 Prometheus。
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/limitations/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle: 限制
 title: 限制
 menuWeight: 110
 excerpt: 了解配置限制
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle: 版本注释
 title: 版本注释
 menuWeight: 130
 excerpt: 版本 0.1.1-2.3.2 的发行说明
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle: 支持的版本
 title: 支持的版本
 menuWeight: 120
 excerpt: 了解 DC/OS Prometheus 服务安装包版本
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/0.1.1-2.3.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: 卸载
 title: 卸载
 menuWeight: 40
 excerpt: 卸载 DC/OS Prometheus 服务
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/prometheus/index.md
+++ b/pages/mesosphere/dcos/cn/services/prometheus/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus
 title: Prometheus 
 menuWeight: 50
 excerpt: DC/OS Prometheus 
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/custom-docker/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle:
 excerpt: 自定义 Spark 图片 
 title: 自定义 Docker 镜像
 menuWeight: 95
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/fault-tolerance/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/fault-tolerance/index.md
@@ -4,7 +4,6 @@ navigationTitle: 容错
 excerpt: 了解 DC/OS Apache Spark 上的容错
 title: 容错
 menuWeight: 100
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/index.md
@@ -4,7 +4,6 @@ title: Spark 2.3.1-2.2.1-2
 navigationTitle: Spark 2.3.1-2.2.1-2
 menuWeight: 0
 excerpt: Apache Spark 是一种用于大数据的快速通用群集计算系统。
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/install/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/install/index.md
@@ -4,7 +4,6 @@ navigationTitle:
 excerpt: 使用 Web 界面或 DC/OS CLI 安装 Spark
 title: 安装和自定义
 menuWeight: 15
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/job-scheduling/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/job-scheduling/index.md
@@ -4,7 +4,6 @@ navigationTitle: 作业计划
 excerpt: 作业计划选项的概述
 title: 作业计划
 menuWeight: 110
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/limitations/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle: 限制
 excerpt: 已知和已测试限制
 title: 限制
 menuWeight: 135
-featureMaturity:
 ---
 
 

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/quickstart/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/quickstart/index.md
@@ -4,7 +4,6 @@ navigationTitle: 快速入门
 excerpt: Spark 入门
 title: 快速入门
 menuWeight: 1
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/release-notes/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle: 版本注释
 title: 版本注释
 menuWeight: 145
 excerpt: Spark 和 Spark 历史版本 2.3.1-2.2.1-2
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/run-job/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/run-job/index.md
@@ -4,7 +4,6 @@ navigationTitle: 运行 Spark 作业
 excerpt: 运行 Spark 作业
 title: 运行 Spark 作业
 menuWeight: 80
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/runtime-config-change/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/runtime-config-change/index.md
@@ -4,7 +4,6 @@ excerpt: 运行时自定义 Spark
 navigationTitle: 运行时更改
 title: 运行时配置更改
 menuWeight: 70
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/spark-auth/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/spark-auth/index.md
@@ -4,7 +4,6 @@ title: 为  Spark 配置 DC/OS Access
 navigationTitle: 为  Spark 配置 DC/OS Access
 menuWeight: 1010
 excerpt:
-featureMaturity:
 enterprise: true
 ---
 # 版本

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/uninstall/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: 卸载
 excerpt: 卸载 DC/OS Apache Spark 服务
 title: 卸载
 menuWeight: 60
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/upgrade/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle: 已升级
 excerpt: 升级您的 DC/OS Apache Spark 服务
 title: 已升级
 menuWeight: 50
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/usage-examples/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/usage-examples/index.md
@@ -4,7 +4,6 @@ navigationTitle: 使用示例
 excerpt: 使用示例
 title: 使用示例
 menuWeight: 16
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/version-policy/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/2.3.1-2.2.1-2/version-policy/index.md
@@ -4,7 +4,6 @@ navigationTitle: 版本政策
 excerpt: 支持的版本
 title: 版本政策
 menuWeight: 130
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/cn/services/spark/index.md
+++ b/pages/mesosphere/dcos/cn/services/spark/index.md
@@ -4,7 +4,6 @@ title: Spark
 navigationTitle: Spark 
 menuWeight: 0
 excerpt: Apache Spark 是一种用于大数据的快速通用群集计算系统。
-featureMaturity:
 model: /mesosphere/dcos/cn/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/architecture/index.md
+++ b/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/architecture/index.md
@@ -5,7 +5,6 @@ title: Jenkins for DC/OS Service Architecture
 menuWeight: 40
 beta: true
 excerpt: The Jenkins for DC/OS service bundles the Jenkins Automation Server with the Jenkins Mesos Plug-in. 
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/custom-install/index.md
@@ -5,7 +5,6 @@ title: Customizing your install
 menuWeight: 20
 beta: true
 excerpt: The Jenkins for DC/OS package accepts a range of custom configuration parameters at install.
-featureMaturity:
 enterprise: false
 ---
 # About customizing your installation parameters

--- a/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/index.md
+++ b/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/index.md
@@ -5,7 +5,6 @@ title: Jenkins for DC/OS (Beta)
 menuWeight: 60
 beta: true
 excerpt: Run your continuous integration, automated testing, and continuous delivery jobs at scale with Jenkins for DC/OS.
-featureMaturity:
 enterprise: false
 category: Continuous Delivery
 ---

--- a/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/jenkins-auth/index.md
@@ -5,7 +5,6 @@ title: Provisioning Jenkins for DC/OS
 menuWeight: 15
 excerpt: This topic describes when and how to provision Jenkins with a service account.
 beta: true
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/quickstart/index.md
@@ -5,7 +5,6 @@ title: Jenkins for DC/OS Quickstart
 menuWeight: 10
 excerpt: Jenkins for DC/OS can be installed using either the web interface or the DC/OS CLI.
 beta: true
-featureMaturity:
 enterprise: false
 ---
 # About installing Jenkins for DC/OS

--- a/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/uninstall/index.md
@@ -5,7 +5,6 @@ title: Uninstalling
 menuWeight: 70
 excerpt: Jenkins for DC/OS can be uninstalled using either the web interface or the CLI. 
 beta: true
-featureMaturity:
 enterprise: false
 ---
 # Uninstalling DC/OS Jenkins Service

--- a/pages/mesosphere/dcos/services/beta-jenkins/index.md
+++ b/pages/mesosphere/dcos/services/beta-jenkins/index.md
@@ -5,7 +5,6 @@ title: Jenkins for DC/OS (Beta)
 menuWeight: 60
 excerpt: Run your continuous integration, automated testing, and continuous delivery jobs at scale with Jenkins for DC/OS.
 beta: true 
-featureMaturity:
 enterprise: false
 category: Continuous Delivery
 ---

--- a/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/example/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/example/index.md
@@ -4,7 +4,6 @@ navigationTitle: Examples
 title: Examples
 menuWeight: 13
 excerpt: Examples of different installation options of Mesosphere Jupyter Service (Beta)
-featureMaturity:
 enterprise: false
 beta: true
 model: /mesosphere/dcos/services/beta-jupyter/data.yml

--- a/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Mesosphere Jupyter Service
 title: Mesosphere Jupyter Service
 menuWeight: 1
 excerpt:
-featureMaturity:
 enterprise: false
 beta: true
 model: /mesosphere/dcos/services/beta-jupyter/data.yml

--- a/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/installing/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/installing/index.md
@@ -4,7 +4,6 @@ navigationTitle: Install
 title: Install
 menuWeight: 10
 excerpt: Install and customize Mesosphere Jupyter Service (Beta)
-featureMaturity:
 beta: true
 enterprise: false
 model: /mesosphere/dcos/services/beta-jupyter/data.yml

--- a/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/limitations/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 90
 excerpt: Limitations of JupyterLab on the DC/OS platform
-featureMaturity:
 enterprise: false
 beta: true
 model: /mesosphere/dcos/services/beta-jupyter/data.yml

--- a/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/overview/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Overview
 title: Overview
 menuWeight: 12
 excerpt: Overview of JupyterLab
-featureMaturity:
 enterprise: false
 beta: true
 model: /mesosphere/dcos/services/beta-jupyter/data.yml

--- a/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/quick-start/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/quick-start/index.md
@@ -4,7 +4,6 @@ navigationTitle: Quick Start
 title: Quick Start
 menuWeight: 5
 excerpt: Quick Start JupyterLab with DC/OS
-featureMaturity:
 enterprise: false
 beta: true
 model: /mesosphere/dcos/services/beta-jupyter/data.yml

--- a/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/1.2.0-0.33.7-beta/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: Uninstall
 title: Uninstall
 menuWeight: 90
 excerpt: Uninstall JupyterLab
-featureMaturity:
 enterprise: false
 beta: true
 model: /mesosphere/dcos/services/beta-jupyter/data.yml

--- a/pages/mesosphere/dcos/services/beta-jupyter/index.md
+++ b/pages/mesosphere/dcos/services/beta-jupyter/index.md
@@ -4,7 +4,6 @@ navigationTitle: Mesosphere Jupyter Service
 title: Mesosphere Jupyter Service
 menuWeight: 155
 excerpt: JupyterLab is the next-generation web-based user interface for Project Jupyter
-featureMaturity:
 beta: true
 enterprise: false
 category: Data Processing

--- a/pages/mesosphere/dcos/services/beta-kafka/index.md
+++ b/pages/mesosphere/dcos/services/beta-kafka/index.md
@@ -4,7 +4,6 @@ navigationTitle: Beta Kafka
 title: Beta Kafka
 menuWeight: 155
 excerpt: DC/OS Kafka is a distributed high-throughput publish-subscribe messaging system with strong ordering guarantees.
-featureMaturity:
 enterprise: false
 category: Messaging Queues
 beta: true

--- a/pages/mesosphere/dcos/services/beta-kafka/kafka-auth/index.md
+++ b/pages/mesosphere/dcos/services/beta-kafka/kafka-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for Kafka
 menuWeight: 5
 excerpt:
-featureMaturity:
 enterprise: true
 beta: true
 model: /mesosphere/dcos/services/beta-kafka/data.yml

--- a/pages/mesosphere/dcos/services/cassandra/cass-auth/index.md
+++ b/pages/mesosphere/dcos/services/cassandra/cass-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for Cassandra
 menuWeight: 10
 excerpt: Configuring DC/OS Access for versions before 2.3.0-3.0.16
-featureMaturity:
 enterprise: true
 ---
 # Versions

--- a/pages/mesosphere/dcos/services/cassandra/index.md
+++ b/pages/mesosphere/dcos/services/cassandra/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Cassandra
 title: Cassandra
 menuWeight: 1
 excerpt:
-featureMaturity:
 enterprise: false
 category: Databases
 ---

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.10.0-5.5.1/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.10.0-5.5.1/index.md
@@ -6,7 +6,6 @@ title: Confluent Kafka 2.10.0-5.5.1
 menuWeight: 1
 model: /mesosphere/dcos/services/confluent-kafka/data.yml
 render: mustache
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.5.0-4.1.2/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.5.0-4.1.2/index.md
@@ -6,7 +6,6 @@ title: Confluent Kafka 2.5.0-4.1.2
 menuWeight: 2
 model: /mesosphere/dcos/services/confluent-kafka/data.yml
 render: mustache
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/confluent-kafka/2.9.1-5.4.0/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/2.9.1-5.4.0/index.md
@@ -6,7 +6,6 @@ title: Confluent Kafka 2.9.1-5.4.0
 menuWeight: 1
 model: /mesosphere/dcos/services/confluent-kafka/data.yml
 render: mustache
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/confluent-kafka/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Confluent Kafka
 title: Confluent Kafka
 menuWeight: 5
 excerpt:
-featureMaturity:
 enterprise: true
 category: Messaging Queues
 ---

--- a/pages/mesosphere/dcos/services/confluent-kafka/kafka-auth/index.md
+++ b/pages/mesosphere/dcos/services/confluent-kafka/kafka-auth/index.md
@@ -6,7 +6,6 @@ title: >
   Kafka
 menuWeight: 300
 excerpt:
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/confluent-zookeeper/confluent-zookeeper-auth/index.md
+++ b/pages/mesosphere/dcos/services/confluent-zookeeper/confluent-zookeeper-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for Confluent Zookeeper
 menuWeight: 660
 excerpt:
-featureMaturity:
 enterprise: true
 
 model: /mesosphere/dcos/services/confluent-zookeeper/data.yml

--- a/pages/mesosphere/dcos/services/confluent-zookeeper/index.md
+++ b/pages/mesosphere/dcos/services/confluent-zookeeper/index.md
@@ -4,7 +4,6 @@ navigationTitle: Confluent ZooKeeper
 title: Confluent ZooKeeper
 menuWeight: 11
 excerpt:
-featureMaturity:
 enterprise: false
 category: Cluster Management
 ---

--- a/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Couchbase 0.2.0-5.5.0
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 130
 excerpt: Discover the new features, updates, and known limitations in this release of the Couchbase Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Couchbase Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.2.0-5.5.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 55
 excerpt: Uninstalling DC/OS Couchbase Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Couchbase 0.3.0-5.5.3
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/limitations/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 5
 excerpt: Discover the new features, updates, and known limitations in this release of the Couchbase Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Couchbase Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/0.3.0-5.5.3/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 55
 excerpt: Uninstalling DC/OS Couchbase Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Couchbase 1.0.0-6.0.0
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 1
 excerpt: Discover new features, updates, and known limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Couchbase Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.0-6.0.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 55
 excerpt: Uninstalling DC/OS Couchbase Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Couchbase 1.0.1-6.0.0
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 1
 excerpt: Discover new features, updates, and known limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Couchbase Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/1.0.1-6.0.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 55
 excerpt: Uninstalling DC/OS Couchbase Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/couchbase/index.md
+++ b/pages/mesosphere/dcos/services/couchbase/index.md
@@ -4,7 +4,6 @@ navigationTitle: Couchbase
 title: Couchbase
 menuWeight: 15
 excerpt: 
-featureMaturity:
 community: true
 model: /mesosphere/dcos/services/couchbase/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/dse/index.md
+++ b/pages/mesosphere/dcos/services/dse/index.md
@@ -4,7 +4,6 @@ navigationTitle:  DataStax Enterprise
 title: DataStax Enterprise
 menuWeight: 20
 excerpt:
-featureMaturity:
 enterprise: true
 category: Databases
 ---

--- a/pages/mesosphere/dcos/services/elastic/elastic-auth/index.md
+++ b/pages/mesosphere/dcos/services/elastic/elastic-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for Elastic
 menuWeight: 290
 excerpt:
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/elastic/index.md
+++ b/pages/mesosphere/dcos/services/elastic/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Elastic
 title: Elastic
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 category: Data Services
 ---

--- a/pages/mesosphere/dcos/services/hdfs/hdfs-auth/index.md
+++ b/pages/mesosphere/dcos/services/hdfs/hdfs-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for HDFS
 menuWeight: 550
 excerpt: Configuring DC/OS Access for HDFS in 2.1.0-2.6.0-cdh5.11.0 and earlier
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/hdfs/index.md
+++ b/pages/mesosphere/dcos/services/hdfs/index.md
@@ -4,7 +4,6 @@ navigationTitle:  HDFS
 title: HDFS
 menuWeight: 50
 excerpt:
-featureMaturity:
 enterprise: false
 category: Storage
 ---

--- a/pages/mesosphere/dcos/services/hive-metastore/index.md
+++ b/pages/mesosphere/dcos/services/hive-metastore/index.md
@@ -4,7 +4,6 @@ navigationTitle: Hive Metastore
 title: Hive Metastore
 menuWeight: 40
 excerpt: DC/OS Hive Metastore is an automated service that makes it easy to deploy and manage Hive Metastore on Mesosphere DC/OS.
-featureMaturity:
 enterprise: false
 category: Data Services
 ---

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/advanced-configuration/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/advanced-configuration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Advanced Configuration
 title: Advanced Configuration
 menuWeight: 50
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Advanced configuration</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your Docker container
 title: Customizing your Docker container
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your Docker container</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/custom-install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your install
 title: Customizing your install
 menuWeight: 20
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your installation parameters</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: Jenkins 3.5.2-2.107.2
 title: Jenkins 3.5.2-2.107.2
 menuWeight: 2
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/jenkins-auth/index.md
@@ -7,7 +7,6 @@ excerpt: >
   This topic describes when and how to
   provision Jenkins with a service
   account.
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/quickstart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Quickstart
 title: Quickstart
 menuWeight: 10
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About installing Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/script-template-job-dsl/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/script-template-job-dsl/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Scripting and templating your jobs
 title: Scripting and templating your jobs
 menuWeight: 30
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About scripting and templating your jobs</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 70
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About uninstalling Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.2-2.107.2/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Upgrading
 title: Upgrading
 menuWeight: 60
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Upgrading</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/advanced-configuration/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/advanced-configuration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Advanced Configuration
 title: Advanced Configuration
 menuWeight: 50
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Advanced configuration</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your Docker container
 title: Customizing your Docker container
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your Docker container</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/custom-install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your install
 title: Customizing your install
 menuWeight: 20
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your installation parameters</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/index.md
@@ -4,7 +4,6 @@ navigationTitle: Jenkins 3.5.3-2.150.1
 title: Jenkins 3.5.3-2.150.1
 menuWeight: 1
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/jenkins-auth/index.md
@@ -7,7 +7,6 @@ excerpt: >
   This topic describes when and how to
   provision Jenkins with a service
   account.
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/quickstart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Quickstart
 title: Quickstart
 menuWeight: 15
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About installing Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/script-template-job-dsl/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/script-template-job-dsl/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Scripting and templating your jobs
 title: Scripting and templating your jobs
 menuWeight: 30
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About scripting and templating your jobs</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 70
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About uninstalling Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.3-2.150.1/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Upgrading
 title: Upgrading
 menuWeight: 60
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Upgrading</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/advanced-configuration/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/advanced-configuration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Advanced Configuration
 title: Advanced Configuration
 menuWeight: 50
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Advanced configuration</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your Docker container
 title: Customizing your Docker container
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your Docker container</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/custom-install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your install
 title: Customizing your install
 menuWeight: 20
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your installation parameters</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/index.md
@@ -4,7 +4,6 @@ navigationTitle: Jenkins 3.5.4-2.150.1
 title: Jenkins 3.5.4-2.150.1
 menuWeight: 1
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/jenkins-auth/index.md
@@ -7,7 +7,6 @@ excerpt: >
   This topic describes when and how to
   provision Jenkins with a service
   account.
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/quickstart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Quickstart
 title: Quickstart
 menuWeight: 10
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About installing Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/script-template-job-dsl/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/script-template-job-dsl/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Scripting and templating your jobs
 title: Scripting and templating your jobs
 menuWeight: 30
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About scripting and templating your jobs</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 70
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About uninstalling Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.5.4-2.150.1/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Upgrading
 title: Upgrading
 menuWeight: 60
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Upgrading</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/advanced-configuration/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/advanced-configuration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Advanced Configuration
 title: Advanced Configuration
 menuWeight: 50
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Advanced configuration</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/architecture/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/architecture/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Jenkins Service Architecture
 title: Jenkins Service Architecture
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your Docker container
 title: Customizing your Docker container
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your Docker container</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/custom-install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your install
 title: Customizing your install
 menuWeight: 20
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your installation parameters</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/index.md
@@ -4,7 +4,6 @@ navigationTitle: Jenkins 3.6.0-2.190.1
 title: Jenkins 3.6.0-2.190.1
 menuWeight: 1
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/jenkins-auth/index.md
@@ -7,7 +7,6 @@ excerpt: >
   This topic describes when and how to
   provision Jenkins with a service
   account.
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/quickstart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Quickstart
 title: Quickstart
 menuWeight: 10
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About installing Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/script-template-job-dsl/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/script-template-job-dsl/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Scripting and templating your jobs
 title: Scripting and templating your jobs
 menuWeight: 30
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About scripting and templating your jobs</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 70
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About uninstalling Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.0-2.190.1/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Upgrading
 title: Upgrading
 menuWeight: 60
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 # Upgrading

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/advanced-configuration/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/advanced-configuration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Advanced Configuration
 title: Advanced Configuration
 menuWeight: 50
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>Advanced configuration</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/architecture/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/architecture/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Jenkins Service Architecture
 title: Jenkins Service Architecture
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your Docker container
 title: Customizing your Docker container
 menuWeight: 40
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your Docker container</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/custom-install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Customizing your install
 title: Customizing your install
 menuWeight: 20
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About customizing your installation parameters</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/index.md
@@ -4,7 +4,6 @@ navigationTitle: Jenkins 3.6.1-2.190.1
 title: Jenkins 3.6.1-2.190.1
 menuWeight: 1
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/jenkins-auth/index.md
@@ -7,7 +7,6 @@ excerpt: >
   This topic describes when and how to
   provision Jenkins with a service
   account.
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/quickstart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Quickstart
 title: Quickstart
 menuWeight: 10
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About installing Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/script-template-job-dsl/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/script-template-job-dsl/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Scripting and templating your jobs
 title: Scripting and templating your jobs
 menuWeight: 30
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About scripting and templating your jobs</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 70
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 <h1>About uninstalling Jenkins for DC/OS</h1>

--- a/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/3.6.1-2.190.1/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Upgrading
 title: Upgrading
 menuWeight: 60
 excerpt:
-featureMaturity:
 enterprise: false
 ---
 # Upgrading

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/architecture/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/architecture/index.md
@@ -5,7 +5,6 @@ title: Jenkins for DC/OS Service Architecture
 menuWeight: 40
 beta: false
 excerpt: The Jenkins for DC/OS service bundles the Jenkins Automation Server with the Jenkins Mesos Plug-in. 
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/custom-install/index.md
@@ -5,7 +5,6 @@ title: Customizing your install
 menuWeight: 20
 beta: false
 excerpt: The Jenkins for DC/OS package accepts a range of custom configuration parameters at install.
-featureMaturity:
 enterprise: false
 ---
 # About customizing your installation parameters

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/index.md
@@ -5,7 +5,6 @@ title: Jenkins for DC/OS
 menuWeight: 60
 beta: false
 excerpt: Run your continuous integration, automated testing, and continuous delivery jobs at scale with Jenkins for DC/OS.
-featureMaturity:
 enterprise: false
 category: Continuous Delivery
 ---

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/jenkins-auth/index.md
@@ -5,7 +5,6 @@ title: Provisioning Jenkins for DC/OS
 menuWeight: 15
 excerpt: This topic describes when and how to provision Jenkins with a service account.
 beta: false
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/quickstart/index.md
@@ -5,7 +5,6 @@ title: Jenkins for DC/OS Quickstart
 menuWeight: 10
 excerpt: Jenkins for DC/OS can be installed using either the web interface or the DC/OS CLI.
 beta: false
-featureMaturity:
 enterprise: false
 ---
 # About installing Jenkins for DC/OS

--- a/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/4.0.0-2.204.6/uninstall/index.md
@@ -5,7 +5,6 @@ title: Uninstalling
 menuWeight: 70
 excerpt: Jenkins for DC/OS can be uninstalled using either the web interface or the CLI. 
 beta: false
-featureMaturity:
 enterprise: false
 ---
 # Uninstalling DC/OS Jenkins Service

--- a/pages/mesosphere/dcos/services/jenkins/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Jenkins
 title: Jenkins
 menuWeight: 60
 excerpt:
-featureMaturity:
 enterprise: false
 category: Continuous Delivery
 ---

--- a/pages/mesosphere/dcos/services/jenkins/jenkins-auth/index.md
+++ b/pages/mesosphere/dcos/services/jenkins/jenkins-auth/index.md
@@ -7,7 +7,6 @@ excerpt: >
   This topic describes when and how to
   provision Jenkins with a service
   account.
-featureMaturity:
 enterprise: true
 beta: false
 ---

--- a/pages/mesosphere/dcos/services/kafka-zookeeper/index.md
+++ b/pages/mesosphere/dcos/services/kafka-zookeeper/index.md
@@ -4,7 +4,6 @@ navigationTitle: Kafka ZooKeeper
 title: Kafka ZooKeeper
 menuWeight: 71
 excerpt:
-featureMaturity:
 enterprise: false
 category: Cluster Management
 ---

--- a/pages/mesosphere/dcos/services/kafka-zookeeper/kafka-zookeeper-auth/index.md
+++ b/pages/mesosphere/dcos/services/kafka-zookeeper/kafka-zookeeper-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for Kafka Zookeeper
 menuWeight: 660
 excerpt:
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/kafka/index.md
+++ b/pages/mesosphere/dcos/services/kafka/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Kafka
 title: Kafka
 menuWeight: 70
 excerpt:
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/kafka/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/kafka/kafka-auth/index.md
+++ b/pages/mesosphere/dcos/services/kafka/kafka-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for Kafka
 menuWeight: 5
 excerpt:
-featureMaturity:
 enterprise: true
 model: /mesosphere/dcos/services/kafka/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/kubernetes/index.md
+++ b/pages/mesosphere/dcos/services/kubernetes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Kubernetes
 title: Kubernetes
 menuWeight: 0
 excerpt:
-featureMaturity:
 enterprise: false
 category: Container Orchestration
 ---

--- a/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Configuring-TLS/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Configuring-TLS/index.md
@@ -4,7 +4,6 @@ navigationTitle: Configuring TLS
 title:  Configuring TLS
 menuWeight: 25
 excerpt: Configuring TLS with DC/OS Minio
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Disk-Caching/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Disk-Caching/index.md
@@ -4,7 +4,6 @@ navigationTitle: Disk Caching
 title: Disk Caching in DC/OS Minio
 menuWeight: 45
 excerpt: Using caching disks to store content 
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Erasure-Coding-Schemes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Erasure-Coding-Schemes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Erasure Coding Scheme
 title: Erasure Coding Scheme in Minio
 menuWeight: 45
 excerpt: Defining two Erasure Coding Schemes in Minio
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Mount-Volumes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Mount-Volumes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Mount Volumes
 title: Configuring Mount Volumes for Minio
 menuWeight: 40
 excerpt: Configuring Mesos mount disk resources across your cluster
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Notification-Service/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Notification-Service/index.md
@@ -4,7 +4,6 @@ navigationTitle: Notification Service
 title: Notification Service
 menuWeight: 25
 excerpt: Enable Notification Services to monitor events
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Server-Side-Encryption/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/configuration/Server-Side-Encryption/index.md
@@ -4,7 +4,6 @@ navigationTitle: Encryption
 title: Server-Side-Encryption
 menuWeight: 35
 excerpt: Encrypt your data using SSE-C keys
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Minio 0.1.0
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/minio/0.1.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle: Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/operations/Backing-up/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/operations/Backing-up/index.md
@@ -4,7 +4,6 @@ navigationTitle: Backup
 title: Backup 
 menuWeight: 30
 excerpt: Backing up your data to AWS S3 storage
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/operations/Restore/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/operations/Restore/index.md
@@ -4,7 +4,6 @@ navigationTitle: Restore
 title: Restore 
 menuWeight: 35
 excerpt: Restoring data backed up in AWS S3-compatible storage
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/operations/recover/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/operations/recover/index.md
@@ -4,7 +4,6 @@ navigationTitle: Recover
 title: Recovering objects on the Minio server 
 menuWeight: 30
 excerpt: Recovering buckets and objects on the Minio server in cases of disk/node failure
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Discover the new features, updates, and known limitations in this release of the Minio Service 
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/security/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title:  Security
 menuWeight: 50
 excerpt: Configuring Minio for DC/OS access
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Minio Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: Uninstall
 title: Uninstall
 menuWeight: 75
 excerpt: Uninstalling DC/OS Minio Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Configuring-TLS/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Configuring-TLS/index.md
@@ -4,7 +4,6 @@ navigationTitle: Configuring TLS
 title:  Configuring TLS
 menuWeight: 25
 excerpt: Configuring TLS with DC/OS Minio
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Disk-Caching/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Disk-Caching/index.md
@@ -4,7 +4,6 @@ navigationTitle: Disk Caching
 title: Disk Caching in DC/OS Minio
 menuWeight: 45
 excerpt: Using caching disks to store content 
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Erasure-Coding-Schemes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Erasure-Coding-Schemes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Erasure Coding Scheme
 title: Erasure Coding Scheme in Minio
 menuWeight: 45
 excerpt: Defining two Erasure Coding Schemes in Minio
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Mount-Volumes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Mount-Volumes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Mount Volumes
 title: Configuring Mount Volumes for Minio
 menuWeight: 40
 excerpt: Configuring Mesos mount disk resources across your cluster
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Notification-Service/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Notification-Service/index.md
@@ -4,7 +4,6 @@ navigationTitle: Notification Service
 title: Notification Service
 menuWeight: 25
 excerpt: Enable Notification Services to monitor events
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Server-Side-Encryption/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/configuration/Server-Side-Encryption/index.md
@@ -4,7 +4,6 @@ navigationTitle: Encryption
 title: Server-Side-Encryption
 menuWeight: 35
 excerpt: Encrypt your data using SSE-C keys
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Minio 0.1.1
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/minio/0.1.1/limitations/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle: Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/operations/Backing-up/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/operations/Backing-up/index.md
@@ -4,7 +4,6 @@ navigationTitle: Backup
 title: Backup 
 menuWeight: 30
 excerpt: Backing up your data to AWS S3 storage
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/operations/Restore/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/operations/Restore/index.md
@@ -4,7 +4,6 @@ navigationTitle: Restore
 title: Restore 
 menuWeight: 35
 excerpt: Restoring data backed up in AWS S3-compatible storage
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/operations/recover/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/operations/recover/index.md
@@ -4,7 +4,6 @@ navigationTitle: Recover
 title: Recovering objects on the Minio server 
 menuWeight: 30
 excerpt: Recovering buckets and objects on the Minio server in cases of disk/node failure
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 0
 excerpt: Discover the new features, updates, and known limitations in this release of the Minio Service 
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/security/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title:  Security
 menuWeight: 50
 excerpt: Configuring Minio for DC/OS access
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Minio Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.1/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.1/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: Uninstall
 title: Uninstall
 menuWeight: 75
 excerpt: Uninstalling DC/OS Minio Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Configuring-TLS/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Configuring-TLS/index.md
@@ -4,7 +4,6 @@ navigationTitle: Configuring TLS
 title:  Configuring TLS
 menuWeight: 25
 excerpt: Configuring TLS with DC/OS Minio
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Disk-Caching/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Disk-Caching/index.md
@@ -4,7 +4,6 @@ navigationTitle: Disk Caching
 title: Disk Caching in DC/OS Minio
 menuWeight: 45
 excerpt: Using caching disks to store content 
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Erasure-Coding-Schemes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Erasure-Coding-Schemes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Erasure Coding Scheme
 title: Erasure Coding Scheme in Minio
 menuWeight: 45
 excerpt: Defining two Erasure Coding Schemes in Minio
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Mount-Volumes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Mount-Volumes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Mount Volumes
 title: Configuring Mount Volumes for Minio
 menuWeight: 40
 excerpt: Configuring Mesos mount disk resources across your cluster
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Notification-Service/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Notification-Service/index.md
@@ -4,7 +4,6 @@ navigationTitle: Notification Service
 title: Notification Service
 menuWeight: 25
 excerpt: Enable Notification Services to monitor events
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Server-Side-Encryption/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/configuration/Server-Side-Encryption/index.md
@@ -4,7 +4,6 @@ navigationTitle: Encryption
 title: Server-Side-Encryption
 menuWeight: 35
 excerpt: Encrypt your data using SSE-C keys
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Minio 0.1.2
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/minio/0.1.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle: Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/operations/Backing-up/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/operations/Backing-up/index.md
@@ -4,7 +4,6 @@ navigationTitle: Backup
 title: Backup 
 menuWeight: 30
 excerpt: Backing up your data to AWS S3 storage
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/operations/Restore/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/operations/Restore/index.md
@@ -4,7 +4,6 @@ navigationTitle: Restore
 title: Restore 
 menuWeight: 35
 excerpt: Restoring data backed up in AWS S3-compatible storage
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/operations/recover/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/operations/recover/index.md
@@ -4,7 +4,6 @@ navigationTitle: Recover
 title: Recovering objects on the Minio server 
 menuWeight: 30
 excerpt: Recovering buckets and objects on the Minio server in cases of disk/node failure
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 0
 excerpt: Discover the new features, updates, and known limitations in this release of the Minio Service 
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/security/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title:  Security
 menuWeight: 50
 excerpt: Configuring Minio for DC/OS access
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Minio Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/0.1.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/minio/0.1.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: Uninstall
 title: Uninstall
 menuWeight: 75
 excerpt: Uninstalling DC/OS Minio Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/minio/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/minio/index.md
+++ b/pages/mesosphere/dcos/services/minio/index.md
@@ -4,7 +4,6 @@ navigationTitle: Minio
 title: Minio   
 menuWeight: 81
 excerpt:
-featureMaturity:
 community: true
 render: mustache
 model: /mesosphere/dcos/services/minio/data.yml

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS Apache NiFi Service API Reference
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config list
 title: dcos nifi config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config show
 title: dcos nifi config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target
 title: dcos nifi config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target_id
 title: dcos nifi config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-config/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config
 title: dcos nifi config
 menuWeight: 61
 excerpt: Displays configuration related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config list
 title: dcos nifi debug config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config show
 title: dcos nifi debug config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target
 title: dcos nifi debug config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target_id
 title: dcos nifi debug config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod pause
 title: dcos nifi debug pod pause
 menuWeight: 9
 excerpt: Pause a pod’s tasks for debugging.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod resume
 title: dcos nifi debug pod resume
 menuWeight: 10
 excerpt: Resume a pod’s normal execution following a pause command.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state framework_id
 title: dcos nifi debug state framework_id
 menuWeight: 5
 excerpt: Display the Mesos framework ID.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state properties
 title: dcos nifi debug state properties
 menuWeight: 6
 excerpt: List names of all custom properties.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state property
 title: dcos nifi debug state property
 menuWeight: 7
 excerpt: Display the content of a specified property.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state refresh_cache
 title: dcos nifi debug state refresh_cache
 menuWeight: 8
 excerpt: Refresh the state cache.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-debug/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug
 title: dcos nifi debug
 menuWeight: 65
 excerpt: Displays debugging related informations and allows debugging for the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-describe/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-describe/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi describe
 title: dcos nifi describe
 menuWeight: 63
 excerpt: View full configuration of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-endpoints/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-endpoints/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi endpoints
 title: dcos nifi endpoints
 menuWeight: 64
 excerpt: Display endpoints related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-complete
 title: dcos nifi plan force-complete
 menuWeight: 8
 excerpt: Force complete a specific step in the provided phase. Example uses include the following: Abort a sidecar operation due to observed failure or known required manual preparation that was not performed.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-restart
 title: dcos nifi plan force-restart
 menuWeight: 7
 excerpt: Restart the plan with the provided name, or a specific phase in the plan with the provided name, or a specific step in a phase of the plan with the provided step name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan list
 title: dcos nifi plan list
 menuWeight: 1
 excerpt: Show all plans for the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan pause
 title: dcos nifi plan pause
 menuWeight: 5
 excerpt: Pause the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan resume
 title: dcos nifi plan resume
 menuWeight: 6
 excerpt: Resume the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan start
 title: dcos nifi plan start
 menuWeight: 3
 excerpt: Start the plan with the provided name and any optional plan arguments.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan status
 title: dcos nifi plan status
 menuWeight: 2
 excerpt: Display the status of the plan with the provided plan name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan stop
 title: dcos nifi plan stop
 menuWeight: 4
 excerpt: Stop the running plan with the provided name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-plan/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan
 title: dcos nifi plan
 menuWeight: 65
 excerpt: Displays plan related informations and allows plan operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod info
 title: dcos nifi pod info
 menuWeight: 3
 excerpt: Display the full state information for tasks in a pod.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod list
 title: dcos nifi pod list
 menuWeight: 1
 excerpt: Display the list of known pod instances
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod replace
 title: dcos nifi pod replace
 menuWeight: 5
 excerpt: Destroy a given pod and moves it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod restart
 title: dcos nifi pod restart
 menuWeight: 4
 excerpt: Restart a given pod without moving it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod status
 title: dcos nifi pod status
 menuWeight: 2
 excerpt: Display the status for tasks in one pod or all pods.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-pod/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod
 title: dcos nifi pod
 menuWeight: 66
 excerpt: Displays pod related informations and allows pod operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state framework_id
 title: dcos nifi state framework_id
 menuWeight: 1
 excerpt: Display the Mesos framework ID
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state properties
 title: dcos nifi state properties
 menuWeight: 2
 excerpt: List names of all custom properties
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state property
 title: dcos nifi state property
 menuWeight: 3
 excerpt: Display the content of a specified property
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state refresh_cache
 title: dcos nifi state refresh_cache
 menuWeight: 4
 excerpt: Refresh the state cache, used for debugging
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-state/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state
 title: dcos nifi state
 menuWeight: 67
 excerpt: Displays state related informations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-complete
 title: dcos nifi update force-complete
 menuWeight: 2
 excerpt: Force complete a specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-restart
 title: dcos nifi update force-restart
 menuWeight: 3
 excerpt: Restart update plan, or specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update package-versions
 title: dcos nifi update package-versions
 menuWeight: 4
 excerpt: View a list of available package versions to downgrade or upgrade to
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update pause
 title: dcos nifi update pause
 menuWeight: 5
 excerpt: Pause update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update resume
 title: dcos nifi update resume
 menuWeight: 6
 excerpt: Resume update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update start
 title: dcos nifi update start
 menuWeight: 1
 excerpt: Launches an update operation
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update status
 title: dcos nifi update status
 menuWeight: 7
 excerpt: View status of a running update
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/dcos-nifi-update/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update
 title: dcos nifi update
 menuWeight: 68
 excerpt: Displays update related informations and allows update operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/command-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Command Reference
 title: Command Reference
 menuWeight: 60
 excerpt: Commands used in the DC/OS NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 0.1.0-1.5.0
 title: NiFi 0.1.0-1.5.0
 menuWeight: 7
 excerpt: Overview of DC/OS Apache NiFi 0.1.0-1.5.0
-featureMaturity:
 community: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/install/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Installing and Customizing
 title: Installing and Customizing
 menuWeight: 20
 excerpt: Installing DC/OS Apache NiFi from the UI or the CLI
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Managing
 title: Managing
 menuWeight: 80
 excerpt: Managing your DC/OS NiFi Service configuration
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/overview/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Overview
 title: Overview
 menuWeight: 10
 excerpt: Getting started with DC/OS Apache NiFi Service fundamentals
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 130
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service 
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 50
 excerpt: DC/OS Apache NiFi Service encryption, authentication and authorization
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS NiFi Services package versioning
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/troubleshooting/debugging/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/troubleshooting/debugging/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Debugging
 title: Debugging
 menuWeight: 102
 excerpt: Some common errors you might find
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/troubleshooting/diagnostictools/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/troubleshooting/diagnostictools/index.md
@@ -4,7 +4,6 @@ navigationTitle: Diagnostic Tools
 title: Diagnostic Tools
 menuWeight: 103
 excerpt: Tools for diagnosing cluster problems
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/troubleshooting/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Troubleshooting
 title: Troubleshooting
 menuWeight: 100
 excerpt: Troubleshooting DC/OS Apache NiFi issues
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.1.0-1.5.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 40
 excerpt: Uninstalling DC/OS Apache NiFi Service
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS NiFi Service API Reference
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config list
 title: dcos nifi config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config show
 title: dcos nifi config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target
 title: dcos nifi config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target_id
 title: dcos nifi config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-config/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config
 title: dcos nifi config
 menuWeight: 61
 excerpt: Displays configuration related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config list
 title: dcos nifi debug config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config show
 title: dcos nifi debug config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target
 title: dcos nifi debug config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target_id
 title: dcos nifi debug config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod pause
 title: dcos nifi debug pod pause
 menuWeight: 9
 excerpt: Pause a pod’s tasks for debugging.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod resume
 title: dcos nifi debug pod resume
 menuWeight: 10
 excerpt: Resume a pod’s normal execution following a pause command.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state framework_id
 title: dcos nifi debug state framework_id
 menuWeight: 5
 excerpt: Display the Mesos framework ID.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state properties
 title: dcos nifi debug state properties
 menuWeight: 6
 excerpt: List names of all custom properties.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state property
 title: dcos nifi debug state property
 menuWeight: 7
 excerpt: Display the content of a specified property.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state refresh_cache
 title: dcos nifi debug state refresh_cache
 menuWeight: 8
 excerpt: Refresh the state cache.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-debug/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug
 title: dcos nifi debug
 menuWeight: 65
 excerpt: Displays debugging related informations and allows debugging for the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-describe/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-describe/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi describe
 title: dcos nifi describe
 menuWeight: 63
 excerpt: View full configuration of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-endpoints/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-endpoints/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi endpoints
 title: dcos nifi endpoints
 menuWeight: 64
 excerpt: Display endpoints related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-complete
 title: dcos nifi plan force-complete
 menuWeight: 8
 excerpt: Force complete a specific step in the provided phase. Example uses include the following: Abort a sidecar operation due to observed failure or known required manual preparation that was not performed.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-restart
 title: dcos nifi plan force-restart
 menuWeight: 7
 excerpt: Restart the plan with the provided name, or a specific phase in the plan with the provided name, or a specific step in a phase of the plan with the provided step name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan list
 title: dcos nifi plan list
 menuWeight: 1
 excerpt: Show all plans for the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan pause
 title: dcos nifi plan pause
 menuWeight: 5
 excerpt: Pause the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan resume
 title: dcos nifi plan resume
 menuWeight: 6
 excerpt: Resume the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan start
 title: dcos nifi plan start
 menuWeight: 3
 excerpt: Start the plan with the provided name and any optional plan arguments.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan status
 title: dcos nifi plan status
 menuWeight: 2
 excerpt: Display the status of the plan with the provided plan name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan stop
 title: dcos nifi plan stop
 menuWeight: 4
 excerpt: Stop the running plan with the provided name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-plan/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan
 title: dcos nifi plan
 menuWeight: 65
 excerpt: Displays plan related informations and allows plan operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod info
 title: dcos nifi pod info
 menuWeight: 3
 excerpt: Display the full state information for tasks in a pod.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod list
 title: dcos nifi pod list
 menuWeight: 1
 excerpt: Display the list of known pod instances
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod replace
 title: dcos nifi pod replace
 menuWeight: 5
 excerpt: Destroy a given pod and moves it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod restart
 title: dcos nifi pod restart
 menuWeight: 4
 excerpt: Restart a given pod without moving it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod status
 title: dcos nifi pod status
 menuWeight: 2
 excerpt: Display the status for tasks in one pod or all pods.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-pod/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod
 title: dcos nifi pod
 menuWeight: 66
 excerpt: Displays pod related informations and allows pod operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state framework_id
 title: dcos nifi state framework_id
 menuWeight: 1
 excerpt: Display the Mesos framework ID
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state properties
 title: dcos nifi state properties
 menuWeight: 2
 excerpt: List names of all custom properties
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state property
 title: dcos nifi state property
 menuWeight: 3
 excerpt: Display the content of a specified property
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state refresh_cache
 title: dcos nifi state refresh_cache
 menuWeight: 4
 excerpt: Refresh the state cache, used for debugging
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-state/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state
 title: dcos nifi state
 menuWeight: 67
 excerpt: Displays state related informations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-complete
 title: dcos nifi update force-complete
 menuWeight: 2
 excerpt: Force complete a specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-restart
 title: dcos nifi update force-restart
 menuWeight: 3
 excerpt: Restart update plan, or specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update package-versions
 title: dcos nifi update package-versions
 menuWeight: 4
 excerpt: View a list of available package versions to downgrade or upgrade to
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update pause
 title: dcos nifi update pause
 menuWeight: 5
 excerpt: Pause update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update resume
 title: dcos nifi update resume
 menuWeight: 6
 excerpt: Resume update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update start
 title: dcos nifi update start
 menuWeight: 1
 excerpt: Launches an update operation
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update status
 title: dcos nifi update status
 menuWeight: 7
 excerpt: View status of a running update
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/dcos-nifi-update/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update
 title: dcos nifi update
 menuWeight: 68
 excerpt: Displays update related informations and allows update operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/command-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Command Reference
 title: Command Reference
 menuWeight: 60
 excerpt: Commands used in the DC/OS NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 ---
 # Deployment Best Practices

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 0.2.0-1.5.0
 title: NiFi 0.2.0-1.5.0
 menuWeight: 6
 excerpt: Overview of DC/OS Apache NiFi 0.2.0-1.5.0
-featureMaturity:
 community: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/install/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Installing and Customizing
 title: Installing and Customizing
 menuWeight: 20
 excerpt: Installing DC/OS NiFi from the UI or the CLI
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration Limitations
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Managing
 title: Managing
 menuWeight: 80
 excerpt: Managing your DC/OS NiFi configuration
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/overview/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Overview
 title: Overview
 menuWeight: 10
 excerpt: Getting started with DC/OS NiFi Service
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 130
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service 
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 50
 excerpt: DC/OS NiFi Service encryption, authentication, and authorization
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS NiFi Services package versioning
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/troubleshooting/debugging/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/troubleshooting/debugging/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Debugging
 title: Debugging
 menuWeight: 101
 excerpt: Some common errors you might find
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/troubleshooting/diagnostictools/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/troubleshooting/diagnostictools/index.md
@@ -4,7 +4,6 @@ navigationTitle: Diagnostic Tools
 title: Diagnostic Tools
 menuWeight: 102
 excerpt: Troubleshooting clusters
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/troubleshooting/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Troubleshooting
 title: Troubleshooting
 menuWeight: 100
 excerpt: Troubleshooting DC/OS Apache NiFi issues
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.2.0-1.5.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 40
 excerpt: Uninstalling DC/OS Apache NiFi Services
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS NiFi Service API Reference
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config list
 title: dcos nifi config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config show
 title: dcos nifi config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target
 title: dcos nifi config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target_id
 title: dcos nifi config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-config/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config
 title: dcos nifi config
 menuWeight: 61
 excerpt: Displays configuration related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config list
 title: dcos nifi debug config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config show
 title: dcos nifi debug config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target
 title: dcos nifi debug config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target_id
 title: dcos nifi debug config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod pause
 title: dcos nifi debug pod pause
 menuWeight: 9
 excerpt: Pause a pod’s tasks for debugging.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod resume
 title: dcos nifi debug pod resume
 menuWeight: 10
 excerpt: Resume a pod’s normal execution following a pause command.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state framework_id
 title: dcos nifi debug state framework_id
 menuWeight: 5
 excerpt: Display the Mesos framework ID.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state properties
 title: dcos nifi debug state properties
 menuWeight: 6
 excerpt: List names of all custom properties.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state property
 title: dcos nifi debug state property
 menuWeight: 7
 excerpt: Display the content of a specified property.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state refresh_cache
 title: dcos nifi debug state refresh_cache
 menuWeight: 8
 excerpt: Refresh the state cache.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-debug/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug
 title: dcos nifi debug
 menuWeight: 65
 excerpt: Displays debugging related informations and allows debugging for the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-describe/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-describe/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi describe
 title: dcos nifi describe
 menuWeight: 63
 excerpt: View full configuration of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-endpoints/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-endpoints/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi endpoints
 title: dcos nifi endpoints
 menuWeight: 64
 excerpt: Display endpoints related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-complete
 title: dcos nifi plan force-complete
 menuWeight: 8
 excerpt: Force complete a specific step in the provided phase. Example uses include the following: Abort a sidecar operation due to observed failure or known required manual preparation that was not performed.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-restart
 title: dcos nifi plan force-restart
 menuWeight: 7
 excerpt: Restart the plan with the provided name, or a specific phase in the plan with the provided name, or a specific step in a phase of the plan with the provided step name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan list
 title: dcos nifi plan list
 menuWeight: 1
 excerpt: Show all plans for the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan pause
 title: dcos nifi plan pause
 menuWeight: 5
 excerpt: Pause the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan resume
 title: dcos nifi plan resume
 menuWeight: 6
 excerpt: Resume the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan start
 title: dcos nifi plan start
 menuWeight: 3
 excerpt: Start the plan with the provided name and any optional plan arguments.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan status
 title: dcos nifi plan status
 menuWeight: 2
 excerpt: Display the status of the plan with the provided plan name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan stop
 title: dcos nifi plan stop
 menuWeight: 4
 excerpt: Stop the running plan with the provided name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-plan/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan
 title: dcos nifi plan
 menuWeight: 65
 excerpt: Displays plan related informations and allows plan operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod info
 title: dcos nifi pod info
 menuWeight: 3
 excerpt: Display the full state information for tasks in a pod.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod list
 title: dcos nifi pod list
 menuWeight: 1
 excerpt: Display the list of known pod instances
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod replace
 title: dcos nifi pod replace
 menuWeight: 5
 excerpt: Destroy a given pod and moves it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod restart
 title: dcos nifi pod restart
 menuWeight: 4
 excerpt: Restart a given pod without moving it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod status
 title: dcos nifi pod status
 menuWeight: 2
 excerpt: Display the status for tasks in one pod or all pods.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-pod/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod
 title: dcos nifi pod
 menuWeight: 66
 excerpt: Displays pod related informations and allows pod operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state framework_id
 title: dcos nifi state framework_id
 menuWeight: 1
 excerpt: Display the Mesos framework ID
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state properties
 title: dcos nifi state properties
 menuWeight: 2
 excerpt: List names of all custom properties
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state property
 title: dcos nifi state property
 menuWeight: 3
 excerpt: Display the content of a specified property
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state refresh_cache
 title: dcos nifi state refresh_cache
 menuWeight: 4
 excerpt: Refresh the state cache, used for debugging
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-state/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state
 title: dcos nifi state
 menuWeight: 67
 excerpt: Displays state related informations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-complete
 title: dcos nifi update force-complete
 menuWeight: 2
 excerpt: Force complete a specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-restart
 title: dcos nifi update force-restart
 menuWeight: 3
 excerpt: Restart update plan, or specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update package-versions
 title: dcos nifi update package-versions
 menuWeight: 4
 excerpt: View a list of available package versions to downgrade or upgrade to
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update pause
 title: dcos nifi update pause
 menuWeight: 5
 excerpt: Pause update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update resume
 title: dcos nifi update resume
 menuWeight: 6
 excerpt: Resume update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update start
 title: dcos nifi update start
 menuWeight: 1
 excerpt: Launches an update operation
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update status
 title: dcos nifi update status
 menuWeight: 7
 excerpt: View status of a running update
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/dcos-nifi-update/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update
 title: dcos nifi update
 menuWeight: 68
 excerpt: Displays update related informations and allows update operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/command-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Command Reference
 title: Command Reference
 menuWeight: 60
 excerpt: Commands used in the DC/OS NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 0.3.0-1.7.1
 title: NiFi 0.3.0-1.7.1
 menuWeight: 5
 excerpt: Overview of DC/OS Apache NiFi 0.3.0-1.7.1
-featureMaturity:
 community: false
 model: ../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/install/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Installing and Customizing
 title: Installing and Customizing
 menuWeight: 20
 excerpt: Installing DC/OS NiFi from the UI or the CLI
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Operations
 menuWeight: 35
 excerpt: Managing your DC/OS NiFi service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/overview/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Overview
 title: Overview
 menuWeight: 10
 excerpt: Getting started with DC/OS Apache NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 5
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/secret-upload/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/secret-upload/index.md
@@ -4,7 +4,6 @@ navigationTitle: Secret Upload
 title: Secret Upload
 menuWeight: 50
 excerpt: DC/OS NiFi service secret upload
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 49
 excerpt: DC/OS NiFi Service encryption, authentication, and authorization
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS NiFi Services package versioning
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/troubleshooting/debugging/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/troubleshooting/debugging/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Debugging
 title: Debugging
 menuWeight: 101
 excerpt: Some common errors you might find
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/troubleshooting/diagnostictools/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/troubleshooting/diagnostictools/index.md
@@ -4,7 +4,6 @@ navigationTitle: Diagnostic Tools
 title: Diagnostic Tools
 menuWeight: 102
 excerpt: Troubleshooting clusters
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/troubleshooting/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Troubleshooting
 title: Troubleshooting
 menuWeight: 100
 excerpt: Troubleshooting DC/OS NiFi issues
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.3.0-1.7.1/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 40
 excerpt: Uninstalling DC/OS NiFi Services
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS NiFi Service API Reference
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config list
 title: dcos nifi config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config show
 title: dcos nifi config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target
 title: dcos nifi config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target_id
 title: dcos nifi config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-config/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config
 title: dcos nifi config
 menuWeight: 61
 excerpt: Displays configuration related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config list
 title: dcos nifi debug config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config show
 title: dcos nifi debug config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target
 title: dcos nifi debug config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target_id
 title: dcos nifi debug config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod pause
 title: dcos nifi debug pod pause
 menuWeight: 9
 excerpt: Pause a pod’s tasks for debugging.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod resume
 title: dcos nifi debug pod resume
 menuWeight: 10
 excerpt: Resume a pod’s normal execution following a pause command.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state framework_id
 title: dcos nifi debug state framework_id
 menuWeight: 5
 excerpt: Display the Mesos framework ID.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state properties
 title: dcos nifi debug state properties
 menuWeight: 6
 excerpt: List names of all custom properties.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state property
 title: dcos nifi debug state property
 menuWeight: 7
 excerpt: Display the content of a specified property.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state refresh_cache
 title: dcos nifi debug state refresh_cache
 menuWeight: 8
 excerpt: Refresh the state cache.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-debug/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug
 title: dcos nifi debug
 menuWeight: 65
 excerpt: Displays debugging related informations and allows debugging for the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-describe/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-describe/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi describe
 title: dcos nifi describe
 menuWeight: 63
 excerpt: View full configuration of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-endpoints/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-endpoints/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi endpoints
 title: dcos nifi endpoints
 menuWeight: 64
 excerpt: Display endpoints related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-complete
 title: dcos nifi plan force-complete
 menuWeight: 8
 excerpt: Force complete a specific step in the provided phase. Example uses include the following: Abort a sidecar operation due to observed failure or known required manual preparation that was not performed.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-restart
 title: dcos nifi plan force-restart
 menuWeight: 7
 excerpt: Restart the plan with the provided name, or a specific phase in the plan with the provided name, or a specific step in a phase of the plan with the provided step name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan list
 title: dcos nifi plan list
 menuWeight: 1
 excerpt: Show all plans for the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan pause
 title: dcos nifi plan pause
 menuWeight: 5
 excerpt: Pause the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan resume
 title: dcos nifi plan resume
 menuWeight: 6
 excerpt: Resume the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan start
 title: dcos nifi plan start
 menuWeight: 3
 excerpt: Start the plan with the provided name and any optional plan arguments.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan status
 title: dcos nifi plan status
 menuWeight: 2
 excerpt: Display the status of the plan with the provided plan name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan stop
 title: dcos nifi plan stop
 menuWeight: 4
 excerpt: Stop the running plan with the provided name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-plan/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan
 title: dcos nifi plan
 menuWeight: 65
 excerpt: Displays plan related informations and allows plan operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod info
 title: dcos nifi pod info
 menuWeight: 3
 excerpt: Display the full state information for tasks in a pod.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod list
 title: dcos nifi pod list
 menuWeight: 1
 excerpt: Display the list of known pod instances
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod replace
 title: dcos nifi pod replace
 menuWeight: 5
 excerpt: Destroy a given pod and moves it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod restart
 title: dcos nifi pod restart
 menuWeight: 4
 excerpt: Restart a given pod without moving it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod status
 title: dcos nifi pod status
 menuWeight: 2
 excerpt: Display the status for tasks in one pod or all pods.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-pod/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod
 title: dcos nifi pod
 menuWeight: 66
 excerpt: Displays pod related informations and allows pod operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state framework_id
 title: dcos nifi state framework_id
 menuWeight: 1
 excerpt: Display the Mesos framework ID
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state properties
 title: dcos nifi state properties
 menuWeight: 2
 excerpt: List names of all custom properties
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state property
 title: dcos nifi state property
 menuWeight: 3
 excerpt: Display the content of a specified property
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state refresh_cache
 title: dcos nifi state refresh_cache
 menuWeight: 4
 excerpt: Refresh the state cache, used for debugging
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-state/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state
 title: dcos nifi state
 menuWeight: 67
 excerpt: Displays state related informations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-complete
 title: dcos nifi update force-complete
 menuWeight: 2
 excerpt: Force complete a specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-restart
 title: dcos nifi update force-restart
 menuWeight: 3
 excerpt: Restart update plan, or specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update package-versions
 title: dcos nifi update package-versions
 menuWeight: 4
 excerpt: View a list of available package versions to downgrade or upgrade to
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update pause
 title: dcos nifi update pause
 menuWeight: 5
 excerpt: Pause update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update resume
 title: dcos nifi update resume
 menuWeight: 6
 excerpt: Resume update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update start
 title: dcos nifi update start
 menuWeight: 1
 excerpt: Launches an update operation
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update status
 title: dcos nifi update status
 menuWeight: 7
 excerpt: View status of a running update
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/dcos-nifi-update/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update
 title: dcos nifi update
 menuWeight: 68
 excerpt: Displays update related informations and allows update operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/command-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Command Reference
 title: Command Reference
 menuWeight: 60
 excerpt: Commands used in the DC/OS NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 0.4.0-1.8.0
 title: NiFi 0.4.0-1.8.0
 menuWeight: 4
 excerpt: Overview of DC/OS Apache NiFi 0.4.0-1.8.0
-featureMaturity:
 community: false
 model: ../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/install/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Installing and Customizing
 title: Installing and Customizing
 menuWeight: 20
 excerpt: Installing DC/OS NiFi from the UI or the CLI
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Operations
 menuWeight: 35
 excerpt: Managing your DC/OS NiFi service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/offload-node/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/offload-node/index.md
@@ -4,7 +4,6 @@ navigationTitle: Offload Node
 title: Offload Node
 menuWeight: 45
 excerpt: DC/OS NiFi service Offload Node
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/overview/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Overview
 title: Overview
 menuWeight: 10
 excerpt: Getting started with DC/OS Apache NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 5
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/secret-upload/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/secret-upload/index.md
@@ -4,7 +4,6 @@ navigationTitle: Secret Upload
 title: Secret Upload
 menuWeight: 50
 excerpt: DC/OS NiFi service secret upload
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 49
 excerpt: DC/OS NiFi Service encryption, authentication, and authorization
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS NiFi Services package versioning
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/troubleshooting/debugging/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/troubleshooting/debugging/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Debugging
 title: Debugging
 menuWeight: 101
 excerpt: Some common errors you might find
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/troubleshooting/diagnostictools/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/troubleshooting/diagnostictools/index.md
@@ -4,7 +4,6 @@ navigationTitle: Diagnostic Tools
 title: Diagnostic Tools
 menuWeight: 102
 excerpt: Troubleshooting clusters
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/troubleshooting/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Troubleshooting
 title: Troubleshooting
 menuWeight: 100
 excerpt: Troubleshooting DC/OS NiFi issues
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.0-1.8.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 40
 excerpt: Uninstalling DC/OS NiFi Services
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS NiFi Service API Reference
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config list
 title: dcos nifi config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config show
 title: dcos nifi config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target
 title: dcos nifi config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target_id
 title: dcos nifi config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-config/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config
 title: dcos nifi config
 menuWeight: 61
 excerpt: Displays configuration related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config list
 title: dcos nifi debug config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config show
 title: dcos nifi debug config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target
 title: dcos nifi debug config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target_id
 title: dcos nifi debug config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod pause
 title: dcos nifi debug pod pause
 menuWeight: 9
 excerpt: Pause a pod’s tasks for debugging.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod resume
 title: dcos nifi debug pod resume
 menuWeight: 10
 excerpt: Resume a pod’s normal execution following a pause command.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state framework_id
 title: dcos nifi debug state framework_id
 menuWeight: 5
 excerpt: Display the Mesos framework ID.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state properties
 title: dcos nifi debug state properties
 menuWeight: 6
 excerpt: List names of all custom properties.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state property
 title: dcos nifi debug state property
 menuWeight: 7
 excerpt: Display the content of a specified property.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state refresh_cache
 title: dcos nifi debug state refresh_cache
 menuWeight: 8
 excerpt: Refresh the state cache.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-debug/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug
 title: dcos nifi debug
 menuWeight: 65
 excerpt: Displays debugging related informations and allows debugging for the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-describe/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-describe/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi describe
 title: dcos nifi describe
 menuWeight: 63
 excerpt: View full configuration of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-endpoints/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-endpoints/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi endpoints
 title: dcos nifi endpoints
 menuWeight: 64
 excerpt: Display endpoints related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-complete
 title: dcos nifi plan force-complete
 menuWeight: 8
 excerpt: Force complete a specific step in the provided phase. Example uses include the following: Abort a sidecar operation due to observed failure or known required manual preparation that was not performed.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-restart
 title: dcos nifi plan force-restart
 menuWeight: 7
 excerpt: Restart the plan with the provided name, or a specific phase in the plan with the provided name, or a specific step in a phase of the plan with the provided step name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan list
 title: dcos nifi plan list
 menuWeight: 1
 excerpt: Show all plans for the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan pause
 title: dcos nifi plan pause
 menuWeight: 5
 excerpt: Pause the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan resume
 title: dcos nifi plan resume
 menuWeight: 6
 excerpt: Resume the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan start
 title: dcos nifi plan start
 menuWeight: 3
 excerpt: Start the plan with the provided name and any optional plan arguments.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan status
 title: dcos nifi plan status
 menuWeight: 2
 excerpt: Display the status of the plan with the provided plan name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan stop
 title: dcos nifi plan stop
 menuWeight: 4
 excerpt: Stop the running plan with the provided name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-plan/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan
 title: dcos nifi plan
 menuWeight: 65
 excerpt: Displays plan related informations and allows plan operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod info
 title: dcos nifi pod info
 menuWeight: 3
 excerpt: Display the full state information for tasks in a pod.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod list
 title: dcos nifi pod list
 menuWeight: 1
 excerpt: Display the list of known pod instances
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod replace
 title: dcos nifi pod replace
 menuWeight: 5
 excerpt: Destroy a given pod and moves it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod restart
 title: dcos nifi pod restart
 menuWeight: 4
 excerpt: Restart a given pod without moving it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod status
 title: dcos nifi pod status
 menuWeight: 2
 excerpt: Display the status for tasks in one pod or all pods.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-pod/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod
 title: dcos nifi pod
 menuWeight: 66
 excerpt: Displays pod related informations and allows pod operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state framework_id
 title: dcos nifi state framework_id
 menuWeight: 1
 excerpt: Display the Mesos framework ID
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state properties
 title: dcos nifi state properties
 menuWeight: 2
 excerpt: List names of all custom properties
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state property
 title: dcos nifi state property
 menuWeight: 3
 excerpt: Display the content of a specified property
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state refresh_cache
 title: dcos nifi state refresh_cache
 menuWeight: 4
 excerpt: Refresh the state cache, used for debugging
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-state/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state
 title: dcos nifi state
 menuWeight: 67
 excerpt: Displays state related informations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-complete
 title: dcos nifi update force-complete
 menuWeight: 2
 excerpt: Force complete a specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-restart
 title: dcos nifi update force-restart
 menuWeight: 3
 excerpt: Restart update plan, or specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update package-versions
 title: dcos nifi update package-versions
 menuWeight: 4
 excerpt: View a list of available package versions to downgrade or upgrade to
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update pause
 title: dcos nifi update pause
 menuWeight: 5
 excerpt: Pause update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update resume
 title: dcos nifi update resume
 menuWeight: 6
 excerpt: Resume update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update start
 title: dcos nifi update start
 menuWeight: 1
 excerpt: Launches an update operation
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update status
 title: dcos nifi update status
 menuWeight: 7
 excerpt: View status of a running update
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/dcos-nifi-update/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update
 title: dcos nifi update
 menuWeight: 68
 excerpt: Displays update related informations and allows update operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/command-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Command Reference
 title: Command Reference
 menuWeight: 60
 excerpt: Commands used in the DC/OS NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 0.4.1-1.8.0
 title: NiFi 0.4.1-1.8.0
 menuWeight: 3
 excerpt: Overview of DC/OS Apache NiFi 0.4.1-1.8.0
-featureMaturity:
 community: true
 model: ../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/install/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Installing and Customizing
 title: Installing and Customizing
 menuWeight: 20
 excerpt: Installing DC/OS NiFi from the UI or the CLI
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Operations
 menuWeight: 35
 excerpt: Managing your DC/OS NiFi service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/offload-node/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/offload-node/index.md
@@ -4,7 +4,6 @@ navigationTitle: Offload Node
 title: Offload Node
 menuWeight: 45
 excerpt: DC/OS NiFi service Offload Node
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/overview/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Overview
 title: Overview
 menuWeight: 10
 excerpt: Getting started with DC/OS Apache NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 5
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/secret-upload/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/secret-upload/index.md
@@ -4,7 +4,6 @@ navigationTitle: Secret Upload
 title: Secret Upload
 menuWeight: 50
 excerpt: DC/OS NiFi service secret upload
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 49
 excerpt: DC/OS NiFi Service encryption, authentication, and authorization
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS NiFi Services package versioning
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/troubleshooting/debugging/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/troubleshooting/debugging/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Debugging
 title: Debugging
 menuWeight: 101
 excerpt: Some common errors you might find
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/troubleshooting/diagnostictools/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/troubleshooting/diagnostictools/index.md
@@ -4,7 +4,6 @@ navigationTitle: Diagnostic Tools
 title: Diagnostic Tools
 menuWeight: 102
 excerpt: Troubleshooting clusters
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/troubleshooting/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Troubleshooting
 title: Troubleshooting
 menuWeight: 100
 excerpt: Troubleshooting DC/OS NiFi issues
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.4.1-1.8.0/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 40
 excerpt: Uninstalling DC/OS NiFi Services
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS NiFi Service API Reference
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config list
 title: dcos nifi config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config show
 title: dcos nifi config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target
 title: dcos nifi config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/dcos-nifi-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config target_id
 title: dcos nifi config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-config/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi config
 title: dcos nifi config
 menuWeight: 61
 excerpt: Displays configuration related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config list
 title: dcos nifi debug config list
 menuWeight: 1
 excerpt: List IDs of all available configurations.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-show/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config show
 title: dcos nifi debug config show
 menuWeight: 2
 excerpt: Display a specified configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target
 title: dcos nifi debug config target
 menuWeight: 3
 excerpt: Display the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-config-target_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug config target_id
 title: dcos nifi debug config target_id
 menuWeight: 4
 excerpt: List ID of the target configuration.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod pause
 title: dcos nifi debug pod pause
 menuWeight: 9
 excerpt: Pause a pod’s tasks for debugging.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-pod-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug pod resume
 title: dcos nifi debug pod resume
 menuWeight: 10
 excerpt: Resume a pod’s normal execution following a pause command.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state framework_id
 title: dcos nifi debug state framework_id
 menuWeight: 5
 excerpt: Display the Mesos framework ID.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state properties
 title: dcos nifi debug state properties
 menuWeight: 6
 excerpt: List names of all custom properties.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state property
 title: dcos nifi debug state property
 menuWeight: 7
 excerpt: Display the content of a specified property.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/dcos-nifi-debug-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug state refresh_cache
 title: dcos nifi debug state refresh_cache
 menuWeight: 8
 excerpt: Refresh the state cache.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-debug/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi debug
 title: dcos nifi debug
 menuWeight: 65
 excerpt: Displays debugging related informations and allows debugging for the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-describe/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-describe/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi describe
 title: dcos nifi describe
 menuWeight: 63
 excerpt: View full configuration of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-endpoints/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-endpoints/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi endpoints
 title: dcos nifi endpoints
 menuWeight: 64
 excerpt: Display endpoints related informations of the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-complete
 title: dcos nifi plan force-complete
 menuWeight: 8
 excerpt: Force complete a specific step in the provided phase. Example uses include the following: Abort a sidecar operation due to observed failure or known required manual preparation that was not performed.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan force-restart
 title: dcos nifi plan force-restart
 menuWeight: 7
 excerpt: Restart the plan with the provided name, or a specific phase in the plan with the provided name, or a specific step in a phase of the plan with the provided step name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan list
 title: dcos nifi plan list
 menuWeight: 1
 excerpt: Show all plans for the NiFi service.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan pause
 title: dcos nifi plan pause
 menuWeight: 5
 excerpt: Pause the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan resume
 title: dcos nifi plan resume
 menuWeight: 6
 excerpt: Resume the plan, or a specific phase in that plan with the provided phase name (or UUID).
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan start
 title: dcos nifi plan start
 menuWeight: 3
 excerpt: Start the plan with the provided name and any optional plan arguments.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan status
 title: dcos nifi plan status
 menuWeight: 2
 excerpt: Display the status of the plan with the provided plan name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/dcos-nifi-plan-stop/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan stop
 title: dcos nifi plan stop
 menuWeight: 4
 excerpt: Stop the running plan with the provided name.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-plan/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi plan
 title: dcos nifi plan
 menuWeight: 65
 excerpt: Displays plan related informations and allows plan operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-info/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod info
 title: dcos nifi pod info
 menuWeight: 3
 excerpt: Display the full state information for tasks in a pod.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-list/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod list
 title: dcos nifi pod list
 menuWeight: 1
 excerpt: Display the list of known pod instances
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-replace/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod replace
 title: dcos nifi pod replace
 menuWeight: 5
 excerpt: Destroy a given pod and moves it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod restart
 title: dcos nifi pod restart
 menuWeight: 4
 excerpt: Restart a given pod without moving it to a new agent.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/dcos-nifi-pod-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod status
 title: dcos nifi pod status
 menuWeight: 2
 excerpt: Display the status for tasks in one pod or all pods.
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-pod/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi pod
 title: dcos nifi pod
 menuWeight: 66
 excerpt: Displays pod related informations and allows pod operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-framework_id/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state framework_id
 title: dcos nifi state framework_id
 menuWeight: 1
 excerpt: Display the Mesos framework ID
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-properties/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state properties
 title: dcos nifi state properties
 menuWeight: 2
 excerpt: List names of all custom properties
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-property/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state property
 title: dcos nifi state property
 menuWeight: 3
 excerpt: Display the content of a specified property
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/dcos-nifi-state-refresh_cache/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state refresh_cache
 title: dcos nifi state refresh_cache
 menuWeight: 4
 excerpt: Refresh the state cache, used for debugging
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-state/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi state
 title: dcos nifi state
 menuWeight: 67
 excerpt: Displays state related informations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-force-complete/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-complete
 title: dcos nifi update force-complete
 menuWeight: 2
 excerpt: Force complete a specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-force-restart/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update force-restart
 title: dcos nifi update force-restart
 menuWeight: 3
 excerpt: Restart update plan, or specific step in the provided phase
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-package-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update package-versions
 title: dcos nifi update package-versions
 menuWeight: 4
 excerpt: View a list of available package versions to downgrade or upgrade to
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-pause/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update pause
 title: dcos nifi update pause
 menuWeight: 5
 excerpt: Pause update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-resume/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update resume
 title: dcos nifi update resume
 menuWeight: 6
 excerpt: Resume update plan
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update start
 title: dcos nifi update start
 menuWeight: 1
 excerpt: Launches an update operation
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/dcos-nifi-update-status/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update status
 title: dcos nifi update status
 menuWeight: 7
 excerpt: View status of a running update
-featureMaturity:
 enterprise: false
 model: ../../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/dcos-nifi-update/index.md
@@ -4,7 +4,6 @@ navigationTitle:  dcos nifi update
 title: dcos nifi update
 menuWeight: 68
 excerpt: Displays update related informations and allows update operations of the NiFi service
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/command-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Command Reference
 title: Command Reference
 menuWeight: 60
 excerpt: Commands used in the DC/OS NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 0.5.0-1.9.2
 title: NiFi 0.5.0-1.9.2
 menuWeight: 2
 excerpt: Overview of DC/OS Apache NiFi 0.5.0-1.9.2
-featureMaturity:
 community: false
 model: ../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/install/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/install/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Installing and Customizing
 title: Installing and Customizing
 menuWeight: 10
 excerpt: Installing DC/OS NiFi from the UI or the CLI
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Operations
 menuWeight: 35
 excerpt: Managing your DC/OS NiFi service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/offload-node/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/offload-node/index.md
@@ -4,7 +4,6 @@ navigationTitle: Offload Node
 title: Offload Node
 menuWeight: 45
 excerpt: DC/OS NiFi service Offload Node
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/overview/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Overview
 title: Overview
 menuWeight: 15
 excerpt: Getting started with DC/OS Apache NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 5
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/secret-upload/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/secret-upload/index.md
@@ -4,7 +4,6 @@ navigationTitle: Secret Upload
 title: Secret Upload
 menuWeight: 50
 excerpt: DC/OS NiFi service secret upload
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 49
 excerpt: DC/OS NiFi Service encryption, authentication, and authorization
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS NiFi Services package versioning
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/troubleshooting/debugging/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/troubleshooting/debugging/index.md
@@ -4,7 +4,6 @@ navigationTitle: Debugging
 title: Debugging
 menuWeight: 101
 excerpt: Some common errors you might find
-featureMaturity:
 enterprise: false
 model: ../../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/troubleshooting/diagnostictools/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/troubleshooting/diagnostictools/index.md
@@ -4,7 +4,6 @@ navigationTitle: Diagnostic Tools
 title: Diagnostic Tools
 menuWeight: 102
 excerpt: Troubleshooting clusters
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/troubleshooting/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/troubleshooting/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Troubleshooting
 title: Troubleshooting
 menuWeight: 100
 excerpt: Troubleshooting DC/OS NiFi issues
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/nifi/0.5.0-1.9.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 40
 excerpt: Uninstalling DC/OS NiFi Services
-featureMaturity:
 enterprise: false
 model: ../../data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS NiFi Service API Reference
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 1.0.0-1.9.2
 title: NiFi 1.0.0-1.9.2
 menuWeight: 1
 excerpt: Overview of DC/OS Apache NiFi 1.0.0-1.9.2
-featureMaturity:
 community: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Operations
 menuWeight: 35
 excerpt: Managing your DC/OS NiFi service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/offload-node/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/offload-node/index.md
@@ -4,7 +4,6 @@ navigationTitle: Offload Node
 title: Offload Node
 menuWeight: 36
 excerpt: DC/OS NiFi service Offload Node feature
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 5
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.0-1.9.2/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 49
 excerpt: DC/OS NiFi Service encryption, authentication, and authorization
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/api-reference/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/api-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  API Reference
 title: API Reference
 menuWeight: 90
 excerpt: DC/OS NiFi Service API Reference
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 70
 excerpt: Connecting clients through service discovery
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 30
 excerpt: Best practices for production deployment
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: NiFi 1.0.1-1.9.2
 title: NiFi 1.0.1-1.9.2
 menuWeight: 1
 excerpt: Overview of DC/OS Apache NiFi 1.0.1-1.9.2
-featureMaturity:
 community: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/managing/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Operations
 menuWeight: 35
 excerpt: Managing your DC/OS NiFi service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/offload-node/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/offload-node/index.md
@@ -4,7 +4,6 @@ navigationTitle: Offload Node
 title: Offload Node
 menuWeight: 36
 excerpt: DC/OS NiFi service Offload Node feature
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 5
 excerpt: Discover the new features, updates, and known limitations in this release of the NiFi Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/security/index.md
+++ b/pages/mesosphere/dcos/services/nifi/1.0.1-1.9.2/security/index.md
@@ -4,7 +4,6 @@ navigationTitle: Security
 title: Security
 menuWeight: 49
 excerpt: DC/OS NiFi Service encryption, authentication, and authorization
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/nifi/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/nifi/configure-dcos-access/index.md
+++ b/pages/mesosphere/dcos/services/nifi/configure-dcos-access/index.md
@@ -4,7 +4,6 @@ navigationTitle: Configuring DC/OS access for NiFi
 title: Configuring DC/OS access for NiFi
 menuWeight: 1010
 excerpt: Configuring DC/OS access for NiFi
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/nifi/index.md
+++ b/pages/mesosphere/dcos/services/nifi/index.md
@@ -4,7 +4,6 @@ navigationTitle:
 title: NiFi
 menuWeight: 82
 excerpt:
-featureMaturity:
 community: true
 category: Data Processing
 ---

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 50
 excerpt: Connecting clients with service discovery
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 45
 excerpt: Using best practices 
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/disaster-recovery/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/disaster-recovery/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Disaster Recovery
 title: Disaster Recovery
 menuWeight: 80
 excerpt: Creating a backup and recovery plan
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Percona-Server-MongoDB 0.4.0-3.6.6
 title: Percona-Server-MongoDB 0.4.0-3.6.6
 menuWeight: 10
 excerpt: Percona-Server-MongoDB 0.4.0-3.6.6
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/known-issues/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/known-issues/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Known Issues
 title: Known Issues
 menuWeight: 100
 excerpt: Known issues in DC/OS
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/limitations/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Limitations in Percona Server for MongoDB
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/managing/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Managing
 title: Managing
 menuWeight: 60
 excerpt: Updating your configuration
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/mongodb-administration/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/mongodb-administration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Percona Server for MongoDB Administration
 title: Percona Server for MongoDB Administration
 menuWeight: 65
 excerpt: Administrative options for Percona Sever for MongoDB
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/quick-start/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/quick-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Quick Start
 title: Quick Start
 menuWeight: 20
 excerpt: Getting Started with Percona Server for MongoDB
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 190
 excerpt: Discover the new features, updates, and known limitations in this release of the Percona Server for MongoDB Service 
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/support/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/support/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 130
 excerpt: Understanding versioning schemes and policies
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/terms-of-use/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.0-3.6.6/terms-of-use/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Terms of Use
 title: Terms of Use
 menuWeight: 150
 excerpt: Apache License terms of use
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 63
 excerpt: Connecting clients with service discovery
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 64
 excerpt: Best practices for deploying DC/OS Percona Server for MongoDB
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/disaster-recovery/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/disaster-recovery/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Disaster Recovery
 title: Disaster Recovery
 menuWeight: 80
 excerpt: Creating a backup and recovery plan
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Percona-Server-MongoDB 0.4.1-3.6.8
 title: Percona-Server-MongoDB 0.4.1-3.6.8
 menuWeight: 5
 excerpt: Percona-Server-MongoDB 0.4.1-3.6.8
-featureMaturity:
 community: true
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/known-issues/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/known-issues/index.md
@@ -6,7 +6,6 @@ menuWeight: 100
 excerpt: Known issues in DC/OS Percona Server for MongoDB
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/limitations/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations in Percona Server for MongoDB
 menuWeight: 110
 excerpt: Limitations in service user, security, networking and other functions
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/managing/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Managing Percona Server for MongoDB
 menuWeight: 60
 excerpt: Managing Percona Server for MongoDB
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/mongodb-administration/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/mongodb-administration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Administration
 title: Percona Server for MongoDB Administration
 menuWeight: 65
 excerpt: Administrative options for Percona Sever for MongoDB
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Discover the new features, updates, and known limitations in this release of the Percona Server for MongoDB Service 
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/support/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/support/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 130
 excerpt: Understanding versioning schemes and policies
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/terms-of-use/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.1-3.6.8/terms-of-use/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Terms of Use
 title: Terms of Use
 menuWeight: 150
 excerpt: Apache License terms of use
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/connecting-clients/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/connecting-clients/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Connecting Clients
 title: Connecting Clients
 menuWeight: 63
 excerpt: Connecting clients with service discovery
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/deploy-best-practice/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/deploy-best-practice/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Deployment Best Practices
 title: Deployment Best Practices
 menuWeight: 64
 excerpt: Best practices for deploying DC/OS Percona Server for MongoDB
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/disaster-recovery/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/disaster-recovery/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Disaster Recovery
 title: Disaster Recovery
 menuWeight: 80
 excerpt: Creating a backup and recovery plan
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Percona-Server-MongoDB 0.4.2-3.6.10
 title: Percona-Server-MongoDB 0.4.2-3.6.10
 menuWeight: 1
 excerpt: Percona-Server-MongoDB 0.4.2-3.6.10
-featureMaturity:
 community: true
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/known-issues/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/known-issues/index.md
@@ -6,7 +6,6 @@ menuWeight: 100
 excerpt: Known issues in DC/OS Percona Server for MongoDB
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/limitations/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations in Percona Server for MongoDB
 menuWeight: 110
 excerpt: Limitations in service user, security, networking and other functions
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/managing/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/managing/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Operations
 title: Managing Percona Server for MongoDB
 menuWeight: 17
 excerpt: Managing Percona Server for MongoDB
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/mongodb-administration/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/mongodb-administration/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Administration
 title: Percona Server for MongoDB Administration
 menuWeight: 65
 excerpt: Administrative options for Percona Sever for MongoDB
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/quick-start/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/quick-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Quick Start
 title: Quick Start
 menuWeight: 20
 excerpt: Getting Started with Percona Server for MongoDB
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Release notes for version 0.4.2-3.6.10
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/support/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/support/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 130
 excerpt: Understanding versioning schemes and policies
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/terms-of-use/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/0.4.2-3.6.10/terms-of-use/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Terms of Use
 title: Terms of Use
 menuWeight: 150
 excerpt: Apache License terms of use
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/index.md
@@ -4,7 +4,6 @@ navigationTitle: Percona-Server-MongoDB
 title: Percona-Server-MongoDB
 menuWeight: 85
 excerpt: Percona Server for MongoDB is a free, enhanced, fully compatible, open source, drop-in replacement for the MongoDB® Community Server that includes enterprise-grade features and functionality.
-featureMaturity:
 community: true
 category: Databases
 ---

--- a/pages/mesosphere/dcos/services/percona-server-mongodb/quick-start/index.md
+++ b/pages/mesosphere/dcos/services/percona-server-mongodb/quick-start/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Configuring DC/OS access for Percona-Server-MongoDB
 title: Configuring DC/OS access for Percona-Server-MongoDB
 menuWeight: 100
 excerpt: How to use Percona-Server-MongoDB with DC/OS
-featureMaturity:
 community: true
 model: /mesosphere/dcos/services/percona-server-mongodb/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/alerting-overview/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/alerting-overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Alerting Overview
 title:  Alerting Overview
 menuWeight: 25
 excerpt: DC/OS Prometheus Alerting Overview
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/prometheus-federation/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/prometheus-federation/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus Federation
 title: Federation
 menuWeight: 35
 excerpt: Configurating Federation for Prometheus
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/remote-storage/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/remote-storage/index.md
@@ -4,7 +4,6 @@ navigationTitle: Remote Storage
 title: Prometheus Remote Storage to InfluxDB
 menuWeight: 40
 excerpt: Integrating Prometheus with remote storage InfluxDB
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/service-discovery/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/service-discovery/index.md
@@ -4,7 +4,6 @@ navigationTitle: Service Discovery
 title: Service Discovery Configuration Options
 menuWeight: 45
 excerpt: Service Discovery
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/visualization/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/configuration/visualization/index.md
@@ -4,7 +4,6 @@ navigationTitle: Visualization
 title: Grafana and Prometheus Expression Browser
 menuWeight: 45
 excerpt: DC/OS Prometheus Service Expression Browser
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus 0.1.0-2.3.2
 title: Prometheus 0.1.0-2.3.2
 menuWeight: 2
 excerpt: Overview of DC/OS Prometheus 0.1.0-2.3.2
-featureMaturity:
 community: true
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration Limitations
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 130
 excerpt: Discover the new features, updates, and known limitations in this release of the Prometheus Service
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Prometheus Services package versioning
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.0-2.3.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 40
 excerpt: Uninstalling DC/OS Prometheus Services
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/alerting-overview/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/alerting-overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Alerting Overview
 title:  Alerting Overview
 menuWeight: 25
 excerpt: DC/OS Prometheus Alerting Overview
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/prometheus-federation/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/prometheus-federation/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus Federation
 title: Federation
 menuWeight: 35
 excerpt: Configurating Federation for Prometheus
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/remote-storage/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/remote-storage/index.md
@@ -4,7 +4,6 @@ navigationTitle: Remote Storage
 title: Prometheus Remote Storage to InfluxDB
 menuWeight: 40
 excerpt: Integrating Prometheus with remote storage InfluxDB
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/service-discovery/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/service-discovery/index.md
@@ -4,7 +4,6 @@ navigationTitle: Service Discovery
 title: Service Discovery Configuration Options
 menuWeight: 45
 excerpt: Service Discovery
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/visualization/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/configuration/visualization/index.md
@@ -4,7 +4,6 @@ navigationTitle: Visualization
 title: Grafana and Prometheus Expression Browser
 menuWeight: 45
 excerpt: DC/OS Prometheus Service Expression Browser
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus 0.1.1-2.3.2
 title: Prometheus 0.1.1-2.3.2
 menuWeight: 1
 excerpt: Overview of DC/OS Prometheus 0.1.1-2.3.2
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/prometheus/data.yml
 community: true

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 0
 excerpt: Discover the new features, updates, and known limitations in this release of the Prometheus Service
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Prometheus Services package versioning
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.1-2.3.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 40
 excerpt: Uninstalling DC/OS Prometheus Services
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/alerting-overview/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/alerting-overview/index.md
@@ -4,7 +4,6 @@ navigationTitle: Alerting Overview
 title:  Alerting Overview
 menuWeight: 25
 excerpt: DC/OS Prometheus Alerting Overview
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/prometheus-federation/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/prometheus-federation/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus Federation
 title: Federation
 menuWeight: 35
 excerpt: Configurating Federation for Prometheus
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/remote-storage/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/remote-storage/index.md
@@ -4,7 +4,6 @@ navigationTitle: Remote Storage
 title: Prometheus Remote Storage to InfluxDB
 menuWeight: 40
 excerpt: Integrating Prometheus with remote storage InfluxDB
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/service-discovery/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/service-discovery/index.md
@@ -4,7 +4,6 @@ navigationTitle: Service Discovery
 title: Service Discovery Configuration Options
 menuWeight: 45
 excerpt: Service Discovery
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/visualization/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/configuration/visualization/index.md
@@ -4,7 +4,6 @@ navigationTitle: Visualization
 title: Grafana and Prometheus Expression Browser
 menuWeight: 45
 excerpt: DC/OS Prometheus Service Expression Browser
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus 0.1.2-2.3.2
 title: Prometheus 0.1.2-2.3.2
 menuWeight: 1
 excerpt: Overview of DC/OS Prometheus 0.1.2-2.3.2
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/prometheus/data.yml
 community: true

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 0
 excerpt: Discover the new features, updates, and known limitations in this release of the Prometheus Service
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Prometheus Services package versioning
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/0.1.2-2.3.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 40
 excerpt: Uninstalling DC/OS Prometheus Services
-featureMaturity:
 enterprise: false
 ---
 

--- a/pages/mesosphere/dcos/services/prometheus/index.md
+++ b/pages/mesosphere/dcos/services/prometheus/index.md
@@ -4,7 +4,6 @@ navigationTitle: Prometheus
 title: Prometheus
 menuWeight: 87
 excerpt:
-featureMaturity:
 community: true
 category: Monitoring
 ---

--- a/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/cli-reference/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/cli-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  CLI Reference
 title: CLI Reference
 menuWeight: 70
 excerpt: All CLI commands available
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/index.md
@@ -4,7 +4,6 @@ navigationTitle: Percona XtraDB Cluster 0.2.0-5.7.21
 title: Percona XtraDB Cluster 0.2.0-5.7.21
 menuWeight: 50
 excerpt: Overview of DC/OS Percona XtraDB Cluster 0.2.0-5.7.21
-featureMaturity:
 community: true
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/limitations/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 90
 excerpt: Understanding configuration limitations
-featureMaturity: 
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/operations/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/operations/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 39
 excerpt: Uninstalling DC/OS Percona XtraDB Cluster Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/overview/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Overview
 title: Overview
 menuWeight: 20
 excerpt: Features of the Percona XtraDB Cluster on DC/OS
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Discover the new features, updates, and known limitations in this release of the Percona XtraDB Cluster Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.0-5.7.21/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 100
 excerpt: Understanding DC/OS Percona XtraDB Cluster Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/cli-reference/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/cli-reference/index.md
@@ -4,7 +4,6 @@ navigationTitle:  CLI Reference
 title: CLI Reference
 menuWeight: 70
 excerpt: All CLI commands available
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/index.md
@@ -4,7 +4,6 @@ navigationTitle: Percona XtraDB Cluster 0.2.1-5.7.21
 title: Percona XtraDB Cluster 0.2.1-5.7.21
 menuWeight: 50
 excerpt: Overview of DC/OS Percona XtraDB Cluster 0.2.1-5.7.21
-featureMaturity:
 community: true
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/limitations/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 90
 excerpt: Understanding configuration limitations
-featureMaturity: 
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/operations/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/operations/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstalling
 title: Uninstalling
 menuWeight: 39
 excerpt: Uninstalling DC/OS Percona XtraDB Cluster Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/overview/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/overview/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Overview
 title: Overview
 menuWeight: 20
 excerpt: Features of the Percona XtraDB Cluster on DC/OS
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Discover the new features, updates, and known limitations in this release of the Percona XtraDB Cluster Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/pxc/0.2.1-5.7.21/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 100
 excerpt: Understanding DC/OS Percona XtraDB Cluster Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/pxc/index.md
+++ b/pages/mesosphere/dcos/services/pxc/index.md
@@ -4,7 +4,6 @@ navigationTitle: Percona XtraDB Cluster
 title: Percona XtraDB Cluster
 menuWeight: 87
 excerpt: Deploy and manage Percona XtraDB Cluster on Mesosphere DC/OS
-featureMaturity:
 community: true
 model: /mesosphere/dcos/services/pxc/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle: Custom Docker Images
 excerpt: Customizing the Docker image in which Spark runs
 title: Custom Docker Images
 menuWeight: 95
-featureMaturity:
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/fault-tolerance/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/fault-tolerance/index.md
@@ -4,7 +4,6 @@ navigationTitle: Fault Tolerance
 excerpt: Understanding DC/OS Apache Spark fault tolerance
 title: Fault Tolerance
 menuWeight: 100
-featureMaturity:
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Apache Spark 2.11.0-2.4.6
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 Welcome to the documentation for the DC/OS {{ model.techName }}. For more information about new and changed features, see the [release notes](/mesosphere/dcos/services/spark/2.11.0-2.4.6/release-notes/).

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/install/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/install/index.md
@@ -6,7 +6,6 @@ title: Install and Customize
 menuWeight: 12
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 {{ model.techShortName }} is available in the Universe and can be installed by using either the DC/OS GUI or the DC/OS CLI.

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/job-scheduling/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/job-scheduling/index.md
@@ -4,7 +4,6 @@ navigationTitle: Job Scheduling
 excerpt: Scheduling jobs with DC/OS Apache Spark
 title: Job Scheduling
 menuWeight: 110
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/limitations/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:
 excerpt: Limitations of DC/OS Apache Spark
 title: Limitations
 menuWeight: 135
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/limits/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/limits/index.md
@@ -4,7 +4,6 @@ navigationTitle: Tested Limits
 excerpt: Mesosphere has scale-tested Spark on DC/OS
 title: Tested Limits
 menuWeight: 140
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/quickstart/index.md
@@ -6,7 +6,6 @@ title: Quick Start
 menuWeight: 11
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 This page explains how to install the DC/OS {{ model.techName }} service.

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Release notes for DC/OS Apache Spark 2.11.0-2.4.6
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/run-job/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/run-job/index.md
@@ -4,7 +4,6 @@ navigationTitle: Run a Spark Job
 excerpt: Running a Spark job
 title: Run a Spark Job
 menuWeight: 80
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/runtime-config-change/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/runtime-config-change/index.md
@@ -4,7 +4,6 @@ navigationTitle: Runtime Configuration Changes
 excerpt: Customizing DC/OS Apache Spark while it is up and running
 title: Runtime Configuration Changes
 menuWeight: 70
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: Uninstall
 excerpt: Uninstalling DC/OS Apache Spark
 title: Uninstalling Spark
 menuWeight: 60
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle: Upgrade
 excerpt: Upgrading DC/OS Apache Spark
 title: Upgrade
 menuWeight: 50
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/usage-examples/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/usage-examples/index.md
@@ -4,7 +4,6 @@ navigationTitle: Usage Examples
 excerpt: Using DC/OS Apache Spark
 title: Usage Examples
 menuWeight: 15
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/version-policy/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.11.0-2.4.6/version-policy/index.md
@@ -4,7 +4,6 @@ navigationTitle: Version Policy
 excerpt: Understanding DC/OS Apache Spark version policy
 title: Version Policy
 menuWeight: 130
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle: Custom Docker Images
 excerpt: Customizing the Docker image in which Spark runs
 title: Custom Docker Images
 menuWeight: 95
-featureMaturity:
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/fault-tolerance/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/fault-tolerance/index.md
@@ -4,7 +4,6 @@ navigationTitle: Fault Tolerance
 excerpt: Understanding DC/OS Apache Spark fault tolerance
 title: Fault Tolerance
 menuWeight: 100
-featureMaturity:
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Apache Spark 2.12.0-3.0.1
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 Welcome to the documentation for the DC/OS {{ model.techName }}. For more information about new and changed features, see the [release notes](/mesosphere/dcos/services/spark/2.12.0-3.0.1/release-notes/).

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/install/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/install/index.md
@@ -6,7 +6,6 @@ title: Install and Customize
 menuWeight: 12
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 {{ model.techShortName }} is available in the Universe and can be installed by using either the DC/OS GUI or the DC/OS CLI.

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/job-scheduling/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/job-scheduling/index.md
@@ -4,7 +4,6 @@ navigationTitle: Job Scheduling
 excerpt: Scheduling jobs with DC/OS Apache Spark
 title: Job Scheduling
 menuWeight: 110
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/limitations/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:
 excerpt: Limitations of DC/OS Apache Spark
 title: Limitations
 menuWeight: 135
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/limits/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/limits/index.md
@@ -4,7 +4,6 @@ navigationTitle: Tested Limits
 excerpt: Mesosphere has scale-tested Spark on DC/OS
 title: Tested Limits
 menuWeight: 140
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/quickstart/index.md
@@ -6,7 +6,6 @@ title: Quick Start
 menuWeight: 11
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 This page explains how to install the DC/OS {{ model.techName }} service.

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Release notes for DC/OS Apache Spark 2.12.0-3.0.1
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/run-job/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/run-job/index.md
@@ -4,7 +4,6 @@ navigationTitle: Run a Spark Job
 excerpt: Running a Spark job
 title: Run a Spark Job
 menuWeight: 80
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/runtime-config-change/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/runtime-config-change/index.md
@@ -4,7 +4,6 @@ navigationTitle: Runtime Configuration Changes
 excerpt: Customizing DC/OS Apache Spark while it is up and running
 title: Runtime Configuration Changes
 menuWeight: 70
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/spark-auth/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/spark-auth/index.md
@@ -4,7 +4,6 @@ navigationTitle: Spark Auth
 excerpt: Configuring DC/OS Access for Spark
 title: Spark Auth
 menuWeight: 1010
-featureMaturity:
 enterprise: true
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: Uninstall
 excerpt: Uninstalling DC/OS Apache Spark
 title: Uninstalling Spark
 menuWeight: 60
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle: Upgrade
 excerpt: Upgrading DC/OS Apache Spark
 title: Upgrade
 menuWeight: 50
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/usage-examples/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/usage-examples/index.md
@@ -4,7 +4,6 @@ navigationTitle: Usage Examples
 excerpt: Using DC/OS Apache Spark
 title: Usage Examples
 menuWeight: 15
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/version-policy/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.12.0-3.0.1/version-policy/index.md
@@ -4,7 +4,6 @@ navigationTitle: Version Policy
 excerpt: Understanding DC/OS Apache Spark version policy
 title: Version Policy
 menuWeight: 130
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/custom-docker/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/custom-docker/index.md
@@ -4,7 +4,6 @@ navigationTitle: Custom Docker Images
 excerpt: Customizing the Docker image in which Spark runs
 title: Custom Docker Images
 menuWeight: 95
-featureMaturity:
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/fault-tolerance/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/fault-tolerance/index.md
@@ -4,7 +4,6 @@ navigationTitle: Fault Tolerance
 excerpt: Understanding DC/OS Apache Spark fault tolerance
 title: Fault Tolerance
 menuWeight: 100
-featureMaturity:
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/index.md
@@ -6,7 +6,6 @@ menuWeight: 3
 excerpt: Documentation for DC/OS Apache Spark 2.6.0-2.3.2
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 Welcome to the documentation for the DC/OS {{ model.techName }}. For more information about new and changed features, see the [release notes](/mesosphere/dcos/services/spark/2.6.0-2.3.2/release-notes/).

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/install/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/install/index.md
@@ -6,7 +6,6 @@ title: Install and Customize
 menuWeight: 12
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 {{ model.techShortName }} is available in the Universe and can be installed by using either the DC/OS web interface or the DC/OS CLI.

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/job-scheduling/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/job-scheduling/index.md
@@ -4,7 +4,6 @@ navigationTitle: Job Scheduling
 excerpt: Scheduling jobs with DC/OS Apache Spark
 title: Job Scheduling
 menuWeight: 110
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:
 excerpt: Limitations of DC/OS Apache Spark
 title: Limitations
 menuWeight: 135
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/limits/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/limits/index.md
@@ -4,7 +4,6 @@ navigationTitle: Tested Limits
 excerpt: Mesosphere has scale-tested Spark on DC/OS
 title: Tested Limits
 menuWeight: 140
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/quickstart/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/quickstart/index.md
@@ -6,7 +6,6 @@ title: Quick Start
 menuWeight: 11
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
-featureMaturity:
 ---
 
 This page explains how to install the DC/OS {{ model.techName }} service.

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle: Release Notes
 title: Release Notes
 menuWeight: 10
 excerpt: Discover the new features, updates, and known limitations in this release of the DC/OS Apache Spark Service 
-featureMaturity:
 ---
 
 # Release Notes for DC/OS Apache Spark Service version 2.6.0-2.3.2

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/run-job/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/run-job/index.md
@@ -4,7 +4,6 @@ navigationTitle: Run a Spark Job
 excerpt: Running a Spark job
 title: Run a Spark Job
 menuWeight: 80
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/runtime-config-change/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/runtime-config-change/index.md
@@ -4,7 +4,6 @@ navigationTitle: Runtime Configuration Changes
 excerpt: Customizing DC/OS Apache Spark while it is up and running
 title: Runtime Configuration Changes
 menuWeight: 70
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle: Uninstall
 excerpt: Uninstalling DC/OS Apache Spark
 title: Uninstalling Spark
 menuWeight: 60
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/upgrade/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/upgrade/index.md
@@ -4,7 +4,6 @@ navigationTitle: Upgrade
 excerpt: Upgrading DC/OS Apache Spark
 title: Upgrade
 menuWeight: 50
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/usage-examples/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/usage-examples/index.md
@@ -4,7 +4,6 @@ navigationTitle: Usage Examples
 excerpt: Using DC/OS Apache Spark
 title: Usage Examples
 menuWeight: 15
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/version-policy/index.md
+++ b/pages/mesosphere/dcos/services/spark/2.6.0-2.3.2/version-policy/index.md
@@ -4,7 +4,6 @@ navigationTitle: Version Policy
 excerpt: Understanding DC/OS Apache Spark version policy
 title: Version Policy
 menuWeight: 130
-featureMaturity:
 render: mustache
 model: /mesosphere/dcos/services/spark/data.yml
 ---

--- a/pages/mesosphere/dcos/services/spark/index.md
+++ b/pages/mesosphere/dcos/services/spark/index.md
@@ -4,7 +4,6 @@ navigationTitle: Spark
 title: Spark
 menuWeight: 90
 excerpt: 
-featureMaturity:
 model: /mesosphere/dcos/services/spark/data.yml
 render: mustache
 enterprise: false

--- a/pages/mesosphere/dcos/services/spark/spark-auth/index.md
+++ b/pages/mesosphere/dcos/services/spark/spark-auth/index.md
@@ -3,7 +3,6 @@ layout: layout.pug
 title: Configuring DC/OS Access for Spark
 menuWeight: 1010
 excerpt:
-featureMaturity:
 enterprise: true
 ---
 

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Spinnaker 0.3.0-1.9.2
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache
-featureMaturity:
 enterprise: true
 community: true
 ---

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 130
 excerpt: Discover the new features, updates, and known limitations in this release of the DC/OS Spinnaker Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Spinnaker Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.0-1.9.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 55
 excerpt: Uninstalling DC/OS Spinnaker Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Spinnaker 0.3.1-1.9.2
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache
-featureMaturity:
 enterprise: true
 community: true
 ---

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 0
 excerpt: Discover the new features, updates, and known limitations in this release of the DC/OS Spinnaker Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Spinnaker Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.1-1.9.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 55
 excerpt: Uninstalling DC/OS Spinnaker Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/index.md
@@ -6,7 +6,6 @@ menuWeight: 1
 excerpt: Documentation for DC/OS Spinnaker 0.3.2-1.9.2
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache
-featureMaturity:
 enterprise: true
 community: true
 ---

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/limitations/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/limitations/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Limitations
 title: Limitations
 menuWeight: 110
 excerpt: Understanding configuration limitations
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/release-notes/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/release-notes/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Release Notes
 title: Release Notes
 menuWeight: 0
 excerpt: Discover the new features, updates, and known limitations in this release of the DC/OS Spinnaker Service
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/supported-versions/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/supported-versions/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Supported Versions
 title: Supported Versions
 menuWeight: 120
 excerpt: Understanding DC/OS Spinnaker Services package versioning
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/uninstall/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/0.3.2-1.9.2/uninstall/index.md
@@ -4,7 +4,6 @@ navigationTitle:  Uninstall
 title: Uninstall
 menuWeight: 55
 excerpt: Uninstalling DC/OS Spinnaker Services
-featureMaturity:
 enterprise: false
 model: /mesosphere/dcos/services/spinnaker/data.yml
 render: mustache

--- a/pages/mesosphere/dcos/services/spinnaker/index.md
+++ b/pages/mesosphere/dcos/services/spinnaker/index.md
@@ -4,7 +4,6 @@ navigationTitle: Spinnaker
 title: Spinnaker
 menuWeight: 100
 excerpt:
-featureMaturity:
 community: true
 enterprise: true
 model: /mesosphere/dcos/services/spinnaker/data.yml


### PR DESCRIPTION
removing: 
* `category: K-Sphere` (has no meaning to the build-process)
* `featureMaturity` (has no meaning to the build-process)