### PR TITLE
security-updates: use live s3 data source

### DIFF
--- a/js/cve.js
+++ b/js/cve.js
@@ -276,6 +276,9 @@ const eyeSlash = (
 ///////////////////////////////////////////////////////////////////////////////
 //                                    APP                                    //
 ///////////////////////////////////////////////////////////////////////////////
+const reportURL = "https://konvoy-staging-devx-cac8-cve-reporter.s3-us-west-2.amazonaws.com/vulnerability_report_latest.json";
+// local reportURL = "/assets/cves.json"
+
 const App = () => {
   React.useEffect(() => {
     // we have a lot of entries in the list that only differ in `resource_purl`.
@@ -284,9 +287,9 @@ const App = () => {
       Object.values(groupBy(cves, (c) => c.vulnerability_name)).map((group) => {
         return { ...group[0], purls: group.map((c) => c.resource_purl) };
       });
-    fetch("/assets/cves.json")
+    fetch(reportURL)
       .then((r) => r.json())
-      .then((cves) => onUpdate({ cves }));
+      .then((cves) => onUpdate({ cves: foldPurlsByVulnName(cves) }));
   }, []);
 
   const [model, setModel] = React.useState(init);

--- a/pages/dkp/security-updates/index.md
+++ b/pages/dkp/security-updates/index.md
@@ -7,7 +7,7 @@ menuWeight: 1000
 beta: false
 ---
 
-The following information describes mitigated or fixed CVEs found in Konvoy 1.7.0.
+The following information describes mitigated or fixed CVEs found in Konvoy.
 
 <div class="cve-table-container">Loading...</div>
 <script src="/js/cve.js"></script>


### PR DESCRIPTION
## Jira Ticket
JIRA: https://jira.d2iq.com/browse/D2IQ-75575

<!-- Link to DOCS work ticket -->

## Description of changes being made
This PR changes the data source for security-updates page from local static file to live data from S3 bucket that is updated by `cve-reporter`.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.