### PR TITLE
fix(styles): changing partner solutions header

### DIFF
--- a/layouts/konvoy-partners-landing.pug
+++ b/layouts/konvoy-partners-landing.pug
@@ -61,9 +61,9 @@ html(lang='en')
     include partials/head.pug
   body.landing.landing--services
     .layout
+      - var sectionTitle = 'Konvoy Documentation'
+      include partials/header/header.pug
       div.layout__content(role='main')
-        - var sectionTitle = 'Konvoy Documentation'
-        include partials/header/header.pug
         .landing__hero
           h1.landing__title Konvoy Partner Solutions
         .landing__container


### PR DESCRIPTION
The position was off and seemed to be floating too low for the
actual content.

## Jira Ticket
N/A

<!-- Link to DOCS work ticket -->

## Description of changes being made
Changing from this: 
![Screen Shot 2021-05-24 at 4 30 48 PM](https://user-images.githubusercontent.com/5703649/119409804-7ac49600-bcad-11eb-87ab-9d13024c7bf1.png)

To this: 
![Screen Shot 2021-05-24 at 4 31 55 PM](https://user-images.githubusercontent.com/5703649/119409884-992a9180-bcad-11eb-8697-54d44c01c025.png)


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.