### PR TITLE
Add Kafka operator docs (2.1.1)

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -136,3 +136,4 @@ yakcl
 Zookeeper
 zookeeper
 ZooKeeper
+sed

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
@@ -8,8 +8,7 @@ excerpt: Deploying Kafka in a project
 
 ## Getting started
 
-<!-- TODO: Fix ZooKeeper operator link - this relies on the zookeeper docs being available in order to pass pre-commit -->
-To get started with creating and managing a Kafka Cluster in a project, you first need to deploy the [Kafka operator](../../../../../workspaces/applications/catalog-applications/kafka-operator/) and the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/) in the workspace where the project exists.
+To get started with creating and managing a Kafka Cluster in a project, you first need to deploy the [Kafka operator](../../../../../workspaces/applications/catalog-applications/kafka-operator/) and the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/zookeeper-operator/) in the workspace where the project exists.
 
 After deploying the Kafka operator, create Kafka Clusters by applying a `KafkaCluster` custom resource in a project's namespace. Refer to the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples) for examples of the custom resources and their configurations.
 

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
@@ -1,0 +1,87 @@
+---
+layout: layout.pug
+navigationTitle: Kafka
+title: Kafka
+menuWeight: 5
+excerpt: Deploying Kafka in a project
+---
+
+## Getting Started
+
+<!-- TODO: Fix ZooKeeper operator link - this relies on the zookeeper docs being available in order to pass pre-commit -->
+To get started with creating and managing a Kafka Cluster in a project, you first need to deploy the [Kafka operator](../../../../../workspaces/applications/catalog-applications/kafka-operator/) and the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/) in the workspace where the project exists.
+
+Once you have the Kafka operator deployed, you can create Kafka Clusters by applying a `KafkaCluster` custom resource in a project's namespace. You can find various examples of the custom resources and their configurations in the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples).
+
+## Example Deployment
+
+1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
+
+    ```bash
+    export PROJECT_NAMESPACE=<project namespace>
+    ```
+
+1.  Create a ZooKeeper Cluster custom resource in your project's namespace:
+
+    ```yaml
+    kubectl apply -f - <<EOF
+    apiVersion: zookeeper.pravega.io/v1beta1
+    kind: ZookeeperCluster
+    metadata:
+      name: zookeeper
+      namespace: ${PROJECT_NAMESPACE}
+    spec:
+      replicas: 1
+    EOF
+    ```
+
+1.  Download the [sample Kafka Cluster](https://raw.githubusercontent.com/banzaicloud/koperator/master/config/samples/simplekafkacluster.yaml) file.
+
+1.  Update the following attribute `zkAddresses`, replacing `zookeeper-client.zookeeper:2181` with `zookeeper-client.<project namespace>:2181`. You can use `sed` to update the file:
+
+    -   MacOS sed
+
+        ```bash
+        # If you are using sed that comes installed on macOS
+        sed -i '' "s/zookeeper-client.zookeeper:2181/zookeeper-client.${PROJECT_NAMESPACE}:2181/g" simplekafkacluster.yaml
+        ```
+
+    -   GNU sed
+
+        ```bash
+        # If you are using GNU sed
+        sed -i "s/zookeeper-client.zookeeper:2181/zookeeper-client.${PROJECT_NAMESPACE}:2181/g" simplekafkacluster.yaml
+        ```
+
+1.  The file should now contain the following line:
+
+    ```yaml
+    ...
+    zkAddresses:
+        - “zookeeper-client.<project namespace>:2181”
+    ...
+    ```
+
+1.  Apply the `KafkaCluster` to your project's namespace:
+
+    ```bash
+    kubectl apply -n ${PROJECT_NAMESPACE} -f simplekafkacluster.yaml
+    ```
+
+1.  Now that you have both the ZooKeeper cluster and Kafka cluster running in your project's namespace, you can find information on how to test and verify they are working as expected in the [Kafka Operator documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/test/)
+
+## Deleting Kafka Custom Resources
+
+1.  View all Kafka resources in the cluster:
+
+    ```bash
+    kubectl get kafkaclusters -A
+    kubectl get kafkausers -A
+    Kubectl get kafkatopics -A
+    ```
+
+1.  Deleting a `KafkaCluster` example:
+
+    ```bash
+    kubectl -n ${PROJECT_NAMESPACE} delete kafkacluster <name of KafkaCluster>
+    ```

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
@@ -11,11 +11,11 @@ excerpt: Deploying Kafka in a project
 <!-- TODO: Fix ZooKeeper operator link - this relies on the zookeeper docs being available in order to pass pre-commit -->
 To get started with creating and managing a Kafka Cluster in a project, you first need to deploy the [Kafka operator](../../../../../workspaces/applications/catalog-applications/kafka-operator/) and the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/) in the workspace where the project exists.
 
