### PR TITLE
Deployment changes for D2IQ-75904 and D2IQ-75903

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,17 @@
 #!/usr/bin/env groovy
 
 boolean main = env.BRANCH_NAME == "main"
-def bucket   = main ? "production"    : "pr-${env.CHANGE_ID}"
-def creds    = main ? 's3-production' : 's3-development'
-def hostname = main ? 'docs.d2iq.com' : "docs-d2iq-com-pr-${env.CHANGE_ID}.s3-website-us-west-2.amazonaws.com"
+boolean beta = env.BRANCH_NAME == "beta"
+def bucket   = main ? "production"
+             : beta ? "staging"
+             : "pr-${env.CHANGE_ID}"
+def creds    = main ? "s3-production"
+             : beta ? "s3-staging"
+             : "s3-development"
+def hostname = main ? "docs.d2iq.com"
+             : beta ? "beta-docs.d2iq.com"
+             : "docs-d2iq-com-pr-${env.CHANGE_ID}.s3-website-us-west-2.amazonaws.com"
+
 
 pipeline {
   agent { label "mesos" }

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -15,4 +15,4 @@ aws s3api put-public-access-block --bucket $BUCKET --public-access-block-configu
 aws s3api put-bucket-policy       --bucket $BUCKET --policy file:///src/.policy
 aws s3api put-bucket-website      --bucket $BUCKET --website-configuration file:///src/.s3config.json
 
-aws s3 sync --quiet --acl bucket-owner-full-control ./build s3://$BUCKET
+aws s3 sync --delete --quiet --acl bucket-owner-full-control ./build s3://$BUCKET


### PR DESCRIPTION
This should implement the changes requested in D2IQ-75903 and D2IQ-75904.
The `--delete` flag to `aws s3 sync` makes sure that files that do not exist in the local `build/` directory are being removed from the remote bucket.
The new `beta` branch will be synced to the existing staging bucket. Once the Jenkins job is created and runs against the `beta` branch we'll check if the `docs-d2iq-com-staging` bucket was synced successfully and point the https://beta-docs.d2iq.com/ Cloudfront distribution to the staging bucket instead of the PR 3578 bucket.
