### PR TITLE
fix: Update link in spark install instructions 

### DIFF
--- a/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/index.md
@@ -36,7 +36,7 @@ After you finish the installation, see [Spark Operator custom resource documenta
 
 -   Using CLI
 
-    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration) for details.
+    See [Application Deployment](../../application-deployment#deploy-an-application-with-a-custom-configuration-using-the-cli) for details.
 
     ```yaml
     cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
 
Fix link reference, taken from https://github.com/mesosphere/dcos-docs-site/pull/4037#discussion_r784328556.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
