### PR TITLE
docs: Clarify metallb config can be deployed to attached clusters

### DIFF
--- a/pages/dkp/kommander/2.1/networking/load-balancing/index.md
+++ b/pages/dkp/kommander/2.1/networking/load-balancing/index.md
@@ -68,7 +68,7 @@ MetalLB will be deployed to all attached clusters within this workspace.
 export WORKSPACE_NAMESPACE=$(kubectl get workspace <type_your_workspace_name> -o jsonpath='{.status.namespaceRef.name}')
 ```
 
-<p class="message--note"><strong>NOTE:</strong> To deploy MetalLB to the Kommander host cluster, this will be the `kommander` namespace.</p>
+<p class="message--note"><strong>NOTE:</strong> To deploy MetalLB to the Kommander host cluster, this will be the <code>kommander</code> namespace.</p>
 
 Next, create the following resources to deploy MetalLB with custom configuration: 
 

--- a/pages/dkp/kommander/2.1/networking/load-balancing/index.md
+++ b/pages/dkp/kommander/2.1/networking/load-balancing/index.md
@@ -59,7 +59,18 @@ If the virtual IP addresses share an interface with the primary IP address of th
 
 MetalLB can be configured in two modes: Layer2 and BGP.
 
-The following example illustrates how to enable MetalLB and configure it with the Layer2 mode:
+The following example illustrates how to enable MetalLB and configure it with the Layer2 mode.
+
+First, set the `WORKSPACE_NAMESPACE` environment variable using the following command to get the name of the workspace's namespace that you would like to deploy MetalLB to.
+MetalLB will be deployed to all attached clusters within this workspace.
+
+```bash
+export WORKSPACE_NAMESPACE=$(kubectl get workspace <type_your_workspace_name> -o jsonpath='{.status.namespaceRef.name}')
+```
+
+<p class="message--note"><strong>NOTE:</strong> To deploy MetalLB to the Kommander host cluster, this will be the `kommander` namespace.</p>
+
+Next, create the following resources to deploy MetalLB with custom configuration: 
 
 ```yaml
 ---
@@ -67,6 +78,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: metallb-overrides
+  namespace: ${WORKSPACE_NAMESPACE}
 data:
   values.yaml: |
     configInline:
@@ -80,6 +92,7 @@ apiVersion: apps.kommander.d2iq.io/v1alpha2
 kind: AppDeployment
 metadata:
   name: metallb
+  namespace: ${WORKSPACE_NAMESPACE}
 spec:
   appRef:
     name: metallb-0.12.2
@@ -99,6 +112,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: metallb-overrides
+  namespace: ${WORKSPACE_NAMESPACE}
 data:
   values.yaml: |
     configInline:


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[<!-- Link to JIRA ticket -->](https://jira.d2iq.com/browse/COPS-7161)

## Description of changes being made

Unclear how to deploy metallb to attached clusters - added a few lines to the existing metallb docs to add the namespace field (which is needed anyways) which is set to workspace namespace, and that this allows you to deploy metallb to attached clusters.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
