### PR TITLE
fix: use correct redirects in s3

### DIFF
--- a/s3config.json
+++ b/s3config.json
@@ -7,9 +7,9 @@
   },
   "RoutingRules": [
     { "Condition": { "KeyPrefixEquals": "mesosphere/dcos/latest/" },                                           "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/2.2/", "HttpRedirectCode": "307" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/konvoy/latest/" },                                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/konvoy/1.8/", "HttpRedirectCode": "307" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/konvoy/latest/" },                                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/konvoy/2.0/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/dispatch/latest/" },                                              "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/dispatch/1.2/", "HttpRedirectCode": "307" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/1.4/", "HttpRedirectCode": "307" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/2.0/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/conductor/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/conductor/1.1/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/kaptain/latest/" },                                               "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kaptain/1.2.0-1.1.0/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/kubeflow/" },                                                     "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kaptain/", "HttpRedirectCode": "307" } },


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made

https://docs.d2iq.com/dkp/kommander/latest/ is redirecting to https://docs.d2iq.com/dkp/kommander/1.4/
This should(?) fix the redirect. I'm not 100% sure this is all which is needed.


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.