### PR TITLE
Review Kaptain 1.2 docs

### DIFF
--- a/pages/dkp/kaptain/1.2.0/custom-configuration/custom-domain-certs/index.md
+++ b/pages/dkp/kaptain/1.2.0/custom-configuration/custom-domain-certs/index.md
@@ -1,48 +1,47 @@
 ---
 layout: layout.pug
 navigationTitle: Custom domain name and certificates
-title: Configuring custom domain name and certificates to access Kaptain
+title: Configure a custom domain name and certificates for Kaptain
 menuWeight: 70
-excerpt: Configuring custom domain name and certificates to access Kaptain
+excerpt: Configure a custom domain name and certificates for Kaptain
 beta: false
 enterprise: false
 ---
 
-Learn how to configure a custom domain name with TLS certificates trusted by your organization. 
-This allows most browsers to validate the certificate for the Kaptain endpoint that users log on to to access the main UI, the central dashboard.
+Learn how to configure a custom domain name with TLS certificates trusted by your organization.
+This will permit browsers to validate the certificate for the Kaptain endpoint that users log on to to access the main Kaptain UI, the central dashboard.
 
 ## Prerequisites
 
--   You already provisioned a Konvoy cluster using at least `v1.7.0`.
--   You can setup a DNS [A record][dnsarecord] for the Kaptain gateway IP, or a [CNAME][dnscname] for the Kaptain
-gateway load balancer hostname in the public cloud cases like AWS.
--   You already have a certificate and private key files for the domain name that will be used for accessing Kaptain.
+-   A Provisioned Konvoy cluster running Konvoy `v1.7.0` or above.
+-   A configured DNS [A record][dnsarecord] for the Kaptain gateway IP, or a [CNAME][dnscname] configured for the Kaptain
+gateway load balancer hostname if you installed Kaptain in a cloud prover.
+-   The certificate and private key files for the domain name that will be used for accessing Kaptain.
 
 ## Setting up the Kaptain hostname and certificates
 
-A custom domain name and certificates can be configured at installation time of Kaptain. Create or update a configuration file to include the following properties:
+A custom domain name and certificates can be configured at installation time of Kaptain. Create or update a configuration file named `parameters.yaml` that includes the following properties:
 
 ```yaml
 customDomainName: <the domain name to use for accessing Kaptain>
-base64CustomCertificate: <Base64-encoded contents of the TLS certificate file For example, kaptain.crt>
+base64CustomCertificate: <Base64-encoded contents of the TLS certificate file. For example, kaptain.crt>
 base64CustomCertificateKey: <Base64-encoded contents of the private key file. For example, kaptain.key>
 ```
 
-To create a base64-encoded values for a certificate and a private key files, run the following command:
+To create the base64-encoded values for the certificate and a private key files, run the following command:
 ```bash
 cat kaptain.crt | base64
 cat kaptain.key | base64
 ```
 
-The resulting configuration file resembles what follows:
+The resulting parameters.yaml configuration file should resemble the following example:
 ```yaml
 customDomainName: kaptain.mycluster.company.com
 base64CustomCertificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVQRENDQXlTZ0F3SUJBZ0lVVm1kOGNBUzlMRTFxM0VXZFRxWGI2K3Fnd2owd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2daSXhDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJREFwRFlXeHBabTl5Ym1saE1SWXdGQVlEVlFRSApEQTFUWVc0Z1JuSmhibU5wYzJOdk1RMHdDd1lEVlFRS0RBUkVNbWxSTVJVd0V3WURWUVFMREF4VVpXRnRJRXRoCmNIUmhhVzR4RFRBTEJnTlZCQU1NQkVReWFWRXhJVEFmQmdrcWhraUc5dzBCQ1FFV0VtRnJhWEpwYkd4dmRrQmsKTW1seExtTnZiVEFlRncweU1ERXhNekF5TVRBME1qSmFGdzB5TXpBek1EVXlNVEEwTWpKYU1JR3pNUXN3Q1FZRApWUVFHRXdKVlV6RVRNQkVHQTFVRUNBd0tRMkZzYVdadmNtNXBZVEVVTUJJR0ExVUVCd3dMVTJGdWRHRWdRMnhoCmNtRXhGVEFUQmdOVkJBb01ERVF5YVZFZ1MyRndkR0ZwYmpFVk1CTUdBMVVFQ3d3TVZHVmhiU0JMWVhCMFlXbHUKTVNnd0pnWURWUVFEREI5cllYQjBZV2x1TG10emNHaGxjbVV0YTNWa2J5NWtNbWx4TG1Oc2IzVmtNU0V3SHdZSgpLb1pJaHZjTkFRa0JGaEpoYTJseWFXeHNiM1pBWkRKcGNTNWpiMjB3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBCkE0SUJEd0F3Z2dFS0FvSUJBUURBNlhtRVpkWFF2NXA3NTM3TWdBN3pZVjM2QkFMSlpJM0xkWXREWTJ4aEZKazEKN3I5UFMxUWpOSnFLMHF3ZC9tM3BYeFB1dGFGYW82UVVzV0NGazFYaGxKNHNmaEVEQkg5ZTRhWFRldjJJWXVoVApRWlpZOG1zTTdzK2J1c0NLR1RUWEZwTzRyS3B2Nmt1dlgrYk9HYVdqRDRRV0N3dFQ5cFg4RkNMNThTOHg0VFZICkQvb1BwcW1XU3RzWGN4azFtU0NjMWF4ZExzRTk4c09zZVQxdlRRVFdkN1pZWUpvZ09qS3NtN2I5Qk4rOHdobWMKK295OEQ1R0lUSEZiMWo5OVY2TGw3ZkxoV21iMkcrZ29NbzJ4RDlBMjdLM2FyKzE3djBJNElYUzJFd2UxSTI1eAppMkNJYnR6VzVUZG1pOE1Fdnd0ZFhXSDMxUUU4N1N4K3VsOXN6ODFqQWdNQkFBR2paekJsTUI4R0ExVWRJd1FZCk1CYUFGTEc1cDIyNC9qVk1zTHAwMmNUb0crc3I4TzFzTUFrR0ExVWRFd1FDTUFBd0N3WURWUjBQQkFRREFnVHcKTUNvR0ExVWRFUVFqTUNHQ0gydGhjSFJoYVc0dWEzTndhR1Z5WlMxcmRXUnZMbVF5YVhFdVkyeHZkV1F3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFDM0R0NERRK3JBd1RSTjAvN3pQQS85WmpPSnJpM0xTMzVSbW9oZVhUc3UyClRvN2NVMFVwSTlwRVRlUE1qVTVxK1RLeXlrdDg2YUxPZ1NEYkRvY21BL053dWhKU0xWRVFtbjJxSFh0cFNQK0MKQzE5R0gzRVFKVHkwcXpob3lBbTh4SmpuRklFNldKazNMRkZqRmdQK0lUZC9JOENBMXhrMFJYNnBZRE5RY3R4dwo5OExkVlNEM2NSL3VlMjRjS2l4aCs0dnpIcmhOSHJlekZ6Yml5TS9ZdnZRcWhkR1lvTTNRR084bmlxT2doVW1LCkhsNDRwenJTUDVoMUljSWRNQ0tQTENYNXR1WjFIZWxqNWhEaWx2cXZyQkI4M0dhcUl4SlYzWmRhd0hCaEZySjQKc3lvNkw3d1ZMMDJsZzdXYUZwcndtNUJhMlVsV1pSL2RrekI5cDF2WFZpND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
 base64CustomCertificateKey: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBd09sNWhHWFYwTCthZStkK3pJQU84MkZkK2dRQ3lXU055M1dMUTJOc1lSU1pOZTYvClQwdFVJelNhaXRLc0hmNXQ2VjhUN3JXaFdxT2tGTEZnaFpOVjRaU2VMSDRSQXdSL1h1R2wwM3I5aUdMb1UwR1cKV1BKckRPN1BtN3JBaWhrMDF4YVR1S3lxYitwTHIxL216aG1sb3crRUZnc0xVL2FWL0JRaStmRXZNZUUxUncvNgpENmFwbGtyYkYzTVpOWmtnbk5Xc1hTN0JQZkxEckhrOWIwMEUxbmUyV0dDYUlEb3lySnUyL1FUZnZNSVpuUHFNCnZBK1JpRXh4VzlZL2ZWZWk1ZTN5NFZwbTlodm9LREtOc1EvUU51eXQycS90ZTc5Q09DRjB0aE1IdFNOdWNZdGcKaUc3YzF1VTNab3ZEQkw4TFhWMWg5OVVCUE8wc2ZycGZiTS9OWXdJREFRQUJBb0lCQVFDejZRb3JMODM0b0xpeQpWWE1yeFVJc09PSXNDUkdRUVBiOGlPTVlOZUVkcU5nNk5DNjNCTW16QzV3VlcrU3BGRi90Qlg3UllSTGFOVU1SCkNWdTdOMjBndERuUHhNS1l6ZGo3NC9XREJYRHRnVkNxVk1DaXMzS2kzUlZCWnltcG9WaG1QK2dFa3dOZzNHRTUKYlhjVFAxZjZlcjMwME5mL3RqaXFueHovZks5SEUrSHRwL0RCOHFveUpSbERzQjJ4YUNFTzJRUVNOeDQyVDI5Mgo1dmNpci96Q2JORWlaOTJpQkZmaHAxbXpTa3VEMEFJV3JUWjFZNFdjZ3VTVUFBN3hYSUl1Vk9TM1FTUWxrSGx6CjJCMnFxcjFPaVVROWlkL1hQaHZmbkp4WXhBYUV1QjUrdUluL21tV21zblZ0SGt2bjdLMmdVYlpjaVMvZHBmUmQKc0JpR0diNEJBb0dCQU8yUTN3WnVaVjBpSHZ2T1A3V0R4NUx1Tzhlc0lOd2JyWXE3Y1BzMU9pT0wxUUNvNStBYQpDaVQ1QWxWSUw0VS95Z25zdmhrQnJSaEg4cTUwT3NocFlhaDhBWlp5NzlYQlo3NDgrTmxrcWNqelYyRTQyNld5CnlBcVgxTFBIL3JOV2hrRXRKKzNKVzhxT0pUZ01pcjVSaXVUQ3VlUjRMQVBPeVhoQllCSU9PNERQQW9HQkFNL2gKazNpdWdvVmxvY1dtTGVOcmo4ejdqMXdSQ25tMzdTTzg3eUxTdEtpRTVpMzdYTmtUL0JNcjltcyt2Q2tiQXNKVApCUzBWSmk0eGtsRnJFcHRUMklzZlRoL01XUWRDYkRGb0ViQ0lyVzhJVUZRY0FicGdrRlhLOUFxeEYvT1A4WGdZClZHWnl5czUxcnYzaEJtaXBVUUxsc3ZGZ1RIVFMxdlp2bUlpbkE0Y3RBb0dBWmpZdmpzL09zdHhzWWtDaDdwSHQKT3cxZkVSREE3cExGL3V1WXQ2eDJBRGM0aE5rbk1xZGhkL2pmQlJ4U3ZjenRPNG50WEVyNVUzb1pNdS8xSHFjZwppbUlZT01mbzRwb2M3Wi9FSFp5TzVGTzJZN0VYNTluYzhablR2U291THJEcWdINVNNSit5NjVwdTd3ZU9aa1lsCk1UbUt5MzdjeVNLZVVpd21qbjRySWNjQ2dZQlUyYUFWL0RUdU9nT0Q1MGFIc3htbzgyMGFpU0liZUlWa3R2TnMKNVZBMEVMcmJQZVF4L3NRL0Z3eW56WjJEc2JDNG5LWmFObTIxSVNxMTdOeFZaaTNXNjFvNkJIQzZVOVJSZmticQpKWCtVK0hIQlF3VTVpN3llS0E3Z1psUitaOXlKeG5SOHRKSXZIejNrQm50Vk1QY09GYStxY2tJQzFTUkV4bHdlCk92MW5xUUtCZ1FEQUdEdkc3WFVJMUJ2b2dEL1BIa0J2azVaMjBKOHNjZkd6c2hGN2hRWWd3VllHd1RIa0pQL3gKbEFnUEFycWJuclEwamdjczVwSWRQSGl0TVhyUGtmbGwzcnNSS2Q3L3ppV0dHL3Jxakd6V29QbEZRWmprT2pUOAo5UEZpL3piVVlPS2dGV0VzTHZreEFCN0ZYeTJ5NXBJS3I3K3YxbGpCVHo4d0wzcHlmdms2UlE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
 ```
 