-After you deploy the Kafka operator, create Kafka Clusters by applying a `KafkaCluster` custom resource in a project's namespace. Refer to the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples) for examples of the custom resources and their configurations.
+After deploying the Kafka operator, create Kafka Clusters by applying a `KafkaCluster` custom resource in a project's namespace. Refer to the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples) for examples of the custom resources and their configurations.
 
 ## Example deployment
 
-This example deployment walks you through first deploying a ZooKeeper cluster and then a Kafka cluster in a project namespace. After following the steps below, you should have a running ZooKeeper cluster and Kafka cluster ready for use in your project's namespace.
+This example deployment walks you through first deploying a ZooKeeper cluster and then a Kafka cluster in a project namespace. The result of this procedure is a running ZooKeeper cluster and Kafka cluster ready for use in your project's namespace.
 
 1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
 
@@ -61,7 +61,7 @@ This example deployment walks you through first deploying a ZooKeeper cluster an
         sed -i "s/zookeeper-client.zookeeper:2181/zookeeper-client.${PROJECT_NAMESPACE}:2181/g" simplekafkacluster.yaml
         ```
 
-1.  The file should now contain the following line:
+1.  Verify the file contains the following line:
 
     ```yaml
     ...
@@ -85,6 +85,8 @@ This example deployment walks you through first deploying a ZooKeeper cluster an
 With both the ZooKeeper cluster and Kafka cluster running in your project's namespace, refer to the [Kafka Operator documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/test/) for information on how to test and verify they are working as expected in. When performing those steps, ensure you substitute: `zookeeper-client.<project namespace>:2181` anywhere that the zookeeper client address is mentioned.
 
 ## Deleting Kafka custom resources
+
+Follow these steps to delete the Kafka custom resources.
 
 1.  View all Kafka resources in the cluster:
 

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
@@ -6,14 +6,16 @@ menuWeight: 5
 excerpt: Deploying Kafka in a project
 ---
 
-## Getting Started
+## Getting started
 
 <!-- TODO: Fix ZooKeeper operator link - this relies on the zookeeper docs being available in order to pass pre-commit -->
 To get started with creating and managing a Kafka Cluster in a project, you first need to deploy the [Kafka operator](../../../../../workspaces/applications/catalog-applications/kafka-operator/) and the [ZooKeeper operator](../../../../../workspaces/applications/catalog-applications/) in the workspace where the project exists.
 
-Once you have the Kafka operator deployed, you can create Kafka Clusters by applying a `KafkaCluster` custom resource in a project's namespace. You can find various examples of the custom resources and their configurations in the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples).
+After you deploy the Kafka operator, create Kafka Clusters by applying a `KafkaCluster` custom resource in a project's namespace. Refer to the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples) for examples of the custom resources and their configurations.
 
-## Example Deployment
+## Example deployment
+
+This example deployment walks you through first deploying a ZooKeeper cluster and then a Kafka cluster in a project namespace. After following the steps below, you should have a running ZooKeeper cluster and Kafka cluster ready for use in your project's namespace.
 
 1.  Set the `PROJECT_NAMESPACE` environment variable to the name of your project’s namespace:
 
@@ -33,6 +35,12 @@ Once you have the Kafka operator deployed, you can create Kafka Clusters by appl
     spec:
       replicas: 1
     EOF
+    ```
+
+1.  Check the status of your ZooKeeper cluster using `kubectl`:
+
+    ```bash
+    kubectl -n ${PROJECT_NAMESPACE} get zookeeper
     ```
 
 1.  Download the [sample Kafka Cluster](https://raw.githubusercontent.com/banzaicloud/koperator/master/config/samples/simplekafkacluster.yaml) file.
@@ -68,9 +76,15 @@ Once you have the Kafka operator deployed, you can create Kafka Clusters by appl
     kubectl apply -n ${PROJECT_NAMESPACE} -f simplekafkacluster.yaml
     ```
 
-1.  Now that you have both the ZooKeeper cluster and Kafka cluster running in your project's namespace, you can find information on how to test and verify they are working as expected in the [Kafka Operator documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/test/)
+1.  Check the status of your Kafka cluster using `kubectl`:
 
