### PR TITLE
Qa/06142021 adding do not build

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,34 @@ Our markdown comes with metadata - also called "frontmatter". Here are the speci
 * **beta: true** - When this value is **true** a beta label is added to the page title.
 * **experimental: true** - When this value is **true** an experimental label is added to the page title.
 
+## DO NOT BUILD sections
+
+If you want to commit work, but
+- you do not want that work to be live on the public documentation site,
+- and also do not want to have it be in a **draft** status:
+
+You can set that section to not be built.
+
+Reasons you may want this would be for ongoing work for upcoming versions where we are still working out complications in the documentation, the feature or the documentation are incomplete but you want to commit work so you can continue to collaborate on this or other projects, features that are built for a certain slice of customers but not for all and not yet released, early beta work where things may still change, more time to review, etc.
+
+Regardless of the reasoning, you will need to modify this repo's `config.json` file to add whatever page or section to not be built when your PR merges.
+
+You need to include the branch that it's being built from (`main` in our case here), and the URL.
+
+For example, if you wanted to add Konvoy 42.0 to the Do Not Build section, you would need to modify the `config.json` to look like this:
+
+```json
+{
+  "main": {
+    "DO_NOT_BUILD": [
+      "dkp/konvoy/42.0/**"
+    ]
+  }
+}
+```
+
+This tells Metalsmith to not build the Konvoy 42.0 section and it's child pages.
+
 ## URL-structure
 
 The directory-tree in `/pages` resembles the URL-structure of the final build. A pages' content **MUST** be in an `index.md`file in the respective directory.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you want to commit work, but
 
 You can set that section to not be built.
 
-Regardless of the reasoning, you will need to modify this repo's `config.json` file to add whatever page or section to not be built when your PR merges.
+Modify this repo's `config.json` file to add whatever page or section to not be built when your PR merges.
 
 You need to include the branch that it's being built from (`main` in our case here), and the URL.
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ If you want to commit work, but
 
 You can set that section to not be built.
 
-Reasons you may want this would be for ongoing work for upcoming versions where we are still working out complications in the documentation, the feature or the documentation are incomplete but you want to commit work so you can continue to collaborate on this or other projects, features that are built for a certain slice of customers but not for all and not yet released, early beta work where things may still change, more time to review, etc.
-
 Regardless of the reasoning, you will need to modify this repo's `config.json` file to add whatever page or section to not be built when your PR merges.
 
 You need to include the branch that it's being built from (`main` in our case here), and the URL.

--- a/config.json
+++ b/config.json
@@ -1,9 +1,9 @@
 {
   "example-git-branch": {
     "DO_NOT_BUILD": [
-      "dkp/exmaple-new-product/1.3/**",
-      "dkp/exmaple-new-product/1.4/**",
-      "dkp/exmaple-old-product/1.0/**"
+      "dkp/example-new-product/1.3/**",
+      "dkp/example-new-product/1.4/**",
+      "dkp/example-old-product/1.0/**"
     ]
   },
   "main": {

--- a/config.json
+++ b/config.json
@@ -1,12 +1,5 @@
 {
   "main": {
-    "DO_NOT_BUILD": [
-      "dkp/kommander/1.3/**"
-    ]
-  },
-  "QA/06142021-adding-do-not-build": {
-    "DO_NOT_BUILD": [
-      "dkp/kommander/1.3/**"
-    ]
+    "DO_NOT_BUILD": []
   }
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+  "main": {
+    "DO_NOT_BUILD": [
+      "dkp/kommander/1.3/**"
+    ]
+  },
+  "QA/06142021-adding-do-not-build": {
+    "DO_NOT_BUILD": [
+      "dkp/kommander/1.3/**"
+    ]
+  }
+}

--- a/config.json
+++ b/config.json
@@ -1,4 +1,11 @@
 {
+  "example-git-branch": {
+    "DO_NOT_BUILD": [
+      "dkp/exmaple-new-product/1.3/**",
+      "dkp/exmaple-new-product/1.4/**",
+      "dkp/exmaple-old-product/1.0/**"
+    ]
+  },
   "main": {
     "DO_NOT_BUILD": []
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 // Packages
+const fs = require("fs");
 const minimatch = require("minimatch");
 const Metalsmith = require("metalsmith");
 const markdown = require("metalsmith-markdownit");
@@ -22,6 +23,15 @@ const includeContent = require("./plugins/metalsmith-include-content-dcos");
 const shortcodes = require("./plugins/metalsmith-shortcodes");
 const webpack = require("./plugins/metalsmith-webpack");
 const Utils = require("./core/utils");
+
+// Configs
+const configData = fs.readFileSync("config.json");
+const config = JSON.parse(configData);
+const shortcodesConfig = require("./shortcodes");
+
+// Environment Variables
+const GIT_BRANCH = process.env.GIT_BRANCH;
+const METALSMITH_SKIP_SECTIONS = (config[GIT_BRANCH] || {}).DO_NOT_BUILD || [];
 
 //
 // Metalsmith

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const markdown = require("metalsmith-markdownit");
 const layouts = require("metalsmith-layouts");
 const assets = require("metalsmith-assets");
 const dataLoader = require("metalsmith-data-loader");
+const ignore = require("metalsmith-ignore");
 const watch = require("metalsmith-watch");
 const serve = require("metalsmith-serve");
 const anchor = require("markdown-it-anchor");
@@ -27,7 +28,6 @@ const Utils = require("./core/utils");
 // Configs
 const configData = fs.readFileSync("config.json");
 const config = JSON.parse(configData);
-const shortcodesConfig = require("./shortcodes");
 
 // Environment Variables
 const GIT_BRANCH = process.env.GIT_BRANCH;
@@ -87,6 +87,9 @@ if (process.env.NODE_ENV === "development") {
     done();
   });
 }
+
+MS.use(ignore(METALSMITH_SKIP_SECTIONS));
+MS.use(timer("Ignore"));
 
 MS.use(assets({ source: "assets", destination: "assets" }));
 MS.use(timer("Assets"));


### PR DESCRIPTION
## Jira Ticket
N/A

## Description of changes being made
Adding a Do Not Build command where we can just axe things from getting built when deploying to the site.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.