### PR TITLE
Add some clarifications about control pre-provisioned CP nodes

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-The control plane should have three, five, or seven nodes, so that it can remain available if one, two, or three nodes fail, respectively. A control plane with one node should not be used in production.
+A control plane should have three, five, or seven nodes, so that it can remain available if one, two, or three nodes fail. A control plane with one node should not be used in production.
 
 In addition, the control plane should have an endpoint that remains available if some nodes fail.
 
@@ -24,24 +24,22 @@ In this example, the control plane endpoint host is `lb.example.com`, and the co
 
 ## External load balancer
 
-We recommend an external load balancer be the control plane endpoint. To distribute request load among the control plane machines, configure the load balancer to send requests to all the control plane machines. Configure the load balancer to send requests only to control plane machines that are responding to API requests.
+It is recommended that an external load balancer be the control plane endpoint. To distribute request load among the control plane machines, configure the load balancer to send requests to all the control plane machines. Configure the load balancer to send requests only to control plane machines that are responding to API requests.
 
-## Built-in Virtual IP
+## Built-in virtual IP
 
 If an external load balancer is not available, use the built-in virtual IP. The virtual IP is _not_ a load balancer; it does not distribute request load among the control plane machines. However, if the machine receiving requests does not respond to them, the virtual IP automatically moves to another machine.
 
-## Single-Node Control Plane
+## Single-Node control plane
 
-A control plane with one node can use its single node as the endpoint; neither an external load balancer, nor the built-in virtual IP, needs to be used.
-
-<p class="message--note"><strong>NOTE: </strong> A single node control plane configuration should not be used in production. Additionally, it is not possible to upgrade the control plane if you only have one node because CAPI does not perform in-situ upgrades, it instead replaces machines. If you wish to upgrade your cluster in the future, use the default <code>--control-plane-replicas</code> setting of 3.</p>
+A control plane with one node can use its single node as the endpoint. Which means that neither an external load balancer, nor the built-in virtual IP is required. But, a single-node control plane configuration should not be used in production becuase it is not possible to upgrade the control plane if you only have one node. This is because CAPI does not perform in-situ upgrades, it instead replaces machines. If you want to upgrade your cluster, use the default <code>--control-plane-replicas</code> setting of 3.
 
 When the API server endpoints are defined, you can [create the cluster][create-cluster].
 
-## Known Limitations
+## Known limitations
 
 <p class="message--note"><strong>NOTE: </strong>Be aware of these limitations in the current release of Konvoy.</p>
 
-- The control plane endpoint port is also used as the API server port on each control plane machine. The default port is 6443. Before you create the cluster, make sure that the port is available for use on each control plane machine.
+The control plane endpoint port is also used as the API server port on each control plane machine. The default port is 6443. Before you create the cluster, ensure  the port is available for use on each control plane machine.
 
 [create-cluster]: ../create-cluster

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
@@ -32,7 +32,7 @@ If an external load balancer is not available, use the built-in virtual IP. The 
 
 ## Single-Node control plane
 
-A control plane with one node can use its single node as the endpoint. Which means that neither an external load balancer, nor the built-in virtual IP is required. But, a single-node control plane configuration should not be used in production becuase it is not possible to upgrade the control plane if you only have one node. This is because CAPI does not perform in-situ upgrades, it instead replaces machines. If you want to upgrade your cluster, use the default <code>--control-plane-replicas</code> setting of 3.
+A control plane with one node can use its single node as the endpoint, so you will not require an external load balancer, or a built-in virtual IP. However, do not use a single-node control plane configuration in production, as it is not possible to upgrade the control plane if you only have one node. This is due to the fact that CAPI does not perform in-situ upgrades, instead, it replaces machines. If you want to upgrade your cluster, use the default <code>--control-plane-replicas</code> setting of 3.
 
 When the API server endpoints are defined, you can [create the cluster][create-cluster].
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
@@ -32,7 +32,9 @@ If an external load balancer is not available, use the built-in virtual IP. The 
 
 ## Single-Node Control Plane
 
