### PR TITLE
Specify Python as an OS prerequisite in air-gapped clusters

### DIFF
--- a/pages/dkp/konvoy/1.7/include/os-svc-nodes.tmpl
+++ b/pages/dkp/konvoy/1.7/include/os-svc-nodes.tmpl
@@ -6,6 +6,6 @@ For all hosts that are part of the cluster, except the **deploy host**, verify t
 - Docker-ce is uninstalled.
 - Swap is disabled.
 - The hostnames for all the machines in the Kubernetes cluster are unique within a single cluster.
-- If you are using the XFS file system for the volume that mounts the /var/lib/containerd/ directory, it must be formatted with the `ftype=1` option.
+- If you are using the XFS file system for the volume that mounts the `/var/lib/containerd/` directory, it must be formatted with the `ftype=1` option.
 
 <p class="message--note"><strong>NOTE: </strong> This is the default in most OS distributions. You can use the <code>xfs_info</code> utility to verify that <code>ftype=1</code> has been used.</p>

--- a/pages/dkp/konvoy/1.7/install/install-airgapped/index.md
+++ b/pages/dkp/konvoy/1.7/install/install-airgapped/index.md
@@ -56,6 +56,10 @@ Before installing, verify that your environment meets the following basic requir
 
 #include /dkp/konvoy/1.7/include/os-svc-nodes.tmpl
 
+The following requirement is specific to air-gapped environments:
+
+- Python is installed and the `python` executable can be found in the standard `PATH`.
+
 # Initialize Konvoy configuration files
 
 To start the Konvoy installation, you first need an [Ansible][ansible] [inventory file][ansible_inventory] in your current working directory to describe the hosts where you want to install Konvoy.

--- a/pages/dkp/konvoy/1.8/include/os-svc-nodes.tmpl
+++ b/pages/dkp/konvoy/1.8/include/os-svc-nodes.tmpl
@@ -6,6 +6,6 @@ For all hosts that are part of the cluster, except the **deploy host**, verify t
 - Docker-ce is uninstalled.
 - Swap is disabled.
 - The hostnames for all the machines in the Kubernetes cluster are unique within a single cluster.
-- If you are using the XFS file system for the volume that mounts the /var/lib/containerd/ directory, it must be formatted with the `ftype=1` option.
+- If you are using the XFS file system for the volume that mounts the `/var/lib/containerd/` directory, it must be formatted with the `ftype=1` option.
 
 <p class="message--note"><strong>NOTE: </strong> This is the default in most OS distributions. You can use the <code>xfs_info</code> utility to verify that <code>ftype=1</code> has been used.</p>

--- a/pages/dkp/konvoy/1.8/install/install-airgapped/index.md
+++ b/pages/dkp/konvoy/1.8/install/install-airgapped/index.md
@@ -56,6 +56,10 @@ Before installing, verify that your environment meets the following basic requir
 
 #include /dkp/konvoy/1.8/include/os-svc-nodes.tmpl
 
+The following requirement is specific to air-gapped environments:
+
+- Python is installed and the `python` executable can be found in the standard `PATH`.
+
 # Initialize Konvoy configuration files
 
 To start the Konvoy installation, you first need an [Ansible][ansible] [inventory file][ansible_inventory] in your current working directory to describe the hosts where you want to install Konvoy.


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-76725

## Description of changes being made

Air-gapped clusters require Python to be installed before running `konvoy up` because, if it is missing, the Ansible scripts use the network to install it.

## Checklist
- [x] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [x] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.