### PR TITLE
point konvoy 2.0 cron to release branch

### DIFF
--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -80,11 +80,11 @@ pipeline {
 
                   apk add curl curl-dev rsync --no-cache
 
+                  ./ci/pull-upstream.sh mesosphere/konvoy2 docs/site release-2.0 pages/dkp/konvoy/2.0
                   ./ci/pull-upstream.sh mesosphere/konvoy docs/site release-1.8 pages/dkp/konvoy/1.8
                   ./ci/pull-upstream.sh mesosphere/konvoy docs/site release-1.7 pages/dkp/konvoy/1.7
                   ./ci/pull-upstream.sh mesosphere/konvoy docs/site release-1.6 pages/dkp/konvoy/1.6
 
-                  ./ci/pull-upstream.sh mesosphere/konvoy2   docs/site main pages/dkp/konvoy/2.0
                   ./ci/pull-upstream.sh mesosphere/kommander docs/site main pages/dkp/kommander/2.0
                 '''
               }

--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -80,12 +80,14 @@ pipeline {
 
                   apk add curl curl-dev rsync --no-cache
 
+                  ##### Konvoy
                   ./ci/pull-upstream.sh mesosphere/konvoy2 docs/site release-2.0 pages/dkp/konvoy/2.0
                   ./ci/pull-upstream.sh mesosphere/konvoy docs/site release-1.8 pages/dkp/konvoy/1.8
                   ./ci/pull-upstream.sh mesosphere/konvoy docs/site release-1.7 pages/dkp/konvoy/1.7
                   ./ci/pull-upstream.sh mesosphere/konvoy docs/site release-1.6 pages/dkp/konvoy/1.6
 
-                  ./ci/pull-upstream.sh mesosphere/kommander docs/site main pages/dkp/kommander/2.0
+                  ##### Kommander
+                  ./ci/pull-upstream.sh mesosphere/kommander docs/site release-2.0 pages/dkp/kommander/2.0
                 '''
               }
             }


### PR DESCRIPTION
Now that a release branch has been cut for konvoy2, should point the
cron job to it.

When we've merged in the changes for the new branching model, we'll add
a konvoy job for 2.1

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to DOCS work ticket -->

## Description of changes being made


## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.