### PR TITLE
fix: updating redirects for Arch and latest

### DIFF
--- a/s3config.json
+++ b/s3config.json
@@ -55,6 +55,6 @@
     { "Condition": { "KeyPrefixEquals": "services/" },                                                         "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/services/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "version-policy/" },                                                   "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/version-policy/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "support" },                                                           "Redirect": { "HostName": "support.d2iq.com", "Protocol": "https", "HttpRedirectCode": "301" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/Architecture/" },                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/latest/architecture/", "HttpRedirectCode": "301" } }
+    { "Condition": { "KeyPrefixEquals": "dkp/kommander/1.4/Architecture/" },                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/1.4/architecture/", "HttpRedirectCode": "301" } }
   ]
 }

--- a/s3config.json
+++ b/s3config.json
@@ -7,9 +7,9 @@
   },
   "RoutingRules": [
     { "Condition": { "KeyPrefixEquals": "mesosphere/dcos/latest/" },                                           "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/2.2/", "HttpRedirectCode": "307" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/konvoy/latest/" },                                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/konvoy/1.7/", "HttpRedirectCode": "307" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/konvoy/latest/" },                                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/konvoy/1.8/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/dispatch/latest/" },                                              "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/dispatch/1.2/", "HttpRedirectCode": "307" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/1.3/", "HttpRedirectCode": "307" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/1.4/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/conductor/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/conductor/1.1/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/kaptain/latest/" },                                               "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kaptain/1.2.0-1.1.0/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/kubeflow/" },                                                     "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kaptain/", "HttpRedirectCode": "307" } },
@@ -54,6 +54,7 @@
     { "Condition": { "KeyPrefixEquals": "([0-9]+\\.[0-9]+/.*)$" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "services/" },                                                         "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/services/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "version-policy/" },                                                   "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/version-policy/", "HttpRedirectCode": "301" } },
-    { "Condition": { "KeyPrefixEquals": "support" },                                                           "Redirect": { "HostName": "support.d2iq.com", "Protocol": "https", "HttpRedirectCode": "301" } }
+    { "Condition": { "KeyPrefixEquals": "support" },                                                           "Redirect": { "HostName": "support.d2iq.com", "Protocol": "https", "HttpRedirectCode": "301" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/Architecture/" },                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/latest/architecture/", "HttpRedirectCode": "301" } }
   ]
 }


### PR DESCRIPTION
D2IQ-75506 - Redirecting the /latest/ to the most up to date versions of konv(1.8)/komm(1.4) and changed a link from Architecture to architecture

## Jira Ticket
[D2IQ-75506](https://jira.d2iq.com/browse/D2IQ-75506)
`Kommander` - Need to update links in Kommander help

## Description of changes being made
Changing the redirects to go from broken in 1.4 /Architecture to /architecture and updating the 'latest' re-directs

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.