### PR TITLE
Update kaptain version-policy

### DIFF
--- a/pages/dkp/kaptain/1.2.0-1.1.0/version-policy/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/version-policy/index.md
@@ -37,3 +37,20 @@ Support for Experimental components is provided on a Standard level, Severity 4 
 Istio is a required pre-requisite for Kaptain.
 Istio usage is only supported in conjunction with Kaptain and the configurations delivered as part of Kaptain.
 All other usage of Istio is considered `experimental`.
+
+## Support for KUDO - Cassandra, Kafka & Spark
+### Support Definition - Secondary Support
+Secondary support covers support for the base technology of platform service, which is Cassandra, Kafka, and Spark, and additionally support for the KUDO-based operator of the mentioned platform services.
+
+*Base Technology refers to Cassandra, Kafka, and Spark.
+
+|Type|Scope Example|Support Offered|
+|:---|:---|:---|
+|Configuration|* Guidance for base technology and DKP interoperability configuration questions and troubleshooting for different components of the DKP platform. <br> * No support for base technology’s configuration that is unrelated to its integration with DKP. <br>  * No support for performance issues with the base technology.|Supported with Severity 4 support terms|
+|Failure Assistance|* Assistance with installation, and upgrade, failures of the service. <br> * Assistance with service failures due to platform issues. For example: Konvoy, Kommander, KUDO. <br> * No assistance for base technology’s failures that is unrelated to its integration with DKP.|  Supported with Severity 3 & 4 support terms|
+|Bug Fixes|* Bug fixes for service integration with DKP.<br>  * Upstream bug fixes to identified issues in the base technology. (Cassandra, Kafka, Spark) on a best effort basis.<br> * No guarantee that changes to upstream will be accepted.<br> * No commitment to maintaining forks of upstream.|Supported with Severity 3 & 4 support terms|
+|Documentation Errors|* Documentation fixes for life cycle management of services and integration with DKP.<br> * Issue or PR submitted to correct any incorrect upstream documentation in base technology. (Cassandra, Kafka, Spark) on a best effort basis.<br> * No guarantee that changes will be accepted.|Supported with Severity 4 support terms|
+
+## Standard Level & Severity Definitions 
+ 
+To view our severity level and support terms refer - https://d2iq.com/legal/support-terms


### PR DESCRIPTION
Adding Secondary Support to Kaptain Version-Policy page PER COPS-6758

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

https://jira.d2iq.com/browse/COPS-6758

## Description of changes being made
Adding Secondary Support in Kaptain's Version Policy

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.