-For what follows, the name of the configuration file is `parameters.yaml`.
-Install Kaptain using that configuration file:
+Install Kaptain using the configuration file:
 ```bash
 kubectl kudo install ./kubeflow-1.3.0_1.2.0.tgz \
 		--instance kaptain \
@@ -55,15 +54,14 @@ To update an already installed Kaptain instance, run the following command:
 kubectl kudo update --instance kaptain --namespace kubeflow -P parameters.yaml
 ```
 
-Verify the installation completes successfully by running the following command:
+Verify that the installation completes successfully by running the following command:
 ```bash
 kubectl kudo plan status --instance kaptain -n kubeflow
 ```
 
-## Create or update DNS record for the Kaptain gateway
+## Create or update the DNS record for the Kaptain gateway
 
-First, obtain the Kaptain gateway IP, or the Kaptain gateway load balancer hostname if you run Kaptain in public clouds.
-This information can be obtained by running the following commands.
+To update the DNS record to point at your Kaptain installation, you must obtain either the Kaptain gateway IP, or the Kaptain gateway load balancer hostname if you run Kaptain in a public cloud.  This information can be obtained by running the following commands.
 
 To obtain the Kaptain gateway IP:
 ```bash
@@ -75,7 +73,7 @@ To obtain the Kaptain gateway load balancer hostname:
 kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
 ```
 
-The output will be something like the following.
+The output will be something like the following:
 
 ```bash
 a070604cbbd7e4c96bf203b9d5069730-259996044.us-west-2.elb.amazonaws.com
@@ -83,12 +81,13 @@ a070604cbbd7e4c96bf203b9d5069730-259996044.us-west-2.elb.amazonaws.com
 
 In the above case, the Kaptain gateway load balancer hostname is `a070604cbbd7e4c96bf203b9d5069730-259996044.us-west-2.elb.amazonaws.com`.
 
-Then, create a DNS record for the Kaptain gateway load balancer hostname.
-In this case, we created a DNS CNAME record `kaptain.mycluster.company.com` to point to `a070604cbbd7e4c96bf203b9d5069730-259996044.us-west-2.elb.amazonaws.com`.
-For the on premise case, the cluster ingress is an IP address, and you need to create a DNS A record.
+If you have installed on-prem, use the Gateway to create a DNS A record that points your domain name at the IP address.
+If you have installed in a public cloud, create a DNS CNAME record that to point to the load balancer hostname.
 
-Once the DNS record is updated, access the Kaptain central dashboard at `https://kaptain.mycluster.company.com/`.
-You will notice that the certificate used by the domain is the one you provided during the installation.
+For example, you might define a CNAME record called `kaptain.mycluster.company.com` to point to `a070604cbbd7e4c96bf203b9d5069730-259996044.us-west-2.elb.amazonaws.com`.
+
+Once the appropriate DNS record is updated, you should be able to access the Kaptain central dashboard at `https://kaptain.mycluster.company.com/`.
+The certificate you provided during the installation will be the one used.
 
 [dnscname]: https://en.wikipedia.org/wiki/CNAME_record
 [dnsarecord]: https://en.wikipedia.org/wiki/List_of_DNS_record_types

