### PR TITLE
[Konvoy] Kubaddon Update for 1.8.5

### DIFF
--- a/pages/dkp/konvoy/1.8/release-notes/kubernetes-base-addon/index.md
+++ b/pages/dkp/konvoy/1.8/release-notes/kubernetes-base-addon/index.md
@@ -14,6 +14,25 @@ enterprise: false
 
 For instructions on how to apply KBA updates, see [Introduction to KBAs](../../addons)
 
+February 17, 2022
+
+[stable-1.20-4.4.0](https://github.com/mesosphere/kubernetes-base-addons/releases/tag/stable-1.20-4.3.0)
+
+-   kube-oidc-proxy:
+    - Bumps kube-oidc-proxy to 0.3.0 to resolve "kubectl log" latency issues (COPS-7123)
+
+-   Nvidia
+    - Fixes Nvidia GPU platform service placement constraints (COPS-7142)
+    - Updates Nvidia DCGM exporter to 2.2.9 to fix metrics (COPS-7132)
+
+-   Prometheus
+    - Alertmanager CRD is now properly upgraded (COPS-6842)
+    - Adds concurrency policy Replace configuration to the Grafana home dashboard CronJob to avoid potentially creating an unbound number of pods (COPS-7105)
+    - Pins Grafana image to 7.5.6 and bumps kubectl image to 1.20.6 (COPS-6963)
+
+-   Traefik
+    - Brings back the in-cluster storage feature.
+
 December 3, 2021
 
 [stable-1.20-4.3.0](https://github.com/mesosphere/kubernetes-base-addons/releases/tag/stable-1.20-4.3.0)


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-83647?filter=-1



## Description of changes being made

Added 4.4 Kubaddons to appropriate page in konvoy.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
