### PR TITLE
[Doc][Komm] D2IQ-74802 Added network tunneling blurb to RelNotes... (1.4)

### DIFF
--- a/pages/dkp/kommander/1.4/clusters/attach-cluster/cluster-with-network-restrictions/index.md
+++ b/pages/dkp/kommander/1.4/clusters/attach-cluster/cluster-with-network-restrictions/index.md
@@ -7,7 +7,7 @@ excerpt: How to attach an existing cluster that has additional networking restri
 beta: true
 ---
 
-Use this option when you want to attach a cluster that is in a DMZ, behind a proxy server or a firewall, or that requires additional access information. This procedure gathers the information required to create a kubeconfig file for the network tunnel between Kommander and the cluster you want to attach.
+Use this option when you want to attach a cluster that is in a DMZ, behind a NAT gateway, behind a proxy server or a firewall, or that requires additional access information. This procedure gathers the information required to create a kubeconfig file for the network tunnel between Kommander and the cluster you want to attach.
 
 <p class="message--note"><strong>NOTE: </strong>If your cluster blocks public access, you may need to make the additional step of allowing certain authorized networks where Docker images are hosted for Konvoy to use your cluster, specifically <code>https://registry-1.docker.io/</code>.</p>
 

--- a/pages/dkp/kommander/1.4/release-notes/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/index.md
@@ -21,6 +21,20 @@ To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [ins
 # Release Summary
 Kommander provides a command center for all your cloud native management needs in public Information as a Service (IaaS), on-premises, and edge environments. Kommander provides a multi-tenant experience to create, secure, and configure Kubernetes clusters and cloud native workloads. Additionally, Kommander enables teams to unlock federated cost management across multiple clusters, whether they are a new Konvoy cluster or an existing 3rd party/DIY distribution installation.
 
+## Network Tunneling
+
+Prior to release 1.4, Kommander required bi-directional connectivity between the Kommander management cluster and clusters that are under management. This effectively blocked several customer-specific use cases:
+
+- Kommander does not have direct access to the managed cluster, for example, when the cluster is on a laptop or behind a NAT gateway.
+
+- The managed cluster does not have direct access to Kommander, for example, Kommander is on-premise and the managed cluster is in a public cloud provider environment.
+
+- The managed cluster is behind a firewall, a proxy, or resides in a DMZ.
+
+A new component, `kubetunnel`, provides communication between Kommander and the managed cluster through a tunneling protocol resolving these blocked use cases. The TLS-encrypted tunnel enables you to access the cluster using SSO and to receive alerts, metrics, and kubecost data.
+
+For more information on this capability, see [Attach an Existing Kubernetes Cluster][attach_existing_kubernetes_cluster]
+
 # Breaking changes
 
 ## Docker hub rate limiting 
@@ -49,3 +63,5 @@ For more information on addressing this limit, see [Docker hub rate limits](../o
 - Bump federated prometheus to 9.3.7
 - Bump kubecost to 0.7.0 which enables PodSecurityPolicy
 - Decrease the amount of time it takes to delete Kommander
+
+[attach_existing_kubernetes_cluster]: /dkp/kommander/1.4/clusters/attach-cluster


### PR DESCRIPTION
...and added NAT gateway to "attach cluster" docs page

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

https://jira.d2iq.com/browse/D2IQ-74802 

## Description of changes being made
Needed to add a Release Notes blurb for the Network Tunneling feature, and also to mention that a managed cluster can be behind a NAT Gateway and still become attached to Kommander.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.