--- a/pages/dkp/kaptain/1.2.0/custom-configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/1.2.0/custom-configuration/external-dex/index.md
@@ -1,35 +1,35 @@
 ---
 layout: layout.pug
 navigationTitle: Configure Dex
-title: Configure external Dex to authenticate to Kaptain
+title: Configure Kaptain to authenticate with a Kommander Management Cluster
 menuWeight: 70
-excerpt: Configure external Dex to authenticate to Kaptain
+excerpt: Configure Kaptain to authenticate with a Kommander Management Cluster
 beta: false
 enterprise: false
 ---
 
-Configure an external Dex instance from a management cluster for authentication with Kaptain.
+Configure Kaptain to use a Kommander management cluster for authentication.
 
 ## Prerequisites
 - A Kommander management cluster.
 - A managed Konvoy cluster, into which Kaptain will be installed.
 - The managed (Konvoy) cluster is [attached][attached-cluster] to the management cluster (Kommander). (You will need to [create a cluster via Kommander][create-managed-cluster] to have a managed Konvoy cluster.)
 
-## Kaptain configuration parameters
-To configure an external Dex instance for authentication with Kaptain, please provide the following parameters:
-- Dex Client identifier of the managed cluster 
-- Dex Client secret corresponding to the client identifier
-- External OIDC provider endpoint that points to the external Dex instance to be used
+## Kaptain configuration requirements
+To use the Kommander Dex instance for authentication with Kaptain you will need to collect the following information:
+- Dex Client Identifier (ID) of the managed cluster
+- Dex Client secret corresponding to the Client ID
+- External OIDC provider endpoint from the management cluster
 - External OIDC provider CA bundle
 
-## Get Dex Client Id 
+## Get Dex Client Id
 To get the external Dex Client ID, run the following command on the managed cluster (Konvoy):
-    
+
 ```bash
 kubectl describe configmaps -n kommander-system traefik-forward-auth-kommander-kubeaddons-configmap | grep client-id | cut -d '-' -f4-
 ```
 
-## Get Dex Client Secret 
+## Get Dex Client Secret
 To get the Dex client secret, run the following command on the management cluster:
 ```bash
 kubectl get secrets -n kubeaddons \
@@ -45,14 +45,14 @@ To get the OIDC provider CA bundle, run the following command on the management 
 kubectl get secret traefik-kubeaddons-certificate -n kubeaddons -o jsonpath="{.data.ca\.crt}"
 ```
 ## Install Kaptain
-Create or update a configuration file `parameters.yaml` to include the following properties:
+Create or update a configuration file named `parameters.yaml` that includes the following properties:
 ```yaml
 externalDexClientId: dex-controller-<Dex Client ID>
 externalDexClientSecret: <Dex Client secret>
 oidcProviderEndpoint: <OIDC provider endpoint>
 oidcProviderBase64CaBundle: <OIDC provider CA bundle>
 ```
-The resulting configuration file looks similar to the following:
+The resulting configuration file should look similar to the following:
 ```yaml
 externalDexClientId: dex-controller-dextfa-client-managed-cluster-admin-managed-cluster-dkzzq
 externalDexClientSecret: kkyhCc0W94WDJezbzsN7Ykif3DrwNuT40p3TWOKlDtdgjfJm1ItrJaqzRqQD7pUn
@@ -60,7 +60,7 @@ oidcProviderEndpoint: https://<Management-cluster-URL>/dex
 oidcProviderBase64CaBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS9tLS0tCk1JSUMrVENDQWVHZ0F3SUJBZ0lSQUp1NlBOSFVsWVZHR0AzRW9vSGNPd1F3RFFZSktvWklodmNOQVFFTEJRQXcKRlRFVE1CRUdBMVVFQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TURFeU1EZ3dPVFEzTkBsYUZ3MHpNREV5TURZdwpPVFEzTkRsYU1CY3hGVEFUQmdOVkJBTVRER05sY25RdGJXRnVZV2RsY2pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCCkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUwzQmlJR0RnVkpzRVhJUjEvc6hkdysvzzFLaG9PdkVwcVM5Mk1pS050cDkKaW1xVUtqZGFMSHVxYlBheWhuMjNwTmhUa2haL0NEOVgyb05xVFhOR0Q2SE44WGFrMWt4VE9xWnd4am9yNktydQpUWGZrREVmZGtHVG9nZUlSaEtpSUdxRUU1Vy9teWNkVkdDUThnNXEvcUprd3JIZHgyOTZMREVwSDEzMm9aQmk1CmVNMlZvNmpVYnUydkp4MHpyVnIzeVWuaUp0TlNpbnFoN1RVc2I2bTZoeFErRkVBZFY1djdraVBLVW4wdmZTVlYKQ1YwNXdmbUU0WEEyY2d5N3RpeEV3NkFCNmFOeGYwcGVSVXpXS0ZoL3FJdGpFWEg5RVJiWVJ5cDA1UGUyb2xCVwpHWXpiVDJsblVPeW5uL0I3YWZRSExWS0RPcTRsa3NmWlBoWTJQWmZwVW5NQ0F3RUFBYU5DTUVBd0RnWURWUjBQCkFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZHZmtITWxVTU1hSzRtRjgKNUNPeXhPMHAvWGNNTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFERjh2d3lhWnpZUmRYRGo5ODJrN0RZRDY2cwpMVE44d3Q0ZkxKbEJKODREFzd0TGJmSVdmYkJ4VzFDd0UxdEhuaTFPd3pROGkzUytpUFhuQ0dCZFNSdm5FQkJsCnF1bkpqdWRBMm9odEs5SmViTUhPTEFpbXRnWVhZdVllTFZudGxpWCtQdmxRMWxoYzByeXFENkRkWUUwckJSdlcKRkgvSTY2b2ZONGZFVlJ2RjFiSG5uZ1BsZlFUcHNRRzZFZVNoa0RvclAwSDhxNnU5RXcyaG5Ba0hwRXVlWUJibQpkeXZvRStVWTM1ck9XK3pEQ3NXNUNPRTVGWjVWQ64lRmJMRmRSUU9tdW9BaXlCV2UyTHZHdjgzdXVSZTRsSWhxCnAxSEIrZlBPTGdJVGRaSHEwYkgvdEZZNEw0YmNkRGhGYnlJRldzN01NZ2FxeCtMZThoMDNIZE5ybG5USQotLS0tWARORCBDRVJUSUZJQ0FURS0tRS0tCg==
 ```
 
-To install Kaptain with the provided parameters, run the following command on the managed cluster:
+Install Kaptain with the provided parameters, by running the following command against the managed cluster:
 ```bash
 kubectl kudo install ./kubeflow-1.3.0_1.2.0.tgz \
 		--instance kaptain \
@@ -79,18 +79,18 @@ kubectl kudo plan status --instance kaptain -n kubeflow
 ```
 
 ## Add the redirect URL to Kaptain authentication service in the management cluster
-Once Kaptain is up, get the redirect URL from Kaptain's authservice by running the following command on the managed cluster: 
+Once Kaptain is up, get the redirect URL from Kaptain's authservice by running the following command on the managed cluster:
 ```bash
 kubectl exec -it -n kubeflow authservice-0 -- sh -c 'echo $REDIRECT_URL'
 ```
 
-On the management cluster add Redirect URL to the `redirectURIs` list of the Dex client resource:
+On the management cluster add the Redirect URL to the `redirectURIs` list of the Dex client resource:
 ```bash
 kubectl patch clients.dex.mesosphere.io -n kubeaddons <Dex Client ID> \
   --type "json" -p '[{"op":"add", "path" :"/spec/redirectURIs/-", "value": "<Redirect URL>"}]'
 ```
 
