### PR TITLE
konvoy: document race condition for pre-provisioned adoption

### DIFF
--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
@@ -283,7 +283,7 @@ The cluster, control plane, and worker node pool should all show the value `True
 
 ### If the Cluster Never Reaches a Steady State
 
-A race condition where the `Machine` objects are reconciled before the appropriate status is set on the `Cluster` object and it gets "stuck", stopping it from reaching a steady state. If this happens, delete the CAPPP pod and let Kubernetes restart it to trigger a reconcile:
+A race condition where the `Machine` objects are reconciled before the appropriate status is set on the `Cluster` object and it gets *stuck*, stopping it from reaching a steady state. If this happens, delete the CAPPP pod and let Kubernetes restart it to trigger a reconcile:
 
 ```sh
 kubectl --kubeconfig=admin.conf delete pods -n cappp-system -l control-plane=controller-manager

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
@@ -283,21 +283,19 @@ The cluster, control plane, and worker node pool should all show the value `True
 
 ### If the Cluster Never Reaches a Steady State
 
-It is possible that the cluster never reaches a steady state. This is caused by a race condition where the `Machine` objects are reconciled before the appropriate status is set on the `Cluster` object and it gets "stuck".
-
-To trigger a reconcile, delete the CAPPP pod and let Kubernetes restart it:
+A race condition where the `Machine` objects are reconciled before the appropriate status is set on the `Cluster` object and it gets "stuck", stopping it from reaching a steady state. If this happens, delete the CAPPP pod and let Kubernetes restart it to trigger a reconcile:
 
 ```sh
 kubectl --kubeconfig=admin.conf delete pods -n cappp-system -l control-plane=controller-manager
 ```
 
-The output appears similar to this:
+The following output appears:
 
 ```sh
 pod "cappp-controller-manager-56fcf85446-66z87" deleted
 ```
 
-## Wait for Calico to be upgraded
+## Wait for Calico to upgrade
 
 Confirm that the `calico-node` DaemonSet is running in the `calico-system` namespace.
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
@@ -281,6 +281,22 @@ NAME                                                                 READY  SEVE
 
 The cluster, control plane, and worker node pool should all show the value `True` in the Ready column.
 
+### If the Cluster Never Reaches a Steady State
+
+It is possible that the cluster never reaches a steady state. This is caused by a race condition where the `Machine` objects are reconciled before the appropriate status is set on the `Cluster` object and it gets "stuck".
+
+To trigger a reconcile, delete the CAPPP pod and let Kubernetes restart it:
+
+```sh
+kubectl --kubeconfig=admin.conf delete pods -n cappp-system -l control-plane=controller-manager
+```
+
+The output appears similar to this:
+
+```sh
+pod "cappp-controller-manager-56fcf85446-66z87" deleted
+```
+
 ## Wait for Calico to be upgraded
 
 Confirm that the `calico-node` DaemonSet is running in the `calico-system` namespace.


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/COPS-7150

## Description of changes being made
Documenting a workaround for this bug, until a proper fix can be worked on/released.


## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