-## Deleting Kafka Custom Resources
+    ```bash
+    kubectl -n ${PROJECT_NAMESPACE} get kafkaclusters 
+    ```
+
+1.  With both the ZooKeeper cluster and Kafka cluster running in your project's namespace, refer to the [Kafka Operator documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/test/) for information on how to test and verify they are working as expected in. When performing those steps, ensure you substitute: `zookeeper-client.<project namespace>:2181` anywhere that the zookeeper client address is mentioned.
+
+## Deleting Kafka custom resources
 
 1.  View all Kafka resources in the cluster:
 
@@ -80,8 +94,15 @@ Once you have the Kafka operator deployed, you can create Kafka Clusters by appl
     Kubectl get kafkatopics -A
     ```
 
-1.  Deleting a `KafkaCluster` example:
+1.  Delete a `KafkaCluster` example:
 
     ```bash
     kubectl -n ${PROJECT_NAMESPACE} delete kafkacluster <name of KafkaCluster>
     ```
+
+## Resources
+
+- [Kafka Operator Documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/)
+- [Kafka Operator GitHub Repository](https://github.com/banzaicloud/koperator)
+- [Sample Kafka Operator Custom Resources](https://github.com/banzaicloud/koperator/tree/master/config/samples)
+- [Apache Kafka Documentation](https://kafka.apache.org/documentation/)

--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/index.md
@@ -82,7 +82,7 @@ This example deployment walks you through first deploying a ZooKeeper cluster an
     kubectl -n ${PROJECT_NAMESPACE} get kafkaclusters 
     ```
 
-1.  With both the ZooKeeper cluster and Kafka cluster running in your project's namespace, refer to the [Kafka Operator documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/test/) for information on how to test and verify they are working as expected in. When performing those steps, ensure you substitute: `zookeeper-client.<project namespace>:2181` anywhere that the zookeeper client address is mentioned.
+With both the ZooKeeper cluster and Kafka cluster running in your project's namespace, refer to the [Kafka Operator documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/test/) for information on how to test and verify they are working as expected in. When performing those steps, ensure you substitute: `zookeeper-client.<project namespace>:2181` anywhere that the zookeeper client address is mentioned.
 
 ## Deleting Kafka custom resources
 

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
@@ -8,9 +8,11 @@ excerpt: Information about the Kafka Operator
 
 ## Overview
 
