### PR TITLE
fix: use default function from cheerio

### DIFF
--- a/plugins/metalsmith-hierarchy.js
+++ b/plugins/metalsmith-hierarchy.js
@@ -11,8 +11,10 @@ const findLongestExisting = (path, fallback) => {
   return paths[path] ? path : findLongestExisting(stripLast(path));
 };
 
+// We added the `.default` because CI broke after a node docker image update
+// We are not sure what the actual reason is 100%, but it fixes the red CI
 const firstParagraph = (file) =>
-  $("p", md.render(file.contents.toString("utf-8"))).first();
+  $.default("p", md.render(file.contents.toString("utf-8"))).first();
 
 /**
  * This plugin puts all files into a tree structure and adds some other variables:


### PR DESCRIPTION
This seems to fix the build issue in CI.
We don't know why this happens right now. This should probably be investigated further to know what's going on. 

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.