### PR TITLE
Add ZooKeeper operator docs (2.1.1)

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -117,3 +117,6 @@ unmount(|ing|ed)
 Velero
 XGBoost
 yakcl
+Zookeeper
+zookeeper
+ZooKeeper

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -16,6 +16,8 @@ A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/
 
 ### Example deployment
 
+This example deployment walks you through deploying a ZooKeeper cluster in a project namespace. After following the steps below, you should have a running ZooKeeper cluster ready for use in your project's namespace.
+
 1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
 
     ```bash
@@ -60,3 +62,9 @@ A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/
     ```bash
     kubectl -n ${PROJECT_NAMESPACE} delete zookeepercluster <name of zookeepercluster>
     ```
+
+## Resources
+
+- [ZooKeeper Operator Documentation](https://github.com/pravega/zookeeper-operator)
+- [ZooKeeper Cluster Helm Chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper)
+- [ZooKeeper Documentation](https://zookeeper.apache.org/documentation)

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -6,7 +6,7 @@ menuWeight: 5
 excerpt: Deploying ZooKeeper in a project
 ---
 
-## Getting Started
+## Getting started
 
 To get started with creating ZooKeeper clusters in your project namespace, you first need to deploy the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/zookeeper-operator/) in the workspace where the project exists.
 
@@ -14,7 +14,7 @@ Once you have the ZooKeeper operator deployed, you can create ZooKeeper Clusters
 
 A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper) exists in the ZooKeeper operator repository that can assist with deploying ZooKeeper clusters.
 
-### Example Deployment
+### Example deployment
 
 1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
 
@@ -36,7 +36,18 @@ A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/
     EOF
     ```
 
-## Deleting ZooKeeper Clusters
+1.  Check the status of your ZooKeeper cluster using `kubectl`:
+
+    ```bash
+    kubectl get zk
+    ```
+
+    ```text
+    NAME        REPLICAS   READY REPLICAS    VERSION   DESIRED VERSION   INTERNAL ENDPOINT    EXTERNAL ENDPOINT   AGE
+    zookeeper   3          3                 0.2.13    0.2.13            10.100.200.18:2181   N/A                 94s
+    ```
+
+## Deleting ZooKeeper clusters
 
 1.  View `ZookeeperClusters` in all namespaces:
 
@@ -44,7 +55,7 @@ A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/
     kubectl get zookeeperclusters -A
     ```
 
-1.  Deleting a specific `ZookeeperCluster`:
+1.  Delete a specific `ZookeeperCluster`:
 
     ```bash
     kubectl -n ${PROJECT_NAMESPACE} delete zookeepercluster <name of zookeepercluster>

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -1,0 +1,51 @@
+---
+layout: layout.pug
+navigationTitle: ZooKeeper
+title: ZooKeeper
+menuWeight: 5
+excerpt: Deploying ZooKeeper in a project
+---
+
+## Getting Started
+
+To get started with creating ZooKeeper clusters in your project namespace, you first need to deploy the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/zookeeper-operator/) in the workspace where the project exists.
+
+Once you have the ZooKeeper operator deployed, you can create ZooKeeper Clusters by applying a `ZookeeperCluster` custom resource in a project's namespace.
+
+A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper) exists in the ZooKeeper operator repository that can assist with deploying ZooKeeper clusters.
+
+### Example Deployment
+
+1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
+
+    ```bash
+    export PROJECT_NAMESPACE=<project namespace>
+    ```
+
+1.  Create a ZooKeeper Cluster custom resource in your project namespace
+
+    ```yaml
+    kubectl apply -f - <<EOF
+    apiVersion: zookeeper.pravega.io/v1beta1
+    kind: ZookeeperCluster
+    metadata:
+      name: zookeeper
+      namespace: ${PROJECT_NAMESPACE}
+    spec:
+      replicas: 1
+    EOF
+    ```
+
+## Deleting ZooKeeper Clusters
+
+1.  View `ZookeeperClusters` in all namespaces:
+
+    ```bash
+    kubectl get zookeeperclusters -A
+    ```
+
+1.  Deleting a specific `ZookeeperCluster`:
+
+    ```bash
+    kubectl delete zookeepercluster <name of zookeepercluster>
+    ```

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -47,5 +47,5 @@ A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/
 1.  Deleting a specific `ZookeeperCluster`:
 
     ```bash
-    kubectl delete zookeepercluster <name of zookeepercluster>
+    kubectl -n ${PROJECT_NAMESPACE} delete zookeepercluster <name of zookeepercluster>
     ```

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -10,13 +10,13 @@ excerpt: Deploying ZooKeeper in a project
 
 To get started with creating ZooKeeper clusters in your project namespace, you first need to deploy the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/zookeeper-operator/) in the workspace where the project exists.
 
