### PR TITLE
docs: copy operator installation notes from 2.1 to 2.2

### DIFF
--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
@@ -36,7 +36,7 @@ After you finish the installation, see [Spark Operator custom resource documenta
 
 -   Using CLI
 
-    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration-using-the-cli) for details.
+    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration) for details.
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
@@ -36,7 +36,7 @@ After you finish the installation, see [Spark Operator custom resource documenta
 
 -   Using CLI
 
-    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration) for details.
+    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration-using-the-cli) for details.
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/kafka/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/kafka/index.md
@@ -10,9 +10,11 @@ excerpt: Deploying Kafka in a project
 
 To get started with creating and managing a Kafka Cluster in a project, you first need to deploy the [Kafka operator](../../../../../../workspaces/applications/catalog-applications/dkp-applications/kafka-operator/) and the [ZooKeeper operator](../../../../../../workspaces/applications/catalog-applications/dkp-applications/zookeeper-operator/) in the workspace where the project exists.
 
-After deploying the Kafka operator, create Kafka Clusters by applying a `KafkaCluster` custom resource in a project's namespace. Refer to the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples) for examples of the custom resources and their configurations.
+After deploying the Kafka operator, create Kafka Clusters by applying a `KafkaCluster` custom resource **on each attached cluster** in a project's namespace. Refer to the [Kafka operator repository](https://github.com/banzaicloud/koperator/tree/master/config/samples) for examples of the custom resources and their configurations.
 
 ## Example deployment
+
+<p class="message--note"><strong>NOTE: </strong>The Custom Resources must be applied to each attached cluster in a project.</p>
 
 This example deployment walks you through first deploying a ZooKeeper cluster and then a Kafka cluster in a project namespace. The result of this procedure is a running ZooKeeper cluster and Kafka cluster ready for use in your project's namespace.
 

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
@@ -13,11 +13,13 @@ To run your Spark workloads with Spark Operator, apply the Spark Operator specif
 
 See [Spark Operator API documentation](https://github.com/mesosphere/spark-on-k8s-operator/blob/d2iq-master/docs/api-docs.md) for more details.
 
+<p class="message--note"><strong>NOTE: </strong>The Custom Resources and RBAC resources must be applied to each attached cluster in a project.</p>
+
 ## Prerequisites
 
 Follow these steps:
 
-1.  Deploy your Spark Operator. See the [Spark Operator](../../../../../../../workspaces/applications/catalog-applications/dkp-applications/spark-operator) documentation for more information.
+1.  Deploy your Spark Operator. See the [Spark Operator](../../../../../../workspaces/applications/catalog-applications/dkp-applications/spark-operator/) documentation for more information.
 
 1.  Ensure the necessary RBAC resources referenced in your custom resources exist, otherwise the custom resources can fail. See the [Spark Operator documentation](https://github.com/mesosphere/spark-on-k8s-operator/blob/d2iq-master/docs/quick-start-guide.md#about-the-spark-job-namespace) for details.
 

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -10,11 +10,13 @@ excerpt: Deploying ZooKeeper in a project
 
 To get started with creating ZooKeeper clusters in your project namespace, you first need to deploy the [ZooKeeper operator](../../../../../../workspaces/applications/catalog-applications/dkp-applications/zookeeper-operator/) in the workspace where the project exists.
 
-After you deploy the ZooKeeper operator, you can create ZooKeeper Clusters by applying a `ZookeeperCluster` custom resource in a project's namespace.
+After you deploy the ZooKeeper operator, you can create ZooKeeper Clusters by applying a `ZookeeperCluster` custom resource **on each attached cluster** in a project's namespace.
 
 A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper) exists in the ZooKeeper operator repository that can assist with deploying ZooKeeper clusters.
 
 ### Example deployment
+
+<p class="message--note"><strong>NOTE: </strong>The Custom Resources must be applied to each attached cluster in a project.</p>
 
 Follow these steps to deploy a ZooKeeper cluster in a project namespace. This procedure results in a running ZooKeeper cluster, ready for use in your project's namespace.
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/kafka-operator/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/kafka-operator/index.md
@@ -14,6 +14,8 @@ excerpt: Information about the Kafka Operator
 
 Follow these steps to install the Kafka operator in a workspace. This procedure results in a Kafka operator running in a workspace namespace, ready to manage and create Kafka clusters in any project namespaces. See the [Kafka custom resource documentation](../../../../../projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/kafka/) for more information on creating Kafka clusters.
 
+<p class="message--note"><strong>NOTE: </strong>Only install the Kafka operator once per workspace.</p>
+
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../../application-deployment/) page.
 
 1.  Within the `AppDeployment`, update the `appRef` to specify the correct `kafka-operator` App. You can find the `appRef.name` by listing the available `Apps` in the workspace namespace:

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
@@ -14,7 +14,9 @@ The Kubernetes Operator for Apache Spark aims to make specifying and running Spa
 
 ## Install
 
-You can find generic installation instructions for workspace catalog applications on the [Application Deployment topic](../../application-deployment).
+You can find generic installation instructions for workspace catalog applications on the [Application Deployment topic](../../application-deployment/).
+
+<p class="message--note"><strong>NOTE: </strong>Only install the Spark operator once per workspace.</p>
 
 For details on custom configuration for the operator, refer to the [Spark Operator Helm Chart documentation](https://github.com/mesosphere/spark-on-k8s-operator/blob/d2iq-master/charts/spark-operator-chart/README.md).
 
@@ -34,7 +36,7 @@ After you finish the installation, see [Spark Operator custom resource documenta
 
 -   Using CLI
 
-    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration) for details.
+    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration-using-the-cli) for details.
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/zookeeper-operator/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/zookeeper-operator/index.md
@@ -14,6 +14,8 @@ excerpt: Information about the ZooKeeper Operator
 
 Follow these steps to install the ZooKeeper operator in a workspace. This procedure results in a ZooKeeper operator running in a workspace namespace, ready to manage and create ZooKeeper clusters in any project namespaces. See the [ZooKeeper custom resource documentation](../../../../../projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/zookeeper/) for more information on creating ZooKeeper clusters.
 
+<p class="message--note"><strong>NOTE: </strong>Only install the ZooKeeper operator once per workspace.</p>
+
 1.  Follow the generic installation instructions for workspace catalog applications on the [Application Deployment](../../application-deployment/) page.
 
 1.  Within the `AppDeployment`, update the `appRef` to specify the correct `zookeeper-operator` App. You can find the `appRef.name` by listing the available `Apps` in the workspace namespace:


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

Copying the changes made for 2.1 in https://github.com/mesosphere/dcos-docs-site/pull/4016/files to 2.2. I also fixed some bad links.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
