### PR TITLE
docs: editing links for kommander uninstall

### DIFF
--- a/pages/dkp/kommander/1.2/uninstall/index.md
+++ b/pages/dkp/kommander/1.2/uninstall/index.md
@@ -7,7 +7,8 @@ excerpt: Remove Kommander and related infrastructure
 menuWeight: 13
 ---
 
-# Remove a Kommander Cluster
+## Remove a Kommander Cluster
+
 Uninstalling Kommander is similar to [uninstalling Konvoy](/dkp/konvoy/1.6/uninstall) except for one critical difference: Managed clusters created by Kommander must be deleted before uninstalling the management Konvoy clusters, otherwise the state of those clusters will be lost and it would be necessary to manually delete those cluster assets on your cloud provider's console.
 
 <p class="message--warning"><strong>WARNING: </strong>

--- a/pages/dkp/kommander/1.3/uninstall/index.md
+++ b/pages/dkp/kommander/1.3/uninstall/index.md
@@ -7,16 +7,19 @@ excerpt: Remove Kommander and related infrastructure
 menuWeight: 13
 ---
 
-# Remove a Kommander Cluster
-Uninstalling Kommander is similar to [uninstalling Konvoy](/dkp/konvoy/1.6/uninstall) except for one critical difference: Managed clusters created by Kommander must be deleted before uninstalling the management Konvoy clusters, otherwise the state of those clusters will be lost and it would be necessary to manually delete those cluster assets on your cloud provider's console.
+## Remove a Kommander Cluster
+
+Uninstalling Kommander is similar to [uninstalling Konvoy][uninstall-konvoy] except for one critical difference: Managed clusters created by Kommander must be deleted before uninstalling the management Konvoy clusters, otherwise the state of those clusters will be lost and it would be necessary to manually delete those cluster assets on your cloud provider's console.
 
 <p class="message--warning"><strong>WARNING: </strong>
 For complete deletion remove all managed clusters before uninstalling Kommander.
 </p>
 
-For more details about uninstalling Konvoy, see the [Konvoy Documentation](/dkp/konvoy/1.6/uninstall)
+For more details about uninstalling Konvoy, see the [Konvoy Documentation][uninstall-konvoy].
 
 **What happens to my provisioned clusters if I remove the Kommander Cluster?**
 
 Managed clusters created by Kommander will not be deleted. Workloads, even if managed by Kommander, will continue to work as before but managing them centrally won’t be possible anymore.
 If you have an Identity Provider (IDP) configured, neither the login nor the kubeconfig that uses the IDP will be working. You can still use the administrator kubeconfig, which can be loaded from the UI to access your managed cluster.
+
+[uninstall-konvoy]: /dkp/konvoy/1.7/uninstall

--- a/pages/dkp/kommander/1.4/uninstall/index.md
+++ b/pages/dkp/kommander/1.4/uninstall/index.md
@@ -7,7 +7,8 @@ excerpt: Remove Kommander and related infrastructure
 menuWeight: 13
 ---
 
-# Remove a Kommander Cluster
+## Remove a Kommander Cluster
+
 Uninstalling Kommander is similar to [uninstalling Konvoy][konvoy-uninstall] except for one critical difference: Managed clusters created by Kommander must be deleted before uninstalling the management Konvoy cluster, otherwise the state of those managed clusters will be lost and it would be necessary to manually delete those cluster assets on your cloud provider's console.
 
 <p class="message--warning"><strong>WARNING: </strong>
@@ -23,4 +24,4 @@ If you have an Identity Provider (IDP) configured, neither the login nor the kub
 You can still use the administrator kubeconfig, which can be [loaded from the UI to access your managed cluster][create-token-for-cluster].
 
 [create-token-for-cluster]: /dkp/kommander/1.4/tutorials/login-cluster/
-[konvoy-uninstall]: /dkp/konvoy/latest/uninstall
+[konvoy-uninstall]: /dkp/konvoy/1.8/uninstall


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

n/a

## Description of changes being made
In doing some research for uninstalling - I noticed these links need to be updated on the Kommander pages for uninstalling - one points to a different version of Konvoy that is not correct. And then the most recent points to `/latest/`, which isn't valid anymore.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [x] Create new PRs against `develop`, or `main` for hotfixes to production.
- [x] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