-Once you have the ZooKeeper operator deployed, you can create ZooKeeper Clusters by applying a `ZookeeperCluster` custom resource in a project's namespace.
+After you deploy the ZooKeeper operator, you can create ZooKeeper Clusters by applying a `ZookeeperCluster` custom resource in a project's namespace.
 
 A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper) exists in the ZooKeeper operator repository that can assist with deploying ZooKeeper clusters.
 
 ### Example deployment
 
-This example deployment walks you through deploying a ZooKeeper cluster in a project namespace. After following the steps below, you should have a running ZooKeeper cluster ready for use in your project's namespace.
+Follow these steps to deploy a ZooKeeper cluster in a project namespace. This procedure results in a running ZooKeeper cluster, ready for use in your project's namespace.
 
 1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
 
@@ -50,6 +50,8 @@ This example deployment walks you through deploying a ZooKeeper cluster in a pro
     ```
 
 ## Deleting ZooKeeper clusters
+
+Follow these steps to delete the Zookeeper clusters.
 
 1.  View `ZookeeperClusters` in all namespaces:
 

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -31,7 +31,7 @@ Uninstalling the ZooKeeper operator will not directly affect any running `Zookee
 1.  Uninstalling a ZooKeeper operator `AppDeployment`:
 
     ```bash
-    kubectl delete AppDeployment <name of AppDeployment>
+    kubectl -n <workspace namespace> delete AppDeployment <name of AppDeployment>
     ```
 
 1.  Removing ZooKeeper CRDs:

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -1,0 +1,59 @@
+---
+layout: layout.pug
+navigationTitle: ZooKeeper Operator
+title: ZooKeeper Operator
+menuWeight: 20
+excerpt: Information about the ZooKeeper Operator
+---
+
+## Overview
+
+[ZooKeeper](https://zookeeper.apache.org/index.html) is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services. The [ZooKeeper operator](https://github.com/pravega/zookeeper-operator) is a Kubernetes operator that handles the provisioning and management of ZooKeeper clusters. It works by watching custom resources, such as `ZookeeperClusters`, to provision the underlying Kubernetes resources (`StatefulSets`) required for a production-ready ZooKeeper Cluster.
+
+## Installation
+
+1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
+
+1.  Within the `AppDeployment`, update the `appRef` to specify the correct `zookeeper-operator` App. You can find the `appRef.name` by listing the available `Apps` in the workspace namespace:
+
+    ```bash
+    kubectl get apps -n ${WORKSPACE_NAMESPACE}
+    ```
+
+For details on custom configuration for the operator, please refer to the [ZooKeeper operator Helm Chart documentation](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper-operator#configuration).
+
+## Uninstall via the CLI
+
+Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperCluster`s. By default, the operator will wait for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you will need to manually clean up any leftover Custom Resource Definitions (CRDs).
+
+1.  View ZookeeperClusters in all namespaces:
+
+    ```bash
+    kubectl get zookeeperclusters -A
+    ```
+
+1.  Deleting a `ZookeeperCluster`:
+
+    ```bash
+    kubectl delete zookeepercluster <name of zookeepercluster>
+    ```
+
+1.  Uninstalling a ZooKeeper operator `AppDeployment`:
+
+    ```bash
+    kubectl delete AppDeployment <name of AppDeployment>
+    ```
+
+1.  Removing ZooKeeper CRDs:
+
+    <p class="message--warning"><strong>WARNING: </strong>Once you remove the CRDs, all deployed ZookeeperClusters will be deleted!</p>
+
+    ```bash
+    kubectl delete crds zookeeperclusters.zookeeper.pravega.io
+    ```
+
+## Resources
+
+- [ZooKeeper Operator Documentation](https://github.com/pravega/zookeeper-operator)
+- [ZooKeeper Cluster Helm Chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper)
+- [ZooKeeper Documentation](https://zookeeper.apache.org/)

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -12,7 +12,7 @@ excerpt: Information about the ZooKeeper Operator
 
 ## Install
 
-These install instructions describe how to install the ZooKeeper operator in a workspace. After following the install instructions, you will have the ZooKeeper operator running in a workspace namespace, ready to manage and create ZooKeeper clusters in any project namespaces. See the [ZooKeeper custom resource documentation](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/) for more information on creating ZooKeeper clusters.
+Follow these steps to install the ZooKeeper operator in a workspace. This procedure results in a ZooKeeper operator running in a workspace namespace, ready to manage and create ZooKeeper clusters in any project namespaces. See the [ZooKeeper custom resource documentation](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/) for more information on creating ZooKeeper clusters.
 
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
 
@@ -26,7 +26,7 @@ For details on custom configuration for the operator, please refer to the [ZooKe
 
 ## Uninstall via the CLI
 
-Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperClusters`. By default, the operator will wait for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you will need to manually clean up any leftover Custom Resource Definitions (CRDs).
+Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperClusters`. By default, the operator waits for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you need to manually clean up any leftover Custom Resource Definitions (CRDs).
 
 1.  Delete all `ZookeeperClusters`, see [Deleting ZooKeeper Clusters](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper#deleting-zookeeper-clusters).
 

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -26,17 +26,7 @@ For details on custom configuration for the operator, please refer to the [ZooKe
 
 Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperCluster`s. By default, the operator will wait for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you will need to manually clean up any leftover Custom Resource Definitions (CRDs).
 
-1.  View ZookeeperClusters in all namespaces:
-
-    ```bash
-    kubectl get zookeeperclusters -A
-    ```
-
-1.  Deleting a `ZookeeperCluster`:
-
-    ```bash
-    kubectl delete zookeepercluster <name of zookeepercluster>
-    ```
+1.  Delete all `ZookeeperCluster`'s, see [Deleting ZooKeeper Clusters](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper#deleting-zookeeper-clusters).
 
 1.  Uninstalling a ZooKeeper operator `AppDeployment`:
 

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -24,17 +24,17 @@ For details on custom configuration for the operator, please refer to the [ZooKe
 
 ## Uninstall via the CLI
 
-Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperCluster`s. By default, the operator will wait for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you will need to manually clean up any leftover Custom Resource Definitions (CRDs).
+Uninstalling the ZooKeeper operator will not directly affect any running `ZookeeperClusters`. By default, the operator will wait for any `ZookeeperClusters` to be deleted before it will fully uninstall (you can set `hooks.delete: true` in the application configuration to disable this behavior). After uninstalling the operator, you will need to manually clean up any leftover Custom Resource Definitions (CRDs).
 
-1.  Delete all `ZookeeperCluster`'s, see [Deleting ZooKeeper Clusters](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper#deleting-zookeeper-clusters).
+1.  Delete all `ZookeeperClusters`, see [Deleting ZooKeeper Clusters](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper#deleting-zookeeper-clusters).
 
-1.  Uninstalling a ZooKeeper operator `AppDeployment`:
+1.  Uninstall a ZooKeeper operator `AppDeployment`:
 
     ```bash
     kubectl -n <workspace namespace> delete AppDeployment <name of AppDeployment>
     ```
 
-1.  Removing ZooKeeper CRDs:
+1.  Remove ZooKeeper CRDs:
 
     <p class="message--warning"><strong>WARNING: </strong>Once you remove the CRDs, all deployed ZookeeperClusters will be deleted!</p>
 

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/zookeeper-operator/index.md
@@ -10,7 +10,9 @@ excerpt: Information about the ZooKeeper Operator
 
 [ZooKeeper](https://zookeeper.apache.org/index.html) is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services. The [ZooKeeper operator](https://github.com/pravega/zookeeper-operator) is a Kubernetes operator that handles the provisioning and management of ZooKeeper clusters. It works by watching custom resources, such as `ZookeeperClusters`, to provision the underlying Kubernetes resources (`StatefulSets`) required for a production-ready ZooKeeper Cluster.
 
-## Installation
+## Install
+
+These install instructions describe how to install the ZooKeeper operator in a workspace. After following the install instructions, you will have the ZooKeeper operator running in a workspace namespace, ready to manage and create ZooKeeper clusters in any project namespaces. See the [ZooKeeper custom resource documentation](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/zookeeper/) for more information on creating ZooKeeper clusters.
 
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
 
@@ -46,4 +48,4 @@ Uninstalling the ZooKeeper operator will not directly affect any running `Zookee
 
 - [ZooKeeper Operator Documentation](https://github.com/pravega/zookeeper-operator)
 - [ZooKeeper Cluster Helm Chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper)
-- [ZooKeeper Documentation](https://zookeeper.apache.org/)
+- [ZooKeeper Documentation](https://zookeeper.apache.org/documentation)


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-82302

## Description of changes being made

Adding docs about the zookeeper operator in the workspace catalog.

The original PR was already approved https://github.com/mesosphere/dcos-docs-site/pull/3961 but I had to create a new branch/PR because the new release-2.1.1 branch is based on `main`

## Checklist

- [ ] Copy this page to 2.2

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
