### PR TITLE
fix: metalsmith staying at 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "markdown-it-anchor": "^4.0.0",
     "markdown-it-attrs": "^1.2.1",
     "markdownlint-cli": "0.30.0",
-    "metalsmith": "^2.3.0",
+    "metalsmith": "2.3.0",
     "metalsmith-assets": "^0.1.0",
     "metalsmith-data-loader": "^1.1.2",
     "metalsmith-ignore": "^0.1.2",


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

n/a

<!-- Link to JIRA ticket -->

## Description of changes being made

Docs site was not building w/Jenkins.

This could be the issue.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