-A control plane with one node, which should not be used in production, can use its single node as the endpoint; neither an external load balancer, nor the built-in virtual IP, needs to be used.
+A control plane with one node can use its single node as the endpoint; neither an external load balancer, nor the built-in virtual IP, needs to be used.
+
+<p class="message--note"><strong>NOTE: </strong> A single node control plane configuration should not be used in production. Additionally, it is not possible to upgrade the control plane if you only have one node because CAPI does not perform in-situ upgrades, it instead replaces machines. If you wish to upgrade your cluster in the future, use the default `--control-plane-replicas` setting of 3.</p>
 
 When the API server endpoints are defined, you can [create the cluster][create-cluster].
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
@@ -34,7 +34,7 @@ If an external load balancer is not available, use the built-in virtual IP. The 
 
 A control plane with one node can use its single node as the endpoint; neither an external load balancer, nor the built-in virtual IP, needs to be used.
 
-<p class="message--note"><strong>NOTE: </strong> A single node control plane configuration should not be used in production. Additionally, it is not possible to upgrade the control plane if you only have one node because CAPI does not perform in-situ upgrades, it instead replaces machines. If you wish to upgrade your cluster in the future, use the default `--control-plane-replicas` setting of 3.</p>
+<p class="message--note"><strong>NOTE: </strong> A single node control plane configuration should not be used in production. Additionally, it is not possible to upgrade the control plane if you only have one node because CAPI does not perform in-situ upgrades, it instead replaces machines. If you wish to upgrade your cluster in the future, use the default <code>--control-plane-replicas</code> setting of 3.</p>
 
 When the API server endpoints are defined, you can [create the cluster][create-cluster].
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -64,6 +64,8 @@ hunter-aws-cluster-pf4a3
     spec:
       hosts:
         # Create as many of these as needed to match your infrastructure
+        # Note that the command line parameter `--control-plane-replicas` determines how many control plane nodes will actually be used.
+        #
         - address: $CONTROL_PLANE_1_ADDRESS
         - address: $CONTROL_PLANE_2_ADDRESS
         - address: $CONTROL_PLANE_3_ADDRESS

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-The control plane should have three, five, or seven nodes, so that it can remain available if one, two, or three nodes fail, respectively. A control plane with one node should not be used in production.
+A control plane should have three, five, or seven nodes, so that it can remain available if one, two, or three nodes fail. A control plane with one node should not be used in production.
 
 In addition, the control plane should have an endpoint that remains available if some nodes fail.
 
@@ -24,24 +24,22 @@ In this example, the control plane endpoint host is `lb.example.com`, and the co
 
 ## External load balancer
 
-We recommend an external load balancer be the control plane endpoint. To distribute request load among the control plane machines, configure the load balancer to send requests to all the control plane machines. Configure the load balancer to send requests only to control plane machines that are responding to API requests.
+It is recommended that an external load balancer be the control plane endpoint. To distribute request load among the control plane machines, configure the load balancer to send requests to all the control plane machines. Configure the load balancer to send requests only to control plane machines that are responding to API requests.
 
-## Built-in Virtual IP
+## Built-in virtual IP
 
 If an external load balancer is not available, use the built-in virtual IP. The virtual IP is _not_ a load balancer; it does not distribute request load among the control plane machines. However, if the machine receiving requests does not respond to them, the virtual IP automatically moves to another machine.
 
-## Single-Node Control Plane
+## Single-Node control plane
 
-A control plane with one node can use its single node as the endpoint; neither an external load balancer, nor the built-in virtual IP, needs to be used.
-
-<p class="message--note"><strong>NOTE: </strong> A single node control plane configuration should not be used in production. Additionally, it is not possible to upgrade the control plane if you only have one node because CAPI does not perform in-situ upgrades, it instead replaces machines. If you wish to upgrade your cluster in the future, use the default <code>--control-plane-replicas</code> setting of 3.</p>
+A control plane with one node can use its single node as the endpoint. Which means that neither an external load balancer, nor the built-in virtual IP is required. But, a single-node control plane configuration should not be used in production becuase it is not possible to upgrade the control plane if you only have one node. This is because CAPI does not perform in-situ upgrades, it instead replaces machines. If you want to upgrade your cluster, use the default <code>--control-plane-replicas</code> setting of 3.
 
 When the API server endpoints are defined, you can [create the cluster][create-cluster].
 
