### PR TITLE
chore: hiding replace node for now to update

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   "main": {
     "DO_NOT_BUILD": [
       "dkp/konvoy/2.1/choose-infrastructure/eks/advanced/replace-node/**",
-      "dkp/konvoy/2.1/choose-infrastructure/aks/**"
+      "dkp/konvoy/2.1/choose-infrastructure/aks/aks-advanced/aa-replace-node/**"
     ]
   }
 }

--- a/config.json
+++ b/config.json
@@ -7,6 +7,9 @@
     ]
   },
   "main": {
-    "DO_NOT_BUILD": []
+    "DO_NOT_BUILD": [
+      "dkp/konvoy/2.1/choose-infrastructure/eks/advanced/replace-node/**",
+      "dkp/konvoy/2.1/choose-infrastructure/aks/**"
+    ]
   }
 }


### PR DESCRIPTION
We don't have the right commands for in the AKS
and EKS replace node topics

## Jira Ticket

[D2IQ-83967](https://jira.d2iq.com/browse/D2IQ-83967)

## Description of changes being made
Hiding this page for now until we can correct the language

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
