### PR TITLE
Konvoy2.1 - D2IQ-82072 Azure Installer: Add missing docs information

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -58,6 +58,7 @@ kmem
 Knative
 Kommander
 Konvoy
+kubeadm
 kubectl
 kubelet
 kubeconfig
@@ -107,6 +108,7 @@ sigmoidal
 softmax
 Splunk
 subcommand
+subnet
 subtree
 TensorFlow
 Thanos

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -117,5 +117,6 @@ Traefik
 uncordon(|ed)
 unmount(|ing|ed)
 Velero
+(vnet|VNET)
 XGBoost
 yakcl

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -25,8 +25,8 @@ DC/OS
 dcos
 Dex
 Dispatch
-DKP
-dkp
+(dkp|DKP)
+(docker|Docker)
 Dockerfile
 DKLB
 DSL(|s)
@@ -42,11 +42,9 @@ Horovod
 hostname
 hotfix(|es)
 hyperparameter(|s)
-HTTP
-HTTPS
-https
-istio
-Istio
+(http|HTTP)
+(https|HTTPS)
+(istio|Istio)
 (json|JSON)
 Kafka
 Kaptain

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -42,8 +42,8 @@ Horovod
 hostname
 hotfix(|es)
 hyperparameter(|s)
-(http|HTTP)
-(https|HTTPS)
+http
+https
 Istio
 (json|JSON)
 Kafka

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -53,8 +53,7 @@ Keras
 keypair
 keyspace
 Kibana
-KIND
-kind
+(kind|KIND)
 kmem
 Knative
 Kommander

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -3,7 +3,7 @@ addon
 Airflow
 Alertmanager
 ANN(|s)
-Ansible
+(ansible|Ansible)
 autoscal(e|es|ed|ing)
 Cassandra
 checkpoint(|s|ed|ing)
@@ -42,7 +42,8 @@ Horovod
 hostname
 hotfix(|es)
 hyperparameter(|s)
-https
+(http|HTTP)
+(https|HTTPS)
 Istio
 (json|JSON)
 Kafka

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/bootstrap/index.md
@@ -18,13 +18,15 @@ Before you begin, you must:
 
 ## Bootstrap Cluster Lifecycle Services
 
-1.  If an HTTP proxy is required for the bootstrap cluster, set the local `http_proxy`, `https_proxy`, and `no_proxy` environment variables. They are copied into the bootstrap cluster.
+1.  If an HTTP proxy is required for the bootstrap cluster, set the local `http_proxy`, `https_proxy`, and `no_proxy` environment variables. Konvoy copies them into the bootstrap cluster.
 
 1.  Create a bootstrap cluster:
 
     ```sh
     dkp create bootstrap --kubeconfig $HOME/.kube/config
     ```
+
+    The output appears similar to:
 
     ```sh
     INFO[2021-11-23T15:54:07-08:00] Creating bootstrap cluster                    src="bootstrap/bootstrap.go:148"
@@ -47,7 +49,7 @@ Before you begin, you must:
     INFO[2021-11-23T15:56:06-08:00] Created/Updated NVIDIA GPU Feature Discovery CustomResourceSet  src="bootstrap/clusterresourceset.go:302"
     ```
 
-    Konvoy creates a bootstrap cluster using [KIND][kind] as a library. Konvoy then deploys the following [Cluster API][capi_book] providers on the cluster:
+    Konvoy creates a bootstrap cluster using [KIND][kind] as a library, and then deploys the following [Cluster API][capi_book] providers on the cluster:
 
     - [Core Provider][capi]
     - [Azure Infrastructure Provider][capz]
@@ -59,6 +61,8 @@ Before you begin, you must:
     ```sh
     kubectl get --all-namespaces deployments -l=clusterctl.cluster.x-k8s.io
     ```
+
+    The output appears similar to
 
     ```sh
     NAMESPACE                           NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
@@ -73,11 +77,13 @@ Before you begin, you must:
     cert-manager                        cert-manager-webhook                            1/1     1            1           5m52s
     ```
 