-## Known Limitations
+## Known limitations
 
-<p class="message--note"><strong>NOTE: </strong>Be aware of these limitations in the current release of Konvoy.</p>
+<p class="message--note"><strong>NOTE: </strong>Be aware of these limitations in the current release of DKP.</p>
 
-- The control plane endpoint port is also used as the API server port on each control plane machine. The default port is 6443. Before you create the cluster, make sure that the port is available for use on each control plane machine.
+The control plane endpoint port is also used as the API server port on each control plane machine. The default port is 6443. Before you create the cluster, ensure  the port is available for use on each control plane machine.
 
 [create-cluster]: ../create-cluster

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-A control plane should have three, five, or seven nodes, so that it can remain available if one, two, or three nodes fail. A control plane with one node should not be used in production.
+A control plane should have three, five, or seven nodes, so it can remain available if one, two, or three nodes fail. A control plane with one node should not be used in production.
 
 In addition, the control plane should have an endpoint that remains available if some nodes fail.
 
@@ -32,7 +32,7 @@ If an external load balancer is not available, use the built-in virtual IP. The 
 
 ## Single-Node control plane
 
-A control plane with one node can use its single node as the endpoint. Which means that neither an external load balancer, nor the built-in virtual IP is required. But, a single-node control plane configuration should not be used in production becuase it is not possible to upgrade the control plane if you only have one node. This is because CAPI does not perform in-situ upgrades, it instead replaces machines. If you want to upgrade your cluster, use the default <code>--control-plane-replicas</code> setting of 3.
+A control plane with one node can use its single node as the endpoint, so you will not require an external load balancer, or a the built-in virtual IP. However, do not use a single-node control plane configuration in production, as it is not possible to upgrade the control plane if you only have one node. This is due to the fact that CAPI does not perform in-situ upgrades, instead, it replaces machines. If you want to upgrade your cluster, use the default <code>--control-plane-replicas</code> setting of 3.
 
 When the API server endpoints are defined, you can [create the cluster][create-cluster].
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-control-plane-endpoint/index.md
@@ -32,7 +32,9 @@ If an external load balancer is not available, use the built-in virtual IP. The 
 
 ## Single-Node Control Plane
 
-A control plane with one node, which should not be used in production, can use its single node as the endpoint; neither an external load balancer, nor the built-in virtual IP, needs to be used.
+A control plane with one node can use its single node as the endpoint; neither an external load balancer, nor the built-in virtual IP, needs to be used.
+
+<p class="message--note"><strong>NOTE: </strong> A single node control plane configuration should not be used in production. Additionally, it is not possible to upgrade the control plane if you only have one node because CAPI does not perform in-situ upgrades, it instead replaces machines. If you wish to upgrade your cluster in the future, use the default <code>--control-plane-replicas</code> setting of 3.</p>
 
 When the API server endpoints are defined, you can [create the cluster][create-cluster].
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -62,6 +62,8 @@ Konvoy needs to know how to access your cluster hosts. This is done using invent
     spec:
       hosts:
         # Create as many of these as needed to match your infrastructure
+        # Note that the command line parameter `--control-plane-replicas` determines how many control plane nodes will actually be used.
+        #
         - address: $CONTROL_PLANE_1_ADDRESS
         - address: $CONTROL_PLANE_2_ADDRESS
         - address: $CONTROL_PLANE_3_ADDRESS


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/COPS-7169

## Description of changes being made

The difficulties documented in COPS-7169 may have been avoided if it had been clearer to the end user that the number of nodes specified in the preprovisioned inventory file does not control how many CP nodes Konvoy will try to use.
Additionally, the docs are not very clear about the fact that you cannot currently upgrade clusters with single node control planes.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4133.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
