### PR TITLE
docs: gatekeeper for 2.2

### DIFF
--- a/pages/dkp/kommander/2.2/security/policy-controls/gatekeeper/index.md
+++ b/pages/dkp/kommander/2.2/security/policy-controls/gatekeeper/index.md
@@ -30,7 +30,7 @@ Before starting this tutorial, verify the following:
 
 Gatekeeper uses the [OPA Constraint Framework][opa-constraints] to describe and enforce policy. Before you can define a constraint, you must first define a `ConstraintTemplate`, which describes both the [`Rego`][opa-rego] (a powerful query language) that enforces the constraint and the schema of the constraint. The schema of the constraint allows an admin to fine-tune the behavior of a constraint, much like arguments to a function.
 
-The Gatekeeper repository includes a [library of policies][gatekeeper-library] to replace Pod Security Policies which we will use in the following tutorials.
+The Gatekeeper repository includes a [library of policies][gatekeeper-library] to replace Pod Security Policies which you will use in the following tutorials.
 
 ### Prevent privileged pods
 
@@ -44,7 +44,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 
 #### Define the Constraint
 
-Constraints are then used to inform Gatekeeper that the admin wants a ConstraintTemplate to be enforced, and how.
+Constraints are then used to inform Gatekeeper that the admin wants to enforce a ConstraintTemplate, and how.
 
 Create the privileged pod policy constraint `psp-privileged-container` by running the following command:
 
@@ -54,7 +54,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 
 #### Test that the constraint is enforced
 
-Try to create a privileged pod by running the following command:
+Create a privileged pod by running the following command:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/example_disallowed.yaml
@@ -78,7 +78,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-
 
 #### Define the Constraint
 
-Constraints are then used to inform Gatekeeper that the admin wants a ConstraintTemplate to be enforced, and how.
+Constraints are then used to inform Gatekeeper that the admin wants to enforce a ConstraintTemplate, and how.
 
 Create the host path volume policy constraint `psp-host-filesystem` by running the following command to only allow `/foo` to be mounted as a host path volume:
 
@@ -102,7 +102,7 @@ EOF
 
 #### Test that the constraint is enforced
 
-Try to create a pod that mounts a disallowed host path by running the following command:
+Create a privileged pod by running the following command:
 
 ```bash
 cat <<EOF | kubectl apply -f -
@@ -135,7 +135,7 @@ Error from server ([denied by psp-host-filesystem] HostPath volume {"hostPath": 
 
 #### Test that the constraint allows allowed host paths
 
-Try to create a pod that mounts an allowed host path by running the following command:
+Create a pod that mounts an allowed host path by running the following command:
 
 ```bash
 cat <<EOF | kubectl apply -f -

--- a/pages/dkp/kommander/2.2/security/policy-controls/gatekeeper/index.md
+++ b/pages/dkp/kommander/2.2/security/policy-controls/gatekeeper/index.md
@@ -12,7 +12,7 @@ enterprise: false
 
 [Gatekeeper][gatekeeper] is the policy controller for Kubernetes, allowing organizations to enforce configurable policies using the [Open Policy Agent][opa], a policy engine for Cloud Native environments hosted by CNCF as a graduated-level project.
 
