### PR TITLE
Sync doc fixes from kudo-kubeflow

### DIFF
--- a/pages/dkp/kaptain/1.2.0/sdk/credentials/index.md
+++ b/pages/dkp/kaptain/1.2.0/sdk/credentials/index.md
@@ -73,7 +73,7 @@ following command:
 
     kubectl create secret generic docker-secret -n <kaptain_namespace> --from-file=config.json
 
-  Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.  
+  Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.
   In this example, we used a namespace named 'user'
 
 Verify the `Secret` is created:
@@ -272,8 +272,8 @@ To create a `Secret` from the YAML specification file (e.g.
 
     kubectl create -f -n <kaptain_namespace> secret.yaml
 
-Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.  
-In this example, we used a namespace named 'user'    
+Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.
+In this example, we used a namespace named 'user'.
 
 Verify the `Secret` is created:
 

--- a/pages/dkp/kaptain/1.2.0/sdk/private-registries/index.md
+++ b/pages/dkp/kaptain/1.2.0/sdk/private-registries/index.md
@@ -60,8 +60,8 @@ following command:
 
     kubectl create secret generic docker-secret -n <kaptain_namespace> --from-file=config.json=config.json
 
-Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.  
-In this example, we used a namespace named 'user'    
+Be sure to replace <kaptain_namespace> with the namespace you use for creating notebooks.
+In this example, we used a namespace named 'user'.
 
 Verify the `Secret` is created:
 

--- a/pages/dkp/kaptain/1.2.0/tutorials/sdk/pytorch/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/sdk/pytorch/index.md
@@ -542,7 +542,7 @@ The Kaptain SDK allows individual trials to be run in parallel as well as traine
 <p class="message--warning"><strong>BEWARE! </strong>With a large number of parallel trials <i>and</i> a fair number of workers per trial, it is easy to max out on the available resources.
     If the worker quota for the namespace is <i>Q</i>, the number of parallel trials is <i>P</i>, and the number of workers per trial is <i>W</i>, please ensure that <i>P</i> &times; <i>W</i> &leq; <i>Q</i></p>
 
-### Run canary rollut
+### Run canary rollout
 To run a canary rollout launch:
 
 

--- a/pages/dkp/kaptain/1.2.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/sdk/tensorflow/index.md
@@ -413,7 +413,7 @@ The Kaptain SDK allows individual trials to be run in parallel as well as traine
 <p class="message--warning"><strong>BEWARE! </strong>With a large number of parallel trials <i>and</i> a fair number of workers per trial, it is easy to max out on the available resources.
     If the worker quota for the namespace is <i>Q</i>, the number of parallel trials is <i>P</i>, and the number of workers per trial is <i>W</i>, please ensure that <i>P</i> &times; <i>W</i> &leq; <i>Q</i></p>
 
-### Run canary rollut
+### Run canary rollout
 To run a canary rollout launch:
 
 


### PR DESCRIPTION
Selective sync from the kudo-kubeflow to fix glaring typos and issues with API docs

Notable fixes include wrapped-parameters were formatting poorly, and '2g' vs '2G' for memory resource specifications (former is invalid)