### PR TITLE
docs: adding kommander open dashboard command

### DIFF
--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -8,29 +8,28 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD018 MD025 MD007 MD030 MD032-->
 This topic shows how to run Kommander on top of an [air-gapped Konvoy cluster][air-gap-konvoy] installation.
 
 ## Prerequisites
 
 Before installing, ensure you have:
 
-- A Docker registry containing all the necessary Docker installation images, including the Kommander images. The `kommander-image-bundle.tar` tarball has the required artifacts.
+-   A Docker registry containing all the necessary Docker installation images, including the Kommander images. The `kommander-image-bundle.tar` tarball has the required artifacts.
 
-- Connectivity with clusters attaching to the management cluster:
-  - Both management and attached clusters must connect to the Docker registry.
-  - Management cluster must connect to the attached cluster's API server.
-  - Management cluster must connect to load balancers created by some platform services.
+-   Connectivity with clusters attaching to the management cluster:
+    - Both management and attached clusters must connect to the Docker registry.
+    - Management cluster must connect to the attached cluster's API server.
+    - Management cluster must connect to load balancers created by some platform services.
 
-- A [configuration file][kommander-config] that you will adapt to your needs using the steps outlined in this topic. Make sure to create that file using the following command:
+-   A [configuration file][kommander-config] that you will adapt to your needs using the steps outlined in this topic. Make sure to create that file using the following command:
 
   ```bash
   kommander install --init > install.yaml
   ```
 
-- All the prerequisites covered in [air-gapped Konvoy installation][air-gap-before-you-begin].
+-   All the prerequisites covered in [air-gapped Konvoy installation][air-gap-before-you-begin].
 
-- [MetalLB enabled and configured][air-gap-install-metallb], which provides load-balancing services.
+-   [MetalLB enabled and configured][air-gap-install-metallb], which provides load-balancing services.
 
 ### Use MetalLB
 
@@ -122,15 +121,15 @@ export VERSION=v2.1.0
 
 ### Load the Docker images into your Docker registry
 
-1. Download the image bundle file:
+1.  Download the image bundle file:
 
     ```bash
     wget "https://downloads.mesosphere.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
     ```
 
-1. Place the bundle in a location where you can load and push the images to your private Docker registry.
+1.  Place the bundle in a location where you can load and push the images to your private Docker registry.
 
-1. Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately, then use the following script to load the air-gapped image bundle:
+1.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately, then use the following script to load the air-gapped image bundle:
 
     ```bash
     #!/usr/bin/env bash
@@ -154,7 +153,7 @@ Based on the network latency between the environment of script execution and the
 
 ## Install on Konvoy
 
-1. Adapt the [configuration file][kommander-config] created from running `kommander install --init > install.yaml` for the air-gapped deployment by changing the `.apps.kommander` section. Ensure you use the actual version number everywhere `${VERSION}` appears:
+1.  Adapt the [configuration file][kommander-config] created from running `kommander install --init > install.yaml` for the air-gapped deployment by changing the `.apps.kommander` section. Ensure you use the actual version number everywhere `${VERSION}` appears:
 
     ```yaml
     apiVersion: config.kommander.mesosphere.io/v1alpha1
@@ -194,7 +193,7 @@ Based on the network latency between the environment of script execution and the
     ...
     ```
 
-1. In the same file, adapt the other image tags accordingly and enable air-gapped mode. Replace `${VERSION}` with the actual version number:
+1.  In the same file, adapt the other image tags accordingly and enable air-gapped mode. Replace `${VERSION}` with the actual version number:
 
     ```yaml
     appManagementImageTag: "${VERSION}-amd64"
@@ -203,7 +202,7 @@ Based on the network latency between the environment of script execution and the
       helmMirrorImageTag: "${VERSION}-amd64"
     ```
 
-1. In the same file, if you are installing Kommander in an AWS VPC, set the Traefik annotation to create an internal facing ELB:
+1.  In the same file, if you are installing Kommander in an AWS VPC, set the Traefik annotation to create an internal facing ELB:
 
     ```yaml
     apps:
@@ -214,19 +213,19 @@ Based on the network latency between the environment of script execution and the
               service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     ```
 
-1. Download and extract the `kommander-applications` bundle.
+1.  Download and extract the `kommander-applications` bundle.
 
     ```bash
     mkdir kommander-applications && wget https://downloads.mesosphere.com/dkp/kommander-applications_${VERSION}.tar.gz -O - | tar xvzf - -C kommander-applications --strip-components 1
     ```
 
-1. To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
+1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
     kommander install --installer-config ./install.yaml --kommander-applications-repository ./kommander-applications
     ```
 
