### PR TITLE
Kommander 1.3 KUDO Spark Docs: Backport docs fixes from 1.4 Docs Review.

### DIFF
--- a/pages/dkp/kommander/1.3/projects/platform-services/platform-services-catalog/kudo-spark/index.md
+++ b/pages/dkp/kommander/1.3/projects/platform-services/platform-services-catalog/kudo-spark/index.md
@@ -11,23 +11,23 @@ beta: false
 <!-- markdownlint-disable MD018 -->
 ## KUDO Spark
 
-Kommander Catalog adds integration for [KUDO Spark Operator](https://github.com/mesosphere/kudo-spark-operator/), which simplifies day 2 operations of [Apache Spark](https://spark.apache.org/). 
+Kommander Catalog adds integration for [KUDO Spark Operator](https://github.com/mesosphere/kudo-spark-operator/), which simplifies day 2 operations of [Apache Spark](https://spark.apache.org/).
 
 #include /dkp/kommander/1.3/include/kudo-intro.tmpl
 
-It is **strongly recommended** to view the [KUDO Spark Documentation](https://github.com/mesosphere/kudo-spark-operator/tree/master/kudo-spark-operator/docs/latest) which covers the KUDO Spark Operator in-depth. This document covers the integration aspects of KUDO Spark Operator with D2iQ Kommander.
+It is **strongly recommended** to view the [KUDO Spark Documentation](https://github.com/mesosphere/kudo-spark-operator/tree/master/kudo-spark-operator/docs/latest) which covers the KUDO Spark Operator in-depth. This document covers the integration aspects of KUDO Spark Operator with Kommander.
 
 
 ### Installation
 
 #### Kommander Catalog
 
-KUDO Spark is located in the Kommander Catalog.   To access the catalog:
-#include /dkp/kommander/1.3/include/kommander-catalog-drilldown.tmpl
+KUDO Spark is located in the Kommander Catalog. To access the catalog:
 
-From the [Project Catalog](/dkp/kommander/1.3/projects/platform-services/) select the desired version of Spark and click Deploy.
+#include /dkp/kommander/1.4/include/kommander-catalog-drilldown.tmpl
 
-Below is an example of what should appear in the Kommander UI.  The dialog is populated with sensible defaults:
+
+Below is an example of what should appear in the Kommander UI. The dialog is populated with defaults:
 
 ![Spark Service Install Configuration](/dkp/kommander/1.3/img/platform-services-spark-config-dialog.png)
 
@@ -65,9 +65,8 @@ Plan(s) for "spark-instance" in namespace "spark":
 
 Requirements:
 
-- Install the [KUDO controller](https://kudo.dev/docs/getting-started/)
-- Install the [KUDO CLI](https://kudo.dev/docs/cli/)
-
+- Install the [KUDO controller](https://kudo.dev/docs/#getting-started)
+- Install the [KUDO CLI](https://kudo.dev/docs/cli/installation.html#cli-installation)
 
 Check existing [limitations](https://github.com/mesosphere/kudo-spark-operator/blob/master/kudo-spark-operator/docs/3.0.0-1.1.0/limitations.md) before installing a KUDO Spark instance. Currently, multi-instance
 (multi-tenant) operator installation supports only a single instance per namespace.
@@ -81,7 +80,7 @@ Install a new instance of Spark operator from the official repository, use the f
 kubectl kudo install spark --namespace spark
 ```
 This will install a Spark operator instance with the name `spark-instance` to the provided namespace.
-You can also specify a different instance name using `--instance` parameter:
+You can also specify a different instance name using the `--instance` parameter:
 
 ```
 kubectl kudo install spark --instance spark-operator --namespace spark
@@ -118,21 +117,25 @@ Operator instances. While Operator instance can be used on a per-namespace basis
 are a cluster-scoped resource which requires a manual cleanup when all KUDO Spark Operator instances are uninstalled.
 
 To completely remove KUDO Spark Operator from a Kubernetes cluster:
+
 1. Wait for the running jobs to complete or terminate them
-  ```
-  kubectl delete sparkapplications --all
-  kubectl delete scheduledsparkapplications --all
-  ```
+
+   ```
+   kubectl delete sparkapplications --all
+   kubectl delete scheduledsparkapplications --all
+   ```
+
 1. Uninstall each KUDO Spark Operator instance:
-  ```
-  kubectl kudo uninstall --instance spark-instance --namespace spark
-  ```
+
+   ```
+   kubectl kudo uninstall --instance spark-instance --namespace spark
+   ```
+
 1. Remove Spark Applications CRDs:
-  ```
-  kubectl delete crds sparkapplications.sparkoperator.k8s.io scheduledsparkapplications.sparkoperator.k8s.io
-  ```
 
-
+   ```
+   kubectl delete crds sparkapplications.sparkoperator.k8s.io scheduledsparkapplications.sparkoperator.k8s.io
+   ```
 
 #### Installing multiple Spark Operator Instances
 
@@ -149,7 +152,6 @@ The above commands will install two Spark Operators in two different namespaces.
 namespace will be handled by the Operator installed in the same namespace. This is achieved by explicitly setting
 the `sparkJobNamespace` parameter to corresponding operator namespace.
 
-
 #### KUDO Spark Operator Upgrade Prior to Konvoy Upgrade or Install
 
 Custom Resource Definitions of KUDO Spark Operator versions prior to 3.0.0-1.1.0 do not specify default values for `x-kubernetes-list-map-keys` properties and will fail validation on Kubernetes versions 1.18.x and later.
@@ -158,9 +160,8 @@ Perform these steps prior to upgrading or installing Konvoy to prevent or mitiga
 
 1. Wait for the KUDO Spark Operator jobs to finish, or terminate the running jobs.
 1. [Uninstall the KUDO Spark Operator](#uninstalling-the-spark-operator).
-1. [Install the new KUDO Spark version](#Installation).
+1. [Install the new KUDO Spark version](#installation).
 1. [Upgrade](../../../../../../konvoy/latest/upgrade) or [install](../../../../../../konvoy/latest/install) Konvoy.
-
 
 ### Submitting Spark Applications
 
@@ -168,7 +169,7 @@ To submit Spark Application you should have KUDO Spark Operator installed.
 
 In order to deploy a Spark Application to Kubernetes using the KUDO Spark Operator, it should be described as a Kubernetes object. To do that, create a specification in `yaml` format with all the necessary configuration required for the application.
 
-Let's take a simple `SparkPi` application as an example. The `yaml` specification could be found here: [spark-pi.yaml](resources/spark-pi.yaml).  This example assumes that you installed KUDO spark to the `spark` namespace.
+Let's take a simple `SparkPi` application as an example. The `yaml` specification could be found here: [spark-pi.yaml](https://raw.githubusercontent.com/kudobuilder/operators/master/repository/spark/docs/3.0.0-1.1.0/resources/spark-pi.yaml). This example assumes that you installed KUDO spark to the `spark` namespace.
 
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
@@ -204,7 +205,7 @@ spec:
 
 Spark application configuration is placed under `spec` section including number of executors, number of cores for drivers/executors, amount of memory. There is also a `sparkConf` section, where you can place [configuration parameters](https://spark.apache.org/docs/latest/configuration.html#application-properties) in the form of key-value pairs.
 
-The format for the service account name is `{spark-operator name}-spark-service-account`.  If you have installed the spark operator without specifying the instance name, its name will be `spark-instance`, thus the service account name will need to be `spark-instance-spark-service-account`.
+The format for the service account name is `{spark-operator name}-spark-service-account`. If you have installed the spark operator without specifying the instance name, its name will be `spark-instance`, thus the service account name will need to be `spark-instance-spark-service-account`.
 
 #### Creating the application
 
@@ -247,6 +248,7 @@ Logging can be configured by placing a custom `log4j.properties` file to `SPARK_
 Spark Operator provides a mechanism for mounting Spark configuration files via K8s `ConfigMap` objects.
 
 1) Create a `ConfigMap` using the following `log4j.properties` as an example:
+
 ```bash
 $ cat <<'EOF'>> log4j.properties
 log4j.rootCategory=DEBUG, console
@@ -259,7 +261,9 @@ EOF
 ```bash
 $ kubectl create configmap spark-conf-map --from-file log4j.properties
 ```
+
 2) Add the following lines to `SparkApplication` spec:
+
 ```yaml
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
@@ -273,6 +277,7 @@ spec:
     executor:
       javaOptions: "-Dlog4j.configuration=file:/etc/spark/conf/log4j.properties"
 ```
+
 The contents of `spark-conf-map` will be placed under `/etc/spark/conf` directory for driver and executor pods,
 and `SPARK_CONF_DIR` environment variable will be set to this directory.
 
@@ -330,13 +335,14 @@ Forwarding from 127.0.0.1:4040 -> 4041
 Forwarding from [::1]:4040 -> 4041
 
 ```
-After that the Spark UI should be available via URL: [localhost:4040](localhost:4040):
+After that the Spark UI should be available via URL:  `localhost:4040`
 
 #### Using a Service
 
 It is possible to create a service with special type that will expose our Spark UI globally via cloud network LB.
 
 Service specification can look like the following:
+
 ```yaml
 apiVersion: v1
 kind: Service
@@ -381,6 +387,7 @@ The current parameter set can be retrieved using the kubectl command in conjunct
 - [yq](https://mikefarah.gitbook.io/yq)
 
 To retrive the current parameters, issue the following command in the terminal with appropriate `INSTANCE` value set:
+
 ```
 INSTANCE=spark-instance;
 kubectl get instances -o json | jq ".items[] | select(.metadata.name == \"$INSTANCE\") | .spec.parameters" | yq eval -P > spark-params.yml
@@ -416,7 +423,7 @@ spark-instance-history-server-68f5645c57-5h2g4   1/1     Running   0          31
 
 To update multiple parameters at once, it is recommended to submit the updated parameters using the KUDO CLI.
 
-See [Available Parameters](#available-parameters) to get the full list of current parameters as a file.
+See [Available Parameters](#available-operator-parameters) to get the full list of current parameters as a file.
 
 Apply the desired updates in `spark-params.yml` using the KUDO CLI:
 ```
@@ -428,15 +435,14 @@ Wait for the deployment plan to `COMPLETE`.
 
 **Example**: Upgrade KUDO Spark Operator from `v3.0.0-1.0.1` to `v3.0.0-1.1.0`
 
-When upgrading, you should understand the mapping between Spark versions and operator versions.  
+When upgrading, you should understand the mapping between Spark versions and operator versions.
 Wait and monitor the deployment plan to become `COMPLETE`.
 
-**Note**: Spark Operator version doesn't necessarily have to match the Apache Spark version to run Spark Applications built with that version. For instance, it is possible to submit Spark 2.4.5 Application using the operator version 3.0.0-1.1.0.
-
+<p class="message--note"><strong>NOTE: </strong>Spark Operator version doesn't have to match the Apache Spark version to run Spark Applications built with that version. For instance, it is possible to submit Spark 2.4.5 Application using the operator version 3.0.0-1.1.0.</p>
 
 ### Monitoring
 
-KUDO Spark Operator has metrics reporting support, which can be enabled during the installation of the operator.  
+KUDO Spark Operator has metrics reporting support, which can be enabled during the installation of the operator.
 By default, it supports integration with the [Prometheus operator](https://github.com/coreos/prometheus-operator).
 
 Prometheus Operator relies on `ServiceMonitor` kind which describes the set of targets to be monitored.
@@ -482,7 +488,7 @@ Full list of metrics configuration parameters and defaults is available in KUDO 
       kubectl kudo install spark -p appMetricsPort=<desired_port>
       ```
         - change the `port` value in the `SparkApplication` yaml definition (`spec.monitoring.prometheus.port`)
-    - Mark `driver` and/or `executor` with the label `metrics-exposed: "true"` -
+    - Mark `driver` and/or `executor` with the label `metrics-exposed: "true"`
       ```yaml
       spec:
         driver:
@@ -494,19 +500,19 @@ Full list of metrics configuration parameters and defaults is available in KUDO 
       ```
     - Install the SparkApplication:
       ```
-      kubectl apply -f <path_to_the_application_yaml>   
+      kubectl apply -f <path_to_the_application_yaml>
       ```
-   Full application configuration example is available in [spark-application-with-metrics.yaml](resources/monitoring/spark-application-with-metrics.yaml)
-1) Now, go to the prometheus dashboard (e.g. `<kubernetes_endpoint_url>/ops/portal/prometheus/graph`) and search for metrics
-   starting with 'spark'. The Prometheus URI might be different depending on how you configured and installed the `prometheus-operator`.
+   Full application configuration example is available in [spark-application-with-metrics.yaml](https://raw.githubusercontent.com/kudobuilder/operators/master/repository/spark/docs/3.0.0-1.1.0/resources/monitoring/spark-application-with-metrics.yaml)
+
+1) Now, go to the prometheus dashboard (e.g. `<kubernetes_endpoint_url>/ops/portal/prometheus/graph`) and search for metrics starting with 'spark'. The Prometheus URI might be different depending on how you configured and installed the `prometheus-operator`.
 
 #### Dashboards
 * [Spark Applications Dashboard](https://github.com/mesosphere/kudo-spark-operator/blob/master/kudo-spark-operator/docs/latest/resources/dashboards/grafana_spark_applications.json)
 * [Spark Operator Dashboard](https://github.com/mesosphere/kudo-spark-operator/blob/master/kudo-spark-operator/docs/latest/resources/dashboards/grafana_spark_operator.json)
 
-Dashboard installation :
+Dashboard installation:
 1) Open the Grafana site (e.g. `<kubernetes_endpoint_url>/ops/portal/grafana`).
 1) Press + button and pick `Import` item from the menu.
 1) Copy content of the dashboard json file and paste it to the textarea on importing form.
 
-For more information visit Grafana documentation: [Importing a dashboard guide](https://grafana.com/docs/reference/export_import/#importing-a-dashboard).
+For more information visit Grafana documentation: [Importing a dashboard guide](https://grafana.com/docs/grafana/next/dashboards/export-import/#importing-a-dashboard).

--- a/pages/dkp/konvoy/1.7/release-notes/1.7/index.md
+++ b/pages/dkp/konvoy/1.7/release-notes/1.7/index.md
@@ -135,8 +135,8 @@ Custom Resource Definitions of KUDO Spark Operator versions prior to 3.0.0-1.1.0
 Perform these steps prior to upgrading or installing Konvoy to prevent or mitigate disruption of currently-running Spark jobs and invalidating Spark CRDs:
 
 1. Wait for the KUDO Spark Operator jobs to finish, or terminate the running jobs.
-1. [Uninstall the KUDO Spark Operator](https://github.com/kudobuilder/operators/blob/master/repository/spark/docs/3.0.0-1.1.0/installation.md#uninstalling-the-spark-operator).
-1. [Install the new KUDO Spark version](https://github.com/kudobuilder/operators/blob/master/repository/spark/docs/3.0.0-1.1.0/installation.md#installing-the-operator).
+1. [Uninstall the KUDO Spark Operator](../../../../kommander/latest/projects/platform-services/platform-services-catalog/kudo-spark/#uninstalling-the-spark-operator).
+1. [Install the new KUDO Spark version](../../../../kommander/latest/projects/platform-services/platform-services-catalog/kudo-spark/#installation).
 1. [Upgrade](../../upgrade) or [install](../../install) Konvoy.
 
 ### Component versions


### PR DESCRIPTION
## Jira Ticket
[D2IQ-75005](https://jira.d2iq.com/browse/D2IQ-75005)

## Description of changes being made
Backport the docs PR review fixes from #3603 to Kommander 1.3 here.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.