### PR TITLE
fix: MetalLB documentation for air-gapped install

### DIFF
--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -24,6 +24,12 @@ Before installing, ensure you have:
   - Management cluster must connect to the attached cluster's API server.
   - Management cluster must connect to load balancers created by some platform services.
 
+- A configuration file that you will adapt to your needs using the steps outlined in this topic. Make sure to create that file using the following command:
+
+  ```bash
+  kommander install --init > install.yaml
+  ```
+
 - All the prerequisites covered in [air-gapped Konvoy installation][air-gap-before-you-begin].
 
 - [MetalLB enabled and configured][air-gap-install-metallb], which provides load-balancing services.
@@ -103,33 +109,21 @@ You can configure MetalLB in two modes: Layer2 and BGP.
 
 #### Layer2
 
-The following example illustrates how to enable MetalLB and configure it with the Layer2 mode:
+The following example illustrates how to enable MetalLB and configure it with the Layer2 mode using the `install.yaml` configuration file created above:
 
    ```yaml
-   ---
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: metallb-overrides
-   data:
-     values.yaml: |
-       configInline:
-         address-pools:
-         - name: default
-           protocol: layer2
-           addresses:
-           - 10.0.50.25-10.0.50.50
-   ---
-   apiVersion: apps.kommander.d2iq.io/v1alpha2
-   kind: AppDeployment
-   metadata:
-     name: metallb
-   spec:
-     appRef:
-       name: metallb-0.12.2
-       kind: ClusterApp
-     configOverrides:
-       name: metallb-overrides
+   apiVersion: config.kommander.mesosphere.io/v1alpha1
+   kind: Installation
+   apps:
+     ...
+     metallb:
+       values: |
+         configInline:
+           address-pools:
+             - name: default
+               protocol: layer2
+               addresses:
+                 - 10.0.50.25-10.0.50.50
    ```
 
 The number of virtual IP addresses in the reserved range determines the maximum number of `LoadBalancer` service types you can create in the cluster.
@@ -141,22 +135,22 @@ MetalLB in `bgp` mode implements only a subset of the BGP protocol. In particula
 The following example illustrates the BGP configuration in the overrides `ConfigMap`:
 
    ```yaml
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: metallb-overrides
-   data:
-     values.yaml: |
-       configInline:
-         peers:
-         - my-asn: 64500
-           peer-asn: 64500
-           peer-address: 172.17.0.4
-         address-pools:
-         - name: my-ip-space
-           protocol: bgp
-           addresses:
-           - 172.40.100.0/24
+    apiVersion: config.kommander.mesosphere.io/v1alpha1
+    kind: Installation
+    apps:
+      ...
+      metallb:
+        values: |
+          configInline:
+            peers:
+              - my-asn: 64500
+                peer-asn: 64500
+                peer-address: 172.17.0.4
+            address-pools:
+              - name: my-ip-space
+                protocol: bgp
+                addresses:
+                  - 172.40.100.0/24
    ```
 
 In the above configuration, `peers` defines the configuration of the BGP peer, such as peer IP address and `autonomous system number` (`asn`).
@@ -208,15 +202,7 @@ Based on the network latency between the environment of script execution and the
 
 ## Install on Konvoy
 
-1. Kommander v2.2 installs with a dedicated CLI.
-
-1. Create an installation configuration file:
-
-    ```bash
-    kommander install --init > install.yaml
-    ```
-
-1. Adapt the configuration file for the air-gapped deployment by changing the `.apps.kommander` field. Ensure you  use the actual version number everywhere `${VERSION}` appears.:
+1. Adapt the configuration file created from running `kommander install --init > install.yaml` for the air-gapped deployment by changing the `.apps.kommander` section. Ensure you use the actual version number everywhere `${VERSION}` appears:
 
     ```yaml
     apps:


### PR DESCRIPTION
I think we need to make the same changes from https://github.com/mesosphere/dcos-docs-site/pull/4087 in the 2.2 directory.

Installing MetalLB is much simpler than described and can actually be
accomplished by simply editing the installation configuration file.

NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4094.s3-website-us-west-2.amazonaws.com/

## Jira Ticket

https://jira.d2iq.com/browse/COPS-7141

## Description of changes being made

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
