### PR TITLE
Use private-beta branch instead of beta

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 boolean main = env.BRANCH_NAME == "main"
-boolean beta = env.BRANCH_NAME == "beta"
+boolean beta = env.BRANCH_NAME == "private-beta"
 def bucket   = main ? "production"
              : beta ? "staging"
              : "pr-${env.CHANGE_ID}"


### PR DESCRIPTION
As discussed on Slack this updates the Jenkinsfile to trigger the https://beta-docs.d2iq.com deployment on the `private-beta` branch instead of `beta`.