### PR TITLE
D2IQ-81520: KM2.1 migration cleanup missing a command

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -42,6 +42,7 @@ Horovod
 hostname
 hyperparameter(|s)
 https
+istio
 Istio
 (json|JSON)
 Kafka

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -31,7 +31,7 @@ release "elasticsearch-kubeaddons" uninstalled
 
 ## Istio
 
-If Istio is installed on the cluster, the upgrade leaves the Helm Secret that belonged to the 1.8 Istio addon in the `istio-system` namespace.
+If Istio is installed on the cluster, the upgrade retains the Helm Secret that belonged to the 1.8 Istio addon in the `istio-system` namespace.
 
 <p class="message--note"><strong>WARNING: </strong>As long as this secret exists, <code>helm list -n istio-system</code> will incorrectly report existence of an "istio-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it may corrupt the Istio Platform Application in Kommander, which can disrupt operation of Istio workloads.</p>
 

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -45,7 +45,7 @@ kubectl delete -n istio-system secret sh.helm.release.v1.istio-kubeaddons.v1
 
 If Gatekeeper is installed on the cluster, the upgrade leaves a Helm Secret, Deployments, and a Service that belonged to the 1.8 Gatekeeper addon in the `kubeaddons` namespace.
 
-<p class="message--note"><strong>WARNING: </strong>As long as the secret exists, `helm list -n kubeaddons` will incorrectly report the existence of a "gatekeeper-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it may corrupt the Gatekeeper Platform Application in Kommander, potentially making Kubernetes on the cluster inoperable.</p>
+<p class="message--note"><strong>WARNING: </strong>As long as the secret exists, `helm list -n kubeaddons` incorrectly reports the existence of a "gatekeeper-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it might corrupt the Gatekeeper Platform Application in Kommander, potentially making Kubernetes on the cluster inoperable.</p>
 
 Delete these objects using the `kubectl`commands:
 

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -33,7 +33,7 @@ release "elasticsearch-kubeaddons" uninstalled
 
 If Istio is installed on the cluster, the upgrade retains the Helm Secret that belonged to the 1.8 Istio addon in the `istio-system` namespace.
 
-<p class="message--note"><strong>WARNING: </strong>As long as this secret exists, <code>helm list -n istio-system</code> will incorrectly report existence of an "istio-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it may corrupt the Istio Platform Application in Kommander, which can disrupt operation of Istio workloads.</p>
+<p class="message--note"><strong>WARNING: </strong>As long as this secret exists, <code>helm list -n istio-system</code> incorrectly reports the existence of an "istio-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it might corrupt the Istio Platform Application in Kommander, which can disrupt operation of Istio workloads.</p>
 
 Delete this secret using the `kubectl` command:
 

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -15,7 +15,7 @@ After you complete the upgrade, some Kubernetes objects that belonged to Konvoy 
 
 After a successful upgrade, the 1.8 addons no longer exist. Helm releases of Kibana, Elasticsearch, and Elasticsearch-Curator remain but are not managed by the addons, if they were installed.
 
-Uninstall these Helm releases from the command line, using this Helm command:
+Uninstall these Helm releases from the command line, using the command:
 
 ```sh
 helm uninstall -n kubeaddons kibana-kubeaddons elasticsearch-curator-kubeaddons elasticsearch-kubeaddons elasticsearchexporter-kubeaddons

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -9,7 +9,7 @@ beta: false
 
 <!-- markdownlint-disable MD0013 MD030 -->
 
-After upgrade is complete, some Kubernetes objects that belonged to Konvoy 1.8 addons, but are not used by Kommander 2.1 Platform Applications may remain on the cluster. The existence of these objects has no impact on the function of Kommander 2.1. However, modifying or deleting them can corrupt the Kommander 2.1 installation produced by the upgrade. As a result, you should remove these objects using the following steps.
+After you complete the upgrade, some Kubernetes objects that belonged to Konvoy 1.8 addons, but are not used by Kommander 2.1 Platform Applications, could remain on the cluster. The existence of these objects has no impact on the function of Kommander 2.1. However, modifying or deleting these objects might corrupt the Kommander 2.1 installation produced by the upgrade. As a result, you should remove these objects using the following procedure:
 
 ## Components of the 1.8 logging stack
 

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -57,4 +57,4 @@ kubectl delete -n kubeaddons service gatekeeper-webhook-service
 ```
 
 <p class="message--note"><strong>WARNING: </strong>As long as the secret exists, <code>helm list -n kubeaddons</code>
-will wrongly report existence of a "gatekeeper-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it may corrupt the Gatekeeper Platform Application in Kommander, potentially making Kubernetes on the cluster inoperable.</p>
+wrongly reports the existence of a "gatekeeper-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it might corrupt the Gatekeeper Platform Application in Kommander, potentially making Kubernetes on the cluster inoperable.</p>

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -13,7 +13,7 @@ After you complete the upgrade, some Kubernetes objects that belonged to Konvoy 
 
 ## Components of the 1.8 logging stack
 
-After a successful upgrade, the 1.8 addons no longer exist. Helm releases of Kibana, Elasticsearch, and Elasticsearch-Curator remain and are not managed by the addons, if they were installed.
+After a successful upgrade, the 1.8 addons no longer exist. Helm releases of Kibana, Elasticsearch, and Elasticsearch-Curator remain but are not managed by the addons, if they were installed.
 
 Uninstall these Helm releases from the command line, using this Helm command:
 

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/cleanup/index.md
@@ -9,14 +9,13 @@ beta: false
 
 <!-- markdownlint-disable MD0013 MD030 -->
 
