### PR TITLE
fixing link for cluster-with-network-restrictions page

### DIFF
--- a/pages/dkp/kommander/1.4/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/1.4/clusters/attach-cluster/index.md
@@ -37,5 +37,5 @@ You have these security options when attaching a cluster:
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [no-network-restrictions]: cluster-no-network-restrictions/
 [platform_service_req]: /dkp/kommander/1.4/workspaces/platform-service-requirements/
-[with-network-restrictions]: cluster-with-networking-restrictions/
+[with-network-restrictions]: cluster-with-network-restrictions/
 [workspace_platform_services]: /dkp/kommander/1.4/workspaces/workspace-platform-services/

--- a/pages/dkp/kommander/1.4/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/1.4/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -49,7 +49,7 @@ Consider the additional resource requirements for running the platform services 
 
 [attach_eks_cluster]: /dkp/kommander/1.4/clusters/attach-cluster/attach-eks-cluster/
 [attach_without_network_restrictions]: /dkp/kommander/1.4/clusters/attach-cluster/cluster-no-network-restrictions
-[attach_with_network_restrictions]: /dkp/kommander/1.4/clusters/attach-cluster/cluster-with-networking-restrictions
+[attach_with_network_restrictions]: /dkp/kommander/1.4/clusters/attach-cluster/cluster-with-network-restrictions
 [manual_cli_attachment]: /dkp/kommander/1.4/clusters/tunnel-cli
 [platform_service_requirements]: /dkp/kommander/1.4/workspaces/platform-service-requirements/
 [projects]: /dkp/kommander/1.4/projects


### PR DESCRIPTION
## Jira Ticket
n/a

## Description of changes being made
missed some links - these pages were linking to a page that no longer is valid.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.