### PR TITLE
docs: Fix kubefed ns

### DIFF
--- a/pages/dkp/kommander/2.1/clusters/tunnel-cli/index.md
+++ b/pages/dkp/kommander/2.1/clusters/tunnel-cli/index.md
@@ -279,9 +279,9 @@ do
   kubefed=$(kubectl get kommandercluster -n ${namespace} ${managed} -o jsonpath="{.status.kubefedclusterRef.name}")
 done
 
-kubectl wait --for=condition=ready --timeout=60s kubefedcluster -n kommander ${kubefed}
+kubectl wait --for=condition=ready --timeout=60s kubefedcluster -n kube-federation-system ${kubefed}
 
-kubectl get kubefedcluster -n kommander ${kubefed}
+kubectl get kubefedcluster -n kube-federation-system ${kubefed}
 ```
 
 ## Using a remote cluster


### PR DESCRIPTION
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4095.s3-website-us-west-2.amazonaws.com/

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->
https://jira.d2iq.com/browse/COPS-7160
<!-- Link to JIRA ticket -->

## Description of changes being made

We changed the kubefed namespace from `kommander` to `kube-federation-system` in 2.1 which resulted in a few outdated commands.

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