-# Log in to Kaptain using the management cluster's Dex  
+# Log in to Kaptain using the management cluster's Dex instance
 
 Discover the Kaptain endpoint:
 -  If you are running Kaptain _on-premises_:
@@ -102,7 +102,7 @@ Discover the Kaptain endpoint:
       kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
       ```
 
-When accessing Kaptain via `https://<Kaptain endpoint>`, you are redirected to login page of the management cluster's Dex instance.
+When accessing Kaptain via `https://<Kaptain endpoint>`, you will be redirected to the login page of the management cluster's Dex instance.
 
 [attached-cluster]: /dkp/kommander/latest/clusters/attach-cluster/
-[create-managed-cluster]: /dkp/kommander/1.4/clusters/create-connect-clusters/
+[create-managed-cluster]: /dkp/kommander/latest/clusters/create-connect-clusters/

--- a/pages/dkp/kaptain/1.2.0/custom-configuration/external-spark/index.md
+++ b/pages/dkp/kaptain/1.2.0/custom-configuration/external-spark/index.md
@@ -1,26 +1,25 @@
 ---
 layout: layout.pug
 navigationTitle: External Spark Operator
-title: Configure Kaptain to use external Spark Operator
+title: Configure Kaptain to use an external Spark Operator
 menuWeight: 70
-excerpt: Configure Kaptain to use external Spark Operator installed on a cluster
+excerpt: Configure Kaptain to use an external Spark Operator installed on a cluster
 beta: false
 enterprise: false
 ---
 
-Learn how to configure Kaptain to use external Spark Operator installed on a cluster. 
-Kaptain includes a Spark Operator and installs it by default. In case a global Spark Operator required on the cluster,
-Kaptain needs additional configuration to use it and to avoid conflicts when running Spark Applications. 
+Kaptain includes a Spark Operator and installs it by default, but it is only accessible to Kaptain users.
+If a global Spark Operator is required on the cluster, Kaptain needs additional configuration to use it and to avoid conflicts when running Spark Applications.
 
 ## Prerequisites
 
--   You already provisioned a Konvoy cluster using at least `v1.7.0`.
+- A Provisioned Konvoy cluster running Konvoy `v1.7.0` or above.
 
-## Installing Kaptain alongside the existing Spark Operator
-To avoid conflicts with the existing Spark Operator installed on a cluster, Kaptain needs to be installed
+## Installing Kaptain alongside an existing Spark Operator
+To avoid conflicts with an existing Spark Operator installed on a cluster, Kaptain needs to be installed
 without the Spark Operator.
 
-Create or update a configuration file `parameters.yaml` to include the following property:
+Create or update a configuration file named `parameters.yaml` that includes the following property:
 ```yaml
 installSparkOperator: "false"
 ```
@@ -68,18 +67,18 @@ Use `kubectl` to apply the `ClusterRole` to the cluster:
 kubectl apply -f spark-role.yaml
 ```
 
-## Configuring Kaptain to use external Spark Operator after the installation
-By default, Spark is only usable by Kaptain users.
-If all users need access to Spark Applications, you need to install an external Spark Operator and disable the one included with Kaptain.
-Spark Operator installation steps are available in the [KUDO Spark Operator documentation](https://github.com/kudobuilder/operators/tree/master/repository/spark).
+## Configuring Kaptain to use an external Spark Operator after the installation
+By default, the Spark instance installed by Kaptain is only usable by Kaptain users.
+If all cluster users need access to Spark Applications, you need to install an external Spark Operator and disable the one included with Kaptain.
+Spark Operator installation steps are available in the [KUDO Spark Operator documentation][kudo_spark_install].
 
 
-Disable the default Spark Operator in Kaptain. Create or update a configuration file `parameters.yaml` to include the following property:
+First, you must disable the default Spark Operator in Kaptain. Create or update a configuration file named `parameters.yaml` to include the following property:
 ```yaml
 installSparkOperator: "false"
 ```
 
-Update Kaptain instance to disable Spark Operator:
+Update the Kaptain instance to disable the Spark Operator:
 ```bash
 kubectl kudo update \
 		--instance kaptain \
@@ -87,7 +86,7 @@ kubectl kudo update \
 		--namespace kubeflow
 ```
 
-Re-create the `ClusterRole` to allow Kaptain users run Spark Applications and save it to a file `spark-role.yaml`:
+Re-create the `ClusterRole` to allow Kaptain users to run Spark Applications and save it to a file named `spark-role.yaml`:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -129,12 +128,13 @@ Delete the previously created `ClusterRole` if it exists:
 kubectl delete clusterrole spark-operator-role
 ```
 
-Create or update a configuration file `parameters.yaml` to include the following property:
+Create or update a configuration file named `parameters.yaml` to include the following property:
 ```yaml
 installSparkOperator: "true"
 ```
 
-Update Kaptain instance to enable the Spark Operator:
+Update the Kaptain instance to enable the Spark Operator:
 ```bash
 kubectl kudo update --instance kaptain -P parameters.yaml
 ```
+[kudo_spark_install]: https://github.com/kudobuilder/operators/tree/master/repository/spark

--- a/pages/dkp/kaptain/1.2.0/custom-configuration/notebook-servers-configuration/index.md
+++ b/pages/dkp/kaptain/1.2.0/custom-configuration/notebook-servers-configuration/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Notebook Servers Configuration
 title: Configuring Notebook Servers
 menuWeight: 70
-excerpt: Configure Notebook Servers pre-defined controls and settings
+excerpt: Configure Notebook Servers controls and settings
 beta: false
 enterprise: false
 ---
@@ -12,19 +12,19 @@ Configure Notebook Servers controls and settings.
 
 ## Prerequisites
 
--   A Konvoy cluster `v1.7.0` or above.
+-   A Provisioned Konvoy cluster running Konvoy `v1.7.0` or above.
 
 ## Creating custom Toleration Groups and Affinity Configurations
 
 You can pre-configure node toleration groups and affinity configurations in the Notebook Servers UI.
-These settings allow users to specify `tolerations` and `affinity` rules for the Notebook pods. 
+These settings allow users to specify `tolerations` and `affinity` rules for the Notebook pods.
 This allows notebook-specific workloads to run on specific nodes from a pool of available resources.
 
 For more information about the pod scheduling controls, please refer to the [official Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/).
 
-Toleration groups and affinity configs can be configured via `notebookTolerationGroups` and `notebookAffinityConfig` parameters respectively.
+Toleration groups and affinity configs can be configured via the `notebookTolerationGroups` and `notebookAffinityConfig` parameters, respectively.
 
-First, create a `parameters.yaml` file in the following format:
+To configure these resources, create a file named `parameters.yaml` with the following contents:
 ```yaml
 notebookTolerationGroups:
   - groupKey: "notebooks"
@@ -36,7 +36,7 @@ notebookTolerationGroups:
         effect: "NoExecute"
 notebookAffinityConfig:
   - configKey: "notebook-affinity-config"
-    displayName: "Notebook Affinity Configuration" 
+    displayName: "Notebook Affinity Configuration"
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -57,12 +57,12 @@ notebookAffinityConfig:
               - another-node-label-value
 ```
 
-You should set any other desired operator parameters in this file as well, so that you have a single file with all the operator configurations.
-Please refer to the [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core) 
-and [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core) 
+You can set any other desired operator parameters in this file as well, so that you have a single file with all the operator configurations.
+Please refer to the [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core)
+and [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core)
 pages in the Kubernetes API documentation to see all the supported fields.
 
