### PR TITLE
fix: remove model

### DIFF
--- a/pages/dkp/kaptain/1.2.0/legal-notices/index.md
+++ b/pages/dkp/kaptain/1.2.0/legal-notices/index.md
@@ -5,7 +5,6 @@ beta: false
 menuWeight: 99
 excerpt: List of Third-party trademarks mentioned in the Kaptain documentation
 render: mustache
-model: /mesosphere/dcos/2.0/data.yml
 ---
 
 D2iQ&reg; and its licensors are the owners of all right, title and interest in and to D2iQ software products, the documentation, all updates, upgrades, and derivative works thereto, and all intellectual property rights therein.  D2iQ software products may additionally include third-party open source software.


### PR DESCRIPTION
This file doesn't exist and causes failures when running the preview

```
Digest: sha256:1c23ced9247b265b0e7b0ef24278a196eafa9463ac65c7d16d2d8b484c94cec3
Status: Downloaded newer image for mesosphere/docs-dev:latest
docker.io/mesosphere/docs-dev:latest
  PID TTY           TIME CMD
29209 ttys001    0:00.01 /bin/bash /Users/dkoshkin/src/github.com/mesosphere/konvoy2/tools/docs/hack/preview.sh /Users/dkoshkin/src/github.com/mesosphere/konvoy2/docs/site dkp/konvoy/2.0

> mesosphere-docs@0.0.1 dev /dcos-docs-site
> NODE_ENV=development DEBUG=metalsmith-timer,metalsmith-algolia,metalsmith-layouts,metalsmith-assets node index.js

[metalsmith-watch] ✓ Live reload server started on port: 35729
  metalsmith-timer Init +0ms
  metalsmith-timer Ignore +58ms
  metalsmith-assets pulling files from /dcos-docs-site/assets +0ms
  metalsmith-assets and putting in assets +1ms
  metalsmith-assets 118 files found. +6ms
  metalsmith-assets 118 files copied. +27ms
  metalsmith-timer Assets +34ms
/dcos-docs-site/index.js:207
  if (err) throw err;
           ^

Error: Unable to process /dcos-docs-site/pages/mesosphere/dcos/2.0/data.yml, needed by dkp/kaptain/1.2.0/legal-notices/index.md: Error: Failed reading file /dcos-docs-site/pages/mesosphere/dcos/2.0/data.yml: Error: ENOENT: no such file or directory, open '/dcos-docs-site/pages/mesosphere/dcos/2.0/data.yml'
    at /dcos-docs-site/node_modules/metalsmith-data-loader/lib/index.js:193:31
    at async Promise.all (index 0)
    at async Promise.all (index 48)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mesosphere-docs@0.0.1 dev: `NODE_ENV=development DEBUG=metalsmith-timer,metalsmith-algolia,metalsmith-layouts,metalsmith-assets node index.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mesosphere-docs@0.0.1 dev script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-08-19T16_27_12_072Z-debug.log
make: *** [docs.preview] Error 1
```