### PR TITLE
docs: Add catalog application chart bundle to install instructions

### DIFF
--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -281,13 +281,30 @@ Based on the network latency between the environment of script execution and the
 1. Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.mesosphere.com/dkp/dkp-kommander-charts-bundle_${VERSION}.tar.gz
+    wget "https://downloads.mesosphere.com/dkp/dkp-kommander-charts-bundle_${VERSION}.tar.gz"
+    ```
+
+1. (Optional) Download the [DKP catalog applications][dkp_catalog_applications] chart bundle if you intend on deploying any DKP catalog applications:
+
+    ```bash
+    wget "https://downloads.mesosphere.com/kommander/airgapped/${VERSION}/dkp-catalog-applications-charts-bundle_${VERSION}.tar.gz"
     ```
 
 1. To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
-    kommander install --installer-config ./install.yaml --kommander-applications-repository kommander-applications_${VERSION}.tar.gz --charts-bundle dkp-kommander-charts-bundle_${VERSION}.tar.gz
+    kommander install --installer-config ./install.yaml \
+    --kommander-applications-repository kommander-applications_${VERSION}.tar.gz \
+    --charts-bundle dkp-kommander-charts-bundle_${VERSION}.tar.gz
+    ```
+
+    To upload the optional [DKP catalog applications][dkp_catalog_applications] chart bundle, add an additional `--chart-bundle` flag to the `install` command:
+
+    ```bash
+    kommander install --installer-config ./install.yaml \
+    --kommander-applications-repository kommander-applications_${VERSION}.tar.gz \
+    --charts-bundle dkp-kommander-charts-bundle_${VERSION}.tar.gz \
+    --charts-bundle dkp-catalog-applications-charts-bundle_${VERSION}.tar.gz
     ```
 
 1. [Verify your installation](../networked#verify-installation).
@@ -298,3 +315,4 @@ Based on the network latency between the environment of script execution and the
 [kommander-load-balancing]: ../../networking/load-balancing
 [metallb]: https://metallb.universe.tf/concepts/
 [metallb_config]: https://metallb.universe.tf/configuration/
+[dkp_catalog_applications]: ../../workspaces/applications/catalog-applications/dkp-applications/

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -50,27 +50,27 @@ Optionally, specify the output using the `-o` parameter:
 The Kommander charts bundle is uploaded to Kommander's internal Helm repository.
 To inspect the contents:
 
-    ```bash
-    kommander helmmirror get charts
-    ```
+  ```bash
+  kommander helmmirror get charts
+  ```
 
 Individual charts can be removed using:
 
-    ```bash
-    kommander helmmirror delete chart [chartName] [chartVersion]
-    ```
+  ```bash
+  kommander helmmirror delete chart [chartName] [chartVersion]
+  ```
 
 It is possible to upload new charts as well:
 
-    ```bash
-    kommander helmmirror upload chart [chartTarball]
-    ```
+  ```bash
+  kommander helmmirror upload chart [chartTarball]
+  ```
 
 Or upload a new bundle:
 
-    ```bash
-    kommander helmmirror upload bundle [chartsTarball]...
-    ```
+  ```bash
+  kommander helmmirror upload bundle [chartsTarball]...
+  ```
 
 Please check the built-in help text for each command for more information.
 

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -69,10 +69,10 @@ It is possible to upload new charts as well:
 Or upload a new bundle:
 
   ```bash
-  kommander helmmirror upload bundle [chartsTarball]...
+  kommander helmmirror upload bundle [chartsTarball]
   ```
 
-Please check the built-in help text for each command for more information.
+Check the built-in help text for each command for more information.
 
 ### Use MetalLB
 
@@ -284,7 +284,7 @@ Based on the network latency between the environment of script execution and the
     wget "https://downloads.mesosphere.com/dkp/dkp-kommander-charts-bundle_${VERSION}.tar.gz"
     ```
 
-1. (Optional) Download the [DKP catalog applications][dkp_catalog_applications] chart bundle if you intend on deploying any DKP catalog applications:
+1. Download the [DKP catalog applications][dkp_catalog_applications] chart bundle if you intend on deploying any DKP catalog applications:
 
     ```bash
     wget "https://downloads.mesosphere.com/kommander/airgapped/${VERSION}/dkp-catalog-applications-charts-bundle_${VERSION}.tar.gz"
@@ -298,7 +298,7 @@ Based on the network latency between the environment of script execution and the
     --charts-bundle dkp-kommander-charts-bundle_${VERSION}.tar.gz
     ```
 
-    To upload the optional [DKP catalog applications][dkp_catalog_applications] chart bundle, add an additional `--chart-bundle` flag to the `install` command:
+    To upload the optional [DKP catalog applications][dkp_catalog_applications] chart bundle, add `--chart-bundle` flag to the `install` command:
 
     ```bash
     kommander install --installer-config ./install.yaml \


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-83643

## Description of changes being made

This PR adds steps to the airgap kommander installation to include downloading/installing the DKP catalog application chart bundle. 

I only included how to upload the charts during the installation. It can also be done post installation using the [upload command](https://dev-docs.d2iq.com/dkp/kommander/2.2/install/air-gapped/#kommanders-internal-helm-repository)

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
