### PR TITLE
point 2.1 to main temporarily

### DIFF
--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -94,7 +94,7 @@ pipeline {
 
                   ##### Next
                   mkdir -p pages/dkp/konvoy/2.1
-                  ./ci/pull-upstream.sh mesosphere/konvoy2 docs/site main pages/dkp/konvoy/2.1 main
+                  ./ci/pull-upstream.sh mesosphere/konvoy2 docs/site release-2.1 pages/dkp/konvoy/2.1 main
                   mkdir -p pages/dkp/kommander/2.1
                   ./ci/pull-upstream.sh mesosphere/kommander docs/site main pages/dkp/kommander/2.1 main
                 '''


### PR DESCRIPTION
We want this release branch to now be the source of truth for 2.1 konvoy
docs that are on main. Once we publish the 2.1 docs to production, we
shall update this again and use main branch of konvoy for 2.2

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to JIRA ticket -->

## Description of changes being made


## Checklist
- [ ] Test all commands and procedures, if applicable.
- [ ] Create any new PRs against `production`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.
