### PR TITLE
[Konvoy] vSphere notes for v1.8.4

### DIFF
--- a/pages/dkp/konvoy/1.8/install/install-vsphere/index.md
+++ b/pages/dkp/konvoy/1.8/install/install-vsphere/index.md
@@ -12,8 +12,6 @@ enterprise: false
 
 This topic describes how to prepare your environment and install Konvoy on VMWare vSphere. This installation is similar to deploying the entire Kubernetes cluster onto vSphere Infrastructure as a Service (IaaS).
 
-<p class="message--warning"><strong>WARNING:</strong> Installing Konvoy 1.8.x on VMWare vSphere in an air-gapped environment is not currently supported.</p>
-
 ## Before you Begin
 
 Before installing, verify that your environment meets the following basic requirements:

--- a/pages/dkp/konvoy/1.8/release-notes/1.8.4/index.md
+++ b/pages/dkp/konvoy/1.8/release-notes/1.8.4/index.md
@@ -53,6 +53,8 @@ This release provides new features and enhancements to improve the user experien
 
 -  Prometheus addon upgrades fail due to a missing alertmanager CRD. To work around this issue, manually apply the missing CRD to the cluster prior to upgrading by running: `kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.47.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml`
 
+-  vSphere provisioning in an air-gapped environment is not supported in this version; however, we will add this functionality to a future release. Refer to the most current release documentation for more information.
+
 ### Component versions
 
 - Ansible 2.9.16.0


### PR DESCRIPTION
Jira ticket: https://jira.d2iq.com/browse/D2IQ-84533

Added note: 
-  vSphere provisioning in an air-gapped environment is not supported in this version; however, we will add this functionality to a future release. Refer to the most current release documentation for more information.

Removed note from vSphere install page.