### PR TITLE
[Konvoy] CentOS 8 EOL, update docs

### DIFF
--- a/pages/dkp/konvoy/1.8/install/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/1.8/install/supported-operating-systems/index.md
@@ -19,7 +19,6 @@ Konvoy supports the following base Operating Systems.
 | [CentOS 7.7][centos7] | 3.10.0-1062.12.1.el7.x86_64 | |
 | [CentOS 7.8][centos7] | 3.10.0-1127.el7.x86_64      | |
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64      | |
-| [CentOS 8.2][centos8] | 4.18.0-193.6.3.el8_2.x86_64 | GPU workloads are not currently supported |
 
 ## RHEL
 
@@ -79,7 +78,6 @@ spec:
 
 [ansible_vars]: https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html
 [centos7]: https://wiki.centos.org/action/show/Manuals/ReleaseNotes/CentOS7.2003
-[centos8]: https://wiki.centos.org/action/show/Manuals/ReleaseNotes/CentOS8.2004
 [rhel_7_7]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.7_release_notes/index
 [rhel_7_8]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.8_release_notes/index
 [rhel_7_9]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.9_release_notes/index


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-84284

## Description of changes being made

Removed CentOS 8 support information on Supported OS page w/in Konvoy.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
