### PR TITLE
fix: use --delete option when rsync from upstream

### DIFF
--- a/ci/pull-upstream.sh
+++ b/ci/pull-upstream.sh
@@ -31,7 +31,7 @@ git fetch
 git checkout "$REPO_BRANCH"
 
 echo "Diffing repo $REPO_SUBFOLDER against docs $DOCS_SUBFOLDER"
-rsync -a "$TMP_DIR/$REPO_NAME/$REPO_SUBFOLDER/" "$PROJECT_ROOT/$DOCS_SUBFOLDER/"
+rsync -a --delete "$TMP_DIR/$REPO_NAME/$REPO_SUBFOLDER/" "$PROJECT_ROOT/$DOCS_SUBFOLDER/"
 cd "$PROJECT_ROOT/$DOCS_SUBFOLDER/"
 
 if [ -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
Avoid issues like https://github.com/mesosphere/dcos-docs-site/pull/3626/files

```
--delete                delete extraneous files from destination dirs
```

Im assuming here that the upstream repo will be the only source of truth and all files must come from there.