### PR TITLE
fix: backticks in the old p tags

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/awsgovcloud/clusterconfig/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/awsgovcloud/clusterconfig/index.md
@@ -22,7 +22,7 @@ enterprise: false
     ./cluster.sh
     ```
 
-    <p class="message--important"><strong>NOTE: </strong>An Amazon Linux 2-based AMI runs the `autotune` utility to set Linux kernel parameters optimal for the EC2 instance type. Kubernetes requires the `ipv4_forward` kernel parameter to be enabled, but the `autotune` utility disables it by default. To override the default, add the following to the <code>cluster-sbx.yaml</code>.</p>
+    <p class="message--important"><strong>NOTE: </strong>An Amazon Linux 2-based AMI runs the <code>autotune</code> utility to set Linux kernel parameters optimal for the EC2 instance type. Kubernetes requires the <code>ipv4_forward</code> kernel parameter to be enabled, but the <code>autotune</code> utility disables it by default. To override the default, add the following to the <code>cluster-sbx.yaml</code>.</p>
 
     ```yaml
     kind: KubeadmControlPlane


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made
Backticks showing up in the p tags in the docs for this one page

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
