### PR TITLE
docs: adding get kubeconfig on preprov docs

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -13,6 +13,9 @@ Before you start, make sure you have created a workload cluster, as described in
 
 ## Explore the cluster
 
+<p class="message--note"><strong>NOTE: </strong>If you have not already retrieved the kubeconfig after creating the cluster, use this command before proceeding: <code>dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf</code>
+</p>
+
 Before setting the cluster to manage itself, explore your cluster with this command:
 
    ```sh
@@ -24,7 +27,7 @@ Before setting the cluster to manage itself, explore your cluster with this comm
 
 To edit the installation file, run the command:
 
-   ```sh 
+   ```sh
    kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf
    ```
 


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

n/a

## Description of changes being made
The get kubeconfig command is on the previous topic, **but** only for under one dkp create path.
This note is to catch every other user that would need the kubeconfig for future steps.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
