### PR TITLE
adding info to release notes about air gapped bundles

### DIFF
--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -22,6 +22,11 @@ This release provides new features and enhancements to improve the user experien
 
 ## New features and capabilities
 
+### Provision Konvoy with air-gapped bundles
+
+You can now provision air-gapped environments with Konvoy using the pre-packaged air-gapped bundles provided by D2iQ. 
+
+For more information, see [AWS Gov Cloud](../../../../konvoy/2.1/choose-infrastructure/awsgovcloud/)
 ### Ability to add catalog applications
 
 With this release, you can now add catalog applications to your Kommander instances. Currently, we provide the following operator applications that are workspace-scoped:

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -27,6 +27,7 @@ This release provides new features and enhancements to improve the user experien
 You can now provision air-gapped environments with Konvoy using the pre-packaged air-gapped bundles provided by D2iQ. 
 
 For more information, see [AWS Gov Cloud](../../../../konvoy/2.1/choose-infrastructure/awsgovcloud/)
+
 ### Ability to add catalog applications
 
 With this release, you can now add catalog applications to your Kommander instances. Currently, we provide the following operator applications that are workspace-scoped:


### PR DESCRIPTION
Signed-off-by: Casie Oxford <coxford@d2iq.com>


NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4041.s3-website-us-west-2.amazonaws.com/

## Jira Ticket

No JIRA 

## Description of changes being made

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
