### PR TITLE
[Konvoy 2.2] Air-gapped AWS GovCloud doc migration from 2.1->2.2

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/clusterconfig/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/clusterconfig/index.md
@@ -1,0 +1,105 @@
+---
+layout: layout.pug
+navigationTitle: Cluster Configuration
+title: Configure Cluster
+menuWeight: 20
+excerpt: Create a cluster configuration file and apply it to your environment.
+beta: false
+enterprise: false
+---
+
+## Create the cluster configuration file
+
+1.  Update `cluster-aws.sh` with the existing infrastructure values.
+
+    ```sh
+    vi cluster-aws.sh
+    ```
+
+1.  Generate the cluster configuration file from the updated cluster.sh file.
+
+    ```sh
+    ./cluster.sh
+    ```
+
+    <p class="message--important"><strong>NOTE: </strong>An Amazon Linux 2-based AMI runs the `autotune` utility to set Linux kernel parameters optimal for the EC2 instance type. Kubernetes requires the `ipv4_forward` kernel parameter to be enabled, but the `autotune` utility disables it by default. To override the default, add the following to the <code>cluster-sbx.yaml</code>.</p>
+
+    ```yaml
+    kind: KubeadmControlPlane
+    ...
+        preKubeadmCommands:
+        - systemctl daemon-reload
+        - systemctl restart containerd
+        - /run/kubeadm/konvoy-set-kube-proxy-configuration.sh
+        - autotune override sysctl:net.ipv4.ip_forward:1
+        - systemctl restart autotune
+    ...
+    kind: KubeadmConfigTemplate
+          preKubeadmCommands:
+          - systemctl daemon-reload
+          - systemctl restart containerd
+          - /run/kubeadm/konvoy-set-kube-proxy-configuration.sh
+          - autotune override sysctl:net.ipv4.ip_forward:1
+          - systemctl restart autotune
+    ```
+
+    <p class="message--important"><strong>NOTE: </strong>Update the AMI root volume size to match the new AMI generated with Konvoy Image Builder for both the control planes and default node pool.</p>
+
+    ```yaml
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: AWSMachineTemplate
+    metadata:
+      name: cluster-sbx-control-plane
+      namespace: default
+    spec:
+      template:
+        spec:
+          ami:
+            id: ami-0d1ab6c50a5f30339
+          cloudInit:
+            insecureSkipSecretsManager: true
+          iamInstanceProfile: ag-role.cluster-api-provider-aws.sigs.k8s.io
+          imageLookupBaseOS: centos-7
+          imageLookupFormat: capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+          imageLookupOrg: "258751437250"
+          instanceType: m5.xlarge
+          rootVolume:
+            size: 250
+    ...
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: AWSMachineTemplate
+    metadata:
+      name: cluster-sbx-md-0
+      namespace: default
+    spec:
+      template:
+        spec:
+          ami:
+            id: ami-0d1ab6c50a5f30339
+          cloudInit:
+            insecureSkipSecretsManager: true
+          iamInstanceProfile: ag-role.cluster-api-provider-aws.sigs.k8s.io
+          imageLookupBaseOS: centos-7
+          imageLookupFormat: capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+          imageLookupOrg: "258751437250"
+          instanceType: m5.2xlarge
+          rootVolume:
+            size: 250
+    ...
+    ```
+
+1.  Apply the cluster configuration.
+
+    ```sh
+    kubectl apply -f cluster-sbx.yaml
+    ```
+
+1.  Monitor the Kubernetes cluster deployment.
+
+    ```sh
+    watch ./dkp describe cluster -c cluster-sbx
+    ```
+
+When ready, begin [configuring the control plane][clustercontrol].
+
+[clustercontrol]: ../clustercontrol

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/clustercontrol/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/clustercontrol/index.md
@@ -1,0 +1,44 @@
+---
+layout: layout.pug
+navigationTitle: Cluster Control
+title: Cluster Control
+menuWeight: 30
+excerpt: Add cluster controllers to set up the cluster control plane.
+beta: false
+enterprise: false
+---
+
+## Add cluster controllers
+
+1.  Get the kubeconfig file.
+
+    ```sh
+    ./dkp get kubeconfig -c cluster-sbx > cluster-sbx.conf
+    ```
+
+1.  Verify the nodes are ‘Ready’.
+
+    ```sh
+    kubectl --kubeconfig cluster-sbx.conf get nodes
+    ```
+
+1.  Add the ClusterAPI controllers to the cluster
+
+    ```sh
+    ./dkp create bootstrap controllers --with-aws-bootstrap-credentials=false --kubeconfig cluster-sbx.conf
+    ```
+
+1.  When the workload cluster is ready, move the cluster lifecycle services to the workload cluster.
+
+    ```sh
+    ./dkp move --to-kubeconfig cluster-sbx.conf
+    ```
+
+1.  Wait for the cluster control-plane to be ready
+
+    ```sh
+    kubectl --kubeconfig cluster-sbx.conf wait --for=condition=ControlPlaneReady "clusters/cluster-sbx" --timeout=20m
+
+    // Output
+    cluster.cluster.x-k8s.io/aws-example condition met
+    ```

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/index.md
@@ -1,0 +1,11 @@
+---
+layout: layout.pug
+navigationTitle:
+title: AWS GovCloud
+menuWeight: 10
+excerpt: AWS GovCloud Installation information
+beta: false
+enterprise: false
+---
+
+Run and deploy DKP to the AWS GovCloud.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/prerequisites/index.md
@@ -1,0 +1,169 @@
+---
+layout: layout.pug
+navigationTitle: Prerequisites
+title: Prerequisites
+menuWeight: 10
+excerpt: Air-gapped GovCloud installation prerequisites.
+beta: false
+enterprise: false
+---
+
+## Prerequisites
+
+Before you begin, you must have:
+
+- Linux machine (bastion) that has access to the existing VPC.
+- The `dkp` binary on the bastion.
+- [Docker][install_docker] version 18.09.2 or later installed on the bastion.
+- [kubectl][install_kubectl] for interacting with the running cluster on the bastion.
+- Valid AWS account with [credentials configured][aws_credentials].
+- VPC ID
+- Subnet IDs
+- Security Group IDs
+- Control Plane Node Instance Profile Name
+- Worker Node Instance Profile Name
+- Region
+- Container Registry Mirror
+
+### Configure AWS prerequisites
+
+1.  Follow the steps in [IAM Policy Configuration](../../aws/iam-policies).
+
+1.  Export the AWS profile with the credentials you want to use to create the Kubernetes cluster:
+
+    ```sh
+    export AWS_PROFILE=<profile>
+    ```
+
+### Download the Air-gapped bundle
+
+
+The air-gapped bundle includes the following packages and tooling
+
+- Command line tooling
+- Konvoy air-gapped bundle,
+- Kommander air-gapped bundle,
+- Konvoy Image Builder
+- CentOS/RHEL 7.9 dependencies
+- Setup script
+- Cluster initialization script
+- Docker registry image
+
+1.  Download the air-gapped bundle.
+
+    ```sh
+    curl -O downloads.mesosphere.io/konvoy/airgapped/os-packages_1.21.6_x86_64_rpms.tar.gz
+    curl -O downloads.mesosphere.io/konvoy/airgapped/pip-packages.tar.gz
+    ```
+
+1.  Expand the air-gapped bundle artifact.
+
+    ```sh
+    tar -xvf os-packages_1.21.6_x86_64_rpms.tar.gz
+    ```
+
+1.  Run setup.
+
+    ```sh
+    sudo ./setup
+    ```
+
+1.  Refresh your group membership.
+
+    ```sh
+    // Logout
+    exit
+
+    // Login
+    ssh user@x.x.x.x
+    ```
+
+After a successful login, move on to setting up Konvoy Image Builder.
+
+### Create AMI
+
+Use Konvoy Image Builder to create an Amazon Machine Image (AMI) based on the desired OS included in the air-gapped bundle.
+
+1.  Unpack the Konvoy Image Builder within the air-gapped bundle.
+
+    ```sh
+    curl -OL https://github.com/mesosphere/konvoy-image-builder/releases/download/v1.5.0-rc.3/konvoy-image-bundle-v1.5.0-rc.3_linux_amd64.tar.gz
+
+    tar -xvf konvoy-image-bundle-v1.5.0-rc.3_linux_amd64.tar.gz
+    ```
+
+1.  Set the following overrides and AWS GovCloud server regions.
+
+    <p class="message--important"><strong>IMPORTANT: </strong>The following usernames and IDs are samples, enter your identification into the appropriate fields where applicable.</p>
+
+    ```sh
+    cat <EOF> overrides/custom.yaml
+    packer:
+      ssh_username: "maintuser"
+      volume_size: "250"
+      # Optional VPC ID
+      # vpc_id: vpc-058da8b5f1fcb1369
+      #Optional Subnet ID
+      # subnet_id: subnet-052653ab52e5773f0
+
+    EOF
+    ```
+
+    ```sh
+    cat <EOF> overrides/images.yaml
+    ---
+    extra_images:
+      - docker.io/mesosphere/cluster-api-aws-controller:v0.7.1-d2iq.0
+      - docker.io/mesosphere/cluster-api-preprovisioned-controller:v0.4.0
+      - gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+      - k8s.gcr.io/cluster-api/cluster-api-controller:v0.4.4
+      - k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v0.4.4
+      - k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v0.4.4
+      - mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v1.8.5
+      - quay.io/jetstack/cert-manager-cainjector:v1.5.3
+      - quay.io/jetstack/cert-manager-controller:v1.5.3
+      - quay.io/jetstack/cert-manager-webhook:v1.5.3
+      - us.gcr.io/k8s-artifacts-prod/cluster-api-azure/cluster-api-azure-controller:v0.5.3
+      - docker.io/mesosphere/konvoy-image-builder:v1.5.0-rc.2
+      - docker.io/plndr/kube-vip:v0.3.7
+      - k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.4.0
+      - k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+      - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+      - k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
+      - k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+      - k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+      - k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+      - k8s.gcr.io/sig-storage/snapshot-controller:v4.2.0
+      - mcr.microsoft.com/k8s/csi/azuredisk-csi:v1.8.0
+      - mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v3.3.0
+      - mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.3.0
+      - mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v2.2.2
+      - mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v1.3.0
+      - mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v3.0.3
+      - mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.4.0
+      - quay.io/external_storage/local-volume-provisioner:v2.4.0
+      - docker.io/calico/cni:v3.20.2
+      - docker.io/calico/kube-controllers:v3.20.2
+      - docker.io/calico/node:v3.20.2
+      - docker.io/calico/pod2daemon-flexvol:v3.20.2
+      - docker.io/calico/typha:v3.20.2
+      - quay.io/tigera/operator:v1.20.4
+      - docker.io/bitnami/kubectl:1.21.6
+      - us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.21.0
+      - k8s.gcr.io/nfd/node-feature-discovery:v0.8.2
+      - nvcr.io/nvidia/gpu-feature-discovery:v0.4.1
+      - docker.io/library/busybox:1
+      - docker.io/mesosphere/pause-alpine:3.2
+      - docker.io/mesosphere/dkp-diagnostics-node-collector:v0.3.3
+    ```
+
+    ```sh
+    ./konvoy-image build --ami-regions us-gov-west-1,us-gov-east-1 --region us-gov-east-1 --source-ami ami-092e75227e47facfc --overrides overrides/custom.yaml --overrides overrides/images.yaml images/ami/centos-7.yaml
+    ```
+
+Then, [generate the cluster configuration file][clusterconfig].
+
+[clusterconfig]: ../clusterconfig
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html


### PR DESCRIPTION

## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-83671

## Description of changes being made

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
