### PR TITLE
[kommander][2.1.1]feat: ws catalog appd & use CR in project

### DIFF
--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
@@ -6,4 +6,5 @@ menuWeight: 20
 excerpt: Use Custom Resources with Workspace Catalog Applications
 ---
 
+
 Some workspace catalog applications will provision some `CustomResourceDefinition`, which allow you to deploy Custom Resources. Please refer to your workspace catalog application's documentation for instructions.

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
@@ -5,4 +5,5 @@ title: Use Custom Resources with Workspace Catalog Applications
 menuWeight: 20
 excerpt: Use Custom Resources with Workspace Catalog Applications
 ---
+
 Some workspace catalog applications will provision some `CustomResourceDefinition`, which allow you to deploy Custom Resources. Please refer to your workspace catalog application's documentation for instructions.

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
@@ -1,0 +1,8 @@
+---
+layout: layout.pug
+navigationTitle: Use Custom Resources with Workspace Catalog Applications
+title: Use Custom Resources with Workspace Catalog Applications
+menuWeight: 20
+excerpt: Use Custom Resources with Workspace Catalog Applications
+---
+Some workspace catalog applications will provision some `CustomResourceDefinition`, which allow you to deploy Custom Resources. Please refer to your workspace catalog application's documentation for instructions.

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/index.md
@@ -7,4 +7,4 @@ excerpt: Use Custom Resources with Workspace Catalog Applications
 ---
 
 
-Some workspace catalog applications will provision some `CustomResourceDefinition`, which allow you to deploy Custom Resources. Please refer to your workspace catalog application's documentation for instructions.
+Some workspace catalog applications will provision some `CustomResourceDefinition`s, which allow you to deploy Custom Resources. Please refer to your workspace catalog application's documentation for instructions.

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
@@ -37,12 +37,12 @@ The list of available applications that can be deployed on the attached cluster 
     apiVersion: apps.kommander.d2iq.io/v1alpha2
     kind: AppDeployment
     metadata:
-      name: cert-manager
+      name: spark-operator
       namespace: ${WORKSPACE_NAMESPACE}
     spec:
       appRef:
-        name: cert-manager-0.2.7
-        kind: ClusterApp
+        name: spark-operator-1.1.6
+        kind: App
     EOF
     ```
 
@@ -59,14 +59,14 @@ The list of available applications that can be deployed on the attached cluster 
     apiVersion: apps.kommander.d2iq.io/v1alpha2
     kind: AppDeployment
     metadata:
-      name: metallb
+      name: spark-operator
       namespace: ${WORKSPACE_NAMESPACE}
     spec:
       appRef:
-        name: metallb-0.12.2
-        kind: ClusterApp
+        name: spark-operator-1.1.6
+        kind: App
       configOverrides:
-        name: metallb-overrides-attached
+        name: spark-operator-overrides
     EOF
     ```
 
@@ -78,15 +78,12 @@ The list of available applications that can be deployed on the attached cluster 
     kind: ConfigMap
     metadata:
       namespace: ${WORKSPACE_NAMESPACE}
-      name: metallb-overrides-attached
+      name: spark-operator-overrides
     data:
       values.yaml: |
         configInline:
-          address-pools:
-          - name: default
-            protocol: layer2
-            addresses:
-            - 172.17.255.150-172.17.255.199
+          uiService:
+            enable: false
     EOF
     ```
 
@@ -98,6 +95,6 @@ The applications are now deployed. Connect to the attached cluster and check the
 
 ```bash
 kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}
