### PR TITLE
Qa/docker hub limits update 1 x

### DIFF
--- a/pages/dkp/konvoy/1.6/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.6/operations/manage-docker-hub-rate-limits/index.md
@@ -55,7 +55,7 @@ spec:
     ...
     ```
 
-<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go on to the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. Restart containerd on your node. You will need to do this for all of the nodes in your cluster.</p>
 
 For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
 

--- a/pages/dkp/konvoy/1.6/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.6/operations/manage-docker-hub-rate-limits/index.md
@@ -8,8 +8,6 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 MD018 MD034 -->
-
 Konvoy customers can configure their cluster to authenticate with registries (such as Docker Hub), and add registries, by defining each in the `ClusterConfiguration` `.spec.imageRegistries` list in the `cluster.yaml` file.
 
 For Konvoy, to add credentials for Docker Hub, set the options in your `cluster.yaml` as follows:
@@ -31,15 +29,15 @@ spec:
           konvoy.docker-registry-password: <password>
 ```
 
-<p class="message--note"><strong>NOTE: </strong>You can use environment variables to specify `imageRegistries` values. For example, if your yaml file has `password: ${REGISTRY_PASSWORD}`, `password` is set to the `REGISTRY_PASSWORD` value in your environment.</p>
+<p class="message--note"><strong>NOTE: </strong>You can use environment variables to specify <code>imageRegistries</code> values. For example, if your yaml file has <code>password: ${REGISTRY_PASSWORD}</code>, <code>password</code> is set to the <code>REGISTRY_PASSWORD</code> value in your environment.</p>
 
-1. Apply the changes to your cluster. Enter the following command:
+1.  Apply the changes to your cluster. Enter the following command:
 
     ```bash
     konvoy up
     ```
 
-1. Confirm the changes made to the cluster. Enter the following command to check the contents of the `containerd` configuration file:
+1.  Confirm the changes made to the cluster. Enter the following command to check the contents of the `containerd` configuration file:
 
     ```bash
     $ cat /etc/containerd/config.toml
@@ -57,4 +55,8 @@ spec:
     ...
     ```
 
-For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to the following documentation: https://docs.d2iq.com/dkp/konvoy/1.6/reference/cluster-configuration/v1beta2/
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+
+For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
+
+[cluster-config-api]: ../../reference/cluster-configuration/v1beta2

--- a/pages/dkp/konvoy/1.6/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.6/operations/manage-docker-hub-rate-limits/index.md
@@ -55,7 +55,7 @@ spec:
     ...
     ```
 
-<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
 
 For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
 

--- a/pages/dkp/konvoy/1.7/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.7/operations/manage-docker-hub-rate-limits/index.md
@@ -69,7 +69,7 @@ For Kommander, to add credentials for Docker Hub, set the options in your `clust
     ...
     ```
 
-<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
 
 For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
 

--- a/pages/dkp/konvoy/1.7/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.7/operations/manage-docker-hub-rate-limits/index.md
@@ -8,8 +8,6 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 MD018 MD034 -->
-
 Konvoy customers can configure their cluster to authenticate with registries (such as Docker Hub), and add registries, by defining each in the `ClusterConfiguration` `.spec.imageRegistries` list in the `cluster.yaml` file.
 
 For Konvoy, to add credentials for Docker Hub, set the options in your `cluster.yaml` as follows:
@@ -45,15 +43,15 @@ For Kommander, to add credentials for Docker Hub, set the options in your `clust
           docker-registry-password: <password>
 ```
 
-<p class="message--note"><strong>NOTE: </strong>You can use environment variables to specify `imageRegistries` values. For example, if your yaml file has `password: ${REGISTRY_PASSWORD}`, `password` is set to the `REGISTRY_PASSWORD` value in your environment.</p>
+<p class="message--note"><strong>NOTE: </strong>You can use environment variables to specify <code>imageRegistries</code> values. For example, if your yaml file has <code>password: ${REGISTRY_PASSWORD}</code>, <code>password</code> is set to the <code>REGISTRY_PASSWORD</code> value in your environment.</p>
 
-1. Apply the changes to your cluster. Enter the following command:
+1.  Apply the changes to your cluster. Enter the following command:
 
     ```bash
     konvoy up
     ```
 
-1. Confirm the changes made to the cluster. Enter the following command to check the contents of the `containerd` configuration file:
+1.  Confirm the changes made to the cluster. Enter the following command to check the contents of the `containerd` configuration file:
 
     ```bash
     $ cat /etc/containerd/config.toml
