### PR TITLE
docs: adding azure to supported OS grid

### DIFF
--- a/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
@@ -16,7 +16,7 @@ Konvoy supports the following base Operating Systems.
 
 <!-- vale Vale.Spelling = NO -->
 <!-- vale Vale.Terms = NO -->
-| Operating System      | Kernel                      | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> <!-- vale Vale.Terms = NO --> |
+| Operating System      | Kernel                      | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> <!-- vale Vale.Terms = YES --> |
 |-----------------------|-----------------------------|----------------|------|------------|----------------------|-------------|
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64      | Yes            | Yes  | Yes        | Yes                  | Yes         |
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64      | Yes            | Yes  | Yes        |                      | Yes         |
@@ -29,7 +29,8 @@ Konvoy supports the following base Operating Systems.
 ## Pre-Provisioned/On Premises
 
 <!-- vale Vale.Spelling = NO -->
-| Operating System         | Kernel | Default Config | FIPS | Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
+<!-- vale Vale.Terms = NO -->
+| Operating System         | Kernel | Default Config | FIPS | Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> <!-- vale Vale.Terms = YES --> |
 |--------------------------|--------|----------------|------|------------|-------------|
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64 |   |      | Yes        |             |
 | [Flatcar][flatcar] | 2905.2.1 | | GPU workloads are not currently supported |

--- a/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
@@ -39,7 +39,8 @@ Konvoy supports the following base Operating Systems.
 ## Azure
 
 <!-- vale Vale.Spelling = NO -->
-| Operating System                        | Kernel | Default Config | FIPS | Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
+<!-- vale Vale.Terms = NO -->
+| Operating System                        | Kernel | Default Config | FIPS | Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> <!-- vale Vale.Terms = YES --> |
 |-----------------------------------------|--------|----------------|------|------------|-------------|
 | [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |        | Yes            |      |            |             |
 

--- a/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
@@ -15,7 +15,8 @@ Konvoy supports the following base Operating Systems.
 ## Amazon Web Services (AWS)
 
 <!-- vale Vale.Spelling = NO -->
-| Operating System      | Kernel                      | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
+<!-- vale Vale.Terms = NO -->
+| Operating System      | Kernel                      | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> <!-- vale Vale.Terms = NO --> |
 |-----------------------|-----------------------------|----------------|------|------------|----------------------|-------------|
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64      | Yes            | Yes  | Yes        | Yes                  | Yes         |
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64      | Yes            | Yes  | Yes        |                      | Yes         |

--- a/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
@@ -34,6 +34,12 @@ Konvoy supports the following base Operating Systems.
 | [Flatcar][flatcar] | 2905.2.1 | | GPU workloads are not currently supported |
 | [Oracle Linux RHCK 7.9][RHCK] | kernel-3.10.0-1160.el7 |  Yes |   Yes   |   Yes         |                      |         |
 
+## Azure
+
+<!-- vale Vale.Spelling = NO -->
+| Operating System                        | Kernel | Default Config | FIPS | Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
+|-----------------------------------------|--------|----------------|------|------------|-------------|
+| [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |        | Yes            |      |            |             |
 
 [centos7]: https://wiki.centos.org/action/show/Manuals/ReleaseNotes/CentOS7.2003
 [centos8]: https://wiki.centos.org/action/show/Manuals/ReleaseNotes/CentOS8.2004


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

n/a

## Description of changes being made
This came up in Konv standup - 
As we support the default configuration for Azure builds, this should be added to this grid.

FYI @JohnB64-JBV 

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
