### PR TITLE
adding notes for preprov challenges

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -85,7 +85,9 @@ Nagios
 namespace
 namespaced
 (nginx|NGINX)
+NVIDIA
 Nvidia
+nvidia
 onboarding
 overfit(|s|ted|ting)
 Papermill
@@ -103,6 +105,7 @@ Scala
 scikit-learn
 serverless
 sigmoidal
+Snapshotter
 softmax
 Splunk
 subcommand

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -116,7 +116,7 @@ Verify `firewalld` is running before you deploy DKP. Use SSH to access each of t
 systemctl status firewalld
 ```
 
-If it is active, you will need to stop `firewalld`:
+If `firewalld` is active, stop it with the command:
 
 ```sh
 systemctl stop firewalld

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -110,7 +110,7 @@ hunter-aws-cluster-pf4a3
 
 For DKP to install completely, you must stop `firewalld`, if enabled.
 
-You will need to check to see if `firewalld` is running. SSH into all the machines you are deploying DKP onto, and check to see if it is running:
+Verify `firewalld` is running before you deploy DKP. Use SSH to access each of the machines onto which you are deploying DKP, and check to see if 'firewalld' is running, using the command:
 
 ```sh
 systemctl status firewalld

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -14,7 +14,7 @@ Konvoy needs to know how to access your cluster hosts. This is done using invent
 
 Give your cluster a unique name suitable for your environment.
 
-Set the environment variable to be used throughout this documentation:
+Set the environment variable to be used throughout this procedure:
 
 ```sh
 CLUSTER_NAME=my-preprovisioned-cluster

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -21,7 +21,7 @@ CLUSTER_NAME=my-preprovisioned-cluster
 ```
 
 Note: If you want to create a unique cluster name, use this command.
-This will create a unique name every time you run it so use it with forethought.
+This creates a unique name every time you run it, so use it carefully.
 
 ```sh
 CLUSTER_NAME=$(whoami)-preprovisioned-cluster-$(LC_CTYPE=C tr -dc 'a-z0-9' </dev/urandom | fold -w 5 | head -n1)

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -108,7 +108,7 @@ hunter-aws-cluster-pf4a3
 
 ## Prepare your machines
 
-In order for DKP to fully install, it is recommended you stop `firewalld` if enabled so DKP can fully deploy.
+For DKP to install completely, you must stop `firewalld`, if enabled.
 
 You will need to check to see if `firewalld` is running. SSH into all the machines you are deploying DKP onto, and check to see if it is running:
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -12,25 +12,27 @@ Konvoy needs to know how to access your cluster hosts. This is done using invent
 
 ## Name your cluster
 
-1.  Give your cluster a unique name suitable for your environment.
+Give your cluster a unique name suitable for your environment.
 
-    Set the environment variable to be used throughout this documentation:
+Set the environment variable to be used throughout this documentation:
 
-    ```sh
-    CLUSTER_NAME=my-preprovisioned-cluster
-    ```
+```sh
+CLUSTER_NAME=my-preprovisioned-cluster
+```
 
-    Note: If you want to create a unique cluster name, use this command.
-    This will create a unique name every time you run it so use it with forethought.
+Note: If you want to create a unique cluster name, use this command.
+This will create a unique name every time you run it so use it with forethought.
 
-    ```sh
-    CLUSTER_NAME=$(whoami)-preprovisioned-cluster-$(LC_CTYPE=C tr -dc 'a-z0-9' </dev/urandom | fold -w 5 | head -n1)
-    echo $CLUSTER_NAME
-    ```
+```sh
+CLUSTER_NAME=$(whoami)-preprovisioned-cluster-$(LC_CTYPE=C tr -dc 'a-z0-9' </dev/urandom | fold -w 5 | head -n1)
+echo $CLUSTER_NAME
+```
 
-    ```text
-    hunter-aws-cluster-pf4a3
-    ```
+```text
+hunter-aws-cluster-pf4a3
+```
+
+## Define your infrastructure
 
 1.  Export these environment variables:
 
