### PR TITLE
DO NOT MERGE SPIKE: different environments from the same branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
     REDIR_HOSTNAME = "${hostname}"
   }
   stages {
+    // This stage needs to be adjusted to build/push the build archive page too
     stage("Build image") {
       steps {
         sh '''
@@ -42,6 +43,7 @@ pipeline {
       }
     }
 
+    // We would need to replicate this stage four times for each environment (prod, preview, beta, archive)
     stage("Build & Deploy Docs") {
       environment {
         ALGOLIA_UPDATE = "${main ? 'true' : ''}"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "dev": "NODE_ENV=development DEBUG=metalsmith-timer,metalsmith-algolia,metalsmith-layouts,metalsmith-assets node index.js",
     "build": "DEBUG=metalsmith-timer,metalsmith-algolia node index.js",
     "webpack": "webpack --progress --colors",
-    "build:production": "NODE_ENV=production npm run build # no drafts and no beta",
-    "build:preview": "NODE_ENV=preview npm run build # includes drafts and beta",
-    "build:beta": "NODE_ENV=beta npm run build # includes beta, no drafts"
+    "build:production": "NODE_ENV=production npm run build # no drafts, no beta, no archive",
+    "build:preview": "NODE_ENV=preview npm run build # includes drafts, beta and archive",
+    "build:beta": "NODE_ENV=beta npm run build # includes beta, no drafts, no archive",
+    "build:archive": "NODE_ENV=archive npm run build # all production and archive"
   },
   "author": "D2iQ",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "private": true,
   "scripts": {
     "dev": "NODE_ENV=development DEBUG=metalsmith-timer,metalsmith-algolia,metalsmith-layouts,metalsmith-assets node index.js",
-    "build": "NODE_ENV=production DEBUG=metalsmith-timer,metalsmith-algolia node index.js",
-    "webpack": "webpack --progress --colors"
+    "build": "DEBUG=metalsmith-timer,metalsmith-algolia node index.js",
+    "webpack": "webpack --progress --colors",
+    "build:production": "NODE_ENV=production npm run build # no drafts and no beta",
+    "build:preview": "NODE_ENV=preview npm run build # includes drafts and beta",
+    "build:beta": "NODE_ENV=beta npm run build # includes beta, no drafts"
   },
   "author": "D2iQ",
   "devDependencies": {

--- a/plugins/metalsmith-hierarchy.js
+++ b/plugins/metalsmith-hierarchy.js
@@ -19,6 +19,26 @@ const firstParagraph = (file) => {
 };
 
 /**
+ * Controls wether a file should be build based on environment variables and file annotations
+ */
+const shouldExcludeFile = (file) => {
+  if (
+    process.env.NODE_ENV === "production" &&
+    (file.beta || file.draft || file.archive)
+  ) {
+    return true;
+  }
+
+  if (process.env.NODE_ENV === "beta" && (file.draft || file.archive)) {
+    return true;
+  }
+
+  if (process.env.NODE_ENV === "archive" && (file.draft || file.beta)) {
+    return true;
+  }
+};
+
+/**
  * This plugin puts all files into a tree structure and adds some other variables:
  * * children
  * * id - used for sorting
@@ -46,18 +66,7 @@ module.exports = (files, metalsmith, done) => {
     file.subtree = Object.assign({}, file.parent.subtree, file.subtree);
     Object.assign(file, file.subtree);
 
-    if (
-      process.env.NODE_ENV === "production" &&
-      (file.beta || file.draft || file.archive)
-    ) {
-      return;
-    }
-
-    if (process.env.NODE_ENV === "beta" && (file.draft || file.archive)) {
-      return;
-    }
-
-    if (process.env.NODE_ENV === "archive" && (file.draft || file.beta)) {
+    if (shouldExcludeFile(file)) {
       return;
     }
 
@@ -68,18 +77,7 @@ module.exports = (files, metalsmith, done) => {
   });
 
   Object.entries(files).forEach(([filePath, file]) => {
-    if (
-      process.env.NODE_ENV === "production" &&
-      (file.beta || file.draft || file.archive)
-    ) {
-      delete files[filePath];
-    }
-
-    if (process.env.NODE_ENV === "beta" && (file.draft || file.archive)) {
-      delete files[filePath];
-    }
-
-    if (process.env.NODE_ENV === "archive" && (file.draft || file.beta)) {
+    if (shouldExcludeFile(file)) {
       delete files[filePath];
     }
   });

--- a/plugins/metalsmith-hierarchy.js
+++ b/plugins/metalsmith-hierarchy.js
@@ -46,7 +46,13 @@ module.exports = (files, metalsmith, done) => {
     file.subtree = Object.assign({}, file.parent.subtree, file.subtree);
     Object.assign(file, file.subtree);
 
-    if (file.draft && process.env.NODE_ENV == "production") return;
+    if (process.env.NODE_ENV === "production" && (file.beta || file.draft)) {
+      return;
+    }
+
+    if (process.env.NODE_ENV === "beta" && file.draft) {
+      return;
+    }
 
     paths[file.path] = file;
     if (file.menus) withMenus.push(file);
@@ -55,8 +61,13 @@ module.exports = (files, metalsmith, done) => {
   });
 
   Object.entries(files).forEach(([filePath, file]) => {
-    if (file.draft && process.env.NODE_ENV == "production")
+    if (process.env.NODE_ENV === "production" && (file.beta || file.draft)) {
       delete files[filePath];
+    }
+
+    if (process.env.NODE_ENV === "beta" && file.draft) {
+      delete files[filePath];
+    }
   });
 
   metalsmith.metadata().hierarchy = {

--- a/plugins/metalsmith-hierarchy.js
+++ b/plugins/metalsmith-hierarchy.js
@@ -46,11 +46,18 @@ module.exports = (files, metalsmith, done) => {
     file.subtree = Object.assign({}, file.parent.subtree, file.subtree);
     Object.assign(file, file.subtree);
 
-    if (process.env.NODE_ENV === "production" && (file.beta || file.draft)) {
+    if (
+      process.env.NODE_ENV === "production" &&
+      (file.beta || file.draft || file.archive)
+    ) {
       return;
     }
 
-    if (process.env.NODE_ENV === "beta" && file.draft) {
+    if (process.env.NODE_ENV === "beta" && (file.draft || file.archive)) {
+      return;
+    }
+
+    if (process.env.NODE_ENV === "archive" && (file.draft || file.beta)) {
       return;
     }
 
@@ -61,11 +68,18 @@ module.exports = (files, metalsmith, done) => {
   });
 
   Object.entries(files).forEach(([filePath, file]) => {
-    if (process.env.NODE_ENV === "production" && (file.beta || file.draft)) {
+    if (
+      process.env.NODE_ENV === "production" &&
+      (file.beta || file.draft || file.archive)
+    ) {
       delete files[filePath];
     }
 
-    if (process.env.NODE_ENV === "beta" && file.draft) {
+    if (process.env.NODE_ENV === "beta" && (file.draft || file.archive)) {
+      delete files[filePath];
+    }
+
+    if (process.env.NODE_ENV === "archive" && (file.draft || file.beta)) {
       delete files[filePath];
     }
   });


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

https://jira.d2iq.com/browse/D2IQ-77945

## Description of changes being made

This is a spike how it could look like to have different environments build from the same branch.
This would remove the need to have a separate archive and beta branch and we could control everything through annotations in the file header.

What is then being built is dependent on the `NODE_ENV` environment variable.
There are 4 of it:
* production
* preview
* beta
* archive

A new annotation added is `archive: <boolean>` which can be used like this:

```md
---
layout: layout.pug
navigationTitle: Kommander 1.0
title: Kommander 1.0
version: 1.0
menuWeight: 0
subtree:
  archive: true
---
```

This would mark everything in this tree as archive.

What is being built?

* production: no drafts, no beta, no archive
* beta: includes beta, no drafts, no archive
* preview: includes drafts, beta and archive
* archive: all production and archive

The downsides:
This branch would be bigger from the amount of files and disk space.
The archive would include also newer documentation, but as they would end up in the archive anyway at some point in time we may can live with that.

The upsides:
We only have a single branch as a single point of truth which makes everything less complex.
We don't need to backport changes made on main to the archive if something has changed (navigation, wording, landing page, whatever).
We don't need any special branches, everything lives in main and we could deploy pull requests with the `NODE_ENV`
 set to preview.


I introduced npm scripts which set the `NODE_ENV` correctly:

```
    "build:production": "NODE_ENV=production npm run build # no drafts, no beta, no archive",
    "build:preview": "NODE_ENV=preview npm run build # includes drafts, beta and archive",
    "build:beta": "NODE_ENV=beta npm run build # includes beta, no drafts, no archive",
    "build:archive": "NODE_ENV=archive npm run build # all production and archive"
```

I didn't touched the CI scripts as I did not want to mess with it right now before GA and I think to configure the CI isn't a dealbreaker here.

If someone reviews this: I added some test documentation in order to be able to test my changes, it's best to skip the `docs: *`-commits.
 
## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.