### PR TITLE
docs: fixing link to be tied to konvoy 1.8

### DIFF
--- a/pages/dkp/kommander/1.2/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.2/backup-and-restore/index.md
@@ -18,4 +18,4 @@ Kommander stores all data as CRDs in the Kubernetes API and can be backed up and
 </ul>
 </div>
 
-[konvoy-backup]: /dkp/konvoy/latest/backup/
+[konvoy-backup]: /dkp/konvoy/1.6/backup/

--- a/pages/dkp/kommander/1.3/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.3/backup-and-restore/index.md
@@ -18,4 +18,4 @@ Kommander stores all data as CRDs in the Kubernetes API and can be backed up and
 </ul>
 </div>
 
-[konvoy-backup]: /dkp/konvoy/latest/backup/
+[konvoy-backup]: /dkp/konvoy/1.7/backup/

--- a/pages/dkp/kommander/1.4/backup-and-restore/index.md
+++ b/pages/dkp/kommander/1.4/backup-and-restore/index.md
@@ -18,4 +18,4 @@ Kommander stores all data as CRDs in the Kubernetes API and can be backed up and
 </ul>
 </div>
 
-[konvoy-backup]: /dkp/konvoy/latest/backup/
+[konvoy-backup]: /dkp/konvoy/1.8/backup/


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

n/a

## Description of changes being made

There is no backup topic for konvoy 2.1 right now - and Kommander 1.4 is not compatible with dkp 2.x.

So, tying the version for backup to the version that Kommander is compatible with on Konvoy. 

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
