### PR TITLE
spaces/formating on pages/dkp/kommander/1.4/clusters/attach-cluster/g…

### DIFF
--- a/pages/dkp/kommander/1.4/clusters/attach-cluster/generate-kubeconfig/index.md
+++ b/pages/dkp/kommander/1.4/clusters/attach-cluster/generate-kubeconfig/index.md
@@ -13,64 +13,64 @@ To get started, ensure you have [kubectl][kubectl] set up and configured with [C
 
 1. Create the required service account using the command:
 
-```shell
-kubectl -n kube-system create serviceaccount kommander-cluster-admin
-```
+   ```shell
+   kubectl -n kube-system create serviceaccount kommander-cluster-admin
+   ```
 
 1. Configure the new service account for `cluster-admin` permissions. You can copy and paste this example ensuring that you use the service account created previously.
 
-```shell
-cat << EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kommander-cluster-admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: kommander-cluster-admin
-  namespace: kube-system
-EOF
-```
+   ```shell
+   cat << EOF | kubectl apply -f -
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: kommander-cluster-admin
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: cluster-admin
+   subjects:
+   - kind: ServiceAccount
+     name: kommander-cluster-admin
+     namespace: kube-system
+   EOF
+   ```
 
 1. Set up the following environment variables with access data needed for producing a new kubeconfig file:
 
-```shell
-export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-cluster-admin -o=jsonpath='{.secrets[0].name}')
-export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
-export CURRENT_CONTEXT=$(kubectl config current-context)
-export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
-export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}"{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}"{{ end }}{{ end }}')
-export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
-```
+   ```shell
+   export USER_TOKEN_NAME=$(kubectl -n kube-system get serviceaccount kommander-cluster-admin -o=jsonpath='{.secrets[0].name}')
+   export USER_TOKEN_VALUE=$(kubectl -n kube-system get secret/${USER_TOKEN_NAME} -o=go-template='{{.data.token}}' | base64 --decode)
+   export CURRENT_CONTEXT=$(kubectl config current-context)
+   export CURRENT_CLUSTER=$(kubectl config view --raw -o=go-template='{{range .contexts}}{{if eq .name "'''${CURRENT_CONTEXT}'''"}}{{ index .context "cluster" }}{{end}}{{end}}')
+   export CLUSTER_CA=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}"{{with index .cluster "certificate-authority-data" }}{{.}}{{end}}"{{ end }}{{ end }}')
+   export CLUSTER_SERVER=$(kubectl config view --raw -o=go-template='{{range .clusters}}{{if eq .name "'''${CURRENT_CLUSTER}'''"}}{{ .cluster.server }}{{end}}{{ end }}')
+   ```
 
 1. Generate a kubeconfig file with these values:
 
-```shell
-cat << EOF > kommander-cluster-admin-config
-apiVersion: v1
-kind: Config
-current-context: ${CURRENT_CONTEXT}
-contexts:
-- name: ${CURRENT_CONTEXT}
-  context:
-    cluster: ${CURRENT_CONTEXT}
-    user: kommander-cluster-admin
-    namespace: kube-system
-clusters:
-- name: ${CURRENT_CONTEXT}
-  cluster:
-    certificate-authority-data: ${CLUSTER_CA}
-    server: ${CLUSTER_SERVER}
-users:
-- name: kommander-cluster-admin
-  user:
-    token: ${USER_TOKEN_VALUE}
-EOF
-```
+   ```shell
+   cat << EOF > kommander-cluster-admin-config
+   apiVersion: v1
+   kind: Config
+   current-context: ${CURRENT_CONTEXT}
+   contexts:
+   - name: ${CURRENT_CONTEXT}
+     context:
+       cluster: ${CURRENT_CONTEXT}
+       user: kommander-cluster-admin
+       namespace: kube-system
+   clusters:
+   - name: ${CURRENT_CONTEXT}
+     cluster:
+       certificate-authority-data: ${CLUSTER_CA}
+       server: ${CLUSTER_SERVER}
+   users:
+   - name: kommander-cluster-admin
+     user:
+       token: ${USER_TOKEN_VALUE}
+   EOF
+   ```
 
 This procedure produces a file in your current working directory called, `kommander-cluster-admin-config`. The contents of this file are used in Kommander to attach the cluster.
 


### PR DESCRIPTION
…enerate-kubeconfig/index.md

## Jira Ticket
n/a

## Description of changes being made
There were some spaces that got a bit on the messed up side here. This takes care of that so the formatting for the numbered list is enforced.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.