-Specify the parameters file as an argument to `kubectl kudo install` command during the installation:
+Specify the parameters file as an argument to the `kubectl kudo install` command during the installation:
 ```bash
 kubectl kudo install \
     --instance kaptain \

--- a/pages/dkp/kaptain/1.2.0/download/index.md
+++ b/pages/dkp/kaptain/1.2.0/download/index.md
@@ -9,4 +9,8 @@ enterprise: false
 
 <!-- markdownlint-disable MD034 -->
 
-For an evaluation license for Kaptain, please contact <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+Kaptain downloads are only available to licensed customers.  To obtain an evaluation license for Kaptain, please contact <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+
+If you already have a license, downloads are available in the [Support Portal][support-portal].
+
+[support-portal]: https://support.d2iq.com/s/

--- a/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
+++ b/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
@@ -27,7 +27,7 @@ Before proceeding, verify that your environment meets the following basic requir
   - min. 200 GiB free disk space per instance
   - min. 64 GiB RAM per instance
   - min. 12 GiB GPU RAM per instance
-  
+
 Please note that these numbers are for the bare minimum.
 Running any realistic machine learning workloads on Kaptain bumps these requirements for nodes, CPUs, RAM, GPUs, and persistent disk.
 In particular, the number of CPU and/or GPU workers, as well as RAM, must be increased considerably.
@@ -51,7 +51,8 @@ For cloud installations, scaling out can be limited by resource quotas.
           enabled: true
     ```
 
-* Add Kaptain addon repository in your Konvoy `cluster.yaml` to install Kaptain dependencies, then follow the [Konvoy documentation to deploy][konvoy-deploy-addons] the addons:
+* Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies,
+then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons:
   ```yaml
       - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
         configVersion: stable-1.20-1.3.0
@@ -60,15 +61,17 @@ For cloud installations, scaling out can be limited by resource quotas.
             enabled: true
   ```
 