@@ -71,4 +69,8 @@ For Kommander, to add credentials for Docker Hub, set the options in your `clust
     ...
     ```
 
-For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to the following documentation: https://docs.d2iq.com/dkp/konvoy/1.6/reference/cluster-configuration/v1beta2/
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+
+For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
+
+[cluster-config-api]: ../../reference/cluster-configuration/v1beta2

--- a/pages/dkp/konvoy/1.7/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.7/operations/manage-docker-hub-rate-limits/index.md
@@ -69,7 +69,7 @@ For Kommander, to add credentials for Docker Hub, set the options in your `clust
     ...
     ```
 
-<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go on to the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. Restart containerd on your node. You will need to do this for all of the nodes in your cluster.</p>
 
 For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
 

--- a/pages/dkp/konvoy/1.8/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.8/operations/manage-docker-hub-rate-limits/index.md
@@ -55,7 +55,7 @@ spec:
     ...
     ```
 
-<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go on to the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. Restart containerd on your node. You will need to do this for all of the nodes in your cluster.</p>
 
 For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
 

--- a/pages/dkp/konvoy/1.8/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.8/operations/manage-docker-hub-rate-limits/index.md
@@ -8,8 +8,6 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 MD018 MD034 -->
-
 Konvoy customers can configure their cluster to authenticate with registries (such as Docker Hub), and add registries, by defining each in the `ClusterConfiguration` `.spec.imageRegistries` list in the `cluster.yaml` file.
 
 For Konvoy, to add credentials for Docker Hub, set the options in your `cluster.yaml` as follows:
@@ -31,15 +29,15 @@ spec:
           konvoy.docker-registry-password: <password>
 ```
 
-<p class="message--note"><strong>NOTE: </strong>You can use environment variables to specify `imageRegistries` values. For example, if your yaml file has `password: ${REGISTRY_PASSWORD}`, `password` is set to the `REGISTRY_PASSWORD` value in your environment.</p>
+<p class="message--note"><strong>NOTE: </strong>You can use environment variables to specify <code>imageRegistries</code> values. For example, if your yaml file has <code>password: ${REGISTRY_PASSWORD}</code>, <code>password</code> is set to the <code>REGISTRY_PASSWORD</code> value in your environment.</p>
 
-1. Apply the changes to your cluster. Enter the following command:
+1.  Apply the changes to your cluster. Enter the following command:
 
     ```bash
     konvoy up
     ```
 
-1. Confirm the changes made to the cluster. Enter the following command to check the contents of the `containerd` configuration file:
+1.  Confirm the changes made to the cluster. Enter the following command to check the contents of the `containerd` configuration file:
 
     ```bash
     $ cat /etc/containerd/config.toml
@@ -57,4 +55,8 @@ spec:
     ...
     ```
 
-For more information on configuring `imageRegistries` in the `cluster.yaml`, refer to the following documentation: https://docs.d2iq.com/dkp/konvoy/1.6/reference/cluster-configuration/v1beta2/
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+
+For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
+
+[cluster-config-api]: ../../reference/cluster-configuration/v1beta2

--- a/pages/dkp/konvoy/1.8/operations/manage-docker-hub-rate-limits/index.md
+++ b/pages/dkp/konvoy/1.8/operations/manage-docker-hub-rate-limits/index.md
@@ -55,7 +55,7 @@ spec:
     ...
     ```
 
-<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>You can also do this directly after your cluster is created and without running <code>konvoy up</code>. Go into the nodes in your cluster directly, and edit your containerd configuration file <code>/etc/containerd/config.toml</code>. Edit your file to apply the changes above and save the file. You will need to do this for all of the nodes in your cluster.</p>
 
 For more information on configuring `imageRegistries` in the `cluster.yaml`, please refer to [cluster configuration API documentation][cluster-config-api].
 


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

[D2IQ-84262](https://jira.d2iq.com/browse/D2IQ-84262)

## Description of changes being made
@tillt found that this did not take for version 1.7. I made a note to say the user can change and confirm this by going into that node's file directly and adding the changes.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [x] Create new PRs against `develop`, or `main` for hotfixes to production.
- [x] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
