### PR TITLE
docs: workaround for kube-oidc-proxy 2.1.1

### DIFF
--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -104,7 +104,7 @@ error: the server doesn't have a resource type "kommandercluster"
 If your cluster is self-managed, the output resembles this example:
 
 ```bash
-NAME     AGE   PHASE
+NAME         AGE   PHASE
 my-cluster   30m   Provisioned
 ```
 

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -149,7 +149,7 @@ spec:
 EOF
 ```
 
-Next, apply this file to your cluster:
+Next, apply this file to your self-managed cluster you are attaching to Kommander:
 
 ```sh
 kubectl apply -f cert_manager_root-ca.yaml
@@ -162,7 +162,7 @@ kubectl patch certificate -n $WORKSPACE_NAMESPACE kube-oidc-proxy --type='merge'
 kubectl patch certificate -n $WORKSPACE_NAMESPACE kommander-traefik --type='merge' -p '{"spec": {"issuerRef": {"kind": "Issuer", "name": "kommander-bootstrap-issuer"}}}'
 ```
 
-Cert-manager will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
+`cert-manager` will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -87,28 +87,24 @@ If you attach a cluster that already has `cert-manager` installed, you need to m
 
 For example, [Konvoy-created clusters that are self-managed][konvoy-self-managed] have `cert-manager` already installed to the `cert-manager` namespace.
 
-Verify that your cluster is self-managed by:
+Verify that your cluster have `cert-manager` installed by:
 
 ```bash
 export KUBECONFIG=<kubeconfig-path>
-export WORKSPACE_NAMESPACE=<your-workspace-namespace>
-kubectl get kommandercluster -n $WORKSPACE_NAMESPACE
+kubectl get pod -A | grep "cert-manager" 
 ```
 
-If your cluster is not self-managed, the output resembles this example:
+If your cluster does not have `cert-manager` installed, the output will be empty.
+
+If your cluster has `cert-manager` installed, the output resembles this example:
 
 ```bash
-error: the server doesn't have a resource type "kommandercluster"
+cert-manager                        cert-manager-848f547974-crl47                                        1/1     Running   0          5m5s
+cert-manager                        cert-manager-cainjector-54f4cc6b5-wbzvr                              1/1     Running   0          5m5s
+cert-manager                        cert-manager-webhook-7c9588c76-pdxrb                                 1/1     Running   0          5m4s
 ```
 
-If your cluster is self-managed, the output resembles this example:
-
-```bash
-NAME         AGE   PHASE
-my-cluster   30m   Provisioned
-```
-
-If your cluster is self-managed, then create the following yaml file:
+If your cluster has `cert-manager` installed, then create the following yaml file:
 
 ```yaml
 cat << EOF > cert_manager_root-ca.yaml
@@ -149,7 +145,7 @@ spec:
 EOF
 ```
 
-Next, apply this file to your self-managed cluster you are attaching to Kommander:
+Next, apply this file to your cluster you are attaching to Kommander:
 
 ```sh
 kubectl apply -f cert_manager_root-ca.yaml
@@ -162,7 +158,7 @@ kubectl patch certificate -n $WORKSPACE_NAMESPACE kube-oidc-proxy --type='merge'
 kubectl patch certificate -n $WORKSPACE_NAMESPACE kommander-traefik --type='merge' -p '{"spec": {"issuerRef": {"kind": "Issuer", "name": "kommander-bootstrap-issuer"}}}'
 ```
 
-`cert-manager` will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
+`cert-manager` HelmRelease will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -77,6 +77,8 @@ The following services and service components have been upgraded to the listed v
 - traefik-forward-auth: 0.3.2
 - velero: 3.1.3
 
+## Known Issues 
+
 ### Create cert-manager resources on attached clusters with cert-manager pre-installed
 
 If you are attaching a cluster that already has `cert-manager` installed, you need to manually create some cert-manager resources after attaching your cluster.
@@ -158,7 +160,7 @@ kubectl patch certificate -n $WORKSPACE_NAMESPACE kube-oidc-proxy --type='merge'
 kubectl patch certificate -n $WORKSPACE_NAMESPACE kommander-traefik --type='merge' -p '{"spec": {"issuerRef": {"kind": "Issuer", "name": "kommander-bootstrap-issuer"}}}'
 ```
 
-You should expect to see that cert-manager will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
+Cert-manager will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -90,13 +90,13 @@ Check whether your cluster is self-managed by:
 ```bash
 export KUBECONFIG=<kubeconfig-path>
 export WORKSPACE_NAMESPACE=<your-workspace-namespace>
-kubectl get cluster -n $WORKSPACE_NAMESPACE
+kubectl get kommandercluster -n $WORKSPACE_NAMESPACE
 ```
 
 If your cluster is not self-managed, it produces output like:
 
 ```bash
-error: the server doesn't have a resource type "cluster"
+error: the server doesn't have a resource type "kommandercluster"
 ```
 
 Otherwise, it should produce output like:

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -79,13 +79,15 @@ The following services and service components have been upgraded to the listed v
 
 ## Known Issues 
 
+The following items are known issues with this release.
+
 ### Create cert-manager resources on attached clusters with cert-manager pre-installed
 