-* Install the [kubectl-kudo CLI plugin](https://kudo.dev/#get-kudo)
+* Install the [kubectl-kudo CLI plugin][kudo_cli]
 
 * After the Konvoy cluster has been deployed (including Istio and Knative), install KUDO:
   ```bash
   kubectl kudo init --wait
   ```
 
-* [Download `kubeflow-1.3.0_1.2.0.tgz` tarball](../../download/).
+* Download [kubeflow-1.3.0_1.2.0.tgz][download] tarball.
 * Install Kaptain:
+<p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
+
   ```bash
   kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.3.0_1.2.0.tgz
   ```
@@ -99,7 +102,7 @@ Once all components have been deployed, you can log in to Kaptain:
   ```
 
 ## Uninstall Kaptain
-  
+
 * Use the following commands to uninstall Kaptain.
   ```bash
   kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
@@ -107,4 +110,6 @@ Once all components have been deployed, you can log in to Kaptain:
   kubectl delete operators.kudo.dev kubeflow --namespace kubeflow
   ```
 
-[konvoy-deploy-addons]: /dkp/konvoy/latest/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
+[download]: ../../download/
+[kudo_cli]: https://kudo.dev/#get-kudo
+[konvoy_deploy_addons]: /dkp/konvoy/latest/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade

--- a/pages/dkp/kaptain/1.2.0/monitoring/index.md
+++ b/pages/dkp/kaptain/1.2.0/monitoring/index.md
@@ -13,25 +13,25 @@ having to piece together information from various sources.
 
 ## Kaptain Dashboard
 
-To access the dashboard application, click on a "Dashboard" link in the left sidebar. 
+To access the dashboard application, click on a "Dashboard" link in the Kubeflow left sidebar.
 The "Kaptain Dashboard" page consists of four sections. To select a time range for graphs, use the "Time Period" control
-on the top-left corner. 
+on the top-left corner.
 
 The top section contains an overview of the current health of Kaptain components.
 
 ![Components](img/components.png)
 
-The "Data" section provides the information about what is currently running in a user's namespace: graphs show the 
+The "Data" section provides the information about what is currently running in a user's namespace; graphs show the
 number of active notebooks, pipelines, ML experiments, and trials:
 
 ![Data](img/data.png)
 
-In the "Jobs" section, users can get the current state of machine learning jobs, e.g., how many `TFJob` of `PytorchJob` 
+In the "Jobs" section, users can get the current state of machine learning jobs, e.g., how many `TFJob` or `PytorchJob`
 resources were created, completed, or failed:
 
 ![Jobs](img/jobs.png)
 
-The "System Resources" section is all about resource consumption. The graphs show how many resources are being used 
+The "System Resources" section is all about resource consumption. The graphs show how many resources are being used
 by workloads in the user's namespace. There are three graphs for each type of resource:
 
 ![System Resources](img/system-resources.png)
@@ -41,17 +41,17 @@ by workloads in the user's namespace. There are three graphs for each type of re
 - "Memory":  how much memory is being used by training jobs and other pods
 - "GPU": how much GPU memory is being utilized
 
-If resource quotas are set for the user's namespace, the following graphs will be displayed depending on what quotas 
+If resource quotas are set for the user's namespace, the following graphs will be displayed depending on what quotas
 types are enabled:
 
 ![System Resources](img/quotas.png)
 
 ## Grafana Dashboards
 
-Kaptain installation includes two Grafana dashboards, which are automatically imported to Grafana and ready-to-use.
-To access the dashboard, follow [Access a Konvoy cluster](https://docs.d2iq.com/dkp/konvoy/latest/access-authentication/access-konvoy/)
-documentation page to access the operations portal, and then click on the "Dashboard" button on the Grafana tile on 
-the"Platform Services" tab.
+Kaptain installation also includes two Grafana dashboards, which are automatically imported to Grafana and ready-to-use.
+To access the dashboard, follow the [Access a Konvoy cluster][access_konvoy]
+documentation page to access the operations portal, and then click on the "Dashboard" button on the Grafana tile on
+the "Platform Services" tab.
 
 Kaptain provides the following dashboards:
 - Kaptain / Operator - contains components health, pods state, resource consumption, and ML operator metrics:
@@ -65,3 +65,5 @@ Kaptain provides the following dashboards:
 ![Kaptain Profiles Dashboard](img/kaptain-profiles-dashboard-1.png)
 
 ![Kaptain Profiles Dashboard](img/kaptain-profiles-dashboard-2.png)
+
+[access_konvoy]: https://docs.d2iq.com/dkp/konvoy/latest/access-authentication/access-konvoy/

--- a/pages/dkp/kaptain/1.2.0/release-notes/1.2.0/index.md
+++ b/pages/dkp/kaptain/1.2.0/release-notes/1.2.0/index.md
@@ -43,8 +43,8 @@ This document describes the new features, caveats, and resolved issues in D2iQ K
 
 ### Limitations
 * When running on Konvoy 1.8.2 with GPU, the default base addons version `stable-1.20-4.1.0` doesn't report GPU
-metrics to Prometheus, and Kaptain Dashboard is unable to display them. Consider using a newer version of the base
-addons or a previous `stable-1.20-4.0.0` in `cluster.yaml`:
+metrics to Prometheus, and thus the Kaptain Dashboard is unable to display them. Consider using a newer version of the base
+addons, or the previous version: `stable-1.20-4.0.0` in your Konvoy `cluster.yaml`:
   ```
   addons:
     - configRepository: https://github.com/mesosphere/kubernetes-base-addons
@@ -53,6 +53,6 @@ addons or a previous `stable-1.20-4.0.0` in `cluster.yaml`:
 
 ### Breaking changes
 * Automatic Profile creation on the first login is disabled by default for security purposes.
-Consult documentation on [onboarding new users][onboarding-new-users] for details.
+Consult the documentation on [onboarding new users][onboarding-new-users] for details.
 
 [onboarding-new-users]: ../../user-management#onboarding-new-users

--- a/pages/dkp/kaptain/1.2.0/sdk/credentials/index.md
+++ b/pages/dkp/kaptain/1.2.0/sdk/credentials/index.md
@@ -6,46 +6,45 @@ beta: false
 menuWeight: 2
 ---
 
-When the model is trained, all model files are packed into a Docker
-image which is then used for the training itself and hyperparameter
+When the model is trained, all the model files are packed into a Docker
+image, which is then used for the training itself, and for hyperparameter
 tuning later on. In order to build that image, the SDK must be provided
-with at least Docker credentials so it can publish the resulting images
+with Docker credentials, so that it can publish the resulting images
 to the registry specified in `Model.image` attribute.
 
 As the image building happens on the cluster, the model files are first
 uploaded to a blob storage such as S3, GCS, or MinIO and then used by
 the builder. By default, the SDK uses a cluster-local MinIO installation
-which doesn't require any configuration. However, in case users need to
-use a specific S3 location, then appropriate AWS credentials should be
-provided to use it.
+which doesn't require any additional configuration. If users wish to
+use a specific S3 location instead, then appropriate AWS credentials need
+to be provided.
 
 This guide focuses on two main aspects of credential distribution and
-configuration: \* secure automatic mounting of credential files and
-environment variables to notebook containers, and \* using the SDK API
-for creating and modifying access credentials and parameters.
+configuration:
+* Secure automatic mounting of credential files and environment variables to notebook containers
+* Using the SDK API for creating and modifying access credentials and parameters.
 
 # Secure mounting of credentials
 
-The standard way of secure sharing of the sensitive information in
-Kubernetes is by using `Secrets`. To find out more about `Secret` check
-the [official Kubernetes
+The standard way of secure sharing of sensitive information in
+Kubernetes is by using `Secret` objects. More information about `Secret` objects
+is available in the [official Kubernetes
 documentation](https://kubernetes.io/docs/concepts/configuration/secret/).
 A `Secret` can be created from a file and can be accessed only by the
-service account which created it and by users with administrative
-privileges. After a `Secret` is created it can be [mounted]{.title-ref}
-to a Notebook container as a file or used to populate environment
-variables. To simplify the process, it is sufficient to create all
-necessary secrets once and then reuse them across the notebooks. To make
-`Secrets` automatically available for mounting, we will need to create a
-`PodDefault` for them. For more information about `PodDefault` follow
-[Kubeflow Notebook Setup
-Guide](https://www.kubeflow.org/docs/notebooks/setup/) or check the
-[PodDefault
-manifest](https://github.com/kubeflow/kubeflow/blob/master/components/admission-webhook/README.md).
+service account which created it, and by users with administrative
+privileges.
+
+After a `Secret` is created it can be mounted to a Notebook container as a file
+or used to populate environment variables. To simplify the process, you can create all
+the necessary secrets once and then reuse them across notebooks. To make
+`Secrets` automatically available for mounting, create a `PodDefault` for them.
+For more information about `PodDefault` follow the
+[Kubeflow Notebook Setup Guide][kubeflow_setup] or check the
+[PodDefault manifest][poddefault_ manifest].
 
 ## Docker credentials
 
-In order to make Docker credentials available as a `Secret` we need to
+In order to make Docker credentials available as a `Secret`,
 create a `config.json` file which has the following standard layout:
 
     {
@@ -58,28 +57,30 @@ create a `config.json` file which has the following standard layout:
 
 The `auth` field is a base64-encoded string of the form
 `<username>:<password>` where `<username>` and `<password>` are the
-actual username and password used to login to Docker registry. To
-generate value for `auth` field, use the following command:
+actual username and password used to login to the Docker registry. To
+generate the value for `auth` field, use the following command:
 `echo -n "<username>:<password>" | base64`.
 
 <p class="message--note">
 <strong>NOTE: </strong>
-It is important the file with Docker credentials is named <code>config.json</code>
-because it is the default name used and recognized by a variety of tools
-and components.
+It is important that the file with Docker credentials is named <code>config.json</code>
+because it is the default name used and recognized by a variety of tools and components.
 </p>
 
 
 To create a `Secret` from the credentials file `config.json` run the
 following command:
 
-    kubectl create secret generic docker-secret --from-file=config.json
+    kubectl create secret generic docker-secret -n <kaptain_namespace> --from-file=config.json
+
+  Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.  
+  In this example, we used a namespace named 'user'
 
 Verify the `Secret` is created:
 
-    kubectl get secret docker-secret -o yaml
+    kubectl get secret docker-secret -n <kaptain_namespace> -o yaml
 
-    # the output should look like this:
+the output should look like this:
 
     apiVersion: v1
     data:
@@ -91,8 +92,7 @@ Verify the `Secret` is created:
     type: Opaque
 
 To make this `Secret` available for selection in the Notebook creation
-dialogue, let's create a `PodDefault` referencing it. Create a file
-`pod_default.yaml` with the following contents:
+dialogue, create a file named `pod_default.yaml` with the following contents:
 
     apiVersion: "kubeflow.org/v1alpha1"
     kind: PodDefault
@@ -114,15 +114,15 @@ dialogue, let's create a `PodDefault` referencing it. Create a file
 
 <p class="message--warning">
 <strong>WARNING: </strong>
-Volume name and <code>mountPath</code> must be unique across all <code>PodDefault</code>s to avoid conflicts when
-mounting <code>Secrets</code> to <code>Pods</code>.
+The volume name and <code>mountPath</code> must be unique across all <code>PodDefault</code>
+objects to avoid conflicts when mounting <code>Secrets</code> to <code>Pods</code>.
 </p>
 
-Create a `PodDefault` resource from file using the following command:
+Create the `PodDefault` resource from the file using the following command:
 
     kubectl create -f pod_default.yaml
 
-After that, the Docker credentials secret becomes available for
+After that, the Docker credentials secret will be available for
 selection in the Notebook Spawner UI and, if selected, will be mounted
 to `/home/kubeflow/.docker/`:
 
@@ -132,29 +132,27 @@ to `/home/kubeflow/.docker/`:
 
 ### File-based and environment variable based configuration
 
-There are two ways to make AWS credentials available in the notebook: \*
-as a file mounted to the `Pod` from a `Secret` \* as environment
-variables injected to the `Pod` from a `Secret`
+There are two ways to make AWS credentials available in a notebook:
+* As a configuration file mounted to the `Pod` from a `Secret`
+* As environment variables injected into the `Pod` from a `Secret`
 
 <p class="message--note">
 <strong>NOTE: </strong>
-How to choose which option is better for AWS configuration:
+Which method to use depends on what AWS settings you need to configure:
 <ul>
-<li>using configuration file is recommended when working with the default account settings, i.e. when only credentials
-    such as AWS Access Key ID, AWS Secret Access Key, and AWS Session Token are sufficient to access associated S3
+<li>The configuration file method is recommended when working with the default account settings, i.e. when only credentials
+    such as AWS Access Key ID, AWS Secret Access Key, and AWS Session Token are needed to access associated S3
     storage.</li>
-<li>using environment variables is recommended when additional configuration is required such as AWS Region, S3 Endpoint
-    URL, S3 Bucket Access style (url or path-style), Protocol Signature version.  Usually, this properties are required
+<li>The environment variables method is recommended when additional configuration is required, such as AWS Region, S3 Endpoint
+    URL, S3 Bucket Access style (url or path-style), and Protocol Signature version. These additional properties are often required
     when working with non-standard S3-compatible storage solutions such as MinIO.</li>
 </ul>
 </p>
 
 ### File-based AWS credentials
 
-Making an AWS credentials file available as a `Secret` follows the same
-steps as with Docker credentials.
-
-First let\'s create AWS `credentials` file with the standard layout:
+Making an AWS credentials file available as a `Secret` follows the same steps as with Docker credentials.
+First, create an AWS `credentials` file with the standard layout:
 
     [default]
     aws_access_key_id     = <your AWS Access Key ID>
@@ -164,20 +162,22 @@ First let\'s create AWS `credentials` file with the standard layout:
 
 <p class="message--note">
 <strong>NOTE: </strong>
-It is important the file with AWS credentials is named <code>credentials</code> because it is the default name used and
+It is important that the file with AWS credentials is named <code>credentials</code> because it is the default name used and
 recognized by AWS-related tools and components.
 </p>
 
 To create a `Secret` from the file `credentials` run the following
 command:
 
-    kubectl create secret generic aws-credentials --from-file=credentials
+    kubectl create secret generic aws-credentials -n <kaptain_namespace> --from-file=credentials
 
-Verify the `Secret` is created:
+Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks. In this example, we used a namespace named 'user'
+
+Verify that the `Secret` is created:
 
     kubectl get secret aws-credentials -o yaml
 
-    # the output should look like this:
+the output should look like this:
 
     apiVersion: v1
     data:
@@ -189,7 +189,7 @@ Verify the `Secret` is created:
     type: Opaque
 
 To make this `Secret` available for selection in the Notebook creation
-dialogue, let\'s create a `PodDefault` referencing it. Create a file
+dialogue, create a `PodDefault` referencing it. Create a file named
 `pod_default.yaml` with the following contents:
 
     apiVersion: "kubeflow.org/v1alpha1"
@@ -212,15 +212,15 @@ dialogue, let\'s create a `PodDefault` referencing it. Create a file
 
 <p class="message--warning">
 <strong>NOTE: </strong>
-Volume name and <code>mountPath</code> must be unique across all <code>PodDefault</code>s to avoid conflicts when
+Volume name and <code>mountPath</code> must be unique across all <code>PodDefault</code> objects to avoid conflicts when
 mounting <code>Secrets</code> to <code>Pods</code>.
 </p>
 
-Create a `PodDefault` resource from file using the following command:
+Create a `PodDefault` resource from the file using the following command:
 
     kubectl create -f pod_default.yaml
 
-After that, AWS credentials secret becomes available for selection in
+After creating this resource, the AWS credentials secret will be available for selection in
 the Notebook Spawner UI and, if selected, will be mounted to
 `/home/kubeflow/.aws/credentials`:
 
@@ -230,9 +230,7 @@ the Notebook Spawner UI and, if selected, will be mounted to
 
 Making AWS configuration and credentials available as environment
 variables requires creating a `Secret` from manifest.
-
-The following environment variables are supported and recognised by the
-SDK:
+The following environment variables are supported and recognized by the SDK:
 
 -   `AWS_ACCESS_KEY_ID` - The access key to authenticate with S3.
 -   `AWS_SECRET_ACCESS_KEY` - The secret key to authenticate with S3.
@@ -240,10 +238,10 @@ SDK:
 -   `AWS_REGION` - The name of AWS region.
 -   `S3_ENDPOINT` - The complete URL of S3 endpoint. This parameter is
     required when working with non-standard, S3-compatible storage
-    solutions such as MinIO. It should be set to a resolvable address of
+    solutions such as MinIO. It should be set to the resolvable address of
     the running server.
 -   `S3_SIGNATURE_VERSION` - The signature version when signing requests
--   `S3_FORCE_PATH_STYLE` - When enabled, the clients will use path
+-   `S3_FORCE_PATH_STYLE` - When enabled, clients will use path
     style instead of URL style for accessing buckets. Supported values:
     `true`\|`false`.
 
@@ -272,7 +270,10 @@ following command:
 To create a `Secret` from the YAML specification file (e.g.
 `secret.yaml`) run the following command:
 
-    kubectl create -f secret.yaml
+    kubectl create -f -n <kaptain_namespace> secret.yaml
+
+Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.  
+In this example, we used a namespace named 'user'    
 
 Verify the `Secret` is created:
 
@@ -295,9 +296,7 @@ Verify the `Secret` is created:
       namespace: user
     type: Opaque
 
-To make this `Secret` available for selection in the Notebook creation
-dialogue, let\'s create a `PodDefault` referencing it. Create a file
-`pod_default.yaml` with the following contents:
+To make this `Secret` available for selection in the Notebook creation dialogue, create a `PodDefault` referencing it. Create the file `pod_default.yaml` with the following contents:
 
     apiVersion: "kubeflow.org/v1alpha1"
     kind: PodDefault
@@ -317,7 +316,7 @@ Create a `PodDefault` resource from file using the following command:
 
     kubectl create -f pod_default.yaml
 
-After that, the AWS configuration secret becomes available for selection in
+After that, the AWS configuration secret will be available for selection in
 the Notebook Spawner UI and, if selected, will make all the environment
 variables available in the Notebook:
 
@@ -329,14 +328,13 @@ The `Model` class serves as the main API for training, tuning, and
 deploying model to serving. It uses a Docker registry for publishing
 images with model files and also requires S3-compatible storage for
 storing trained models and transient data. For configuring access to
-Docker registry and storage, `Model` exposes a `config` argument which
-allows users to fine-tune their configurations. This section covers the
-available configuration providers and their defaults.
+the Docker registry and storage, `Model` exposes a `config` argument which
+allows users to fine-tune their configurations. This section covers the available configuration providers and their defaults.
 
 <p class="message--note">
 <strong>NOTE: </strong>
-If no <code>Config</code> is provided, the <code>Model</code> constructor will use Docker credentials from file
-<code>$HOME/.docker/config.json</code> and in-cluster MinIO server configuration for storage. Docker
+If no <code>Config</code> is provided, the <code>Model</code> constructor will use Docker credentials from the file
+<code>$HOME/.docker/config.json</code>, and the in-cluster MinIO server configuration for storage. A Docker
 <code>config.json</code> is mandatory for <code>Model</code> instantiation.
 </p>
 
@@ -369,14 +367,13 @@ S3-compatible storage configuration providers.
 ## Docker Configuration
 
 `DockerConfigurationProvider` supports Docker credentials reading from
-file only.
+a file only.
 
 `DockerConfigurationProvider.default()` loads a configuration from
-`/home/kubeflow/.docker/config.json` and errors out if the file is not
-present.
+`/home/kubeflow/.docker/config.json` and fails with an error if the file is not present.
 
 `DockerConfigurationProvider.from_file(<path/to/config.json>)` loads a
-configuration from the specified path and can be used when the config
+configuration from the specified path, and can be used when the config
 `Secret` is mounted to a non-default path or created by the user.
 
 Example:
@@ -403,11 +400,10 @@ Example:
 
 ## AWS Configuration
 
-`S3ConfigurationProvider` supports Docker credentials reading from file
-only.
+`S3ConfigurationProvider` supports reading Docker credentials only from a file.
 
 `S3ConfigurationProvider.default()` loads configuration from
-`/home/kubeflow/.aws/credentials` and errors out if the file is not
+`/home/kubeflow/.aws/credentials` and fails with an error if the file is not
 present.
 
 `S3ConfigurationProvider.from_file(<path/to/aws/credentials>)` loads
@@ -447,8 +443,9 @@ model = Model(
 ## MinIO Configuration
 
 `DefaultMinioConfigurationProvider` is a special configuration provider
-pre-configured for in-cluster MinIO.
-`DefaultMinioConfigurationProvider.default()` returns an configured
+pre-configured for an in-cluster MinIO instance.
+
+`DefaultMinioConfigurationProvider.default()` returns a configured
 instance ready to be used with it. It is used by default when no S3
 provider is specified. `DefaultMinioConfigurationProvider` extends
 `S3ConfigurationProvider` and supports all the same methods.
@@ -477,6 +474,9 @@ Example:
 
 <p class="message--note">
 <strong>NOTE: </strong>
-The above example is the default behavior of SDK for <code>Config</code>
+The above example is the default behavior of the SDK for <code>Config</code>
 instantiation when no config is provided to the <code>Model</code> constructor.
 </p>
+
+[kubeflow_setup]: https://www.kubeflow.org/docs/notebooks/setup/
+[poddefault_manifest]: https://github.com/kubeflow/kubeflow/blob/master/components/admission-webhook/README.md

--- a/pages/dkp/kaptain/1.2.0/sdk/quickstart/index.md
+++ b/pages/dkp/kaptain/1.2.0/sdk/quickstart/index.md
@@ -6,20 +6,20 @@ beta: false
 menuWeight: 0
 ---
 
-The SDK provides high-level API to support model development workflows and deals with Kubernetes specifics for the
-users' benefit. The main building blocks required for a model development are user-provided model definition and
-training source code and a configured instance of the `Model` class from the SDK.
+The Kaptain SDK provides a high-level API to support model development workflows and deals with Kubernetes specifics for the
+users' benefit. The main building blocks required for model development are a user-provided model definition,
+training source code, and a configured instance of the `Model` class from the SDK.
 
 The SDK automatically packs user-provided files into a Docker image which is then used in the model training and
-tuning. SDK also provides utilities to simplify the export of the trained models to the supported storage locations.
+tuning. The SDK also provides utilities to simplify the export of the trained models to the supported storage locations.
 
-# Using the SDK from Jupyter Notebook
+# Using the SDK from a Jupyter Notebook
 
 ## Configure Docker credentials
 
-In order to use the SDK from a Jupyter Notebook, it is required to configure credentials for accessing a Docker
-registry. It is recommended to distribute configuration and credentials using
-`configuration-and-credentials`{.interpreted-text role="ref"} guide.
+In order to use the SDK from a Jupyter Notebook, you must configure credentials for accessing a Docker
+registry. It is recommended to distribute registry configuration and credentials by following the
+[Accessing Docker and Cloud Storage][credentials] guide.
 
 However, to hit the ground running, it is also sufficient to create a valid Docker credentials file from a notebook
 running in Kaptain. The file has the following format and must be saved at `$HOME/.docker/config.json`:
@@ -33,19 +33,19 @@ running in Kaptain. The file has the following format and must be saved at `$HOM
     }
 
 The `auth` field is a base64-encoded string of the form `<username>:<password>` where `<username>` and `<password>` are
-the actual username and password used to login to Docker registry. To generate value for `auth` field, use the following
+the actual username and password used to login to Docker registry. To generate the value for the `auth` field, use the following
 command: `echo -n "<username>:<password>" | base64`.
 
 <p class="message--note">
 <strong>NOTE: </strong>You can also inject your docker credentials by creating a secret and
-mounting it at <code>/home/kaptain/.docker/config.json</code>. <a href="https://github.com/mesosphere/kudo-kubeflow/blob/master/sdk/docs/source/credentials.rst">See the credentials docs</a>.
+mounting it at <code>/home/kaptain/.docker/config.json</code>.  See the <a href="../credentials/">credentials documentation</a> for more details.
 </p>
 
 ## Prepare the model training
 
 ### Tensorflow
 
-Let's pick MNIST image classification as an example of the training code.
+What follows is an example of how to deploy a training model for MNIST image classification:
 
 1.  Create a file named `train.py` with the following contents:
 
@@ -126,7 +126,7 @@ Let's pick MNIST image classification as an example of the training code.
     )
     ```
 
-<p class="message--note">The Docker repository passed via the <code>image_name</code> argument, must exist or be created before using it.</p>
+<p class="message--note">The Docker repository passed via the <code>image_name</code> argument must exist or be created before using it.</p>
 
 3.  Execute model training in a distributed mode using 3 workers:
 
@@ -137,7 +137,7 @@ Let's pick MNIST image classification as an example of the training code.
     )
 ```
 
-4. Verify the model was exported to the default location. Launch Notebook terminal to connect to MinIO and list the
+4. Verify the model was exported to the default location, by launching a Notebook terminal to connect to MinIO and listing the
 uploaded trained model files:
 
 ```bash
@@ -168,25 +168,24 @@ dev-mnist            False
 dev-mnist            True       100                             http://dev-mnist.demo.example.com
 ```
 
-Follow the [Kaptain SDK](https://docs.d2iq.com/dkp/kaptain/1.2.0/tutorials/sdk/) tutorial for more detailed
-information.
+Follow the [Kaptain SDK][kaptain_sdk] tutorial for more detailed information.
 
 ## Environment Variables
 
-There are some environment variables that can be changed to modify some of the behavior of the SDK:
+Several environment variables can be specified to modify some of the behavior of the SDK:
 
 - **KAPTAIN_SDK_VERBOSE**: will set the output to show all of pod logs and any event related to Job, Pods, Secrets and
     Service Accounts.
-- **KAPTAIN_SDK_LOG_TIMEFORMAT**: a string to change the format of the log date time from the default "%Y-%m-%d
+- **KAPTAIN_SDK_LOG_TIMEFORMAT**: a string used to change the format of the log date time from the default "%Y-%m-%d
     %H:%M:%S,%f" following strftime format.
 - **KAPTAIN_SDK_DEBUG**: will set the logging level to DEBUG for Kaptain related logging.
 
-A `"true"` value is any of `"true"`, `"yes"`, `"y"` or `"1"`, anything else is interpreted as `"false"`. Changing environment
+A `"true"` value is any of `"true"`, `"yes"`, `"y"` or `"1"`, anything else is interpreted as `"false"`. Changing the environment
 variables `KAPTAIN_SDK_LOG_TIMEFORMAT` and `KAPTAIN_SDK_DEBUG` only take effect if used at the beginning of the script or
 Notebook.
 
-You can also change them from Python/Jupyter using the variables in `kaptain.envs`. Changing them this way
-will actually make the changes take effect immediately for all.
+You can also change these environment variables from Python/Jupyter using the variables in `kaptain.envs`. Changing them this way
+will make the changes take effect immediately for all.
 
 ```python
 import kaptain.envs as envs   # (showing default values)
@@ -195,3 +194,5 @@ envs.DEBUG = False
 envs.VERBOSE = False
 envs.LOG_TIMEFORMAT = "%Y/%m/%d %H:%M:%S,%f"
 ```
+[credentials]: ../credentials/
+[kaptain_sdk]: https://docs.d2iq.com/dkp/kaptain/1.2.0/tutorials/sdk/

--- a/pages/dkp/kaptain/1.2.0/version-policy/index.md
+++ b/pages/dkp/kaptain/1.2.0/version-policy/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Version Support Policy
 title: Version Support Policy
-menuWeight: 5
+menuWeight: 98
 excerpt: Kaptain's supported version policy
 beta: false
 enterprise: false
@@ -15,7 +15,7 @@ D2iQ recommends that you install the newest Kaptain version available to stay up
 
 ## Supported Konvoy Versions
 
-Kaptain 1.2.0 runs on Konvoy 1.8.
+Kaptain 1.2.0 runs on Konvoy 1.7 and 1.8.
 
 ## Supported Kommander Versions
 


### PR DESCRIPTION
## Jira Ticket

No JIRA, this is the 'support review' of the Kaptain 1.2 docs which was accidentally missed out.
However, I did try to address https://jira.d2iq.com/browse/COPS-7003, which documents the inconsistent version requirements in the current docs.

## Description of changes being made

Most of the changes are grammatical. There were a number of broken link references in the new SDK pages, which I fixed.  I also tried to clean up and 'standardize' many of the link references, and make similar pages consistent with each other.  

Outstanding issues:
+ We need to resolve what versions of Konvoy are supported.  Many of the pages in these docs say "at least 1.7.0, but there are other places that only mention 1.8.0.    These should be consistent.
+ The new "Monitoring" page that was added, as well as the existing "Manage Users" and "Manage Secrets" pages, seem like things that should be in the "Operations" submenu rather than standalone pages.
+ The autogenerated SDK pages have some odd looking stuff on them


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [X] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.