-    Konvoy then creates additional resources for Cluster API to apply to every new cluster. The resources, called `ClusterResourceSets`, contain complete YAML manifests to deploy essential cluster applications, such as the [Calico][calico] Container Networking Interface (CNI) implementation, and Container Storage Interface (CSI) implementations for various infrastructure APIs. List ClusterResourceSets using this command:
+    Konvoy then creates additional resources for Cluster API to apply to every new cluster. The resources, called `ClusterResourceSets`, contain complete YAML manifests to deploy essential cluster applications, such as the [Calico][calico] Container Networking Interface (CNI) implementation, and Container Storage Interface (CSI) implementations for various infrastructure APIs. List the ClusterResourceSets using this command:
 
     ```sh
     kubectl get clusterresourceset
     ```
+
+    The output appears similar to:
 
     ```sh
     NAME                       AGE
@@ -90,9 +96,9 @@ Before you begin, you must:
     tigera-operator            5m38s
     ```
 
-    A ClusterResourceSet object defines selectors that match against cluster labels, and a reference to a ConfigMap. The ConfigMap contains a YAML manifest. When a cluster with matching labels is created, the YAML manifest is applied to the cluster. The manifest is applied only once, when the cluster is created.
+    A ClusterResourceSet object defines selectors that match against cluster labels, and a reference to a ConfigMap. The ConfigMap contains a YAML manifest. When Konvoy creates a cluster with matching labels, it applies the YAML manifest to the cluster. Konvoy applies the manifest only once, during cluster creation.
 
-    For example, this is the `azure-disk-csi` ClusterResourceSet, which is now deployed by Konvoy from the above actions:
+    For example, this is the `azure-disk-csi` ClusterResourceSet, deployed by Konvoy from the actions described previously:
 
     ```yaml
     kind: ClusterResourceSet

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/certificate_renewal/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/certificate_renewal/index.md
@@ -9,13 +9,13 @@ enterprise: false
 
 ## Certificate Renewal
 
-During cluster creation, Kubernetes establishes a Public Key Infrastructure (PKI) for generating the TLS certificates needed for securing cluster communication for various components such as `etcd`, `kubernetes-apiserver` and `front-proxy`. The certificates created by these components have a default expiration of one year and are renewed when an administrator updates the cluster.
+During cluster creation, Kubernetes establishes a Public Key Infrastructure (PKI) for generating the TLS certificates needed for securing cluster communication for various components such as `etcd`, `kubernetes-apiserver` and `front-proxy`. The certificates created by these components have a default expiration of one year, and are renewed when an administrator updates the cluster.
 
 Kubernetes provides a facility to renew all certificates automatically during control plane updates. For administrators who need long-running clusters or clusters that are not upgraded often, `dkp` provides automated certificate renewal, without a cluster upgrade.
 
 ### Requirements
 
-This feature requires Python 3.5 or greater to be installed on all control plane hosts.
+This feature requires that you install Python 3.5 or greater on all control plane hosts.
 
 ## Prerequisites
 
@@ -31,11 +31,11 @@ To enable the automated certificate renewal, create a Konvoy cluster using the `
 dkp create cluster azure --certificate-renew-interval=60 --cluster-name=long-running
 ```
 
-The `certificate-renew-interval` is the number of days after which Kubernetes-managed PKI certificates will be renewed. For example, an `certificate-renew-interval` value of 30 means the certificates will be renewed every 30 days.
+The `certificate-renew-interval` is the number of days after which Kubernetes-managed PKI certificates will be renewed. For example, a `certificate-renew-interval` value of "30" means that Kubernetes renews the certificates every 30 days.
 
 ### Technical details
 
-The following manifests are modified on the control plane hosts, and are located at `/etc/kubernetes/manifests`. Modifications to these files requires SUDO access.
+The renewal processing modifies the following manifests on the control plane hosts, located at `/etc/kubernetes/manifests`. Modifications to these files require SUDO access.
 
 ```sh
 kube-controller-manager.yaml
