### PR TITLE
Update 1.8.4 RN with correct date

### DIFF
--- a/pages/dkp/konvoy/1.8/release-notes/1.8.4/index.md
+++ b/pages/dkp/konvoy/1.8/release-notes/1.8.4/index.md
@@ -9,7 +9,7 @@ enterprise: false
 ---
 <!-- markdownlint-disable MD034 -->
 
-**D2iQ&reg; Konvoy&reg; version 1.8.4 was released on **
+**D2iQ&reg; Konvoy&reg; version 1.8.4 was released on December 14, 2021**
 
 [button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Description of changes being made
Added date to 1.8.4 RNs
## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](./CONTRIBUTING.md) for more information.