@@ -101,7 +103,23 @@ Konvoy needs to know how to access your cluster hosts. This is done using invent
 1.  Apply the new infrastructure file with the command:
 
     ```shell
-    kubectl apply -f preprovisioned_inventory.yaml
+    envsubst < preprovisioned_inventory.yaml | kubectl apply -f -
     ```
+
+## Prepare your machines
+
+In order for DKP to fully install, it is recommended you stop `firewalld` if enabled so DKP can fully deploy.
+
+You will need to check to see if `firewalld` is running. SSH into all the machines you are deploying DKP onto, and check to see if it is running:
+
+```sh
+systemctl status firewalld
+```
+
+If it is active, you will need to stop `firewalld`:
+
+```sh
+systemctl stop firewalld
+```
 
 After defining the infrastructure, [define the control plane endpoint](../define-control-plane-endpoint).

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -13,7 +13,7 @@ Before you start, make sure you have created a workload cluster, as described in
 
 ## Explore the cluster
 
-Before checking making the cluster manage itself, explore your cluster:
+Before setting the cluster to manage itself, explore your cluster with this command:
 
    ```sh
    kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -28,7 +28,7 @@ To edit the installation file, run the command:
    kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf
    ```
 
-Change the `spec.calicoNetwork.nodeAddressAutodetectionV4` to be `interface: ens192`, and save this file:
+Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interface: ens192`, and save the file:
 
    ```sh
    spec:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -38,7 +38,7 @@ Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interfa
          interface: ens192
    ```
 
-After this, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace if it failed. This pod will then reconcile.
+After saving the file, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace, if it failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
 
 ## Make the new Kubernetes cluster manage itself
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -19,7 +19,7 @@ Before setting the cluster to manage itself, explore your cluster with this comm
    kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf
    ```
 
-<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not working on your ready on your cluster, you will have to edit the <code>installation</code> file.
+<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not ready on your cluster, you need to edit the <code>installation</code> file.
 </p>
 
 If you have to edit the installation file, run the command:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -11,6 +11,35 @@ Konvoy deploys all cluster lifecycle services to a bootstrap cluster, which then
 
 Before you start, make sure you have created a workload cluster, as described in [Create the Cluster][createthecluster].
 
+## Explore the cluster
+
+Before checking making the cluster manage itself, explore your cluster:
+
+   ```sh
+   kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf
+   ```
+
+<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not working on your ready on your cluster, you will have to edit the <code>installation</code> file.
+</p>
+
+If you have to edit the installation file, run the command:
+
+   ```sh 
+   kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf
+   ```
+
+Change the `spec.calicoNetwork.nodeAddressAutodetectionV4` to be `interface: ens192`, and save this file:
+
+   ```sh
+   spec:
+     calicoNetwork:
+     ...
+       nodeAddressAutodetectionV4:
+         interface: interface: ens192
+   ```
+
+After this, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace if it failed. This pod will then reconcile.
+
 ## Make the new Kubernetes cluster manage itself
 
 1.  Deploy cluster lifecycle services on the workload cluster:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -35,7 +35,7 @@ Change the `spec.calicoNetwork.nodeAddressAutodetectionV4` to be `interface: ens
      calicoNetwork:
      ...
        nodeAddressAutodetectionV4:
-         interface: interface: ens192
+         interface: ens192
    ```
 
 After this, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace if it failed. This pod will then reconcile.

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -22,7 +22,7 @@ Before setting the cluster to manage itself, explore your cluster with this comm
 <p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not ready on your cluster, you need to edit the <code>installation</code> file.
 </p>
 
