### PR TITLE
fix: change detail of security updates

### DIFF
--- a/pages/dkp/security-updates/index.md
+++ b/pages/dkp/security-updates/index.md
@@ -2,13 +2,12 @@
 layout: layout.pug
 navigationTitle: Security Updates
 title: Security Updates
-excerpt: View CVE security scans and update information for Konvoy
+excerpt: View CVE security scans and update information for DKP
 menuWeight: 1000
 beta: false
 ---
 
-The following information describes mitigated or fixed CVEs found in Konvoy.
+The following information describes mitigated or fixed CVEs found in DKP.
 
 <div class="cve-table-container">Loading...</div>
 <script src="/js/cve.js"></script>
-


### PR DESCRIPTION
## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

Closes D2IQ-79191

## Description of changes being made

Now that security scans include kommander as well as konvoy, changing
the title of the security updates page to use DKP rather than Konvoy.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.