-This tutorial describes how to use Gatekeeper to enforce policies by rejecting non-compliant resources. Specifically, this tutorial describes two constraints as a way to show how to use Gatekeeper as an alternative to [Pod Security Policies][psp]:
+This tutorial describes how to use Gatekeeper to enforce policies by rejecting non-compliant resources. Specifically, this tutorial describes two constraints as a way to use Gatekeeper as an alternative to [Pod Security Policies][psp]:
 
 - [Prevent the running of privileged pods](#prevent-privileged-pods)
 - [Prevent mounting host path volumes](#prevent-host-path-volumes)
@@ -24,7 +24,7 @@ Before starting this tutorial, verify the following:
 
 - You must have a properly deployed and running cluster. For information about deploying Kubernetes with default settings on different types of infrastructures, see the [Choose Infrastructure][choose-infrastructure] topic.
 
-- If you install Kommander with a custom configuration, make sure you enabled gatekeeper.
+- If you install Kommander with a custom configuration, make sure you enabled Gatekeeper.
 
 ## Use Gatekeeper
 
@@ -133,7 +133,7 @@ You should see the following output:
 Error from server ([denied by psp-host-filesystem] HostPath volume {"hostPath": {"path": "/tmp", "type": ""}, "name": "cache-volume"} is not allowed, pod: nginx-host-filesystem. Allowed path: [{"readOnly": true, "pathPrefix": "/foo"}]): error when creating "STDIN": admission webhook "validation.gatekeeper.sh" denied the request: [denied by psp-host-filesystem] HostPath volume {"hostPath": {"path": "/tmp", "type": ""}, "name": "cache-volume"} is not allowed, pod: nginx-host-filesystem. Allowed path: [{"readOnly": true, "pathPrefix": "/foo"}]
 ```
 
-#### Test that the constraint allows allowed host paths
+#### Test that the constraint allows the allowed host paths
 
 Create a pod that mounts an allowed host path by running the following command:
 

--- a/pages/dkp/kommander/2.2/security/policy-controls/gatekeeper/index.md
+++ b/pages/dkp/kommander/2.2/security/policy-controls/gatekeeper/index.md
@@ -1,0 +1,175 @@
+---
+layout: layout.pug
+navigationTitle: Enforce policies using Gatekeeper
+title: Enforce policies using Gatekeeper
+menuWeight: 24
+excerpt: Learn how to enforce policies using Gatekeeper
+beta: false
+enterprise: false
+---
+
+<!-- markdownlint-disable MD024 -->
+
+[Gatekeeper][gatekeeper] is the policy controller for Kubernetes, allowing organizations to enforce configurable policies using the [Open Policy Agent][opa], a policy engine for Cloud Native environments hosted by CNCF as a graduated-level project.
+
+This tutorial describes how to use Gatekeeper to enforce policies by rejecting non-compliant resources. Specifically, this tutorial describes two constraints as a way to show how to use Gatekeeper as an alternative to [Pod Security Policies][psp]:
+
+- [Prevent the running of privileged pods](#prevent-privileged-pods)
+- [Prevent mounting host path volumes](#prevent-host-path-volumes)
+
+## Before you begin
+Before starting this tutorial, verify the following:
+
+- You must have access to a Linux, macOS, or Windows computer with a supported operating system version.
+
+- You must have a properly deployed and running cluster. For information about deploying Kubernetes with default settings on different types of infrastructures, see the [Choose Infrastructure][choose-infrastructure] topic.
+
+- If you install Kommander with a custom configuration, make sure you enabled gatekeeper.
+
+## Use Gatekeeper
+
+Gatekeeper uses the [OPA Constraint Framework][opa-constraints] to describe and enforce policy. Before you can define a constraint, you must first define a `ConstraintTemplate`, which describes both the [`Rego`][opa-rego] (a powerful query language) that enforces the constraint and the schema of the constraint. The schema of the constraint allows an admin to fine-tune the behavior of a constraint, much like arguments to a function.
+
+The Gatekeeper repository includes a [library of policies][gatekeeper-library] to replace Pod Security Policies which we will use in the following tutorials.
+
+### Prevent privileged pods
+
+#### Define the ConstraintTemplate
+
+Create the privileged pod policy constraint template `k8spspprivilegedcontainer` by running the following command:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/template.yaml
+```
+
+#### Define the Constraint
+
+Constraints are then used to inform Gatekeeper that the admin wants a ConstraintTemplate to be enforced, and how.
+
+Create the privileged pod policy constraint `psp-privileged-container` by running the following command:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/constraint.yaml
+```
+
+#### Test that the constraint is enforced
+
+Try to create a privileged pod by running the following command:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/example_disallowed.yaml
+```
+
+You should see the following output:
+
+```bash
+Error from server ([denied by psp-privileged-container] Privileged container is not allowed: nginx, securityContext: {"privileged": true}): error when creating "https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/example_disallowed.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [denied by psp-privileged-container] Privileged container is not allowed: nginx, securityContext: {"privileged": true}
+```
+
+### Prevent host path volumes
+
+#### Define the ConstraintTemplate
+
+Create the host path volume policy constraint template `k8spsphostfilesystem` by running the following command:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/host-filesystem/template.yaml
+```
+
+#### Define the Constraint
+
+Constraints are then used to inform Gatekeeper that the admin wants a ConstraintTemplate to be enforced, and how.
+
+Create the host path volume policy constraint `psp-host-filesystem` by running the following command to only allow `/foo` to be mounted as a host path volume:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostFilesystem
+metadata:
+  name: psp-host-filesystem
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    allowedHostPaths:
+    - readOnly: true
+      pathPrefix: "/foo"
+EOF
+```
+
+#### Test that the constraint is enforced
+
+Try to create a pod that mounts a disallowed host path by running the following command:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-host-filesystem
+  labels:
+    app: nginx-host-filesystem
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    volumeMounts:
+    - mountPath: /cache
+      name: cache-volume
+      readOnly: true
+  volumes:
+  - name: cache-volume
+    hostPath:
+      path: /tmp # directory location on host
+EOF
+```
+
+You should see the following output:
+
+```bash
+Error from server ([denied by psp-host-filesystem] HostPath volume {"hostPath": {"path": "/tmp", "type": ""}, "name": "cache-volume"} is not allowed, pod: nginx-host-filesystem. Allowed path: [{"readOnly": true, "pathPrefix": "/foo"}]): error when creating "STDIN": admission webhook "validation.gatekeeper.sh" denied the request: [denied by psp-host-filesystem] HostPath volume {"hostPath": {"path": "/tmp", "type": ""}, "name": "cache-volume"} is not allowed, pod: nginx-host-filesystem. Allowed path: [{"readOnly": true, "pathPrefix": "/foo"}]
+```
+
+#### Test that the constraint allows allowed host paths
+
+Try to create a pod that mounts an allowed host path by running the following command:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-host-filesystem
+  labels:
+    app: nginx-host-filesystem
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    volumeMounts:
+    - mountPath: /cache
+      name: cache-volume
+      readOnly: true
+  volumes:
+  - name: cache-volume
+    hostPath:
+      path: /foo # directory location on host
+EOF
+```
+
+You should see the following output:
+
+```bash
+pod/nginx-host-filesystem created
+```
+
+[gatekeeper]:https://github.com/open-policy-agent/gatekeeper
+[gatekeeper-library]:https://github.com/open-policy-agent/gatekeeper-library/tree/master/library/pod-security-policy
+[opa]:https://github.com/open-policy-agent/opa
+[opa-constraints]:https://github.com/open-policy-agent/frameworks/tree/master/constraint
+[opa-rego]:https://www.openpolicyagent.org/docs/latest/policy-language/
+[psp]:https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+[choose-infrastructure]: /dkp/konvoy/2.2/choose-infrastructure/

--- a/pages/dkp/kommander/2.2/security/policy-controls/index.md
+++ b/pages/dkp/kommander/2.2/security/policy-controls/index.md
@@ -1,0 +1,10 @@
+---
+layout: layout.pug
+navigationTitle: Policy Controls
+title: Policy Controls
+menuWeight: 200
+excerpt: Workload Policy Controls
+beta: false
+enterprise: false
+---
+Workload Policy Controls


### PR DESCRIPTION

NOTE: You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4112.s3-website-us-west-2.amazonaws.com/


## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

https://jira.d2iq.com/browse/D2IQ-78966

## Description of changes being made

policy control / gatekeeper docs for 2.2

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Create new PRs against `develop`, or `main` for hotfixes to production.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