@@ -52,7 +52,7 @@ metadata:
     konvoy.d2iq.io/restartedAt: $(date +%s)
 ```
 
-This only occurs when the PKI certificates are older than the interval given at cluster creation time. This is activated by a `systemd` `timer` called `renew-certs.timer` that triggers an associated `systemd` service called `renew-certs.service` that runs on all of the control plane hosts.
+The renewal processing only occurs when the PKI certificates are older than the interval given at cluster creation time. The process is activated by a `systemd` `timer` called `renew-certs.timer` that triggers an associated `systemd` service called `renew-certs.service` that runs on all of the control plane hosts.
 
 ### Debugging
 
@@ -62,7 +62,7 @@ To debug the automatic certificate renewal feature, a cluster administrator can 
 kubectl get pod -n kube-system kube-scheduler-ip-10-0-xx-xx.us-west-2.compute.internal -o yaml
 ```
 
-The output of the command will be similar to the following:
+The output appears similar to:
 
 ```yaml
 apiVersion: v1
@@ -72,7 +72,7 @@ metadata:
     konvoy.d2iq.io/restartedAt: "1626124940.735733"
 ```
 
-Administrators who want more details on the execution of the `systemd` service can use `ssh` to connect to the control plane hosts, and then use the `systemctl` and `journalctl` commands that follow to help diagnose potential issues.
+Administrators who want more details on the execution of the `systemd` service can use `ssh` to connect to the control plane hosts, and then use the following `systemctl` and `journalctl` commands to help diagnose potential issues.
 
 To check the status of the timers, when they last ran, and when they are scheduled to run next, use the command:
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/delete/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/delete/index.md
@@ -15,13 +15,15 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
 
 1.  Create a bootstrap cluster:
 
-    The bootstrap cluster will host the Cluster API controllers that reconcile the cluster objects marked for deletion:
+    The bootstrap cluster hosts the Cluster API controllers that reconcile the cluster objects marked for deletion:
 
     <p class="message--note"><strong>NOTE: </strong>To avoid using the wrong kubeconfig, the following steps use explicit kubeconfig paths and contexts.</p>
 
     ```sh
     dkp create bootstrap --kubeconfig $HOME/.kube/config
     ```
+
+    The output appears similar to:
 
     ```sh
     INFO[2021-11-23T15:54:07-08:00] Creating bootstrap cluster                    src="bootstrap/bootstrap.go:148"
@@ -55,6 +57,8 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
         --to-context kind-konvoy-capi-bootstrapper
     ```
 
+    The output appears similar to:
+
     ```sh
     INFO[2021-06-09T11:47:11-07:00] Running pivot command                         fromClusterKubeconfig=azure-example.conf fromClusterContext= src="move/move.go:83" toClusterKubeconfig=/home/clusteradmin/.kube/config toClusterContext=
     INFO[2021-06-09T11:47:36-07:00] Pivot operation complete.                     src="move/move.go:108"
@@ -66,6 +70,8 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
     ```sh
     dkp describe cluster --kubeconfig $HOME/.kube/config -c ${CLUSTER_NAME}
     ```
+
+    The output appears similar to:
 
     ```text
     NAME                                                                       READY  SEVERITY  REASON  SINCE  MESSAGE
@@ -88,13 +94,15 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
     kubectl --kubeconfig $HOME/.kube/config wait --for=condition=controlplaneready "clusters/${CLUSTER_NAME}" --timeout=60m
     ```
 
+    The output appears similar to:
+
     ```sh
     cluster.cluster.x-k8s.io/my-azure-example condition met
     ```
 
 ## Delete the workload cluster
 
-1.  Make sure your Azure credentials are up to date. Refresh the credentials using this command:
+1.  Make sure your Azure credentials are up-to-date. Refresh the credentials using this command:
 
     ```sh
     dkp update bootstrap credentials azure --kubeconfig $HOME/.kube/config