-NAMESPACE               NAME        READY   STATUS                             AGE
-workspace-test-vjsfq    metallb     True    Release reconciliation succeeded   7m3s
+NAMESPACE               NAME               READY   STATUS                             AGE
+workspace-test-vjsfq    spark-operator     True    Release reconciliation succeeded   7m3s
 ```

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
@@ -1,0 +1,103 @@
+---
+layout: layout.pug
+navigationTitle: Application Deployment
+title: Deployment of Applications
+menuWeight: 5
+beta: false
+excerpt: Deploy applications to attached clusters using the CLI
+---
+
+<!-- markdownlint-disable MD004 MD040 -->
+
+This topic describes how to use the CLI to deploy a workspace catalog application to attached clusters within a workspace.
+
+## Prerequisites
+
+Before you begin, you must have:
+
+- A running cluster with [Kommander installed](../../../../install/).
+- An [existing Kubernetes cluster attached to Kommander](../../../../clusters/attach-cluster/).
+
+Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace's namespace where the cluster is attached:
+
+```sh
+export WORKSPACE_NAMESPACE=<workspace_namespace>
+```
+
+## Deploy the application
+
+The list of available applications that can be deployed on the attached cluster can be found [in this documentation](../../catalog-applications#workspace-catalog-applications).
+
+1.  Deploy a supported application to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
+
+1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be deployed:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: apps.kommander.d2iq.io/v1alpha2
+    kind: AppDeployment
+    metadata:
+      name: cert-manager
+      namespace: ${WORKSPACE_NAMESPACE}
+    spec:
+      appRef:
+        name: cert-manager-0.2.7
+        kind: ClusterApp
+    EOF
+    ```
+
+1.  Create the resource in the workspace you just created, which instructs Kommander to deploy the `AppDeployment` to the `KommanderCluster`s in the same workspace.
+
+<p class="message--note"><strong>NOTE: </strong>The <code>appRef.name</code> must match the app <code>name</code> from the list of available catalog applications.</p>
+
+## Deploy an application with a custom configuration
+
+1.  Provide the name of a `ConfigMap` in the `AppDeployment`, which provides custom configuration on top of the default configuration:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: apps.kommander.d2iq.io/v1alpha2
+    kind: AppDeployment
+    metadata:
+      name: metallb
+      namespace: ${WORKSPACE_NAMESPACE}
+    spec:
+      appRef:
+        name: metallb-0.12.2
+        kind: ClusterApp
+      configOverrides:
+        name: metallb-overrides-attached
+    EOF
+    ```
+
+1.  Create the `ConfigMap` with the name provided in the step above, with the custom configuration:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      namespace: ${WORKSPACE_NAMESPACE}
+      name: metallb-overrides-attached
+    data:
+      values.yaml: |
+        configInline:
+          address-pools:
+          - name: default
+            protocol: layer2
+            addresses:
+            - 172.17.255.150-172.17.255.199
+    EOF
+    ```
+
+Kommander waits for the `ConfigMap` to be present before deploying the `AppDeployment` to the attached clusters.
+
+## Verify applications
+
+The applications are now deployed. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
+
+```bash
+kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}
+NAMESPACE               NAME        READY   STATUS                             AGE
+workspace-test-vjsfq    metallb     True    Release reconciliation succeeded   7m3s
+```

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
@@ -7,7 +7,6 @@ beta: false
 excerpt: Deploy applications to attached clusters using the CLI
 ---
 
-<!-- markdownlint-disable MD004 MD040 -->
 
 This topic describes how to use the CLI to deploy a workspace catalog application to attached clusters within a workspace.
 
@@ -18,7 +17,7 @@ Before you begin, you must have:
 - A running cluster with [Kommander installed](../../../../install/).
 - An [existing Kubernetes cluster attached to Kommander](../../../../clusters/attach-cluster/).
 
-Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace's namespace where the cluster is attached:
+Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace's namespace the attached cluster exists:
 
 ```sh
 export WORKSPACE_NAMESPACE=<workspace_namespace>
@@ -26,11 +25,11 @@ export WORKSPACE_NAMESPACE=<workspace_namespace>
 
 ## Deploy the application
 
-The list of available applications that can be deployed on the attached cluster can be found [in this documentation](../../catalog-applications#workspace-catalog-applications).
+See [workspace catalog applications](../../catalog-applications#workspace-catalog-applications) for the list of available applications that you can deploy on the attached cluster.
 
 1.  Deploy a supported application to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
 
-1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be deployed:
+1.  Within the `AppDeployment`, define the `appRef` to specify which `App` to deploy:
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/application-deployment/index.md
@@ -17,7 +17,7 @@ Before you begin, you must have:
 - A running cluster with [Kommander installed](../../../../install/).
 - An [existing Kubernetes cluster attached to Kommander](../../../../clusters/attach-cluster/).
 
-Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace's namespace the attached cluster exists:
+Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace's namespace the attached cluster exists in:
 
 ```sh
 export WORKSPACE_NAMESPACE=<workspace_namespace>

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
@@ -14,4 +14,4 @@ Catalog applications are any third-party or open source applications that appear
 | ----------------------------- | --------------------- |
 | kafka-operator-0.20.0         | kafka-operator        |
 | spark-operator-1.1.6          | spark-operator        |
-| zookeepr-operator-0.2.13      | zookeepr-operator     |
+| zookeeper-operator-0.2.13     | zookeeper-operator    |

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
@@ -7,3 +7,11 @@ excerpt: Workspace Catalog Applications
 ---
 <!-- TODO: settle down the link target to custom applications -->
 Catalog applications are any third-party or open source applications that appear in the Catalog. These applications can be provided by D2iQ for use in your environment.
+
+## Workspace catalog applications
+
+| NAME                          | APP ID                |
+| ----------------------------- | --------------------- |
+| kafka-operator-0.20.0         | kafka-operator        |
+| spark-operator-1.1.6          | spark-operator        |
+| zookeepr-operator-0.2.13      | zookeepr-operator     |


### PR DESCRIPTION
added new folder of use CR in project with workspace catalog

copy-pasted the /application-deployment/index.md from the workspace platform application one and modified.

added a table of supported workspace catalog apps