### PR TITLE
konvoy: remove incorrect information about AWS_REGION env

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -25,12 +25,6 @@ Before you begin using Konvoy with AWS, you must:
 
 -   Create an [IAM policy configuration][iampolicies].
 
--   Export the AWS region where you want to deploy the cluster:
-
-    ```sh
-    export AWS_REGION=us-west-2
-    ```
-
 -   Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
 
     ```sh

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/prerequisites/index.md
@@ -22,12 +22,6 @@ Before you begin, you must have:
 
 1.  Follow the steps in [IAM Policy Configuration](../../iam-policies).
 
-1.  Export the AWS region where you want to deploy the cluster:
-
-    ```sh
-    export AWS_REGION=us-west-2
-    ```
-
 1.  Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
 
      ```sh

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
@@ -24,12 +24,6 @@ Before starting the Konvoy installation, verify that you have:
 
 1.  Follow the steps in [IAM Policy Configuration](../iam-policies).
 
-1.  Export the AWS region where you want to deploy the cluster:
-
-    ```sh
-    export AWS_REGION=us-west-2
-    ```
-
 1.  Export the AWS Profile with the credentials that you want to use to create the Kubernetes cluster:
 
     ```sh

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/eks/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/eks/advanced/prerequisites/index.md
@@ -25,12 +25,6 @@ Before you begin using Konvoy with AWS, you must:
 
 -   Create an [IAM policy configuration][iampolicies].
 
--   Export the AWS region where you want to deploy the cluster:
-
-    ```sh
-    export AWS_REGION=us-west-2
-    ```
-
 -   Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
 
     ```sh

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/eks/quick-start/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/eks/quick-start/index.md
@@ -27,12 +27,6 @@ Before starting the Konvoy installation, verify that you have:
 
 1.  Follow the steps in [IAM Policy Configuration](../../aws/iam-policies).
 
-1.  Export the AWS region where you want to deploy the EKS cluster:
-
-    ```sh
-    export AWS_REGION=us-west-2
-    ```
-
 1.  Export the AWS Profile with the credentials that you want to use to create the EKS Kubernetes cluster:
 
     ```sh


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/D2IQ-82104

## Description of changes being made

The information is incorrect, setting `AWS_REGION` will not change the region of the cluster and as of v2.1.1 no longer required to be set by the user.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
