### PR TITLE
docs(fix): removing h tags for open source pages

### DIFF
--- a/pages/dkp/kommander/1.4/release-notes/open-source-attributions/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/open-source-attributions/index.md
@@ -9,12 +9,12 @@ render: mustache
 
 The table below lists the third party open source software which is provided by D2iQ&reg; in connection with Kommander&trade;.
 
-## Software Sources
+**Software Sources**
 
 The table below lists the Sources for the Free Software under GNU General Public License, and Mozilla Public License
 Software that are utilized by D2IQ Komander.
 
-## Project dependencies
+**Project dependencies**
 
 | Vendor | Name | Version | License Id |
 | -------|------|---------|------------|
@@ -2732,16 +2732,16 @@ Software that are utilized by D2IQ Komander.
 |  | regenerate | 1.4.2 | [MIT](https://opensource.org/licenses/MIT) |
 |  | terser | 4.8.0 | [BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause) |
 
-## Kubetunnel
+**Kubetunnel**
 
 The table below lists the third party open source software which is provided by D2iQ&reg; in connection with Kubetunnel&trade;.
 
-## Software Sources
+**Software Sources**
 
 The table below lists the Sources for the Free Software under GNU General Public License, and Mozilla Public License
 Software that are utilized by D2IQ&reg; Kubetunnel&trade;.
 
-## Project dependencies
+**Project dependencies**
 
 | Vendor | Name | Version | License Id |
 | -------|------|---------|------------|
@@ -2777,16 +2777,16 @@ Software that are utilized by D2IQ&reg; Kubetunnel&trade;.
 | k8s.io | code-generator | v0.18.8 | [Apache-2.0](https://pkg.go.dev/k8s.io/code-generator?tab=licenses) |
 | sigs.k8s.io | controller-tools | v0.3.0 | [Apache-2.0](https://pkg.go.dev/sigs.k8s.io/controller-tools?tab=licenses) |
 
-## Yakcl
+**Yakcl**
 
 The table below lists the third party open source software which is provided by D2iQ&reg; in connection with Yakcl&trade;.
 
-## Software Sources
+**Software Sources**
 
 The table below lists the Sources for the Free Software under GNU General Public License, and Mozilla Public License
 Software that are utilized by D2IQ&reg; Yakcl&trade;.
 
-## Project dependencies
+**Project dependencies**
 
 | Vendor | Name | Version | License Id |
 | -------|------|---------|------------|

--- a/pages/dkp/konvoy/1.8/legal/open-source-attribution/index.md
+++ b/pages/dkp/konvoy/1.8/legal/open-source-attribution/index.md
@@ -11,7 +11,7 @@ render: mustache
 
 The table below lists the third party open source software which is provided by D2iQ&reg; in connection with Konvoy&trade;.
 
-## Project dependencies
+**Project dependencies**
 
 | Vendor | Name | Version | License Id |
 | -------|------|---------|------------|
@@ -1530,7 +1530,7 @@ The table below lists the third party open source software which is provided by 
 | k8s.io | apimachinery | v0.19.6 | [Apache-2.0](https://pkg.go.dev/k8s.io/apimachinery?tab=licenses) |
 | k8s.io | client-go | v0.19.6 | [Apache-2.0](https://pkg.go.dev/k8s.io/client-go?tab=licenses) |
 
-## Software Sources
+**Software Sources**
 
 The table below lists the Sources for the Free Software under GNU General Public License, and Mozilla Public License
 Software that are utilized by D2iQ Konvoy.


### PR DESCRIPTION
The h tags (in markdown, ##) would add a sidebar
for the table pages here

## Jira Ticket
n/a

<!-- Link to DOCS work ticket -->

## Description of changes being made
Changed the markdown headers (`##`) to just be bold, so that it doesn't add a sidebar nav on these pages that are literally just tables anyway.

Issue is visualized here: 
![Screen Shot 2021-06-03 at 11 53 18 AM](https://user-images.githubusercontent.com/5703649/120694838-418be300-c470-11eb-8a07-29c0f00b2ce1.png)


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.