### PR TITLE
Add ZooKeeper operator docs

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -142,3 +142,4 @@ XGBoost
 yakcl
 Zookeeper
 zookeeper
+ZooKeeper

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -1,0 +1,51 @@
+---
+layout: layout.pug
+navigationTitle: ZooKeeper
+title: ZooKeeper
+menuWeight: 5
+excerpt: Deploying ZooKeeper in a project
+---
+
+## Getting Started
+
+To get started with creating ZooKeeper clusters in your project namespace, you first need to deploy the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/zookeeper-operator/) in the workspace where the project exists.
+
+Once you have the ZooKeeper operator deployed, you can create ZooKeeper Clusters by applying a `ZookeeperCluster` custom resource in a project's namespace.
+
+A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper) exists in the ZooKeeper operator repository that can assist with deploying ZooKeeper clusters.
+
+### Example Deployment
+
+1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
+
+    ```bash
+    export PROJECT_NAMESPACE=<project namespace>
+    ```
+
+1.  Create a ZooKeeper Cluster custom resource in your project namespace
+
+    ```yaml
+    kubectl apply -f - <<EOF
+    apiVersion: zookeeper.pravega.io/v1beta1
+    kind: ZookeeperCluster
+    metadata:
+      name: zookeeper
+      namespace: ${PROJECT_NAMESPACE}
+    spec:
+      replicas: 1
+    EOF
+    ```
+
+## Deleting ZooKeeper Clusters
+
+1.  View `ZookeeperClusters` in all namespaces:
+
+    ```bash
+    kubectl get zookeeperclusters -A
+    ```
+
+1.  Deleting a specific `ZookeeperCluster`:
+
+    ```bash
+    kubectl delete zookeepercluster <name of zookeepercluster>
+    ```

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -47,5 +47,5 @@ A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/
 1.  Deleting a specific `ZookeeperCluster`:
 
     ```bash
-    kubectl delete zookeepercluster <name of zookeepercluster>
+    kubectl -n ${PROJECT_NAMESPACE} delete zookeepercluster <name of zookeepercluster>
     ```

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -31,7 +31,7 @@ Uninstalling the ZooKeeper operator will not directly affect any running `Zookee
 1.  Uninstalling a ZooKeeper operator `AppDeployment`:
 
     ```bash
-    kubectl delete AppDeployment <name of AppDeployment>
+    kubectl -n <workspace namespace> delete AppDeployment <name of AppDeployment>
     ```
 
 1.  Removing ZooKeeper CRDs:

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -1,0 +1,59 @@
+---
+layout: layout.pug
+navigationTitle: ZooKeeper Operator
+title: ZooKeeper Operator
+menuWeight: 20
+excerpt: Information about the ZooKeeper Operator
+---
+
+## Overview
+
+[ZooKeeper](https://zookeeper.apache.org/index.html) is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services. The [ZooKeeper operator](https://github.com/pravega/zookeeper-operator) is a Kubernetes operator that handles the provisioning and management of ZooKeeper clusters. It works by watching custom resources, such as `ZookeeperClusters`, to provision the underlying Kubernetes resources (`StatefulSets`) required for a production-ready ZooKeeper Cluster.
+
+## Installation
+
+1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
+
+1.  Within the `AppDeployment`, update the `appRef` to specify the correct `zookeeper-operator` App. You can find the `appRef.name` by listing the available `Apps` in the workspace namespace:
+
+    ```bash
+    kubectl get apps -n ${WORKSPACE_NAMESPACE}
+    ```
+
+For details on custom configuration for the operator, please refer to the [ZooKeeper operator Helm Chart documentation](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper-operator#configuration).
+
+## Uninstall via the CLI
+
+Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperCluster`s. By default, the operator will wait for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you will need to manually clean up any leftover Custom Resource Definitions (CRDs).
+
+1.  View ZookeeperClusters in all namespaces:
+
+    ```bash
+    kubectl get zookeeperclusters -A
+    ```
+
+1.  Deleting a `ZookeeperCluster`:
+
+    ```bash
+    kubectl delete zookeepercluster <name of zookeepercluster>
+    ```
+
+1.  Uninstalling a ZooKeeper operator `AppDeployment`:
+
+    ```bash
+    kubectl delete AppDeployment <name of AppDeployment>
+    ```
+
+1.  Removing ZooKeeper CRDs:
+
+    <p class="message--warning"><strong>WARNING: </strong>Once you remove the CRDs, all deployed ZookeeperClusters will be deleted!</p>
+
+    ```bash
+    kubectl delete crds zookeeperclusters.zookeeper.pravega.io
+    ```
+
+## Resources
+
+- [ZooKeeper Operator Documentation](https://github.com/pravega/zookeeper-operator)
+- [ZooKeeper Cluster Helm Chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper)
+- [ZooKeeper Documentation](https://zookeeper.apache.org/)

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -26,17 +26,7 @@ For details on custom configuration for the operator, please refer to the [ZooKe
 
 Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperCluster`s. By default, the operator will wait for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you will need to manually clean up any leftover Custom Resource Definitions (CRDs).
 
-1.  View ZookeeperClusters in all namespaces:
-
-    ```bash
-    kubectl get zookeeperclusters -A
-    ```
-
-1.  Deleting a `ZookeeperCluster`:
-
-    ```bash
-    kubectl delete zookeepercluster <name of zookeepercluster>
-    ```
+1.  Delete all `ZookeeperCluster`'s, see [Deleting ZooKeeper Clusters](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper#deleting-zookeeper-clusters).
 
 1.  Uninstalling a ZooKeeper operator `AppDeployment`:
 


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-82302

## Description of changes being made

Adding docs about the zookeeper operator in the workspace catalog.

There are a few additional changes that are needed but opening this to start the review process.

1. Copy this page to 2.2 (needs https://github.com/mesosphere/dcos-docs-site/pull/3956)
2. Add project level docs (will be done in another PR)

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
