### PR TITLE
docs env variable to control preview environments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,13 @@
 #!/usr/bin/env groovy
 
-boolean isProduction = env.BRANCH_NAME == "main"
+boolean isMain = env.BRANCH_NAME == "main"
 boolean isBeta = env.BRANCH_NAME == "beta"
-boolean isPreview = env.BRANCH_NAME == "develop"
 
-def bucket   = isProduction ? "production"
+def bucket   = isMain ? "preview"
              : isBeta ? "staging"
-             : isPreview ? "preview"
              : "pr-${env.CHANGE_ID}"
 
-def creds    = isProduction ? "s3-production"
-             : isBeta ? "s3-staging"
-             : "s3-development"
-def hostname = isProduction ? "docs.d2iq.com"
-             : isBeta ? "beta-docs.d2iq.com"
-             : isPreview ? "dev-docs.d2iq.com"
+def hostname = isMain ? "dev-docs.d2iq.com"
              : "docs-d2iq-com-pr-${env.CHANGE_ID}.s3-website-us-west-2.amazonaws.com"
 
 pipeline {
@@ -22,7 +15,7 @@ pipeline {
   environment {
     DOCKER = credentials('docker-hub-credentials')
     ALGOLIA_PRIVATE_KEY = credentials('algolia_private_key')
-    REDIR_HOSTNAME = "${hostname}"
+    AWS_DEFAULT_REGION = "us-west-2"
   }
   stages {
     stage("Build image") {
@@ -36,26 +29,16 @@ pipeline {
       }
     }
 
-    stage("Push image") {
-      when { branch "main" }
-      steps {
-        sh '''
-          docker login -u ${DOCKER_USR} -p ${DOCKER_PSW}
-          docker push mesosphere/docs:latest
-        '''
-      }
-    }
-
-    stage("Build & Deploy Docs") {
+    stage("Build & Deploy Preview Docs") {
       environment {
-        ALGOLIA_UPDATE = "${isProduction ? 'true' : ''}"
-        AWS_DEFAULT_REGION = "us-west-2"
+        ALGOLIA_UPDATE = ""
         BUCKET = "docs-d2iq-com-${bucket}"
-        PRINCIPAL = "arn:aws:iam::139475575661:role/Jenkins/Jenkins-S3-DOCS-${isProduction ? 'Production' : 'Development'}"
-        REDIR_HOSTNAME = "${hostname}"
+        PRINCIPAL = "arn:aws:iam::139475575661:role/Jenkins/Jenkins-S3-DOCS-Development"
+        REDIR_HOSTNAME = "${prevhostname}"
+        DOCS_ENV = "preview"
       }
       steps {
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: creds]]) {
+        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "s3-development"]]) {
         sh '''
           docker run \
             -v "$PWD/pages":/src/pages \
@@ -68,15 +51,90 @@ pipeline {
             -e BUCKET \
             -e PRINCIPAL \
             -e REDIR_HOSTNAME \
+            -e DOCS_ENV \
             mesosphere/docs /src/ci/deploy.sh
           '''
         }
       }
     }
 
