### PR TITLE
fix: missing PreprovisionedInventory label for md

### DIFF
--- a/pages/dkp/konvoy/2.0/choose_infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.0/choose_infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -61,6 +61,7 @@ Konvoy needs to know how to access your cluster hosts. This is done using invent
       name: $CLUSTER_NAME-md-0
       namespace: default
       labels:
+        cluster.x-k8s.io/cluster-name: $CLUSTER_NAME
         clusterctl.cluster.x-k8s.io/move: ""
     spec:
       hosts:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -84,6 +84,7 @@ hunter-aws-cluster-pf4a3
       name: $CLUSTER_NAME-md-0
       namespace: default
       labels:
+        cluster.x-k8s.io/cluster-name: $CLUSTER_NAME
         clusterctl.cluster.x-k8s.io/move: ""
     spec:
       hosts:


### PR DESCRIPTION
Adding a missing label reported in https://mesosphere.slack.com/archives/C02MR1P7286/p1641919879062300.

Based it on `main` because this is a bug in existing docs, but let me know if I should PR it somewhere else.