-If you are attaching a cluster that already has `cert-manager` installed, you need to manually create some cert-manager resources after attaching your cluster.
+If you attach a cluster that already has `cert-manager` installed, you need to manually create the three cert-manager resources, in the yaml file, after attaching your cluster.
 
 For example, [Konvoy-created clusters that are self-managed][konvoy-self-managed] have `cert-manager` already installed to the `cert-manager` namespace.
 
-Check whether your cluster is self-managed by:
+Verify that your cluster is self-managed by:
 
 ```bash
 export KUBECONFIG=<kubeconfig-path>
@@ -93,20 +95,20 @@ export WORKSPACE_NAMESPACE=<your-workspace-namespace>
 kubectl get kommandercluster -n $WORKSPACE_NAMESPACE
 ```
 
-If your cluster is not self-managed, it produces output like:
+If your cluster is not self-managed, the output resembles this example:
 
 ```bash
 error: the server doesn't have a resource type "kommandercluster"
 ```
 
-Otherwise, it should produce output like:
+If your cluster is self-managed, the output resembles this example:
 
 ```bash
 NAME     AGE   PHASE
 my-cluster   30m   Provisioned
 ```
 
-Create the following yaml file only if your cluster is self-managed:
+If your cluster is self-managed, then create the following yaml file:
 
 ```yaml
 cat << EOF > cert_manager_root-ca.yaml
@@ -147,13 +149,13 @@ spec:
 EOF
 ```
 
-Then, apply this file to your cluster:
+Next, apply this file to your cluster:
 
 ```sh
 kubectl apply -f cert_manager_root-ca.yaml
 ```
 
-Now, fix the broken certificates for the attached cluster:
+Finally, fix the broken certificates for the attached cluster:
 
 ```bash
 kubectl patch certificate -n $WORKSPACE_NAMESPACE kube-oidc-proxy --type='merge' -p '{"spec": {"issuerRef": {"kind": "Issuer", "name": "kommander-bootstrap-issuer"}}}'

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -77,6 +77,89 @@ The following services and service components have been upgraded to the listed v
 - traefik-forward-auth: 0.3.2
 - velero: 3.1.3
 
+### Create cert-manager resources on attached clusters with cert-manager pre-installed
+
+If you are attaching a cluster that already has `cert-manager` installed, you need to manually create some cert-manager resources after attaching your cluster.
+
+For example, [Konvoy-created clusters that are self-managed][konvoy-self-managed] have `cert-manager` already installed to the `cert-manager` namespace.
+
+Check whether your cluster is self-managed by:
+
+```bash
+export KUBECONFIG=<kubeconfig-path>
+export WORKSPACE_NAMESPACE=<your-workspace-namespace>
+kubectl get cluster -n $WORKSPACE_NAMESPACE
+```
+
+If your cluster is not self-managed, it produces output like:
+
+```bash
+error: the server doesn't have a resource type "cluster"
+```
+
+Otherwise, it should produce output like:
+
+```bash
+NAME     AGE   PHASE
+my-cluster   30m   Provisioned
+```
+
+Create the following yaml file only if your cluster is self-managed:
+
+```yaml
+cat << EOF > cert_manager_root-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kommander-bootstrap-ca-issuer
+  namespace: $WORKSPACE_NAMESPACE
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kommander-bootstrap-root-certificate
+  namespace: $WORKSPACE_NAMESPACE
+spec:
+  commonName: ca.kommander-bootstrap
+  dnsNames:
+    - ca.kommander-bootstrap
+  duration: 8760h
+  isCA: true
+  issuerRef:
+    name: kommander-bootstrap-ca-issuer
+  secretName: kommander-bootstrap-root-ca
+  subject:
+    organizations:
+      - cert-manager
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kommander-bootstrap-issuer
+  namespace: $WORKSPACE_NAMESPACE
+spec:
+  ca:
+    secretName: kommander-bootstrap-root-ca
+EOF
+```
+
+Then, apply this file to your cluster:
+
+```sh
+kubectl apply -f cert_manager_root-ca.yaml
+```
+
+Now, fix the broken certificates for the attached cluster:
+
+```bash
+kubectl patch certificate -n $WORKSPACE_NAMESPACE kube-oidc-proxy --type='merge' -p '{"spec": {"issuerRef": {"kind": "Issuer", "name": "kommander-bootstrap-issuer"}}}'
+kubectl patch certificate -n $WORKSPACE_NAMESPACE kommander-traefik --type='merge' -p '{"spec": {"issuerRef": {"kind": "Issuer", "name": "kommander-bootstrap-issuer"}}}'
+```
+
+You should expect to see that cert-manager will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
+
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -77,7 +77,7 @@ The following services and service components have been upgraded to the listed v
 - traefik-forward-auth: 0.3.2
 - velero: 3.1.3
 
-## Known Issues 
+## Known Issues
 
 The following items are known issues with this release.
 


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-D2IQ-80341.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket


https://jira.d2iq.com/browse/D2IQ-80341

## Description of changes being made

Adding a guide to 2.1.1 release note about a workaround towards broken certificates/kube-oidc-proxy. kommander-traefik cert is broken too and also included in the guide.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
