### PR TITLE
chore: remove jira link that no longer works

### DIFF
--- a/layouts/components/content-actions.pug
+++ b/layouts/components/content-actions.pug
@@ -1,16 +1,5 @@
 if (!title)
   - throw `File ${path} does not contain a title`
--
-  var feedbackPath = 'https://jira.d2iq.com/secure/CreateIssueDetails!init.jspa'
-   + '?pid=14105'
-   + '&issuetype=1'
-   + `&summary=Feedback+for+${title.replace(/ /g, '+')}`
-   + '&description=Source:%20' + url + path
-   + '&labels=documentation'
-   + '&labels=needs_triage'
-   + '&components=19804'
-   + '&priority=3'
-   + '&customfield_12300=44' // Sets the team field to Documentation Team
 
 .actions
   ul.actions__list
@@ -22,7 +11,3 @@ if (!title)
       a.actions__link(href=`https://github.com/mesosphere/dcos-docs-site/tree/main/pages${path}/index.md`, target="_blank")
         i.actions__icon(data-feather='github')
         span.actions__text Contribute
-    li.actions__item
-      a.actions__link(href=feedbackPath, target="_blank")
-        i.actions__icon(data-feather='message-square')
-        span.actions__text Feedback


### PR DESCRIPTION
## Jira Ticket
D2IQ-80923

## Description of changes being made
Feedback button is broken for external customers
Removing that button

## Checklist
- [x] Test all commands and procedures, if applicable.
- [x] Create any new PRs against `production`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.
