### PR TITLE
adding link to version support policy in upgrade/index.md

### DIFF
--- a/pages/dkp/kommander/1.4/upgrade/index.md
+++ b/pages/dkp/kommander/1.4/upgrade/index.md
@@ -10,7 +10,8 @@ enterprise: false
 
 Kommander is also an addon running on a Konvoy cluster. It is updated in the same way as every [Konvoy addon is upgraded][addons-upgrade].
 
-When upgrading Kommander, use the equivalent [new version of the Konvoy CLI and update][konvoy-upgrade] for your `cluster.yaml` file according to the instructions. Confirm that you are using the configVersion for Kommander that matches the version of the Konvoy CLI you are deploying.
+When upgrading Kommander, use the equivalent [new version of the Konvoy CLI and update][konvoy-upgrade] for your `cluster.yaml` file according to the instructions. Confirm that you are using the configVersion for [Kommander that matches the version of the Konvoy CLI][version-support-policy] you are deploying.
 
 [addons-upgrade]: /dkp/konvoy/latest/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
 [konvoy-upgrade]: /dkp/konvoy/latest/upgrade/upgrade-cli/
+[version-support-policy]: ../version-policy/

--- a/pages/dkp/kommander/1.4/upgrade/index.md
+++ b/pages/dkp/kommander/1.4/upgrade/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 Kommander is also an addon running on a Konvoy cluster. It is updated in the same way as every [Konvoy addon is upgraded][addons-upgrade].
 
-When upgrading Kommander, use the equivalent [new version of the Konvoy CLI and update][konvoy-upgrade] for your `cluster.yaml` file according to the instructions. Confirm that you are using the configVersion for [Kommander that matches the version of the Konvoy CLI][version-support-policy] you are deploying.
+When upgrading Kommander, use the equivalent [new version of the Konvoy CLI and update][konvoy-upgrade] for your `cluster.yaml` file according to the instructions. Confirm that you are using the `configVersion` for [Kommander that matches the version of the Konvoy CLI][version-support-policy] you are deploying.
 
 [addons-upgrade]: /dkp/konvoy/latest/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
 [konvoy-upgrade]: /dkp/konvoy/latest/upgrade/upgrade-cli/


### PR DESCRIPTION
## Jira Ticket
n/a

## Description of changes being made
Adding link to version support policy in the upgrade page, so people know what version is supported by Konvoy for a Kommander upgrade.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [x] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.