### PR TITLE
Add AWS download instructions for Kaptain

### DIFF
--- a/pages/dkp/kaptain/1.3.0/download/index.md
+++ b/pages/dkp/kaptain/1.3.0/download/index.md
@@ -9,8 +9,27 @@ enterprise: false
 
 <!-- markdownlint-disable MD034 -->
 
-Kaptain downloads are only available to licensed customers.  To obtain an evaluation license for Kaptain, please contact <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+Kaptain downloads are only available to licensed customers. To obtain an evaluation license for Kaptain, please contact <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
 
 If you already have a license, downloads are available in the [Support Portal][support-portal].
 
-[support-portal]: https://support.d2iq.com/hc/en-us
+## Download from the AWS Marketplace
+
+Follow the instructions on AWS console to download the container image.
+
+After downloading the image, run the following command to copy the binaries onto your host.
+
+```sh
+docker run -it --rm -v $(pwd):/kaptain <container_image_name>
+```
+
+You will then see the following output:
+
+```sh
+Kaptain install package placed in the local directory. See install instructions at: https://docs.d2iq.com/dkp/kaptain/
+```
+
+You will now see the `kubeflow-1.4.0_1.3.0.tgz` file in your working directory. Follow the [Kaptain installation instructions][install] using these binaries. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+
+[support-portal]: https://support.d2iq.com/hc/en-us/
+[install]: ../install/konvoy-dkp/

--- a/pages/dkp/kaptain/1.3.0/download/index.md
+++ b/pages/dkp/kaptain/1.3.0/download/index.md
@@ -29,7 +29,7 @@ You will then see the following output:
 Kaptain install package placed in the local directory. See install instructions at: https://docs.d2iq.com/dkp/kaptain/
 ```
 
-You will now see the `kubeflow-1.4.0_1.3.0.tgz` file in your working directory. Follow the [Kaptain installation instructions][install] using these binaries. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+You will now see the `kubeflow-1.4.0_1.3.0.tgz` file in your working directory. Follow the [Kaptain installation instructions][install] using these binaries. If you have problems downloading or installing Kaptain, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
 
 [support-portal]: https://support.d2iq.com/hc/en-us/
 [install]: ../install/konvoy-dkp/


### PR DESCRIPTION
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4093.s3-website-us-west-2.amazonaws.com/

Add the AWS download instructions for Kaptain.   This needs to go against Main because we're going to publish kaptain on AWS in the next few days.   I believe this change will then need to be added to the kudo-kubeflow repo so that we don't lose it going forward.   I don't believe it needs to go into the develop branch because AIUI Kaptain docs are not published from there.

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-82306

## Description of changes being made

## Checklist

- [x] Test all commands and procedures, if applicable.
- [ x] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
