### PR TITLE
docs: add generated kommander api docs in references for 2.1

### DIFF
--- a/pages/dkp/kommander/2.1/reference/dispatch/index.md
+++ b/pages/dkp/kommander/2.1/reference/dispatch/index.md
@@ -1,0 +1,8 @@
+---
+layout: layout.pug
+navigationTitle: dispatch.d2iq.io
+title: dispatch.d2iq.io
+menuWeight: 260
+excerpt: Review detailed Kommander API reference information
+beta: false
+---

--- a/pages/dkp/kommander/2.1/reference/dispatch/v1alpha2/index.md
+++ b/pages/dkp/kommander/2.1/reference/dispatch/v1alpha2/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
 navigationTitle: v1alpha2
-title: workspaces.kommander.mesosphere.io/v1alpha2
+title: dispatch.d2iq.io/v1alpha2
 menuWeight: 10
 notes: Automatically generated, DO NOT EDIT
 enterprise: false

--- a/pages/dkp/kommander/2.1/reference/dispatch/v1alpha2/index.md
+++ b/pages/dkp/kommander/2.1/reference/dispatch/v1alpha2/index.md
@@ -1,0 +1,62 @@
+---
+layout: layout.pug
+navigationTitle: v1alpha2
+title: workspaces.kommander.mesosphere.io/v1alpha2
+menuWeight: 10
+notes: Automatically generated, DO NOT EDIT
+enterprise: false
+excerpt: Review detailed Kommander API reference information
+---
+
+> This document is automatically generated from the API definition in the code.
+
+## Table of Contents
+
+- [GitopsRepository](#gitopsrepository)
+- [GitopsRepositoryList](#gitopsrepositorylist)
+- [GitopsRepositorySpec](#gitopsrepositoryspec)
+- [GitopsRolloutTemplate](#gitopsrollouttemplate)
+
+## GitopsRepository
+
+GitopsRepository represents an SCM repository that backs a gitops resource. A gitops resource can be a FluxCD HelmRelease or Kustomization resource.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ObjectMeta](https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
+| spec |  | [GitopsRepositorySpec](#gitopsrepositoryspec) | true |
+
+[Back to TOC](#table-of-contents)
+
+## GitopsRepositoryList
+
+GitopsRepositoryList contains a list of Repository.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| items |  | [][GitopsRepository](#gitopsrepository) | true |
+| metadata |  | [metav1.ListMeta](https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
+
+[Back to TOC](#table-of-contents)
+
+## GitopsRepositorySpec
+
+GitopsRepositorySpec defines the desired state of GitopsRepository.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| cloneUrl | URL to clone the repository from. | string | false |
+| secret | Reference to the secret to use when interacting with the Git provider API. The secret should contain the following fields:\n  username: the username (if password is not a token).\n  password: the password or token (required). | string | false |
+| template | Template of the gitops resource backing the repository. | [GitopsRolloutTemplate](#gitopsrollouttemplate) | false |
+
+[Back to TOC](#table-of-contents)
+
+## GitopsRolloutTemplate
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| path | Root path to fetch manifests from in the Git repository. | string | false |
+| ref | The Git reference to checkout and monitor for changes, defaults to master branch. This field supersedes the \"revision\" field in v1alpha1 API and is a breaking change. | sourcectrlv1beta1.GitRepositoryRef | false |
+| suspend | Whether to suspend periodic or webhook-notified sync. | bool | false |
+
+[Back to TOC](#table-of-contents)

--- a/pages/dkp/kommander/2.1/reference/kommander/v1beta1/index.md
+++ b/pages/dkp/kommander/2.1/reference/kommander/v1beta1/index.md
@@ -191,7 +191,8 @@ LicenseStatus defines the observed state of License.
 | customerId | The customer's ID. This is the customer name provided from Salesforce. | string | true |
 | endDate | End date of the licensing period. | metav1.Time | false |
 | licenseId | The license's ID as provided from Salesforce. | string | true |
-| productName | The product (Konvoy or Kommander) the license is for. | string | true |
+| productName | The product name the license is for. | string | true |
+| productSKU | The product SKU the license is for. | string | true |
 | startDate | Start date of the licensing period. | metav1.Time | false |
 | valid | Indicates whether the license is valid, i.e. the secret containing the JWT exists and the JWT carries a valid D2iQ signature. This does NOT indicate whether the license has expired or terms have been breached. | bool | true |
 | version | The license's version ID as provided when the license was created. | string | true |


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

Add docs for aws licensing changes in 2.1 production docs page.

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
