### PR TITLE
Add upgrade info for kubecost, and update 1.3.3 RN

### DIFF
--- a/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
@@ -38,22 +38,23 @@ An alternative is to create an `allow-all` NetworkPolicy for each project in eac
 
 1. Enter the following command:
 
-``` shell
-cat <<EOF | kubectl apply -f -
-  apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-all
-    namespace: <namespace corresponding to the project>
- spec:
-   ingress:
-   - {}
-   podSelector: {}
-   policyTypes:
-   - Ingress
- EOF
-```
-1. Repeat steps 1 & 2 for each project namespace and managed cluster
+   ``` shell
+   cat <<EOF | kubectl apply -f -
+     apiVersion: networking.k8s.io/v1
+     kind: NetworkPolicy
+     metadata:
+       name: allow-all
+       namespace: <namespace corresponding to the project>
+    spec:
+      ingress:
+      - {}
+      podSelector: {}
+      policyTypes:
+      - Ingress
+    EOF
+   ```
+
+1. Repeat steps 1 & 2 for each project namespace and managed cluster.
 
 # Breaking changes
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
@@ -28,7 +28,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-In Kommander 1.3.2 and below, Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that requiire a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the [upgrade instructions in the 1.3.3 release notes](../1.3.3/).
+In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 In Kommander 1.3, unless a default NetworkPolicy existed prior to upgrading to 1.3, a default NetworkPolicy is created that allows traffic originating only within your Projects namespace. Pods can not talk to Pods outside of that namespace. In some cases this can have an unpredictable and unwanted impact on your system.
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
@@ -28,7 +28,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
+In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 In Kommander 1.3, unless a default NetworkPolicy existed prior to upgrading to 1.3, a default NetworkPolicy is created that allows traffic originating only within your Projects namespace. Pods can not talk to Pods outside of that namespace. In some cases this can have an unpredictable and unwanted impact on your system.
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
@@ -26,7 +26,9 @@ Kommander provides a command center for all your cloud native management needs i
 | **Maximum**        | 1.19.x  |
 | **Default**        | 1.19.7  |
 
-# Known issue
+# Known issues
+
+In Kommander 1.3.2 and below, Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that requiire a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the [upgrade instructions in the 1.3.3 release notes](../1.3.3/).
 
 In Kommander 1.3, unless a default NetworkPolicy existed prior to upgrading to 1.3, a default NetworkPolicy is created that allows traffic originating only within your Projects namespace. Pods can not talk to Pods outside of that namespace. In some cases this can have an unpredictable and unwanted impact on your system.
 
@@ -55,7 +57,7 @@ cat <<EOF | kubectl apply -f -
 
 # Breaking changes
 
-## Docker hub rate limiting 
+## Docker hub rate limiting
 Docker Hub announced an update to their image pull policies in August, 2020. The change results in the need to change cluster configurations to accommodate new account structures that enable image pull rate limiting.
 
 Rate limiting happens on a per-pull basis regardless of whether the pulled image is owned by a paid user. This means D2iQ, as owner of most images used in Konvoy, does not have any influence as to whether your current address is rate-limited or not. Konvoy does not have a strict dependency on Docker Hub accounts or plans.
@@ -63,7 +65,7 @@ Rate limiting happens on a per-pull basis regardless of whether the pulled image
 For more information on addressing this limit, see [Docker hub rate limits](../../operations/manage-docker-hub-rate-limits).
 
 # New Features
-<!-- ## KUDO Spark compatibility 
+<!-- ## KUDO Spark compatibility
 
 Kommander 1.3 requires KUDO Spark 3.0 because Spark 2.4 does not support Kubernetes 1.18.
 To continue using KUDO Spark Kommander 1.3 and above, upgrade to Spark 3.0.
