### PR TITLE
Kaptain: remove invalid links from Pipelines tutorial

### DIFF
--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/pipelines/index.md
@@ -577,17 +577,6 @@ run_result = client.create_run_from_pipeline_func(
 )
 ```
 
-    [I 200512 09:16:17 _client:267] Creating experiment End-to-End MNIST Pipeline.
-
-
-
-Experiment link <a href="/pipeline/#/experiments/details/" target="_blank" >here</a>
-
-
-
-Run link <a href="/pipeline/#/runs/details/" target="_blank" >here</a>
-
-
 The pipeline is now running. Wait for it to complete successfully. In the meantime you can use the links above to see the pipelines UI.
 
 

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/pipelines/index.md
@@ -578,17 +578,6 @@ run_result = client.create_run_from_pipeline_func(
 )
 ```
 
-    [I 200512 09:16:17 _client:267] Creating experiment End-to-End MNIST Pipeline.
-
-
-
-Experiment link <a href="/pipeline/#/experiments/details/" target="_blank" >here</a>
-
-
-
-Run link <a href="/pipeline/#/runs/details/" target="_blank" >here</a>
-
-
 The pipeline is now running. Wait for it to complete successfully. In the meantime you can use the links above to see the pipelines UI.
 
 


### PR DESCRIPTION
Signed-off-by: Alex Lembiyeuski <alembiyeuski@d2iq.com>

## Jira Ticket
[D2IQ-70019: broken links in kubeflow docs](https://jira.d2iq.com/browse/D2IQ-70019).

## Description of changes being made
Removes irrelevant links from the tutorials.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.