-After upgrade is complete, some Kubernetes objects that belonged to Konvoy 1.8 Addons, but are not used by Kommander 2.1 Platform Applications may remain on
-the cluster. While the existence of these objects has no impact on the function of Kommander 2.1, modifying or deleting them can corrupt the Kommander 2.1 installation produced by the upgrade. Therefore, you should remove these objects using the following steps.
+After upgrade is complete, some Kubernetes objects that belonged to Konvoy 1.8 addons, but are not used by Kommander 2.1 Platform Applications may remain on the cluster. The existence of these objects has no impact on the function of Kommander 2.1. However, modifying or deleting them can corrupt the Kommander 2.1 installation produced by the upgrade. As a result, you should remove these objects using the following steps.
 
 ## Components of the 1.8 logging stack
 
-After successful upgrade, 1.8 Addons no longer exist. Helm releases of Kibana, Elacticsearch and Elasticsearch-Curator remain and are not managed by the Addons if they were installed.
+After a successful upgrade, the 1.8 addons no longer exist. Helm releases of Kibana, Elasticsearch, and Elasticsearch-Curator remain and are not managed by the addons, if they were installed.
 
-Uninstall the Helm releases manually using Helm from the command line:
+Uninstall these Helm releases from the command line, using this Helm command:
 
 ```sh
 helm uninstall -n kubeaddons kibana-kubeaddons elasticsearch-curator-kubeaddons elasticsearch-kubeaddons elasticsearchexporter-kubeaddons
@@ -32,42 +31,23 @@ release "elasticsearch-kubeaddons" uninstalled
 
 ## Istio
 
-If Istio is installed on the cluster, the upgrade leaves the Helm Secret
-that belonged to the 1.8 Istio Addon in the `istio-system` namespace.
+If Istio is installed on the cluster, the upgrade leaves the Helm Secret that belonged to the 1.8 Istio addon in the `istio-system` namespace.
 
-**WARNING:** As long as this secret exists, `helm list -n istio-system`
-will incorrectly report the existence of a Helm release called "istio-kubeaddons".
-If you manipulate this "Helm release" using Helm, it may corrupt the Istio
-Platform Application in Kommander, potentially disrupting operation of
-Istio workloads.
+<p class="message--note"><strong>WARNING: </strong>As long as this secret exists, <code>helm list -n istio-system</code> will incorrectly report existence of an "istio-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it may corrupt the Istio Platform Application in Kommander, which can disrupt operation of Istio workloads.</p>
 
-Delete this secret using `kubectl`:
+Delete this secret using the `kubectl` command:
 
 ```sh
 kubectl delete -n istio-system secret sh.helm.release.v1.istio-kubeaddons.v1
 ```
 
-<p class="message--note"><strong>WARNING: </strong>
-As long as this secret exists, <code>helm list -n istio-system</code>
-will wrongly report existence of a Helm release called "istio-kubeaddons".
-If you manipulate this "Helm release" using Helm, it may corrupt the Istio
-Platform Application in Kommander, potentially disrupting operation of
-Istio workloads.
-</p>
-
 ## Gatekeeper
 
-If Gatekeeper is installed on the cluster, the upgrade leaves a Helm Secret,
-Deployments, and a Service that belonged to the 1.8 Gatekeeper Addon
-in the `kubeaddons` namespace.
+If Gatekeeper is installed on the cluster, the upgrade leaves a Helm Secret, Deployments, and a Service that belonged to the 1.8 Gatekeeper addon in the `kubeaddons` namespace.
 
-**WARNING:** As long as the secret exists, `helm list -n kubeaddons`
-will incorrectly report the existence of a Helm release called "gatekeeper-kubeaddons".
-If you manipulate this "Helm release" using Helm, it may corrupt the Gatekeeper
-Platform Application in Kommander, potentially making Kubernetes on the cluster
-inoperable.
+<p class="message--note"><strong>WARNING: </strong>As long as the secret exists, `helm list -n kubeaddons` will incorrectly report the existence of a "gatekeeper-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it may corrupt the Gatekeeper Platform Application in Kommander, potentially making Kubernetes on the cluster inoperable.</p>
 
-Delete these objects using `kubectl`:
+Delete these objects using the `kubectl`commands:
 
 ```sh
 kubectl delete -n kubeaddons secret sh.helm.release.v1.gatekeeper-kubeaddons.v1
@@ -76,10 +56,5 @@ kubectl delete -n kubeaddons service gatekeeper-webhook-service
 
 ```
 
-<p class="message--note"><strong>WARNING: </strong>
-As long as the secret exists, <code>helm list -n kubeaddons</code>
-will wrongly report existence of a Helm release called "gatekeeper-kubeaddons".
-If you manipulate this "Helm release" using Helm, it may corrupt the Gatekeeper
-Platform Application in Kommander, potentially making Kubernetes on the cluster
-inoperable.
-</p>
+<p class="message--note"><strong>WARNING: </strong>As long as the secret exists, <code>helm list -n kubeaddons</code>
+will wrongly report existence of a "gatekeeper-kubeaddons" Helm release. If you manipulate this "Helm release" using Helm, it may corrupt the Gatekeeper Platform Application in Kommander, potentially making Kubernetes on the cluster inoperable.</p>


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## [Jira Ticket]. (https://jira.d2iq.com/browse/D2IQ-81520)

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

While the changes requested in this ticket had mostly been made already, there were some writing changes that needed to be made for this to be properly ready for customers. That's done now, and the substantive command and output changes verified. Should be a slam dunk. Also had to add "istio" to the list of Vale's accepted terms to get the commit to work.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