@@ -109,6 +117,8 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
     dkp delete cluster --cluster-name=${CLUSTER_NAME} --kubeconfig $HOME/.kube/config
     ```
 
+    The output appears similar to:
+
     ```sh
     INFO[2021-06-09T11:53:42-07:00] Running cluster delete command                clusterName=my-azure-example managementClusterKubeconfig= namespace=default src="cluster/delete.go:95"
     INFO[2021-06-09T11:53:42-07:00] Waiting for cluster to be fully deleted       src="cluster/delete.go:123"
@@ -122,6 +132,8 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
 ```sh
 dkp delete bootstrap --kubeconfig $HOME/.kube/config
 ```
+
+The output appears similar to:
 
 ```sh
 INFO[2021-06-09T12:15:20-07:00] Deleting bootstrap cluster                    src="bootstrap/bootstrap.go:182"

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/explore/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/explore/index.md
@@ -7,7 +7,7 @@ excerpt: Learn to interact with your Kubernetes cluster
 enterprise: false
 ---
 
-This guide explains how to use the command line to interact with your newly deployed Kubernetes cluster.
+This guide explains how to use the command line to interact with your newly-deployed Kubernetes cluster.
 
 Before you start, make sure you have created a workload cluster, as described in [Create a New Cluster][createnewcluster].
 
@@ -15,7 +15,7 @@ Before you start, make sure you have created a workload cluster, as described in
 
 1.  Get a kubeconfig file for the workload cluster:
 
-    When the workload cluster is created, the cluster lifecycle services generate a kubeconfig file for the workload cluster, and write it to a _Secret_. The kubeconfig file is scoped to the cluster administrator.
+    When the workload cluster is created, the cluster lifecycle services generate a kubeconfig file for the workload cluster, and writes it to a _Secret_. The kubeconfig file is scoped to the cluster administrator.
 
     Get the kubeconfig from the _Secret_, and write it to a file, using this command:
 
@@ -29,19 +29,23 @@ Before you start, make sure you have created a workload cluster, as described in
     kubectl --kubeconfig=${CLUSTER_NAME}.conf get nodes
     ```
 
+    The output appears similar to:
+
     ```sh
     NAME                                   STATUS   ROLES                  AGE     VERSION
     my-azure-cluster-control-plane-t6pzx   Ready    control-plane,master   8m17s   v1.21.6
     my-azure-cluster-md-0-hvg4b            Ready    <none>                 6m17s   v1.21.6
     ```
 
-    <p class="message--note"><strong>NOTE: </strong>It may take a few minutes for the Status to move to <code>Ready</code> while the Pod network is deployed. The Nodes' Status should change to Ready soon after the <code>calico-node</code> DaemonSet Pods are Ready.</p>
+    <p class="message--note"><strong>NOTE: </strong>It may take a few minutes for the Status to move to <code>Ready</code> while the Pod network is deployed. The Node's Status should change to Ready soon after the <code>calico-node</code> DaemonSet Pods are Ready.</p>
 
 1.  List the Pods using this command:
 
     ```sh
     kubectl --kubeconfig=${CLUSTER_NAME}.conf get --all-namespaces pods
     ```
