### PR TITLE
[Konvoy 2.1.1] AirGap Bundle - Gov Environment Requirements

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/airbundle/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/airbundle/index.md
@@ -1,0 +1,36 @@
+---
+layout: layout.pug
+navigationTitle: Prerequisites
+title: Prerequisites
+menuWeight: 10
+excerpt: Air-gapped installation prerequisites
+beta: false
+enterprise: false
+---
+
+## Prerequisites
+
+Before you begin, you must have:
+
+- Linux machine (bastion) that has access to the existing VPC.
+- The `dkp` binary on the bastion.
+- [Docker][install_docker] version 18.09.2 or later installed on the bastion.
+- [kubectl][install_kubectl] for interacting with the running cluster on the bastion.
+- Valid AWS account with [credentials configured][aws_credentials].
+
+### Configure AWS prerequisites
+
+1.  Follow the steps in [IAM Policy Configuration](../../iam-policies).
+
+1.  Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
+
+     ```sh
+     export AWS_PROFILE=<profile>
+     ```
+
+Then, [begin creating the bootstrap cluster][bootstrap].
+
+[bootstrap]: ../bootstrap
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/clusterconfig/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/clusterconfig/index.md
@@ -1,0 +1,36 @@
+---
+layout: layout.pug
+navigationTitle: Prerequisites
+title: Prerequisites
+menuWeight: 10
+excerpt: Air-gapped installation prerequisites
+beta: false
+enterprise: false
+---
+
+## Prerequisites
+
+Before you begin, you must have:
+
+- Linux machine (bastion) that has access to the existing VPC.
+- The `dkp` binary on the bastion.
+- [Docker][install_docker] version 18.09.2 or later installed on the bastion.
+- [kubectl][install_kubectl] for interacting with the running cluster on the bastion.
+- Valid AWS account with [credentials configured][aws_credentials].
+
+### Configure AWS prerequisites
+
+1.  Follow the steps in [IAM Policy Configuration](../../iam-policies).
+
+1.  Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
+
+     ```sh
+     export AWS_PROFILE=<profile>
+     ```
+
+Then, [begin creating the bootstrap cluster][bootstrap].
+
+[bootstrap]: ../bootstrap
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/clustercontrol/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/clustercontrol/index.md
@@ -1,0 +1,36 @@
+---
+layout: layout.pug
+navigationTitle: Prerequisites
+title: Prerequisites
+menuWeight: 10
+excerpt: Air-gapped installation prerequisites
+beta: false
+enterprise: false
+---
+
+## Prerequisites
+
+Before you begin, you must have:
+
+- Linux machine (bastion) that has access to the existing VPC.
+- The `dkp` binary on the bastion.
+- [Docker][install_docker] version 18.09.2 or later installed on the bastion.
+- [kubectl][install_kubectl] for interacting with the running cluster on the bastion.
+- Valid AWS account with [credentials configured][aws_credentials].
+
+### Configure AWS prerequisites
+
+1.  Follow the steps in [IAM Policy Configuration](../../iam-policies).
+
+1.  Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
+
+     ```sh
+     export AWS_PROFILE=<profile>
+     ```
+
+Then, [begin creating the bootstrap cluster][bootstrap].
+
+[bootstrap]: ../bootstrap
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/air-gappedgovaws/prerequisites/index.md
@@ -1,0 +1,36 @@
+---
+layout: layout.pug
+navigationTitle: Prerequisites
+title: Prerequisites
+menuWeight: 10
+excerpt: Air-gapped installation prerequisites
+beta: false
+enterprise: false
+---
+
+## Prerequisites
+
+Before you begin, you must have:
+
+- Linux machine (bastion) that has access to the existing VPC.
+- The `dkp` binary on the bastion.
+- [Docker][install_docker] version 18.09.2 or later installed on the bastion.
+- [kubectl][install_kubectl] for interacting with the running cluster on the bastion.
+- Valid AWS account with [credentials configured][aws_credentials].
+
+### Configure AWS prerequisites
+
+1.  Follow the steps in [IAM Policy Configuration](../../iam-policies).
+
+1.  Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
+
+     ```sh
+     export AWS_PROFILE=<profile>
+     ```
+
+Then, [begin creating the bootstrap cluster][bootstrap].
+
+[bootstrap]: ../bootstrap
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html


### PR DESCRIPTION
Hey all,

This new subset of docs are for the Air-gapped AWS GovCloud environment as outlined here: https://hackmd.io/kxTqHRn-S5WOXYl1klRc_w#Prerequisties by John Miller.

## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-82031

## Description of changes being made

Information concerning OS/image bundles have been added, as well as environment setup for AWS GovCloud. 

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