-If you have to edit the installation file, run the command:
+To edit the installation file, run the command:
 
    ```sh 
    kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf

--- a/pages/dkp/konvoy/2.1/release-notes/index.md
+++ b/pages/dkp/konvoy/2.1/release-notes/index.md
@@ -73,7 +73,7 @@ The following components have been upgraded to the listed version:
 - Node Feature Discovery 0.8.2
 - Nvidia Node Feature Discovery 0.4.1
 
-### Building on a CentOS OS using Pre-provisioned
+### Build on a CentOS OS using pre-provisioned
 
 If you are deploying to CentOS using the [pre-provisioned provider](../choose-infrastructure/pre-provisioned) method, ensure this setting is followed on your machines:
 

--- a/pages/dkp/konvoy/2.1/release-notes/index.md
+++ b/pages/dkp/konvoy/2.1/release-notes/index.md
@@ -77,31 +77,31 @@ The following components have been upgraded to the listed version:
 
 If you are deploying to CentOS using the [pre-provisioned provider](../choose-infrastructure/pre-provisioned) method, ensure this setting is followed on your machines:
 
-First, check your `/etc/fstab` file:
+1.  Check your `/etc/fstab` file:
 
-```sh
-cat /etc/fstab
-```
+    ```sh
+    cat /etc/fstab
+    ```
 
-If there is the line, you will need to comment that out:
+1.  Search for this line:
 
-```sh
-/dev/mapper/centos-swap swap                    swap    defaults        0 0
-```
+    ```sh
+    /dev/mapper/centos-swap swap                    swap    defaults        0 0
+    ```
 
-This will then look like this:
+1.  Comment out the line, if it exists:
 
-```sh
-# /dev/mapper/centos-swap swap                    swap    defaults        0 0
-```
+    ```sh
+    # /dev/mapper/centos-swap swap                    swap    defaults        0 0
+    ```
 
-Then, run:
+1.  Run this command to complete the process:
 
-```sh
-swapoff /dev/mapper/centos-swap
-```
+    ```sh
+    swapoff /dev/mapper/centos-swap
+    ```
 
-Now you will be able to install a pre-provisioned DKP cluster on a CentOS machine.
+You are now able to install a pre-provisioned DKP cluster on a CentOS machine.
 
 ## Additional resources
 

--- a/pages/dkp/konvoy/2.1/release-notes/index.md
+++ b/pages/dkp/konvoy/2.1/release-notes/index.md
@@ -75,7 +75,7 @@ The following components have been upgraded to the listed version:
 
 ### Building on a CentOS OS using Pre-provisioned
 
-If you are deploying to CentOS using the [pre-provisioned provider](../choose-infrastructure/pre-provisioned) method, you will need to ensure this setting is followed on your machines:
+If you are deploying to CentOS using the [pre-provisioned provider](../choose-infrastructure/pre-provisioned) method, ensure this setting is followed on your machines:
 
 First, check your `/etc/fstab` file:
 

--- a/pages/dkp/konvoy/2.1/release-notes/index.md
+++ b/pages/dkp/konvoy/2.1/release-notes/index.md
@@ -73,6 +73,36 @@ The following components have been upgraded to the listed version:
 - Node Feature Discovery 0.8.2
 - Nvidia Node Feature Discovery 0.4.1
 
+### Building on a CentOS OS using Pre-provisioned
+
+If you are deploying to CentOS using the [pre-provisioned provider](../choose-infrastructure/pre-provisioned) method, you will need to ensure this setting is followed on your machines:
+
+First, check your `/etc/fstab` file:
+
+```sh
+cat /etc/fstab
+```
+
+If there is the line, you will need to comment that out:
+
+```sh
+/dev/mapper/centos-swap swap                    swap    defaults        0 0
+```
+
+This will then look like this:
+
+```sh
+# /dev/mapper/centos-swap swap                    swap    defaults        0 0
+```
+
+Then, run:
+
+```sh
+swapoff /dev/mapper/centos-swap
+```
+
+Now you will be able to install a pre-provisioned DKP cluster on a CentOS machine.
+
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->


### PR DESCRIPTION
## Jira Ticket


## Description of changes being made
Added some notes for preprovisioning cluster create. Includes: 
- the swapoff deal for centos in release notes (FYI @cmastr - this is resolved in an upcoming release)
- stopping firewalld
- adding a bit about calico nodes pods if they aren't working post-deploy (@dkoshkin - I know there is a way to run --dry-run for this, but I wasn't able to get that to work in a quick timeframe, so I just did an after-the-fact review for this guy)

## Checklist

- [x] Test all commands and procedures, if applicable.
- [x] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](./CONTRIBUTING.md) for more information.
