### PR TITLE
[COPS-7075] dkp2 docs 1 export cmd not applicable for MacOS

### DIFF
--- a/pages/dkp/konvoy/2.0/choose_infrastructure/aws/advanced/update/control-plane/index.md
+++ b/pages/dkp/konvoy/2.0/choose_infrastructure/aws/advanced/update/control-plane/index.md
@@ -54,7 +54,7 @@ The control plane is described by a KubeadmControlPlane resource. This reference
     ```sh
     export KUBEADMCONTROLPLANE_NAME=$(kubectl get kubeadmcontrolplanes --selector=cluster.x-k8s.io/cluster-name=${CLUSTER_NAME} -ojsonpath='{.items[0].metadata.name}')
     export CURRENT_TEMPLATE_NAME=$(kubectl get kubeadmcontrolplanes ${KUBEADMCONTROLPLANE_NAME} -ojsonpath='{.spec.machineTemplate.infrastructureRef.name}')
-    export NEW_TEMPLATE_NAME=${KUBEADMCONTROLPLANE_NAME}-$(cat /proc/sys/kernel/random/uuid | head -c4)
+    export NEW_TEMPLATE_NAME=${KUBEADMCONTROLPLANE_NAME}-$(([[ $OSTYPE == 'darwin'* ]] && uuidgen || cat /proc/sys/kernel/random/uuid) | head -c4 | tr "[:upper:]" "[:lower:]")
     ```
 
 1.  Prepare the patch files.

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/update/control-plane/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/update/control-plane/index.md
@@ -56,7 +56,7 @@ The control plane is described by a KubeadmControlPlane resource. This reference
     ```sh
     export KUBEADMCONTROLPLANE_NAME=$(kubectl get kubeadmcontrolplanes --selector=cluster.x-k8s.io/cluster-name=${CLUSTER_NAME} -ojsonpath='{.items[0].metadata.name}')
     export CURRENT_TEMPLATE_NAME=$(kubectl get kubeadmcontrolplanes ${KUBEADMCONTROLPLANE_NAME} -ojsonpath='{.spec.machineTemplate.infrastructureRef.name}')
-    export NEW_TEMPLATE_NAME=${KUBEADMCONTROLPLANE_NAME}-$(cat /proc/sys/kernel/random/uuid | head -c4)
+    export NEW_TEMPLATE_NAME=${KUBEADMCONTROLPLANE_NAME}-$(([[ $OSTYPE == 'darwin'* ]] && uuidgen || cat /proc/sys/kernel/random/uuid) | head -c4 | tr "[:upper:]" "[:lower:]")
     ```
 
 1.  Prepare the patch files.


### PR DESCRIPTION


## Jira Ticket

https://jira.d2iq.com/browse/COPS-7075

## Description of changes being made

Replaced the third command in section 4 of this page: https://docs.d2iq.com/dkp/konvoy/2.0/choose_infrastructure/aws/advanced/update/control-plane/ for MacOS users in both Konvoy 2.0 and 2.1.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
