### PR TITLE
Updated docs to use autoscaler for konvoy1.8

### DIFF
--- a/pages/dkp/konvoy/1.8/autoscaling/index.md
+++ b/pages/dkp/konvoy/1.8/autoscaling/index.md
@@ -76,7 +76,11 @@ When deploying the cluster for the first time using `konvoy up`, **you must ensu
 After the cluster specification is configured, run `konvoy up -y` to apply the required
 changes to the cluster and to start autoscaling the worker pool on
 demand. When the command completes successfully, certain configuration files of the cluster
-are stored in Kubernetes.
+are stored in Kubernetes. 
+Please make sure the kubeconfig has correct login information
+```shell
+export KUBECONFIG=admin.conf
+```
 This keeps the cluster state up-to-date for any change triggered by the autoscaler and prevents the system from having multiple or out-dated cluster specifications.
 
 The following files are stored in Kubernetes when using the autoscaling feature:
@@ -357,12 +361,12 @@ in our respective `KonvoyCluster` resource in Kubernetes. These are the two even
 scaling up and down decisions, as shown below:
 
 ```shell
-Events:
-  Type    Reason                  Age    From                Message
-  ----    ------                  ----   ----                -------
-  Normal  ClusterScaleUpSuccess   13m    cluster-autoscaler  2 machine(s) added to nodepool "worker" by autoscaler (provider: konvoy)
-  ...
-  Normal  ClusterScaleDownSuccess 3m     cluster-autoscaler  1 machine removed from nodepool "worker" by autoscaler (provider: konvoy)
+kubectl get events | grep autoscaler
+Type    Reason                  Age    From                Message
+----    ------                  ----   ----                -------
+Normal  ClusterScaleUpSuccess   13m    cluster-autoscaler  2 machine(s) added to nodepool "worker" by autoscaler (provider: konvoy)
+...
+Normal  ClusterScaleDownSuccess 3m     cluster-autoscaler  1 machine removed from nodepool "worker" by autoscaler (provider: konvoy)
 ```
 
 [autoscaler]: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made
While using autoscaler with konvoy 1.8, one of the commands for events was missing and added explicit info to update kubeconfig after konvoy cluster is up.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [x] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.