### PR TITLE
chore: updating version for 2.2

### DIFF
--- a/pages/dkp/kommander/2.2/index.md
+++ b/pages/dkp/kommander/2.2/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Kommander 2.2
 title: Kommander 2.2
-version: 2.1
+version: 2.2
 menuWeight: 0
 subtree:
   beta: false

--- a/pages/dkp/konvoy/2.2/index.md
+++ b/pages/dkp/konvoy/2.2/index.md
@@ -1,8 +1,8 @@
 ---
 layout: layout.pug
-navigationTitle: Konvoy 2.1
-title: Welcome to Konvoy 2.1
-version: 2.1
+navigationTitle: Konvoy 2.2
+title: Welcome to Konvoy 2.2
+version: 2.2
 menuWeight: 0
 subtree:
   beta: false


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made
Nav and version need to be updated to 2.2 for develop for kommander and konvoy. This should do the trick.

Checked locally and that's good.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
