### PR TITLE
vale warns but doesnt block

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -5,6 +5,7 @@ jobs:
   prose:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: true
     steps:
     - name: Checkout
       uses: actions/checkout@master


### PR DESCRIPTION
We are ignoring most vale warnings at this point but we have to admin
merge if it fails. This should maintain the errors but allow us to
merge. Because these are happening on PRs coming from upstream, we'd
need to change it there anyhow.

## Jira Ticket
Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel.

<!-- Link to JIRA ticket -->

## Description of changes being made


## Checklist
- [ ] Test all commands and procedures, if applicable.
- [ ] Create any new PRs against `production`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.
