### PR TITLE
docs: updating release notes konvoy download link

### DIFF
--- a/pages/dkp/kommander/1.2/release-notes/1.2.0/index.md
+++ b/pages/dkp/kommander/1.2/release-notes/1.2.0/index.md
@@ -19,11 +19,11 @@ For more information on addressing this limit, refer to this [procedure](../oper
 
 # Release notes for Kommander 1.2
 
-**D2iQ&reg; Kommander&reg; 1.2 was released on 16, November 2020** 
+**D2iQ&reg; Kommander&reg; 1.2 was released on November 16, 2020** 
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.6/download/) and [install](/dkp/konvoy/1.6/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.2/release-notes/1.2.1/index.md
+++ b/pages/dkp/kommander/1.2/release-notes/1.2.1/index.md
@@ -8,11 +8,11 @@ excerpt: View release-specific information for Kommander 1.2.1
 enterprise: false
 ---
 
-**D2iQ&reg; Kommander&reg; version 1.2.1 was released on 11, March 2021.**
+**D2iQ&reg; Kommander&reg; version 1.2.1 was released on March 11, 2021.**
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.6/download/) and [install](/dkp/konvoy/1.6/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.2/release-notes/1.2.2/index.md
+++ b/pages/dkp/kommander/1.2/release-notes/1.2.2/index.md
@@ -8,11 +8,11 @@ excerpt: View release-specific information for Kommander 1.2.2
 enterprise: false
 ---
 
-**D2iQ&reg; Kommander&reg; version 1.2.l was released on 25, March 2021.**
+**D2iQ&reg; Kommander&reg; version 1.2.2 was released on March 25, 2021.**
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.6/download/) and [install](/dkp/konvoy/1.6/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
@@ -8,11 +8,11 @@ excerpt: View release-specific information for Kommander 1.3.0
 enterprise: false
 ---
 
-**D2iQ&reg; Kommander&reg; version 1.3.0 was released on 10, February 2021.**
+**D2iQ&reg; Kommander&reg; version 1.3.0 was released on February 10, 2021.**
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
@@ -8,11 +8,11 @@ excerpt: View release-specific information for Kommander 1.3.1
 enterprise: false
 ---
 
-**D2iQ&reg; Kommander&reg; version 1.3.1 was released on 11, March 2021.**
+**D2iQ&reg; Kommander&reg; version 1.3.1 was released on March 11, 2021.**
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
@@ -8,11 +8,11 @@ excerpt: View release-specific information for Kommander 1.3.2
 enterprise: false
 ---
 
-**D2iQ&reg; Kommander&reg; version 1.3.2 was released on 8, April 2021.**
+**D2iQ&reg; Kommander&reg; version 1.3.2 was released on April 8, 2021.**
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -8,11 +8,11 @@ excerpt: View release-specific information for Kommander 1.3.3
 enterprise: false
 ---
 
-**D2iQ&reg; Kommander&reg; version 1.3.3 was released on 9, June 2021.**
+**D2iQ&reg; Kommander&reg; version 1.3.3 was released on June 9, 2021.**
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.4/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.4/index.md
@@ -14,7 +14,7 @@ enterprise: false
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.4/release-notes/1.4.0/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/1.4.0/index.md
@@ -14,7 +14,7 @@ enterprise: false
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.8/download/) and [install](/dkp/konvoy/1.8/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.4/release-notes/1.4.1/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/1.4.1/index.md
@@ -14,7 +14,7 @@ enterprise: false
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.8/download/) and [install](/dkp/konvoy/1.8/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 

--- a/pages/dkp/kommander/1.4/release-notes/1.4.2/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/1.4.2/index.md
@@ -14,7 +14,7 @@ enterprise: false
 
 [button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
 
-To get started with Kommander, [download](/dkp/konvoy/latest/download/) and [install](/dkp/konvoy/latest/install/) the latest version of Konvoy.
+To get started with Kommander, [download](/dkp/konvoy/1.8/download/) and [install](/dkp/konvoy/1.8/install/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 


### PR DESCRIPTION
Also updated the date format for consistency

## Jira Ticket
N/A

## Description of changes being made
Same thing as here:
https://github.com/mesosphere/dcos-docs-site/pull/3814

So, the links here were using:
`/dkp/konvoy/latest/download/`
and
`/dkp/konvoy/latest/install/`
for the links from the Kommander release notes pages.
This worked up until we got to Konvoy 2.x. Now, those pages aren't the same and the links will go to a dead page.
So, I versioned the release note link of Kommander to the applicable version of Konvoy. Because it's kind of a one-off correction, I feel like this is fine, because we don't have to keep on versioning this in the future, as the 2.x release notes of Kommander have also evolved.

Also updated all the dates here to be consistent with recent date formats for releases.

## Checklist
- [ ] Change all affected versions, if applicable (e.g. 1.13, 2.0, 2.1).
- [ ] Test all commands and procedures, if applicable.
- [ ] Create your PR against `main`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.