### PR TITLE
(kommander 2.2) Fix kommander CA secret name in kubetunnel docs

### DIFF
--- a/pages/dkp/kommander/2.2/clusters/tunnel-cli/index.md
+++ b/pages/dkp/kommander/2.2/clusters/tunnel-cli/index.md
@@ -17,7 +17,7 @@ Obtain the hostname and CA certificate for the management cluster:
 
 ```shell
 hostname=$(kubectl get service -n kommander kommander-traefik -o go-template='{{with index .status.loadBalancer.ingress 0}}{{or .hostname .ip}}{{end}}')
-b64ca_cert=$(kubectl get secret -n kommander kommander-bootstrap-root-ca -o=go-template='{{index .data "tls.crt"}}')
+b64ca_cert=$(kubectl get secret -n cert-manager kommander-ca -o=go-template='{{index .data "tls.crt"}}')
 ```
 
 ### Specify a workspace namespace


### PR DESCRIPTION
<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/COPS-7159

## Description of changes being made

This updates the location of the kommander CA secret. This was changed in Kommander 2.1.

## Checklist

- [x] Test all commands and procedures, if applicable.
- [x] Create new PRs against `develop`, or `main` for hotfixes to production.
- [x] Update all links if you are moving a page.
- [x] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