+
+    The output appears similar to:
 
     ```sh
     NAMESPACE                           NAME                                                                 READY   STATUS    RESTARTS   AGE

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/new/index.md
@@ -67,7 +67,7 @@ Be sure also that you review the [known limitations section](../new#known-limita
 
 This procedure uses the `--dry-run` and `--output-yaml` flags together to create basic Azure Kubernetes cluster objects in a YAML file. This approach allows you to examine the YAML objects before creating the actual Azure Kubernetes cluster itself.
 
-When creating the basic Azure Kubernetes cluster objects, you need to first consider whether you need to use an HTTP proxy.  If you do, you need to do some additional configuration when creating the cluster objects. Consult the optional "Configure the control plane and workers to use an HTTP Proxy" section for more details.
+When creating the basic Azure Kubernetes cluster objects, you need to first consider whether you need to use an HTTP proxy. If you do, you need to do some additional configuration when creating the cluster objects. Consult the optional "Configure the control plane and workers to use an HTTP Proxy" section for more details.
 
 1.  Generate the basic Kubernetes cluster objects:
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/new/index.md
@@ -23,18 +23,20 @@ enterprise: false
 
 ## Tips and Tricks
 
-1.  To create a cluster name that's unique, use the following command:
+1.  To create a cluster name that is unique, use the following command:
 
     ```sh
     CLUSTER_NAME=$(whoami)-azure-cluster-$(LC_CTYPE=C tr -dc 'a-z0-9' </dev/urandom | fold -w 5 | head -n1)
     echo $CLUSTER_NAME
     ```
 
+    The output appears similar to:
+
     ```text
     hunter-azure-cluster-pf4a3
     ```
 
-    This will create a unique name every time you run it, so use it with forethought.
+    This command creates a unique name every time you run it, so use it carefully.
 
 1.  Set the environment variable to the name you assigned this cluster:
 
@@ -53,7 +55,7 @@ enterprise: false
     > ${CLUSTER_NAME}.yaml
     ```
 
-1.  (Optional) To configure the Control Plane and Worker nodes to use an HTTP proxy:
+1.  (Optional) To configure the Control Plane and Worker nodes to use an HTTP proxy, copy these commands to an editor and apply the list of edits that follows to customize them before executing them from the command line:
 
     ```sh
     export CONTROL_PLANE_HTTP_PROXY=http://example.org:8080
@@ -66,13 +68,13 @@ enterprise: false
     ```
 
     - Replace `example.org,example.com,example.net` with your internal addresses
-    - `localhost` and `127.0.0.1` addesses should not use the proxy
+    - `localhost` and `127.0.0.1` addresses should not use the proxy
     - `10.96.0.0/12` is the default Kubernetes service subnet
     - `192.168.0.0/16` is the default Kubernetes pod subnet
     - `kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local` is the internal Kubernetes kube-apiserver service
     - `.svc,.svc.cluster,.svc.cluster.local` is the internal Kubernetes services
     - `169.254.169.254` is the Azure metadata server
-    - `.cloudapp.azure.com` is for the worker nodes to allow them to communicate directly to the kube-apiserver loadbalancer
+    - `.cloudapp.azure.com` is for the worker nodes to allow them to communicate directly to the kube-apiserver load balancer
 
 1.  (Optional) Create a Kubernetes cluster with HTTP proxy configured. This step assumes you did not already create a cluster in the previous steps:
 
@@ -91,7 +93,7 @@ enterprise: false
 
 1.  Inspect or edit the cluster objects:
 
-    <p class="message--note"><strong>NOTE: </strong>Familiarize yourself with Cluster API before editing the cluster objects as edits can prevent the cluster from deploying successfully.</p>
+    <p class="message--note"><strong>NOTE: </strong>Familiarize yourself with [Cluster API][capi_book] before editing the cluster objects as edits may prevent the cluster from deploying successfully.</p>
 
     The objects are [Custom Resources][k8s_custom_resources] defined by Cluster API components, and they belong in three different categories:
 
@@ -105,11 +107,11 @@ enterprise: false
 
     1.  Node Pool
 
