### PR TITLE
Add last minute change in KBA to Release notes

### DIFF
--- a/pages/dkp/konvoy/1.8/release-notes/kubernetes-base-addon/index.md
+++ b/pages/dkp/konvoy/1.8/release-notes/kubernetes-base-addon/index.md
@@ -18,6 +18,9 @@ February 17, 2022
 
 [stable-1.20-4.4.0](https://github.com/mesosphere/kubernetes-base-addons/releases/tag/stable-1.20-4.4.0)
 
+-   defaultstorageclass-protection
+    - Add a version tag to the chart and image, instead of using :latest. (COPS-7184)
+
 -   kube-oidc-proxy:
     - Bumps kube-oidc-proxy to 0.3.0 to resolve "kubectl log" latency issues (COPS-7123)
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7184

## Description of changes being made

We held up 1.8.5 release to get one more KBA change but missed out adding that change to the release notes.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
