### PR TITLE
Add install instructions for the workspace catalog repo

### DIFF
--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
@@ -25,6 +25,8 @@ Catalog applications are any third-party or open source applications that appear
     metadata:
       name: dkp-catalog-applications
       namespace: ${WORKSPACE_NAMESPACE}
+      labels:
+        kommander.d2iq.io/gitapps-gitrepository-type: catalog
     spec:
       interval: 1m0s
       ref:

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/index.md
@@ -8,6 +8,38 @@ excerpt: Workspace Catalog Applications
 <!-- TODO: settle down the link target to custom applications -->
 Catalog applications are any third-party or open source applications that appear in the Catalog. These applications can be provided by D2iQ for use in your environment.
 
+## Installing the workspace catalog via the CLI
+
+1.  Set the `WORKSPACE_NAMESPACE` environment variable to the name of your workspace’s namespace:
+
+    ```bash
+    export WORKSPACE_NAMESPACE=<workspace namespace>
+    ```
+
+1.  Create the `GitRepository`:
+
+    ```sh
+    kubectl apply -f - <<EOF
+    apiVersion: source.toolkit.fluxcd.io/v1beta1
+    kind: GitRepository
+    metadata:
+      name: dkp-catalog-applications
+      namespace: ${WORKSPACE_NAMESPACE}
+    spec:
+      interval: 1m0s
+      ref:
+        branch: main
+      timeout: 20s
+      url: https://github.com/mesosphere/dkp-catalog-applications  
+    EOF
+    ```
+
+1.  You should now see the workspace catalog `Apps` available in the UI and CLI
+
+    ```bash
+    kubectl get apps -n ${WORKSPACE_NAMESPACE}
+    ```
+
 ## Workspace catalog applications
 
 | NAME                          | APP ID                |


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

Adding docs about how to install the workspace catalog since this will be a manual task for now until https://jira.d2iq.com/browse/D2IQ-79950 is resolved. I just don't want this to get lost!

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