-        A Node Pool is a collection of machines with identical properties. For example, a cluster might have one Node Pool with large memory capacity, another Node Pool with GPU support. Each Node Pool is described by three objects: The MachinePool references an object that describes the configuration of Kubernetes components (e.g., kubelet) deployed on each node pool machine, and an infrastructure-specific object that describes the properties of all node pool machines. Here, it references a _KubeadmConfigTemplate_, and an _AzureMachineTemplate_ object, which describes the instance type, the type of disk used, the size of the disk, among other properties.
+        A Node Pool is a collection of machines with identical properties. For example, a cluster might have one Node Pool with large memory capacity, another Node Pool with GPU support. Each Node Pool is described by three objects: The MachinePool references an object that describes the configuration of Kubernetes components (for example, the kubelet) deployed on each node pool machine, and an infrastructure-specific object that describes the properties of all node pool machines. Here, it references a _KubeadmConfigTemplate_, and an _AzureMachineTemplate_ object, which describes the instance type, the type of disk used, the size of the disk, among other properties.
 
     For in-depth documentation about the objects, read [Concepts][capi_concepts] in the Cluster API Book.
 
-1.  Create the cluster from the objects.
+1.  Create the cluster from the objects with the command:
 
     ```sh
     kubectl apply -f ${CLUSTER_NAME}.yaml
@@ -144,7 +146,7 @@ enterprise: false
     ```
 
     ```text
-    NAME                                                                       READY  SEVERITY  REASON  SINCE  MESSAGE
+    NAME                                                                 READY  SEVERITY  REASON  SINCE  MESSAGE
     /my-azure-cluster                                                    True                     6m37s
     ├─ClusterInfrastructure - AzureCluster/my-azure-cluster              True                     13m
     ├─ControlPlane - KubeadmControlPlane/my-azure-cluster-control-plane  True                     6m37s
@@ -203,3 +205,4 @@ Next, you can [Explore the New Cluster][explore-new-cluster].
 [explore-new-cluster]: ../explore
 [capi_concepts]: https://cluster-api.sigs.k8s.io/user/concepts.html
 [k8s_custom_resources]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+[capi_book]: https://cluster-api.sigs.k8s.io/

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/new/index.md
@@ -65,7 +65,9 @@ Be sure also that you review the [known limitations section](../new#known-limita
 
 ## Create new Azure Kubernetes cluster objects
 
-This procedure uses the `--dry-run` and `--output-yaml` flags together to create basic Azure Kubernetes cluster objects in a YAML file. This approach allows you to examine the YAML objects before creating the actual Azure Kubernetes cluster itself. For example, you may need to specify an HTTP proxy for your control plane and worker nodes. You could also configure the cluster to use your existing network infrastructure. If you need either of those additional configurations, skip to the relevant procedures _without_ executing this one.
+This procedure uses the `--dry-run` and `--output-yaml` flags together to create basic Azure Kubernetes cluster objects in a YAML file. This approach allows you to examine the YAML objects before creating the actual Azure Kubernetes cluster itself.
+
+When creating the basic Azure Kubernetes cluster objects, you need to first consider whether you need to use an HTTP proxy.  If you do, you need to do some additional configuration when creating the cluster objects. Consult the optional "Configure the control plane and workers to use an HTTP Proxy" section for more details.
 
 1.  Generate the basic Kubernetes cluster objects:
 
@@ -76,11 +78,11 @@ This procedure uses the `--dry-run` and `--output-yaml` flags together to create
     > ${CLUSTER_NAME}.yaml
     ```
 
-The output of this command is `${CLUSTER_NAME}.yaml` file that you can examine or modify. If you use this method to create a basic cluster without HTTP proxies or setting existing network infrastructure values, skip to the heading, "Inspect or edit the cluster objects."
+The output of this command is a `${CLUSTER_NAME}.yaml` file that you can examine or modify. If you use this method to create a basic cluster without HTTP proxies, skip to the heading, "Inspect or edit the cluster objects."
 
 ## (Optional) Configure the control plane and workers to use an HTTP Proxy
 
-This procedure uses the `--dry-run` and `--output-yaml` flags together to create basic Azure Kubernetes cluster objects in a YAML file. This approach allows you to examine the YAML objects before creating the actual Azure Kubernetes cluster itself. To configure the Control Plane and Worker nodes to use an HTTP proxy:
+To configure the Control Plane and Worker nodes to use an HTTP proxy:
 
 1.  Copy the commands in the following code block to an editor and apply the list of edits that follows to customize them, then execute them from the command line:
 
