### PR TITLE
Remove cron job for beta branch

### DIFF
--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -76,14 +76,6 @@ pipeline {
 
 
 
-                  ##### UPDATE PRIVATE BETA
-
-                  git checkout -t origin/private-beta
-                  git rebase main
-                  git push origin private-beta --force-with-lease
-
-
-
                   ##### CREATE SYNC PRS
 
                   apk add curl curl-dev rsync --no-cache


### PR DESCRIPTION
Moving to a pipeline branching strategy and we no longer want to rebase
this every night. Instead we'll try handling hotfixes on a case by case
basis. This will allow us to close the PR and delete the `private-beta` branch.

Tried to update the other crons as well but they have not created
release branches for Konvoy2 and Kommander2 yet.

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.