+    stage("Preview Deployment URL") {
+      steps { echo "http://${hostname}" }
+    }
+
+    stage("Build & Deploy Beta Docs") {
+      when { branch "beta" }
+      environment {
+        ALGOLIA_UPDATE = ""
+        BUCKET = "docs-d2iq-com-staging"
+        PRINCIPAL = "arn:aws:iam::139475575661:role/Jenkins/Jenkins-S3-DOCS-Development"
+        REDIR_HOSTNAME = "beta-docs.d2iq.com"
+        DOCS_ENV = "beta"
+      }
+      steps {
+        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "s3-staging"]]) {
+        sh '''
+          docker run \
+            -v "$PWD/pages":/src/pages \
+            -e ALGOLIA_PRIVATE_KEY \
+            -e ALGOLIA_UPDATE \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_DEFAULT_REGION \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_SESSION_TOKEN \
+            -e BUCKET \
+            -e PRINCIPAL \
+            -e REDIR_HOSTNAME \
+            -e DOCS_ENV \
+            mesosphere/docs /src/ci/deploy.sh
+          '''
+        }
+      }
+    }
+
+    stage("Build & Deploy Production Docs") {
+      when { branch "main" }
+      environment {
+        ALGOLIA_UPDATE = "true"
+        BUCKET = "docs-d2iq-com-production"
+        PRINCIPAL = "arn:aws:iam::139475575661:role/Jenkins/Jenkins-S3-DOCS-Production"
+        REDIR_HOSTNAME = "docs.d2iq.com"
+        DOCS_ENV = "production"
+      }
+      steps {
+        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "s3-production"]]) {
+        sh '''
+          docker run \
+            -v "$PWD/pages":/src/pages \
+            -e ALGOLIA_PRIVATE_KEY \
+            -e ALGOLIA_UPDATE \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_DEFAULT_REGION \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_SESSION_TOKEN \
+            -e BUCKET \
+            -e PRINCIPAL \
+            -e REDIR_HOSTNAME \
+            -e DOCS_ENV \
+            mesosphere/docs /src/ci/deploy.sh
+          '''
+        }
+      }
+    }
+
+    stage("Push image") {
+      when { branch "main" }
+      steps {
+        sh '''
+          docker login -u ${DOCKER_USR} -p ${DOCKER_PSW}
+          docker push mesosphere/docs:latest
+        '''
+      }
+    }
+
     stage("Restart dev deployment") {
       agent { label 'docs-site-kubectl' }
-      when { branch "develop" }
+      when { branch "main" }
       steps {
         sh '''
           kubectl -n docs-site rollout restart deployment docs-site-dev
@@ -85,8 +143,6 @@ pipeline {
       }
     }
 
-    stage("Deployment URL") {
-      steps { echo "http://${hostname}" }
-    }
+
   }
 }

--- a/config.json
+++ b/config.json
@@ -1,12 +1,18 @@
 {
-  "example-git-branch": {
+  "example-docs-env": {
     "DO_NOT_BUILD": [
       "dkp/example-new-product/1.3/**",
       "dkp/example-new-product/1.4/**",
       "dkp/example-old-product/1.0/**"
     ]
   },
-  "main": {
+  "preview": {
+    "DO_NOT_BUILD": ["dkp/kommander/2.2/**", "dkp/konvoy/2.2/**"]
+  },
+  "beta": {
+    "DO_NOT_BUILD": []
+  },
+  "production": {
     "DO_NOT_BUILD": []
   }
 }

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ const configData = fs.readFileSync("config.json");
 const config = JSON.parse(configData);
 
 // Environment Variables
-const GIT_BRANCH = process.env.GIT_BRANCH;
-const METALSMITH_SKIP_SECTIONS = (config[GIT_BRANCH] || {}).DO_NOT_BUILD || [];
+const DOCS_ENV = process.env.DOCS_ENV;
+const METALSMITH_SKIP_SECTIONS = (config[DOCS_ENV] || {}).DO_NOT_BUILD || [];
 
 //
 // Metalsmith

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "npm": "^6.0.0"
   },
   "lint-staged": {
-    "*.js": "eslint --cache --fix",
     "*.md": [
       "vale --config=./.vale.ini",
       "remark --quiet --frail --no-stdout",


### PR DESCRIPTION
rather than have a develop branch deploy a preview environment, we can
leverage the existing DO_NOT_BUILD logic that Dolbey put in to do an env
based hiding of certain folders. So, main branch will now deploy
dev-docs as well as the production site, only we'll add some
DO_NOT_BUILD dirs into the production DOCS_ENV list in the config json.

Hopefully this will clear up some of the confusion around which branch
to use, creating multiple PRs, etc.

<!--
NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
-->

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