@@ -118,7 +120,7 @@ This procedure uses the `--dry-run` and `--output-yaml` flags together to create
     > ${CLUSTER_NAME}.yaml
     ```
 
-The output of this command is `${CLUSTER_NAME}.yaml` file that you can examine or modify further. If you are using this method to create your cluster without setting existing network infrastructure values, review the information under "Inspect or edit the cluster objects" and then go to "Create the actual Kubernetes cluster."
+The output of this command is a `${CLUSTER_NAME}.yaml` file that you can examine or modify further.
 
 ## Inspect or edit the cluster objects
 
@@ -142,9 +144,9 @@ The output of this command is `${CLUSTER_NAME}.yaml` file that you can examine o
 
     For in-depth documentation about the objects, read [Concepts][capi_concepts] in the Cluster API Book.
 
-## Configure existing network infrastructure in the cluster
+## (Optional) Configure existing network infrastructure in the cluster
 
-As part of inspecting and editing your cluster objects, you can also configure it to use existing network infrastructure.
+As part of inspecting and editing your cluster objects, you can also configure it to use existing network infrastructure. If you do not need to use an existing network infrastructure, you can skip this step.
 
 1.  Review the following AzureCluster excerpt, noting the entries under `networkSpec` for the apiServerLB, nodeOutboundLB, subnets, and vnet values:
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
@@ -8,7 +8,7 @@ enterprise: false
 menuWeight: 6
 ---
 
-This Quick Start guide provides simplified instructions for using Konvoy to get your Kubernetes cluster up and running with minimal configuration requirements on an Azure public cloud instances.
+This Quick Start guide provides simplified instructions for using Konvoy to get your Kubernetes cluster up and running with minimal configuration requirements on an Azure public cloud instance.
 
 ## Prerequisites
 
@@ -68,7 +68,7 @@ Before starting the Konvoy installation, verify that you have:
     export AZURE_CLIENT_SECRET='<password>' # Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C
     ```
 
-1.  Base64 encode the same environment variables:
+1.  Base64 encode those same environment variables:
 
     ```sh
     export AZURE_SUBSCRIPTION_ID_B64="$(echo -n "${AZURE_SUBSCRIPTION_ID}" | base64 | tr -d '\n')"
@@ -84,7 +84,7 @@ Before starting the Konvoy installation, verify that you have:
     ```sh
     CLUSTER_NAME=my-azure-cluster
 
-1.  Create a Kubernetes cluster:
+1.  Create a Kubernetes cluster, with the command:
 
     ```sh
     dkp create cluster azure \
@@ -93,7 +93,7 @@ Before starting the Konvoy installation, verify that you have:
     --self-managed
     ```
 
-    You will see output similar to the following:
+    The output appears similar to:
 
     ```text
     INFO[2021-11-16T12:27:38-06:00] Creating bootstrap cluster                    src="bootstrap/bootstrap.go:148"
@@ -107,22 +107,22 @@ Before starting the Konvoy installation, verify that you have:
     ```
 
     As part of the underlying processing, the DKP CLI:
-    - creates a bootstrap cluster
-    - creates a workload cluster
-    - moves CAPI controllers from the bootstrap cluster to the workload cluster, making it self-managed
-    - deletes the bootstrap cluster
+    - Creates a bootstrap cluster
+    - Creates a workload cluster
+    - Moves CAPI controllers from the bootstrap cluster to the workload cluster, making it self-managed
+    - Deletes the bootstrap cluster
 
 ## Explore the new Kubernetes cluster
 
 The kubeconfig file is written to your local directory and you can now explore the cluster.
 
-1.  List the Nodes with the command:
+1.  List the cluster's Nodes with the command:
 
     ```sh
     kubectl --kubeconfig=${CLUSTER_NAME}.conf get nodes
     ```
 