-1. [Verify your installation](../networked#verify-installation).
+1.  [Verify your installation](../networked#verify-installation).
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.1/install/networked/index.md
+++ b/pages/dkp/kommander/2.1/install/networked/index.md
@@ -94,13 +94,21 @@ helmrelease.helm.toolkit.fluxcd.io/velero condition met
 
 ## Access Kommander Web UI
 
-When all the `HelmReleases` are ready, use the following command to retrieve the URL used for accessing Kommander's Web interface:
+When all the `HelmReleases` are ready, use the following command to open the Kommander dashboard in your browser:
+
+```sh
+kommander open dashboard
+```
+
+This command will open your default browser and go to the URL of the Kommander web interface, and also print the username and password in the CLI.
+
+If you prefer not to open your browser immediately, you can also use the following command to retrieve the URL used for accessing Kommander's Web interface:
 
 ```sh
 kubectl -n kommander get svc kommander-traefik -o go-template='https://{{with index .status.loadBalancer.ingress 0}}{{or .hostname .ip}}{{end}}/dkp/kommander/dashboard{{ "\n"}}'
 ```
 
-Use the following command to access the Username and Password stored on the cluster:
+And, use the following command to access the Username and Password stored on the cluster:
 
 ```sh
 kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}'

--- a/pages/dkp/kommander/2.1/install/networked/index.md
+++ b/pages/dkp/kommander/2.1/install/networked/index.md
@@ -100,15 +100,15 @@ When all the `HelmReleases` are ready, use the following command to open the Kom
 kommander open dashboard
 ```
 
-This command will open your default browser and go to the URL of the Kommander web interface, and also print the username and password in the CLI.
+This command opens the URL of the Kommander web interface in your default browser, and prints the username and password in the CLI.
 
-If you prefer not to open your browser immediately, you can also use the following command to retrieve the URL used for accessing Kommander's Web interface:
+If you prefer not to open your browser, run this command to retrieve the URL used for accessing Kommander's web interface:
 
 ```sh
 kubectl -n kommander get svc kommander-traefik -o go-template='https://{{with index .status.loadBalancer.ingress 0}}{{or .hostname .ip}}{{end}}/dkp/kommander/dashboard{{ "\n"}}'
 ```
 
-And, use the following command to access the Username and Password stored on the cluster:
+And, use the following command to access the username and password stored on the cluster:
 
 ```sh
 kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}'

--- a/pages/dkp/kommander/2.1/operations/identity-providers/index.md
+++ b/pages/dkp/kommander/2.1/operations/identity-providers/index.md
@@ -7,8 +7,6 @@ menuWeight: 20
 excerpt: Grant access to users in your organization
 ---
 
-<!--- markdownlint-disable MD030 --->
-
 ## Log in with Username and Password
 
 By default, you can log in to Kommander with the credentials given by the following command to access the Username and Password stored on the cluster:

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -37,6 +37,11 @@ For more information, see [DKP catalog applications](../../workspaces/applicatio
 - Fixed an issue where the `dkp delete` command could fail with a SIGSEGV when attempting to delete a DKP cluster from AWS where you have permanent credentials. (COPS-7109)
 - Fixed an issue where the AWS `--region` or Azure `--location` installer flags were not being enforced in the target cluster. (COPS-7101)
 - Corrected an issue where the `PreprovisionedInventory` object and SSH key secret were not moved to the target cluster when making the cluster self-managing.(COPS-7079)
+- When Kommander installation is complete, you can open the Kommander dashboard and access the username and password credentials by running:
+
+```sh
+kommander open dashboard
+```
 
 ## Component updates
 

--- a/pages/dkp/kommander/2.2/install/networked/index.md
+++ b/pages/dkp/kommander/2.2/install/networked/index.md
@@ -94,13 +94,21 @@ helmrelease.helm.toolkit.fluxcd.io/velero condition met
 
 ## Access Kommander Web UI
 
-When all the `HelmReleases` are ready, use the following command to retrieve the URL used for accessing Kommander's Web interface:
+When all the `HelmReleases` are ready, use the following command to open the Kommander dashboard in your browser:
+
+```sh
+kommander open dashboard
+```
+
+This command will open your default browser and go to the URL of the Kommander web interface, and also print the username and password in the CLI.
+
+If you prefer not to open your browser immediately, you can also use the following command to retrieve the URL used for accessing Kommander's Web interface:
 
 ```sh
 kubectl -n kommander get svc kommander-traefik -o go-template='https://{{with index .status.loadBalancer.ingress 0}}{{or .hostname .ip}}{{end}}/dkp/kommander/dashboard{{ "\n"}}'
 ```
 
-Use the following command to access the Username and Password stored on the cluster:
+And, use the following command to access the Username and Password stored on the cluster:
 
 ```sh
 kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}'

--- a/pages/dkp/kommander/2.2/install/networked/index.md
+++ b/pages/dkp/kommander/2.2/install/networked/index.md
@@ -100,15 +100,15 @@ When all the `HelmReleases` are ready, use the following command to open the Kom
 kommander open dashboard
 ```
 
-This command will open your default browser and go to the URL of the Kommander web interface, and also print the username and password in the CLI.
+This command opens the URL of the Kommander web interface in your default browser, and prints the username and password in the CLI.
 
-If you prefer not to open your browser immediately, you can also use the following command to retrieve the URL used for accessing Kommander's Web interface:
+If you prefer not to open your browser, run this command to retrieve the URL used for accessing Kommander's web interface:
 
 ```sh
 kubectl -n kommander get svc kommander-traefik -o go-template='https://{{with index .status.loadBalancer.ingress 0}}{{or .hostname .ip}}{{end}}/dkp/kommander/dashboard{{ "\n"}}'
 ```
 
-And, use the following command to access the Username and Password stored on the cluster:
+And, use the following command to access the username and password stored on the cluster:
 
 ```sh
 kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}'


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made
I didn't know this kommander open dashboard command was a thing.
Totally worth adding this in the docs, methinks

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4134.s3-website-us-west-2.amazonaws.com/

## Checklist

- [x] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