-[Apache Kafka](https://kafka.apache.org/) is an open-source distributed event streaming platform used for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications. The [Kafka Operator](https://banzaicloud.com/docs/supertubes/kafka-operator/) is a Kubernetes operator to automate provisioning, management, autoscaling, and operations of Apache Kafka clusters deployed to Kubernetes. It works by watching custom resources, such as `KafkaClusters`, `KafkaUsers`, and `KafkaTopics` to provision underlying Kubernetes resources (i.e `StatefulSets`) required for a production-ready Kafka Cluster.
+[Apache Kafka](https://kafka.apache.org/) is an open-source distributed event streaming platform used for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications. The [Kafka Operator](https://banzaicloud.com/docs/supertubes/kafka-operator/) is a Kubernetes operator to automate provisioning, management, autoscaling, and operations of Apache Kafka clusters deployed to Kubernetes. It works by watching custom resources, such as `KafkaClusters`, `KafkaUsers`, and `KafkaTopics`, to provision underlying Kubernetes resources (i.e `StatefulSets`) required for a production-ready Kafka Cluster.
 
 ## Install
+
+These install instructions describe how to install the Kafka operator in a workspace. After following the install instructions, you will have the Kafka operator running in a workspace namespace, ready to manage and create Kafka clusters in any project namespaces. See the [Kafka custom resource documentation](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/) for more information on creating Kafka clusters.
 
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
 
@@ -20,22 +22,22 @@ excerpt: Information about the Kafka Operator
     kubectl get apps -n ${WORKSPACE_NAMESPACE}
     ```
 
-For details on custom configuration for the operator, please refer to the [Kafka operator Helm Chart documentation](https://github.com/banzaicloud/koperator/tree/master/charts/kafka-operator#configuration).
+Refer to the [Kafka operator Helm Chart documentation](https://github.com/banzaicloud/koperator/tree/master/charts/kafka-operator#configuration) for details on custom configuration for the operator.
 
 ## Uninstall via the CLI
 
-Uninstalling the Kafka operator will not affect existing `KafkaCluster` deployments. After uninstalling the operator, you will need to manually remove any leftover Custom Resource Definitions (CRDs) from the operator.
+Uninstalling the Kafka operator does not affect existing `KafkaCluster` deployments. After uninstalling the operator, you must manually remove any remaining Custom Resource Definitions (CRDs) from the operator.
 
-1.  Delete all Kafka custom resources that are deployed, see [Deleting Kafka Custom Resources](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka#deleting-kafka-custom-resources).
+1.  Delete all Kafka custom resources that are deployed (see [Deleting Kafka Custom Resources](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka#deleting-kafka-custom-resources)).
 
-1.  Uninstalling a Kafka operator `AppDeployment`:
+1.  Uninstall a Kafka operator `AppDeployment`:
 
     ```bash
     kubectl -n <workspace namespace> delete AppDeployment <name of AppDeployment>
     ```
 
-1.  Removing Kafka CRDs:
-    <p class="message--note"><strong>NOTE: </strong>the CRDs are not finalized for deletion until you delete the associated custom resources.</p>
+1.  Remove Kafka CRDs:
+    <p class="message--note"><strong>NOTE: </strong>The CRDs are not finalized for deletion until you delete the associated custom resources.</p>
 
     ```bash
     kubectl delete crds kafkaclusters.kafka.banzaicloud.io kafkausers.kafka.banzaicloud.io kafkatopics.kafka.banzaicloud.io
@@ -46,4 +48,4 @@ Uninstalling the Kafka operator will not affect existing `KafkaCluster` deployme
 - [Kafka Operator Documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/)
 - [Kafka Operator GitHub Repository](https://github.com/banzaicloud/koperator)
 - [Sample Kafka Operator Custom Resources](https://github.com/banzaicloud/koperator/tree/master/config/samples)
-- [Apache Kafka Documentation](https://kafka.apache.org/)
+- [Apache Kafka Documentation](https://kafka.apache.org/documentation/)

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
@@ -14,7 +14,7 @@ excerpt: Information about the Kafka Operator
 
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
 
-1.  Within the `AppDeployment`, update the `appRef` to specify the correct `zookeeper-operator` App. You can find the `appRef.name` by listing the available `Apps` in the workspace namespace:
+1.  Within the `AppDeployment`, update the `appRef` to specify the correct `kafka-operator` App. You can find the `appRef.name` by listing the available `Apps` in the workspace namespace:
 
     ```bash
     kubectl get apps -n ${WORKSPACE_NAMESPACE}
@@ -26,24 +26,12 @@ For details on custom configuration for the operator, please refer to the [Kafka
 
 Uninstalling the Kafka operator will not affect existing `KafkaCluster` deployments. After uninstalling the operator, you will need to manually remove any leftover Custom Resource Definitions (CRDs) from the operator.
 
-1.  View all Kafka resources in the cluster:
-
-    ```bash
-    kubectl get kafkaclusters -A
-    kubectl get kafkausers -A
-    Kubectl get kafkatopics -A
-    ```
-
-1.  Deleting a `KafkaCluster`:
-
-    ```bash
-    kubectl delete kafkacluster <name of KafkaCluster>
-    ```
+1.  Delete all Kafka custom resources that are deployed, see [Deleting Kafka Custom Resources](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka#deleting-kafka-custom-resources).
 
 1.  Uninstalling a Kafka operator `AppDeployment`:
 
     ```bash
-    kubectl delete AppDeployment <name of AppDeployment>
+    kubectl -n <workspace namespace> delete AppDeployment <name of AppDeployment>
     ```
 
 1.  Removing Kafka CRDs:

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
@@ -1,0 +1,61 @@
+---
+layout: layout.pug
+navigationTitle: Kafka Operator
+title: Kafka Operator
+menuWeight: 20
+excerpt: Information about the Kafka Operator
+---
+
+## Overview
+
+[Apache Kafka](https://kafka.apache.org/) is an open-source distributed event streaming platform used for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications. The [Kafka Operator](https://banzaicloud.com/docs/supertubes/kafka-operator/) is a Kubernetes operator to automate provisioning, management, autoscaling, and operations of Apache Kafka clusters deployed to Kubernetes. It works by watching custom resources, such as `KafkaClusters`, `KafkaUsers`, and `KafkaTopics` to provision underlying Kubernetes resources (i.e `StatefulSets`) required for a production-ready Kafka Cluster.
+
+## Installation
+
+1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
+
+1.  Within the `AppDeployment`, update the `appRef` to specify the correct `zookeeper-operator` App. You can find the `appRef.name` by listing the available `Apps` in the workspace namespace:
+
+    ```bash
+    kubectl get apps -n ${WORKSPACE_NAMESPACE}
+    ```
+
+For details on custom configuration for the operator, please refer to the [Kafka operator Helm Chart documentation](https://github.com/banzaicloud/koperator/tree/master/charts/kafka-operator#configuration).
+
+## Uninstall via the CLI
+
+Uninstalling the Kafka operator will not affect existing `KafkaCluster` deployments. After uninstalling the operator, you will need to manually remove any leftover Custom Resource Definitions (CRDs) from the operator.
+
+1.  View all Kafka resources in the cluster:
+
+    ```bash
+    kubectl get kafkaclusters -A
+    kubectl get kafkausers -A
+    Kubectl get kafkatopics -A
+    ```
+
+1.  Deleting a `KafkaCluster`:
+
+    ```bash
+    kubectl delete kafkacluster <name of KafkaCluster>
+    ```
+
+1.  Uninstalling a Kafka operator `AppDeployment`:
+
+    ```bash
+    kubectl delete AppDeployment <name of AppDeployment>
+    ```
+
+1.  Removing Kafka CRDs:
+    <p class="message--note"><strong>NOTE: </strong>the CRDs are not finalized for deletion until you delete the associated custom resources.</p>
+
+    ```bash
+    kubectl delete crds kafkaclusters.kafka.banzaicloud.io kafkausers.kafka.banzaicloud.io kafkatopics.kafka.banzaicloud.io
+    ```
+
+## Resources
+
+- [Kafka Operator Documentation](https://banzaicloud.com/docs/supertubes/kafka-operator/)
+- [Kafka Operator GitHub Repository](https://github.com/banzaicloud/koperator)
+- [Sample Kafka Operator Custom Resources](https://github.com/banzaicloud/koperator/tree/master/config/samples)
+- [Apache Kafka Documentation](https://kafka.apache.org/)

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
@@ -10,7 +10,7 @@ excerpt: Information about the Kafka Operator
 
 [Apache Kafka](https://kafka.apache.org/) is an open-source distributed event streaming platform used for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications. The [Kafka Operator](https://banzaicloud.com/docs/supertubes/kafka-operator/) is a Kubernetes operator to automate provisioning, management, autoscaling, and operations of Apache Kafka clusters deployed to Kubernetes. It works by watching custom resources, such as `KafkaClusters`, `KafkaUsers`, and `KafkaTopics` to provision underlying Kubernetes resources (i.e `StatefulSets`) required for a production-ready Kafka Cluster.
 
-## Installation
+## Install
 
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
 

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/kafka-operator/index.md
@@ -12,7 +12,7 @@ excerpt: Information about the Kafka Operator
 
 ## Install
 
-These install instructions describe how to install the Kafka operator in a workspace. After following the install instructions, you will have the Kafka operator running in a workspace namespace, ready to manage and create Kafka clusters in any project namespaces. See the [Kafka custom resource documentation](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/) for more information on creating Kafka clusters.
+Follow these steps to install the Kafka operator in a workspace. This procedure results in a Kafka operator running in a workspace namespace, ready to manage and create Kafka clusters in any project namespaces. See the [Kafka custom resource documentation](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka/) for more information on creating Kafka clusters.
 
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../application-deployment/) page.
 
@@ -28,7 +28,7 @@ Refer to the [Kafka operator Helm Chart documentation](https://github.com/banzai
 
 Uninstalling the Kafka operator does not affect existing `KafkaCluster` deployments. After uninstalling the operator, you must manually remove any remaining Custom Resource Definitions (CRDs) from the operator.
 
-1.  Delete all Kafka custom resources that are deployed (see [Deleting Kafka Custom Resources](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka#deleting-kafka-custom-resources)).
+1.  Delete all of the deployed Kafka custom resources (see [Deleting Kafka Custom Resources](../../../../projects/applications/catalog-applications/custom-resources-workspace-catalog/kafka#deleting-kafka-custom-resources)).
 
 1.  Uninstall a Kafka operator `AppDeployment`:
 


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-82301

## Description of changes being made

Adding docs about the kafka operator in the workspace catalog and kafka cluster deployments in projects.

## Checklist

- [ ]  Copy this page to 2.2 (needs #3956)
- [ ] Update link to ZooKeeper operator docs once they are merged


See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