-    You will see output similar to:
+    The output appears similar to:
 
     ```sh
     NAME                                   STATUS   ROLES                  AGE     VERSION
@@ -141,7 +141,7 @@ The kubeconfig file is written to your local directory and you can now explore t
     kubectl --kubeconfig=${CLUSTER_NAME}.conf get pods -A
     ```
 
-    You will see output similar to:
+    The output appears similar to:
 
     ```text
     NAMESPACE                           NAME                                                                 READY   STATUS    RESTARTS   AGE
@@ -156,7 +156,7 @@ The kubeconfig file is written to your local directory and you can now explore t
 
 ## Delete the Kubernetes cluster and cleanup your environment
 
-1.  Delete the provisioned Kubernetes cluster and wait a few minutes:
+1.  Delete the provisioned Kubernetes cluster and wait a few minutes for the processing to complete:
 
     ```sh
     dkp delete cluster \

--- a/pages/dkp/konvoy/2.1/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
+++ b/pages/dkp/konvoy/2.1/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
@@ -8,6 +8,8 @@ enterprise: false
 menuWeight: 105
 ---
 
+## Overrides for AMI
+
 An HTTP proxy configuration can be used when creating your AMI image. The ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file and specify the following:
 
 ```yaml
@@ -19,4 +21,16 @@ export no_proxy: example.org,example.com,example.net
 
 ```
 
-These values are only used for the image creation. After the image is created, the ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file. The `dkp` command can be used to configure the `KubeadmConfigTemplate` object to create this file on bootup of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.
+These values are only used for the image creation. After the image is created, the Ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file. You can use the `dkp` command to configure the `KubeadmConfigTemplate` object to create this file on boot-up of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.
+
+## Overrides for Azure
+
+For Azure override files, you are defining variables for http_proxy, https_proxy and no_proxy in a YAML file, and providing values for each. The following sample file shows the structure as part of a simple `cat` command:
+
+```yaml
+cat <<EOF > overrides.yaml
+https_proxy: "http://10.0.64.5:3128"
+http_proxy: "http://10.0.64.5:3128"
+no_proxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
+EOF
+```

--- a/pages/dkp/konvoy/2.1/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
+++ b/pages/dkp/konvoy/2.1/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
@@ -8,29 +8,14 @@ enterprise: false
 menuWeight: 105
 ---
 
-## Overrides for AMI
+An HTTP proxy configuration can be used when creating your image. The Ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file like the following example, and specify the correct values for your environment:
 
-An HTTP proxy configuration can be used when creating your AMI image. The ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file and specify the following:
-
-```yaml
-# Example override-proxy.yaml
----
-export http_proxy: http://example.org:8080
-export https_proxy: http://example.org:8081
-export no_proxy: example.org,example.com,example.net
-
-```
-
-These values are only used for the image creation. After the image is created, the Ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file. You can use the `dkp` command to configure the `KubeadmConfigTemplate` object to create this file on boot-up of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.
-
-## Overrides for Azure
-
-For Azure override files, you are defining variables for http_proxy, https_proxy and no_proxy in a YAML file, and providing values for each. The following sample file shows the structure as part of a simple `cat` command:
-
-```yaml
+```sh
 cat <<EOF > overrides.yaml
 https_proxy: "http://10.0.64.5:3128"
 http_proxy: "http://10.0.64.5:3128"
 no_proxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
 EOF
 ```
+
+These values are only used for the image creation. After the image is created, the Ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file. You can use the `dkp` command to configure the `KubeadmConfigTemplate` object to create this file on boot-up of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## [Jira Ticket]

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[<!-- Link to JIRA ticket -->]

(https://jira.d2iq.com/browse/D2IQ-82072) 

## Description of changes being made
Adding information to help customer be able to add VNET, subnet and other network infrastructure to their Azure clusters. May not have time to put the override file for proxy and the private network info into this specific PR. If not, I will break those pieces out into other tickets.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
