### PR TITLE
Fix support portal links in Komm 1.x docs

### DIFF
--- a/pages/dkp/kommander/1.2/licensing/index.md
+++ b/pages/dkp/kommander/1.2/licensing/index.md
@@ -104,5 +104,5 @@ license.kommander.mesosphere.io "license-sample" deleted
 
 You have now successfuly deleted a license.
 
-[support-downloads]: https://support.d2iq.com/s/downloads
-[support-creds]: https://support.d2iq.com/s/login/
+[support-downloads]: https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads
+[support-creds]: https://support.d2iq.com/hc/en-us/

--- a/pages/dkp/kommander/1.2/release-notes/1.2.0/index.md
+++ b/pages/dkp/kommander/1.2/release-notes/1.2.0/index.md
@@ -21,7 +21,7 @@ For more information on addressing this limit, refer to this [procedure](../oper
 
 **D2iQ&reg; Kommander&reg; 1.2 was released on November 16, 2020** 
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.6/download/) and [install](/dkp/konvoy/1.6/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.2/release-notes/1.2.1/index.md
+++ b/pages/dkp/kommander/1.2/release-notes/1.2.1/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.2.1 was released on March 11, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.6/download/) and [install](/dkp/konvoy/1.6/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.2/release-notes/1.2.2/index.md
+++ b/pages/dkp/kommander/1.2/release-notes/1.2.2/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.2.2 was released on March 25, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.6/download/) and [install](/dkp/konvoy/1.6/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.3/licensing/index.md
+++ b/pages/dkp/kommander/1.3/licensing/index.md
@@ -107,5 +107,5 @@ license.kommander.mesosphere.io "license-sample" deleted
 
 You have now successfuly deleted a license.
 
-[support-downloads]: https://support.d2iq.com/s/downloads
-[support-creds]: https://support.d2iq.com/s/login/
+[support-downloads]: https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads
+[support-creds]: https://support.d2iq.com/hc/en-us/

--- a/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.0/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.3.0 was released on February 10, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.1/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.3.1 was released on March 11, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.2/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.3.2 was released on April 8, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.3/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.3.3 was released on June 9, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.3/release-notes/1.3.4/index.md
+++ b/pages/dkp/kommander/1.3/release-notes/1.3.4/index.md
@@ -12,7 +12,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.3.4 was released on September 23, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.7/download/) and [install](/dkp/konvoy/1.7/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.4/licensing/index.md
+++ b/pages/dkp/kommander/1.4/licensing/index.md
@@ -154,5 +154,5 @@ To delete a license from Kommander, you have to delete the `Secret` and `License
 
 You have now successfully deleted a license.
 
-[support-downloads]: https://support.d2iq.com/s/downloads
-[support-creds]: https://support.d2iq.com/s/login/
+[support-downloads]: https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads
+[support-creds]: https://support.d2iq.com/hc/en-us/

--- a/pages/dkp/kommander/1.4/release-notes/1.4.0/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/1.4.0/index.md
@@ -12,7 +12,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.4.0 was released on May 5, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.8/download/) and [install](/dkp/konvoy/1.8/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.4/release-notes/1.4.1/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/1.4.1/index.md
@@ -12,7 +12,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.4.1 was released on June 9, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.8/download/) and [install](/dkp/konvoy/1.8/install/) the latest version of Konvoy.
 

--- a/pages/dkp/kommander/1.4/release-notes/1.4.2/index.md
+++ b/pages/dkp/kommander/1.4/release-notes/1.4.2/index.md
@@ -12,7 +12,7 @@ enterprise: false
 
 **D2iQ&reg; Kommander&reg; version 1.4.2 was released on September 23, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/s/entitlement-based-product-downloads"]Download Konvoy[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
 To get started with Kommander, [download](/dkp/konvoy/1.8/download/) and [install](/dkp/konvoy/1.8/install/) the latest version of Konvoy.
 


### PR DESCRIPTION
## Jira Ticket
No ticket

## Description of changes being made
Fix the support portal links for the old Kommander 1.x pages.   Rest of the links fixes should sync from the code repos.

## Checklist
- [X] Test all commands and procedures, if applicable.
- [X] Create any new PRs against `production`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.