@@ -73,6 +75,7 @@ For details on how to migrate workloads to Spark 3.0, consult the official [migr
 Customers now have the ability to control and configure which platform services get installed into an attached cluster by workspace. In Kommander specific platform services can be federated to attached non-Konvoy clusters. In each workspace customers can specify which platform services are federated to the attached non-Konvoy clusters.
 
 For more information, see [Workspace Platform Services](../../workspaces/workspace-platform-services/).
+
 ## Managed cluster multi-tenancy
 Kommander now supports managing network policies across project clusters. Projects are created with a secure-by-default network policy and users needing more flexibility can edit or add more policies to tailor to their unique security needs.
 
@@ -82,6 +85,7 @@ For more information, see [Network Policies](../../projects/project-network-poli
 Kommander now supports continuous deployments as part of projects. Teams can leverage GitOps best practices to deploy configurations from source repositories to managed clusters using Dispatch and FluxCD. You can also configure source repositories to be deployed across all managed clusters using GitOps best practices. Kommander uses Dispatch and FluxCD to enable continuous deployments as a standard feature of projects.
 
 For more information, see [Continuous Deployments](../../projects/project-deployments/).
+
 ## Component versions
 - Addon: 1.3.0-6
 - Chart: 0.13.7
@@ -96,6 +100,7 @@ For more information, see [Continuous Deployments](../../projects/project-deploy
 - karma: 0.70
 - thanos: 0.10.1
 - cost-analyzer: 1.70.1
+
 ## Fixed and Improved Issues
 - Added Kubecost Prometheus health dashboards to Grafana.
 - Added the ability to edit network policies.

--- a/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
@@ -28,7 +28,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
+In Kommander 1.3.2 and earlier versions, the Kubecost cost analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 In Kommander 1.3, unless a default NetworkPolicy existed prior to upgrading to 1.3, a default NetworkPolicy is created that allows traffic originating only within your Projects namespace. Pods can not talk to Pods outside of that namespace. In some cases this can have an unpredictable and unwanted impact on your system.
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
@@ -28,7 +28,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
+In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. To resolve this issue upgrade to Kommander version 1.3.3. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 # Breaking changes
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
@@ -26,6 +26,10 @@ Kommander provides a command center for all your cloud native management needs i
 | **Maximum**        | 1.19.x  |
 | **Default**        | 1.18.10  |
 
+# Known issues
+
+Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that require a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the [upgrade instructions in the 1.3.3 release notes](../1.3.3/).
+
 # Breaking changes
 
 In Kommander 1.3, all new projects were created with a default NetworkPolicy that only allowed traffic originating within your Projects namespace. This policy was also created in all existing projects that did not already have a NetworkPolicy when upgrading to Kommander 1.3.
@@ -33,6 +37,7 @@ In Kommander 1.3, all new projects were created with a default NetworkPolicy tha
 The result of this default policy was that Pods could not talk to Pods outside of that namespace. In some cases this was not a desired default state. As of Kommander 1.3.1, no default NetworkPolicy is created in new (or existing projects) and thus no traffic blocking is done by default.
 
 If you are upgrading from Kommander 1.3 and already made the necessary changes to address this issue (for example, by adding a NetworkPolicy with the desired traffic rules), then upgrading to Kommander 1.3.1 will not impact those existing policies.
+
 # New features
 
 - Add license delete mutation.

--- a/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
@@ -28,7 +28,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that require a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the [upgrade instructions in the 1.3.3 release notes](../1.3.3/).
+In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 # Breaking changes
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
@@ -21,7 +21,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that require a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the [upgrade instructions in the 1.3.3 release notes](../1.3.3/).
+In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 # Bug fixes
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
@@ -21,7 +21,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
+In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. To resolve this issue upgrade to Kommander version 1.3.3. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 # Bug fixes
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
@@ -17,7 +17,7 @@ To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [ins
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 
 # Release Summary
-Kommander provides a command center for all your cloud native management needs in public Information as a Service (IaaS), on-premises, and edge environments. Kommander provides a multi-tenant experience to create, secure, and configure Kubernetes clusters and cloud native workloads. Additionally, Kommander enables teams to unlock federated cost management across multiple clusters, whether they are a new Konvoy cluster or an existing 3rd party/DIY distribution installation.
+Kommander provides a command center for all your cloud native management needs in public IaaS, on-premises, and edge environments. Kommander provides a multi-tenant experience to create, secure, and configure Kubernetes clusters and cloud native workloads. Additionally, Kommander enables teams to unlock federated cost management across multiple clusters, whether they are a new Konvoy cluster or an existing 3rd party/DIY distribution installation.
 
 # Known issues
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
@@ -19,6 +19,10 @@ To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [ins
 # Release Summary
 Kommander provides a command center for all your cloud native management needs in public Information as a Service (IaaS), on-premises, and edge environments. Kommander provides a multi-tenant experience to create, secure, and configure Kubernetes clusters and cloud native workloads. Additionally, Kommander enables teams to unlock federated cost management across multiple clusters, whether they are a new Konvoy cluster or an existing 3rd party/DIY distribution installation.
 
+# Known issues
+
+Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that require a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the [upgrade instructions in the 1.3.3 release notes](../1.3.3/).
+
 # Bug fixes
 
 - Updated UI to handle new KUDO param types.

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -1,0 +1,59 @@
+---
+layout: layout.pug
+beta: false
+navigationTitle: Release Notes Kommander 1.3.3
+title: Release Notes Kommander 1.3.3
+menuWeight: 40
+excerpt: View release-specific information for Kommander 1.3.3
+enterprise: false
+---
+
+**D2iQ&reg; Kommander&reg; version 1.3.3 was released on x, May 2021.**
+
+[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+
+To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+
+<p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
+
+# Release Summary
+Kommander provides a command center for all your cloud native management needs in public Information as a Service (IaaS), on-premises, and edge environments. Kommander provides a multi-tenant experience to create, secure, and configure Kubernetes clusters and cloud native workloads. Additionally, Kommander enables teams to unlock federated cost management across multiple clusters, whether they are a new Konvoy cluster or an existing 3rd party/DIY distribution installation.
+
+# Known issues
+
+In versions prior to 1.3.3, Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that require a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the upgrade instructions below.
+
+## Upgrading
+The default cost-analyzer persistent volume size has been increased to 32Gi. Upgrades may require manual intervention if your provisioner does not support volume expansion. Here are some recommendations from the [Kubecost storage documentation](https://github.com/kubecost/docs/blob/master/storage.md):
+
+**If you are upgrading an existing version of Kommander**
+  - If your provisioner does supports volume expansion, we will automatically resize you to a 32GB disk in an upgrade.
+  - If your provisioner does not support volume expansion:
+    - If you have not added or modified Kubecost configuration from the settings page on the Kubecost frontend, you can safely delete the PV and upgrade.
+      - We suggest you delete the old PV, then upgrade Kommander.
+    - If you cannot safely delete the PV storing your configs and configure them on a new PV:
+      - If you are not on a regional cluster, we recommend that you provision a second PV by setting `kubecost.cost-analyzer.persistentVolume.dbPVEnabled=true` in your cluster.yaml under Kommander values.
+      - If you are on a regional cluster,  we recommend that you provision a second PV using a topology-aware storage class ([more info](https://kubernetes.io/blog/2018/10/11/topology-aware-volume-provisioning-in-kubernetes/#getting-started)). You can set this disk’s storage class by setting `kubecost.cost-analyzer.persistentVolume.dbStorageClass=<your-topology-aware-storage-class-name>`.
+
+# Bug fixes
+
+- UI: Resolved kubecost performance issue.
+- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See Upgrading above if upgrading from a previous version. (COPS-6937)
+
+
+## Component versions
+
+- Addon: 1.3.3-4
+- Chart: 0.15.12
+- kommander-federation (yakcl): 0.8.11
+- kommander-licensing (yakcl): 0.8.11
+- UI: 6.91.3
+- kommander-karma: 0.3.12
+- kubeaddons-catalog: 0.1.15
+- kommander-thanos: 0.1.16
+- kubecost: 0.11.0
+- grafana: 6.6.0
+- karma: 0.70
+- thanos: 0.10.1
+- cost-analyzer: 1.79.1
+

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -28,7 +28,6 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 - UI: Resolved Kubecost performance issue. (COPS-6895)
 - Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Known issues](#known-issues) above if upgrading from a previous version. (COPS-6937)
 
-
 ## Component versions
 
 - Addon: 1.3.3-4

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -21,19 +21,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-In versions prior to 1.3.3, Kubecost cost-analyzer by default requests a PVC of size 0.2Gi. This may cause issues with certain provisioners that require a minimum storage size of 1Gi. To resolve this issue, upgrade to 1.3.3 following the upgrade instructions below.
-
-## Upgrading
-The default cost-analyzer persistent volume size has been increased to 32Gi. Upgrades may require manual intervention if your provisioner does not support volume expansion. Here are some recommendations from the [Kubecost storage documentation](https://github.com/kubecost/docs/blob/master/storage.md):
-
-**If you are upgrading an existing version of Kommander**
-  - If your provisioner does supports volume expansion, we will automatically resize you to a 32GB disk in an upgrade.
-  - If your provisioner does not support volume expansion:
-    - If you have not added or modified Kubecost configuration from the settings page on the Kubecost frontend, you can safely delete the PV and upgrade.
-      - We suggest you delete the old PV, then upgrade Kommander.
-    - If you cannot safely delete the PV storing your configs and configure them on a new PV:
-      - If you are not on a regional cluster, we recommend that you provision a second PV by setting `kubecost.cost-analyzer.persistentVolume.dbPVEnabled=true` in your cluster.yaml under Kommander values.
-      - If you are on a regional cluster,  we recommend that you provision a second PV using a topology-aware storage class ([more info](https://kubernetes.io/blog/2018/10/11/topology-aware-volume-provisioning-in-kubernetes/#getting-started)). You can set this disk’s storage class by setting `kubecost.cost-analyzer.persistentVolume.dbStorageClass=<your-topology-aware-storage-class-name>`.
+In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 # Bug fixes
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -25,7 +25,7 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 
 # Bug fixes
 
-- UI: Resolved kubecost performance issue.
+- UI: Resolved Kubecost performance issue.
 - Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See Upgrading above if upgrading from a previous version. (COPS-6937)
 
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -25,7 +25,7 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 
 # Bug fixes
 
-- UI: Resolved Kubecost performance issue.
+- UI: Resolved Kubecost performance issue. (COPS-6895)
 - Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Kown issues](#known-issues) above if upgrading from a previous version. (COPS-6937)
 
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -26,7 +26,7 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 # Bug fixes
 
 - UI: Resolved Kubecost performance issue. (COPS-6895)
-- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Kown issues](#known-issues) above if upgrading from a previous version. (COPS-6937)
+- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Known issues](#known-issues) above if upgrading from a previous version. (COPS-6937)
 
 
 ## Component versions

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -26,7 +26,7 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 # Bug fixes
 
 - UI: Resolved Kubecost performance issue.
-- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See Upgrading above if upgrading from a previous version. (COPS-6937)
+- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Upgrading above](#upgrading) if upgrading from a previous version. (COPS-6937)
 
 
 ## Component versions

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -8,7 +8,7 @@ excerpt: View release-specific information for Kommander 1.3.3
 enterprise: false
 ---
 
-**D2iQ&reg; Kommander&reg; version 1.3.3 was released on x, May 2021.**
+**D2iQ&reg; Kommander&reg; version 1.3.3 was released on 9, June 2021.**
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -38,7 +38,7 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 - kommander-karma: 0.3.12
 - kubeaddons-catalog: 0.1.15
 - kommander-thanos: 0.1.16
-- kubecost: 0.11.0
+- kubecost: 0.13.0
 - grafana: 6.6.0
 - karma: 0.70
 - thanos: 0.10.1

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -26,7 +26,7 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 # Bug fixes
 
 - UI: Resolved Kubecost performance issue.
-- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Upgrading above](#upgrading) if upgrading from a previous version. (COPS-6937)
+- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Upgrading](#upgrading) above if upgrading from a previous version. (COPS-6937)
 
 
 ## Component versions

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -26,7 +26,7 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 # Bug fixes
 
 - UI: Resolved Kubecost performance issue.
-- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Upgrading](#upgrading) above if upgrading from a previous version. (COPS-6937)
+- Increased the default Kubecost cost-analyzer PVC storage size from 0.2Gi to 32Gi to resolve deployment issues that occurred with provisioners that require a minimum size of 1Gi. See [Kown issues](#known-issues) above if upgrading from a previous version. (COPS-6937)
 
 
 ## Component versions

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -21,7 +21,7 @@ Kommander provides a command center for all your cloud native management needs i
 
 # Known issues
 
-In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
+In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a PVC of size 0.2Gi by default. This can cause issues with provisioners requiring a minimum storage size of 1Gi. Upgrade to version 1.3.3 to resolve this issue. Refer [here](https://github.com/kubecost/docs/blob/master/storage.md) for more information. 
 
 # Bug fixes
 
@@ -44,4 +44,3 @@ In Kommander 1.3.2 and earlier versions, Kubecost cost-analyzer requests a PVC o
 - karma: 0.70
 - thanos: 0.10.1
 - cost-analyzer: 1.79.1
-

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -42,4 +42,4 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 - grafana: 6.6.0
 - karma: 0.70
 - thanos: 0.10.1
-- cost-analyzer: 1.79.1
+- cost-analyzer: 1.81.1

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -30,11 +30,11 @@ In Kommander 1.3.2 and earlier versions, the Kubecost cost-analyzer requests a P
 
 ## Component versions
 
-- Addon: 1.3.3-4
-- Chart: 0.15.12
-- kommander-federation (yakcl): 0.8.11
-- kommander-licensing (yakcl): 0.8.11
-- UI: 6.91.3
+- Addon: 1.3.3-5
+- Chart: 0.15.13
+- kommander-federation (yakcl): 0.8.12
+- kommander-licensing (yakcl): 0.8.12
+- UI: 6.91.8
 - kommander-karma: 0.3.12
 - kubeaddons-catalog: 0.1.15
 - kommander-thanos: 0.1.16


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->
https://jira.d2iq.com/browse/D2IQ-75774

https://jira.d2iq.com/browse/D2IQ-75885 

## Description of changes being made
Add known issues section with note that kubecost deployment _may_ fail for some customers if their provisioner doesn't allow storage size <1Gi, and an upgrading section in 1.3.3 (not yet released) referencing/repeating kubecost docs and recs on upgrades. I struggled a bit with where to put this info / how to write it so please feel free to rewrite/move things! And whether we need to dupe this in the konvoy RN, since technically kommander is released with konvoy so I guess this upgrade path would be upgrading konvoy versions ❓ 🤔 

When this reviewed, will apply same RN updates over to 1.4 RN

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.