### PR TITLE
fix: add auto-ips ip range to no_proxy variable

### DIFF
--- a/pages/dkp/konvoy/1.8/install/http-proxy/index.md
+++ b/pages/dkp/konvoy/1.8/install/http-proxy/index.md
@@ -118,7 +118,7 @@ spec:
             env:
               HTTP_PROXY: "http://proxy.company.com:3128"
               HTTPS_PROXY: "http://proxy.company.com:3128"
-              NO_PROXY: "10.0.0.0/18,localhost,127.0.0.1,169.254.169.254,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
+              NO_PROXY: "10.0.0.0/18,localhost,127.0.0.1,169.254.169.254,169.254.0.0/24,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
     ...
 ```
 
@@ -155,7 +155,7 @@ spec:
     - name: HTTPS_PROXY
       value: "http://proxy.company.com:3128"
     - name: NO_PROXY
-      value: "10.0.0.0/18,localhost,127.0.0.1,169.254.169.254,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
+      value: "10.0.0.0/18,localhost,127.0.0.1,169.254.169.254,169.254.0.0/24,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
 ```
 
 See [Define Environment Variables for a Container](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container) for more details.


### PR DESCRIPTION
## Description of changes being made
Add missing autoip ip range in NO_PROXY variable.

https://jira.d2iq.com/browse/COPS-7078

## Checklist
- [ ] Test all commands and procedures, if applicable.
- [ ] Create any new PRs against `production`. 
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://wiki.d2iq.com/display/ENG/Contributing+to+Docs) for more information.
