### PR TITLE
docs: updating cli upgrade versions and linting

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -1,6 +1,7 @@
 ad hoc
 (Addon|addon)
 Airflow
+air gapped bundle
 air gapped environment
 (Alertmanager|alertmanager)
 ANN(|s)
@@ -9,6 +10,7 @@ archiver
 auto-assign
 Auto-IP
 (auto-provisioner|Auto-Provisioner)
+auto-provisioning
 autoscal(e|es|ed|ing)
 autotune
 (AWS|aws)
@@ -22,7 +24,7 @@ Cassandra
 CentOS
 checkpoint(|s|ed|ing)
 (chronos|Chronos)
-Chrony
+(Chrony|chrony)
 clusterawsadm
 CNN(|s)
 CNTK
@@ -30,6 +32,7 @@ CNTK
 Conda
 config
 (ConfigMap|configmap|configMap)
+conntrack
 (Containerd|containerd)
 contravariant
 COPS
@@ -41,6 +44,8 @@ cpu
 CPU
 CRD
 Crunchbase
+cthelper
+cttimeout
 datacenter
 datasource
 D2iQ
@@ -57,12 +62,15 @@ distroless
 DKLB
 Dockerfile
 DSL(|s)
+ebtables
 ECR
 (Elasticsearch|elasticsearch)
 elasticsearchexporter
 (ETCD|etcd)
+ethtool
 fastai
 felix
+Fermie
 finalizer(|s)
 fips
 FIPS
@@ -88,8 +96,11 @@ hotfix(|es)
 hyperparameter(|s)
 (http|HTTP)
 (https|HTTPS)
+IAM
 (Imagefs|imagefs)
 io
+iproute
+iptables
 (istio|Istio)
 journald
 Jira
@@ -128,6 +139,9 @@ kustomize
 KUDO
 Kustomization
 (Kustomize|kustomize)
+libblkid
+libnetfilter
+libseccomp
 licensors
 linkerd
 liveness
@@ -159,8 +173,10 @@ mypy
 Nagios
 namespac(e|es|ed|ing)
 (nginx|NGINX)
+Nouveau
 (nvidia|Nvidia|NVIDIA)
 onboarding
+openssl
 (OpsPortal|opsportal)
 overfit(|s|ted|ting)
 Papermill
@@ -175,14 +191,16 @@ Purestorage
 Pushgateway
 pytest
 PyTorch
+rpcbind
 rebalance
-Reloader
-reloader
-repo
 (reloader|Reloader)
+repo
+retags
 RGB
+(rhel|RHEL)
 RNN(|s)
 runbook(|s)
+runc
 Scala
 scikit-learn
 sd_material_ui
@@ -190,6 +208,7 @@ sed
 serverless
 sigmoidal
 Snapshotter
+socat
 softmax
 Splunk
 stdout
@@ -218,6 +237,7 @@ unpause(|s)
 (Velero|velero)
 (WebSocket|Websocket|websocket)
 (VNET|vnet)
+xfsprogs
 XGBoost
 xlarge
 yakcl

--- a/pages/dkp/konvoy/1.8/gpu/index.md
+++ b/pages/dkp/konvoy/1.8/gpu/index.md
@@ -8,11 +8,9 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
-
 This section describes the Nvidia GPU support on Konvoy. This document assumes familiarity with Kubernetes GPU support. The AMD GPU is currently not supported.
 
-# Konvoy GPU Overview
+## Konvoy GPU Overview
 
 GPU support on Konvoy is achieved by using the [nvidia-container-runtime][nvidia_container_runtime].
 With the Nvidia GPU turned on, Konvoy configures the container runtime, for running GPU containers, and installs all the necessary items to power up the Nvidia GPU devices.
@@ -22,22 +20,22 @@ Konvoy runs every Nvidia GPU dependent component as daemonsets, making it easier
 
 The following components provide Nvidia GPU support on Konvoy:
 
-* [libnvidia-container][libnvidia_container] and [nvidia-container-runtime][nvidia_container_runtime]: Konvoy uses containerd as kubernetes container runtime by default. [libnvidia-container][libnvidia_container] and [nvidia-container-runtime][nvidia_container_runtime] shim between containerd and runc, which simplifies the container runtime integration with GPU support. Another benefit is this avoids using [nvidia-docker2][nvidia_docker].
-* [Nvidia Device Plugin][nvidia_k8s_device_plugin]: Konvoy makes use of Nvidia GPUs via this Kubernetes device plugin. It enables running GPU enabled containers on Kubernetes, tracks the number of available GPUs on each node and their health.
-* [NVIDIA Data Center GPU Manager][nvidia_dcgm]: Contains a Prometheus exporter that provides Nvidia GPU metrics.
+- [libnvidia-container][libnvidia_container] and [nvidia-container-runtime][nvidia_container_runtime]: Konvoy uses containerd as kubernetes container runtime by default. [libnvidia-container][libnvidia_container] and [nvidia-container-runtime][nvidia_container_runtime] shim between containerd and runc, which simplifies the container runtime integration with GPU support. Another benefit is this avoids using [nvidia-docker2][nvidia_docker].
+- [Nvidia Device Plugin][nvidia_k8s_device_plugin]: Konvoy makes use of Nvidia GPUs via this Kubernetes device plugin. It enables running GPU enabled containers on Kubernetes, tracks the number of available GPUs on each node and their health.
+- [NVIDIA Data Center GPU Manager][nvidia_dcgm]: Contains a Prometheus exporter that provides Nvidia GPU metrics.
 
-## Requirements
+### Requirements
 
-1.  Centos 7 or Ubuntu 16.04/18.04 with the IPMI driver enabled and the Nouveau driver disabled.
+1.  CentOS 7 or Ubuntu 16.04/18.04 with the IPMI driver enabled and the Nouveau driver disabled.
     <!-- If you are running Ubuntu 18.04 with an AWS kernal, you also need to enable the i2c_core kernel module. -->
 
 1.  NVIDIA GPU with Fermie architecture version 2.1 or greater.
 
 1.  Nvidia driver must be running on each GPU host node. Nvidia driver version `450.51.06-1` is recommended. Follow the official [Nvidia Driver Installation Guide][nvidia_driver_installation_guide] to setup the driver on the host. For example,
 
-<p class="message--important"><strong>IMPORTANT: </strong>For Konvoy versions v1.8.0, 1.8.1, and v1.8.2, Nvidia driver version 450.51.06-1 is recommended. For Konvoy versions v1.8.4, Nvidia driver version 460.73.01 is recommended.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>For Konvoy versions v1.8.0, 1.8.1, and v1.8.2, Nvidia driver version 450.51.06-1 is recommended. For Konvoy versions v1.8.4 and above, Nvidia driver version 460.73.01 is recommended.</p>
 
-* Centos 7
+- CentOS 7
 
 ```bash
 sudo yum update -y
@@ -58,7 +56,7 @@ sudo yum clean expire-cache
 sudo yum install -y nvidia-driver-latest-dkms-3:450.51.06-1.el7.x86_64
 ```
 
-* Ubuntu 16.04/18.04 LTS
+- Ubuntu 16.04/18.04 LTS
 
 ```bash
 sudo apt-get install linux-headers-$(uname -r)
@@ -74,7 +72,7 @@ sudo apt-get update
 sudo apt-get -y install cuda-drivers-460
 ```
 
-* Verify the Nvidia driver is running on the host
+- Verify the Nvidia driver is running on the host
 
 ```bash
 [centos@ip-10-0-130-28 ~]$ nvidia-smi
@@ -100,9 +98,9 @@ Fri Jun 11 09:05:31 2021
 +-----------------------------------------------------------------------------+
 ```
 
-## Configuration
+### Configuration
 
-### Enable Nvidia GPU on Konvoy
+#### Enable Nvidia GPU on Konvoy
 
 To enable Nvidia GPU support on Konvoy, add the Nvidia GPU `nodePools` in ClusterProvisioner and ClusterConfiguration, then enable the `nvidia` addon. Here is an example of the `cluster.yaml`:
 
@@ -138,7 +136,7 @@ spec:
       enabled: true
 ```
 
-### How to prevent other workloads from running on GPU nodes
+#### How to prevent other workloads from running on GPU nodes
 
 Use Kubernetes taints to ensure only dedicated workloads are deployed on GPU machines. You must add tolerations to your GPU workloads to deploy on the dedicated GPU nodes. See [Kubernetes Taints and Tolerations][k8s_taints_and_tolerations] for details.
 
@@ -203,11 +201,11 @@ spec:
 ......
 ```
 
-## Nvidia GPU Monitoring
+### Nvidia GPU Monitoring
 
 Konvoy uses the [NVIDIA Data Center GPU Manager][nvidia_dcgm] to export GPU metrics towards Prometheus. By default, Konvoy has a Grafana dashboard called `NVIDIA DCGM Exporter Dashboard` to monitor GPU metrics. This GPU dashboard is shown in Konvoy's Grafana UI.
 
-## Upgrade
+### Upgrade
 
 Konvoy is capable of automatically upgrading the Nvidia GPU addon. However, GPU workload needs to be drained if the Nvidia addon is being upgraded.
 
@@ -219,7 +217,7 @@ Konvoy is capable of automatically upgrading the Nvidia GPU addon. However, GPU 
     kubectl delete clusteraddon nvidia
     ```
 
-1. Wait for all Nvidia-related resources in the `Terminating` state to be cleaned up. You can check pod status with:
+1.  Wait for all Nvidia-related resources in the `Terminating` state to be cleaned up. You can check pod status with:
 
     ```bash
     kubectl get pod -A | grep nvidia
@@ -231,7 +229,7 @@ Konvoy is capable of automatically upgrading the Nvidia GPU addon. However, GPU 
     konvoy deploy addons
     ```
 
-## Debugging
+### Debugging
 
 1.  Determine if all Nvidia pods are in `Running` state, as expected:
 

--- a/pages/dkp/konvoy/1.8/install/install-airgapped/index.md
+++ b/pages/dkp/konvoy/1.8/install/install-airgapped/index.md
@@ -8,51 +8,53 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 MD018 -->
+<!-- markdownlint-disable MD018 -->
 
-# Before you begin
+## Before you begin
 
 Before installing, verify that your environment meets the following basic requirements:
 
-- [Docker][install_docker] version 18.09.2 or later
+-   [Docker][install_docker] version 18.09.2 or later
 
-  You must have Docker installed on the host where the Konvoy command line interface (CLI) will run.
-  For example, if you are installing Konvoy on your laptop, be sure the laptop has a supported version of Docker.
+    You must have Docker installed on the host where the Konvoy command line interface (CLI) will run.
+    For example, if you are installing Konvoy on your laptop, be sure the laptop has a supported version of Docker.
 
-- [kubectl][install_kubectl] v1.20.6 or later
+-   [kubectl][install_kubectl] v1.20.6 or later
 
-  To enable interaction with the running cluster, you must have `kubectl` installed on the host where the Konvoy command line interface (CLI) will run.
+    To enable interaction with the running cluster, you must have `kubectl` installed on the host where the Konvoy command line interface (CLI) will run.
 
-- The `konvoy_air_gapped.tar.bz2` that will contain the required artifacts to perform an air-gapped installation.
+-   The `konvoy_air_gapped.tar.bz2` that will contain the required artifacts to perform an air-gapped installation.
 
-- If you would like to use Kommander for multi-cluster management capabilities, you need to exercise additional configuration steps. Refer to the [Kommander air-gapped installation documentation][kommander_air_gapped_install].
+<!-- vale Vale.Spelling = NO -->
+- If you would like to use Kommander for multi-cluster management capabilities, you need to exercise additional configuration steps. Refer to the [Kommander air gapped environment installation documentation][kommander_ag_install].
+<!-- vale Vale.Spelling = YES -->
 
-## Control plane nodes
+### Control plane nodes
 
-- You should have at least three control plane nodes.
+-   You should have at least three control plane nodes.
 
-- Each control plane node should have at least:
-  - 4 cores
-  - 16 GiB memory
-  - Approximately 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
-  - Disk usage must be below 85% on the root volume.
+-   Each control plane node should have at least:
+    - 4 cores
+    - 16 GiB memory
+    - Approximately 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
+    - Disk usage must be below 85% on the root volume.
 
-## Worker nodes
+### Worker nodes
 
-- You should have at least four worker nodes.
+-   You should have at least four worker nodes.
 
-  The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
+    The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
 
-- Each worker node should have at least:
-  - 8 cores
-  - 32 GiB memory
-  - Approximately 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
-  - Disk usage must be below 85% on the root volume.
+-   Each worker node should have at least:
+    - 8 cores
+    - 32 GiB memory
+    - Approximately 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
+    - Disk usage must be below 85% on the root volume.
 
-- If you plan to use **local volume provisioning** to provide [persistent volumes][persistent_volume] for the workloads, you must mount at least four volumes to `/mnt/disks/` mount point on each node.
+-   If you plan to use **local volume provisioning** to provide [persistent volumes][persistent_volume] for the workloads, you must mount at least four volumes to `/mnt/disks/` mount point on each node.
   Each volume must have **at least** 55 GiB of capacity if the default addon configurations are used.
 
-## Operating system and services for all nodes
+### Operating system and services for all nodes
 
 #include /dkp/konvoy/1.8/include/os-svc-nodes.tmpl
 
@@ -60,57 +62,57 @@ The following requirement is specific to air-gapped environments:
 
 - Python is installed and the `python` executable can be found in the standard `PATH`.
 
-# Initialize Konvoy configuration files
+## Initialize Konvoy configuration files
 
 To start the Konvoy installation, you first need an [Ansible][ansible] [inventory file][ansible_inventory] in your current working directory to describe the hosts where you want to install Konvoy.
 Konvoy will automatically generate the skeleton of the inventory file for you during initialization:
 
-1. Create an empty working directory on the computer you are using as the deploy host.
+1.  Create an empty working directory on the computer you are using as the deploy host.
 
-   For example, you might run the following on your laptop:
+    For example, you might run the following on your laptop:
 
-   ```bash
-   mkdir konvoy-deploy
-   cd konvoy-deploy
-   ```
+    ```bash
+    mkdir konvoy-deploy
+    cd konvoy-deploy
+    ```
 
-1. Run the following commands to initialize Konvoy in the current working directory:
+1.  Run the following commands to initialize Konvoy in the current working directory:
 
-   ```bash
-   konvoy init --provisioner=<provisioner type> --addons-repositories /opt/konvoy/artifacts/kubernetes-base-addons,/opt/konvoy/artifacts/kubeaddons-kommander,/opt/konvoy/artifacts/kubeaddons-dispatch [--cluster-name <your-specified-name>]
-   ```
+    ```bash
+    konvoy init --provisioner=<provisioner type> --addons-repositories /opt/konvoy/artifacts/kubernetes-base-addons,/opt/konvoy/artifacts/kubeaddons-kommander,/opt/konvoy/artifacts/kubeaddons-dispatch [--cluster-name <your-specified-name>]
+    ```
 
-In case of on-premises, the `provisioner type` should be equal to `none`, for AWS it is `aws`.
+    In case of on-premises, the `provisioner type` should be equal to `none`, for AWS it is `aws`.
 
-<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _.</code></p>
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>.</p>
 
-   Running the `konvoy init` command generates an inventory file skeleton `inventory.yaml` and a default `cluster.yaml` configuration file in the current working directory.
+    Running the `konvoy init` command generates an inventory file skeleton `inventory.yaml` and a default `cluster.yaml` configuration file in the current working directory.
 
-   The additional `--addons-repositories` flag results in the generated `cluster.yaml` setting the corresponding values to use locally available addon configs instead of using the default ones that are usually reachable over the Internet.
-   The path `/opt/konvoy/artifacts/...` is the directory path where the `konvoy` binary is mounted from the host into the container.
+    The additional `--addons-repositories` flag results in the generated `cluster.yaml` setting the corresponding values to use locally available addon configs instead of using the default ones that are usually reachable over the Internet.
+    The path `/opt/konvoy/artifacts/...` is the directory path where the `konvoy` binary is mounted from the host into the container.
 
-   <p class="message--note"><strong>NOTE: </strong> This should not be changed unless you are referencing a different repo than the one provided in the tar.</p>
+    <p class="message--note"><strong>NOTE: </strong> This should not be changed unless you are referencing a different repo than the one provided in the tar.</p>
 
-   ```yaml
-   kind: ClusterConfiguration
-   apiVersion: konvoy.mesosphere.io/v1beta2
-   spec:
-   ...
-     addons:
-     - configRepository: /opt/konvoy/artifacts/kubernetes-base-addons
+    ```yaml
+    kind: ClusterConfiguration
+    apiVersion: konvoy.mesosphere.io/v1beta2
+    spec:
+    ...
+      addons:
+      - configRepository: /opt/konvoy/artifacts/kubernetes-base-addons
+        addonsList:
+        ...
+     - configRepository: /opt/konvoy/artifacts/kubeaddons-dispatch
        addonsList:
-       ...
-    - configRepository: /opt/konvoy/artifacts/kubeaddons-dispatch
-      addonsList:
-      - name: dispatch
-        enabled: false
-    - configRepository: /opt/konvoy/artifacts/kubeaddons-kommander
-      addonsList:
-      - name: kommander
-        enabled: true
-   ```
+       - name: dispatch
+         enabled: false
+     - configRepository: /opt/konvoy/artifacts/kubeaddons-kommander
+       addonsList:
+       - name: kommander
+         enabled: true
+    ```
 
-1. Open inventory file `inventory.yaml` in a text editor to specify the hosts.
+1.  Open inventory file `inventory.yaml` in a text editor to specify the hosts.
 
 The inventory file `inventory.yaml` follows the standard [Ansible inventory file yaml format][ansible_inventory] for hosts and groups.
 
@@ -122,7 +124,7 @@ For Konvoy, specify two [groups][ansible_group]
 The `control-plane` group defines the host IP addresses for your control plane nodes.
 The `node` group defines the host IP addresses for your worker nodes.
 
-## Specifying IP addresses and host names
+### Specifying IP addresses and host names
 
 The IP addresses you specify in the inventory file can be the private IP addresses you use in your internal network.
 The primary requirement is that all of the hosts in the cluster can communicate with each other using the IP addresses you specify.
@@ -130,14 +132,14 @@ Note that placing all of the hosts in the same subnet (for example, 10.0.50.0/24
 
 For each host, you can also optionally specify the `ansible_host` attribute if you want Ansible to use different host names to reach the hosts.
 
-## Ensuring connectivity
+### Ensuring connectivity
 
 Make sure that the computer you are using as the **deploy host** can open secure shell (SSH) connections to communicate with each host specified in the inventory file.
 To ensure a successful installation, the `ansible_user` account must be able to open a secure shell on each host without typing password.
 
 You can use `ssh-agent` to pass identity keys and passphrases for authentication.
 
-## Sample inventory file
+### Sample inventory file
 
 The following `inventory.yaml` file will be generated after running `konvoy init`:
 
@@ -165,15 +167,15 @@ all:
     version: v1beta1
 ```
 
-- `<ip-address>` is the host's private IP address that will be used by Kubernetes for the Node's identity.
-- `ansible_host` is the IP used by Konvoy to SSH into the host, if removed the `<ip-address>` will be used instead.
-- `ansible_port` is an optional port used by Konvoy to SSH into the host, the default value is 22.
-- `node_pool` is used to group nodes into pools, Konvoy will apply a Kubernetes label based on this value and use it internally when selecting Nodes based on their pool.
+-   `<ip-address>` is the host's private IP address that will be used by Kubernetes for the Node's identity.
+-   `ansible_host` is the IP used by Konvoy to SSH into the host, if removed the `<ip-address>` will be used instead.
+-   `ansible_port` is an optional port used by Konvoy to SSH into the host, the default value is 22.
+-   `node_pool` is used to group nodes into pools, Konvoy will apply a Kubernetes label based on this value and use it internally when selecting Nodes based on their pool.
 
-- `ansible_ssh_private_key_file` is the name of the private SSH key used by Konvoy to SSH into the hosts.
-- `ansible_user` is the user used by Konvoy to SSH into the hosts.
-- `control_plane_endpoint` is an address for a loadbalancer used by all of the Nodes to reach the Kubernetes API.
-- The values of `order: sorted` and `version: v1beta1` should not be modfied.
+-   `ansible_ssh_private_key_file` is the name of the private SSH key used by Konvoy to SSH into the hosts.
+-   `ansible_user` is the user used by Konvoy to SSH into the hosts.
+-   `control_plane_endpoint` is an address for a load balancer used by all of the Nodes to reach the Kubernetes API.
+-   The values of `order: sorted` and `version: v1beta1` should not be modified.
 
 The following example illustrates a simple `inventory.yaml` file with three control plane nodes and three worker nodes.
 
@@ -211,12 +213,12 @@ In this example:
 - The `ansible_ssh_private_key_file` is set to `mysshkey.pem` and is expected to be in working directory.
 - The `ansible_user` is the `centos` user account that has administrative privileges.
 
-# Configure the Kubernetes cluster
+## Configure the Kubernetes cluster
 
 After you edit the inventory file, edit the generated `cluster.yaml` file.
 The `cluster.yaml` file provides the configuration details for creating your Konvoy cluster.
 
-## Configure the RPM and DEB package repository
+### Configure the RPM and DEB package repository
 
 By default Konvoy adds new RPM and DEB repositories to the control-plane and worker hosts that are required to install a container runtime and a Kubernetes cluster.
 In an air-gapped environment these repos will not be available, but instead the packages will be copied from the konvoy directory.
@@ -234,7 +236,7 @@ The RPM packages installed by Konvoy:
 - chrony
 - conntrack
 - containerd.io
-- container-selinux, on RHEL you can install the [Centos RPM][selinux-rpm] directly
+- container-selinux, on RHEL you can install the [CentOS RPM][selinux-rpm] directly
 - cri-tools
 - ebtables
 - ethtool
@@ -258,7 +260,7 @@ The RPM packages installed by Konvoy:
 - util-linux
 - yum-plugin-versionlock
 
-<p class="message--note"><strong>NOTE: </strong>The above list of RPM packages is sufficient for the default Centos 7 AMI used in Konvoy. There may be additional dependencies that need to be installed that can be found in the standard CentOS/RHEL repositories.</p>
+<p class="message--note"><strong>NOTE: </strong>The above list of RPM packages is sufficient for the default CentOS 7 AMI used in Konvoy. There may be additional dependencies that need to be installed that can be found in the standard CentOS/RHEL repositories.</p>
 
 The DEB packages installed by Konvoy:
 
@@ -297,9 +299,11 @@ For example on `Ubuntu 18.04`, you must replace the following Deb packages and t
     - libnspr4_2%3a4.18-1ubuntu1_amd64.deb
     - libnss3_2%3a3.35-2ubuntu2.12_amd64.deb
 
-### Enterprise Linux 8 Airgapped Packages
+<!-- vale Vale.Spelling = NO -->
+#### Enterprise Linux 8 air gapped packages
 
-The airgapped bundle contains package archives for both EL7 and EL8. The installer, however, is configured to copy only one set of packages, and it defaults to the EL7 packages. If you are using EL8 (centos 8 or rhel 8), copy the EL8 package archive to the default location:
+The air gapped bundle contains package archives for both EL7 and EL8. The installer, however, is configured to copy only one set of packages, and it defaults to the EL7 packages. If you are using EL8 (CentOS 8 or RHEL 8), copy the EL8 package archive to the default location:
+<!-- vale Vale.Spelling = YES -->
 
 ```shell
 # backup the centos 7 archive (optional)
@@ -309,7 +313,7 @@ cp konvoy_<konvoy-version>_x86_64_rpms.tar.gz konvoy_<konvoy-version>_el7_x86_64
 mv konvoy_<konvoy-version>_el8_x86_64_rpms.tar.gz konvoy_<konvoy-version>_x86_64_rpms.tar.gz
 ```
 
-## Configure the image registry
+### Configure the image registry
 
 In an air-gapped environment your cluster nodes will not have access to any public Docker registries, therefore you are required to provide your own that is accessible on the local network.
 
@@ -346,19 +350,19 @@ spec:
 ```
 
 The above assumes that the certificate used by `myregistry` is signed by a trusted authority.
-If you are using a self-signed certificate, you must add that trusted root certificate to all the Kubernete hosts before running `konvoy up`.
+If you are using a self-signed certificate, you must add that trusted root certificate to all the Kubernetes hosts before running `konvoy up`.
 
-- On Centos/RHEL:
+- On CentOS/RHEL:
 
 1. Install the ca-certificates package: `yum install ca-certificates`
-2. Enable the dynamic CA configuration feature: `update-ca-trust force-enable`
-3. Add the CA as a new file to /etc/pki/ca-trust/source/anchors/: `cp myregistry.crt /etc/pki/ca-trust/source/anchors/myregistry.crt`
-4. Update the CA trust: `update-ca-trust extract`
+1. Enable the dynamic CA configuration feature: `update-ca-trust force-enable`
+1. Add the CA as a new file to `/etc/pki/ca-trust/source/anchors/`: `cp myregistry.crt /etc/pki/ca-trust/source/anchors/myregistry.crt`
+1. Update the CA trust: `update-ca-trust extract`
 
 - On Ubuntu/Debian:
 
-1. Copy your CA to dir /usr/local/share/ca-certificates/: `cp myregistry.crt /usr/local/share/ca-certificates/myregistry.crt`
-2. Update the CA store: `sudo update-ca-certificates`
+1. Copy your CA to dir `/usr/local/share/ca-certificates/`: `cp myregistry.crt /usr/local/share/ca-certificates/myregistry.crt`
+1. Update the CA store: `sudo update-ca-certificates`
 
 Konvoy provides a convenient CLI command to setup your registry with the required images which you must run in order to populate your registry with all necessary images prior to installing Konvoy.
 Running the command below loads all of the images, retags them, and pushes them to the specified image registry:
@@ -370,7 +374,7 @@ konvoy config images seed
 In addition to the default `images.json` file and `images/` directory, it is also possible to use the same `konvoy config images seed` with additional images.
 In your working directory, create an `extras/images/<some-directory>/` and place an `images.json` and the corresponding image tars.
 
-## Configure the control plane
+### Configure the control plane
 
 Konvoy supports Kubernetes control plane high availability (HA) out-of-the-box for on-premises deployments if you do not have a third-party load balancer.
 
@@ -378,14 +382,14 @@ The default control plane load balancer for Konvoy is based on [Keepalived][keep
 
 To use `keepalived` control plane load balancing:
 
-- Identify and reserve an unused virtual IP (VIP) address from your networking infrastructure. During the installation, the Konvoy installer will check if the designated IP is free to use as a Keepalived's VIP by pinging it.
+-   Identify and reserve an unused virtual IP (VIP) address from your networking infrastructure. During the installation, the Konvoy installer will check if the designated IP is free to use as a Keepalived's VIP by pinging it.
 
-- Configure your networking infrastructure so that the reserved virtual IP address is reachable:
-  - from all hosts specified in the inventory file.
-  - from the computer you are using as the deploy host.
+-   Configure your networking infrastructure so that the reserved virtual IP address is reachable:
+    - from all hosts specified in the inventory file.
+    - from the computer you are using as the deploy host.
 
-  If all cluster hosts and the reserved virtual IP address are in the same subnet, you typically do not need to perform any additional configuration to your networking infrastructure.
-  If you are using more than one subnet for the cluster, however, you should work with your networking team to ensure connectivity between all hosts and the reserved virtual IP address.
+    If all cluster hosts and the reserved virtual IP address are in the same subnet, you typically do not need to perform any additional configuration to your networking infrastructure.
+    If you are using more than one subnet for the cluster, however, you should work with your networking team to ensure connectivity between all hosts and the reserved virtual IP address.
 
 The following example illustrates the configuration if the reserved virtual IP address is `10.0.50.20`:
 
@@ -411,7 +415,7 @@ If not set, Konvoy will randomly pick a Virtual Router ID for you.
 
 If you are not setting any of the optional values, use `spec.kubernetes.controlPlane.keepalived: {}` to enable it with the default values.
 
-## Configure pod and service networking
+### Configure pod and service networking
 
 The following example illustrates how you can configure the pod subnet and service subnet in the `cluster.yaml` configuration file:
 
@@ -427,7 +431,7 @@ spec:
 
 When configuring these settings, you should make sure that the values you set for `podSubnet` and `serviceSubnet` do not overlap with your node subnet and your `keepalived` virtual IP address.
 
-## Configure autoscaling and the Docker registry
+### Configure autoscaling and the Docker registry
 
 Konvoy provides an [autoscaling feature that works at the node pool level][autoscaling]. When installing Konvoy in an air-gapped environment, you have to configure auto-provisioning with a local Docker registry.
 
@@ -483,11 +487,13 @@ spec:
         chartRepo: http://konvoy-addons-chart-repo.kubeaddons.svc:8879
 ```
 
-Details regarding the autoscaler are provided in [the autoscaling documentation][autoscaling-air-gapped].
+Details regarding the autoscaler are provided in [the autoscaling documentation][autoscaling-air].
 
-### Autoscaling on AWS
+#### Autoscaling on AWS
 
-In an airgapped environment, accessing AWS services requires setting up VPC endpoints. These are gateways/interfaces which enable direct access to services like EC2, without going through the public Internet.
+<!-- vale Vale.Spelling = NO -->
+In an air gapped environment, accessing AWS services requires setting up VPC endpoints. These are gateways/interfaces which enable direct access to services like EC2, without going through the public Internet.
+<!-- vale Vale.Spelling = YES -->
 
 To enable the VPC endpoints needed to make autoscaler work on AWS, apply the following changes in the `cluster.yaml`:
 
@@ -500,11 +506,13 @@ spec:
       enableVPCEndpoints: true
 ```
 
-## Configure Addon repository
+### Configure Addon repository
 
+<!-- vale Vale.Spelling = NO -->
 In a non-air-gapped deployment, your cluster has access to publicly hosted Helm chart repos for all of the addons.
 This is not the case for air-gapped installations, therefore Konvoy can be configured to host the required Helm charts in the cluster.
 Modify the `addons` section and specify the image containing the Helm charts:
+<!-- vale Vale.Spelling = YES -->
 
 ```yaml
 kind: ClusterConfiguration
@@ -514,28 +522,30 @@ spec:
   addons:
     - configRepository: /opt/konvoy/artifacts/kubernetes-base-addons
       addonRepository:
-        image: mesosphere/konvoy-addons-chart-repo:v1.8.4
+        image: mesosphere/konvoy-addons-chart-repo:v1.8.5
       addonsList:
       ...
     - configRepository: /opt/konvoy/artifacts/kubeaddons-dispatch
       addonRepository:
-        image: mesosphere/konvoy-addons-chart-repo:v1.8.4
+        image: mesosphere/konvoy-addons-chart-repo:v1.8.5
       addonsList:
       - name: dispatch
         enabled: false
     - configRepository: /opt/konvoy/artifacts/kubeaddons-kommander
       addonRepository:
-        image: mesosphere/konvoy-addons-chart-repo:v1.8.4
+        image: mesosphere/konvoy-addons-chart-repo:v1.8.5
       addonsList:
       - name: kommander
         enabled: false
 ```
 
-## Load balancing
+### Load balancing
 
-Some of the aspects of Konvoy load balancing configuration depend on the type of airgapped environment where Konvoy is being deployed.
+<!-- vale Vale.Spelling = NO -->
+Some of the aspects of Konvoy load balancing configuration depend on the type of air gapped environment where Konvoy is being deployed.
+<!-- vale Vale.Spelling = YES -->
 
-### Load balancing on-premises
+#### Load balancing on-premises
 
 If you do not have a third-party load balancer Konvoy supports [Service][kubernetes_service] type `LoadBalancer` out-of-the-box for on-premises deployments.
 
@@ -543,11 +553,11 @@ The default load balancer service for addons is based on [MetalLB][metallb].
 
 To use MetalLB for addon load balancing:
 
-- Identify and reserve a range of virtual IP addresses (VIPs) from your networking infrastructure.
+-   Identify and reserve a range of virtual IP addresses (VIPs) from your networking infrastructure.
 
-- Configure your networking infrastructure so that the reserved virtual IP addresses are reachable:
-  - from all hosts specified in the inventory file.
-  - from the computer you are using as the deploy host.
+-   Configure your networking infrastructure so that the reserved virtual IP addresses are reachable:
+    - from all hosts specified in the inventory file.
+    - from the computer you are using as the deploy host.
 
 If all cluster hosts and the reserved virtual IP addresses are in the same subnet, you typically do not need to perform any additional configuration to your networking infrastructure.
 If you are using more than one subnet for the cluster, however, you should work with your networking team to ensure connectivity between all hosts and the reserved range of virtual IP addresses.
@@ -598,9 +608,11 @@ spec:
 
 The number of virtual IP addresses in the reserved range determines the maximum number of services with a type of `LoadBalancer` that you can create in the cluster.
 
-### Load balancing on AWS
+#### Load balancing on AWS
 
-Airgapped AWS clusters cannot use externally-visible load balancers as they would be unavailable for the VPC. Instead, use internal load balancers by updating the `cluster.yaml`.
+<!-- vale Vale.Spelling = NO -->
+Air gapped AWS clusters cannot use externally-visible load balancers as they would be unavailable for the VPC. Instead, use internal load balancers by updating the `cluster.yaml`.
+<!-- vale Vale.Spelling = YES -->
 
 - Enabling internal load balancing for apiserver's endpoint:
 
@@ -613,48 +625,50 @@ spec:
       internal: true
 ```
 
-- Enabling internal load balancing for addons requires modifying the `values` field for each of the addons mentioned below, if they were enabled.
+-   Enabling internal load balancing for addons requires modifying the `values` field for each of the addons mentioned below, if they were enabled.
 
-  - Velero addon:
+    - Velero addon:
 
-```yaml
-- name: velero
-  values: |-
-    minioBackendConfiguration:
-      service:
-        annotations:
-          "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
-```
+    ```yaml
+    - name: velero
+      values: |-
+        minioBackendConfiguration:
+          service:
+            annotations:
+              "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
+    ```
 
-  - [experimental] Istio addon:[/experimental]
+    - [experimental] Istio addon:[/experimental]
 
-```yaml
-- name: istio
-  values: |-
-    gateways:
-      istio-ingressgateway:
-        serviceAnnotations:
-          "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
-```
+    ```yaml
+    - name: istio
+      values: |-
+        gateways:
+          istio-ingressgateway:
+            serviceAnnotations:
+              "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
+    ```
 
-  - Traefik addon:
+    - Traefik addon:
 
-```yaml
-- name: traefik
-  values: |-
-    service:
-      annotations:
-        "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
-```
+    ```yaml
+    - name: traefik
+      values: |-
+        service:
+          annotations:
+            "service.beta.kubernetes.io/aws-load-balancer-internal": "true"
+    ```
 
-# Storage
+## Storage
 
-## Storage on AWS
+### Storage on AWS
 
-In case of AWS provider, volumes by default are provisioned automatically in an airgapped environement, provided that VPC endpoints are enabled.
-See the [Autoscalling on AWS](#autoscaling-on-aws) section.
+<!-- vale Vale.Spelling = NO -->
+In case of AWS provider, volumes by default are provisioned automatically in an air gapped environment, provided that VPC endpoints are enabled.
+See the [Autoscaling on AWS](#autoscaling-on-aws) section.
+<!-- vale Vale.Spelling = YES -->
 
-## Storage on-premises
+### Storage on-premises
 
 Konvoy supports [local persistent volume][local_persistent_volume] provisioning out-of-the-box if you do not have a third-party storage vendor.
 
@@ -667,7 +681,7 @@ Konvoy uses the [static local volume provisioner][static_pv_provisioner] to perf
 
 To mount local volumes:
 
-1. Format and mount the volume by running commands similar to the following:
+1.  Format and mount the volume by running commands similar to the following:
 
     ```bash
     sudo mkfs.ext4 /dev/path/to/disk
@@ -676,13 +690,13 @@ To mount local volumes:
     sudo mount -t ext4 /dev/path/to/disk /mnt/disks/$DISK_UUID
     ```
 
-1. Persist the mount entry by adding it to `/etc/fstab` as follows:
+1.  Persist the mount entry by adding it to `/etc/fstab` as follows:
 
     ```bash
     echo UUID=`sudo blkid -s UUID -o value /dev/path/to/disk` /mnt/disks/$DISK_UUID ext4 defaults 0 2 | sudo tee -a /etc/fstab
     ```
 
-1. Verify that local volumes stay mounted after the host is rebooted.
+1.  Verify that local volumes stay mounted after the host is rebooted.
 
 For more information on how to mount local volumes, see the [Operations][static_pv_provisioner_operations] guide for Kubernetes.
 
@@ -690,26 +704,26 @@ Note that if your stateful workload is using a [local persistent volume][local_p
 If the node fails, the stateful workload might lose its data.
 You should consider another storage option if this limitation is unacceptable.
 
-# Pre-flight checks
+## Pre-flight checks
 
 After you have completed the basic configuration in the `cluster.yaml` file, you should run the Konvoy pre-flight checks before you run the installation command.
 The pre-flight checks help to ensure that your on-premises environment has everything ready for installing Konvoy.
 
 To perform the pre-flight checks:
 
-1. Run the following command:
+1.  Run the following command:
 
-   ```bash
-   konvoy check preflight
-   ```
+    ```bash
+    konvoy check preflight
+    ```
 
-1. Fix any issue reported by the pre-flight check.
+1.  Fix any issue reported by the pre-flight check.
 
-1. Re-run the `konvoy check preflight` command.
+1.  Re-run the `konvoy check preflight` command.
 
-1. Repeat the previous steps until pre-flight checks pass with a return status of `OK`.
+1.  Repeat the previous steps until pre-flight checks pass with a return status of `OK`.
 
-# Install Konvoy
+## Install Konvoy
 
 After verifying your infrastructure, you create a Konvoy Kubernetes cluster by running the following command:
 
@@ -743,7 +757,7 @@ This is the set of Addons deployed by default:
 - [Traefik forward authorization proxy][traefik_foward_auth] to provide basic authorization for Traefik ingress.
 - Kommander for multi-cluster management.
 
-# Viewing cluster operations
+## Viewing cluster operations
 
 You can access user interfaces to monitor your cluster through the [operations portal][ops_portal].
 
@@ -763,7 +777,7 @@ And login using the credentials below.
 If the cluster was recently created, the dashboard and services may take a few minutes to be accessible.
 ```
 
-# Checking the files installed
+## Checking the files installed
 
 When the `konvoy deploy` completes its setup operations, the following files are generated:
 
@@ -776,7 +790,7 @@ When the `konvoy deploy` completes its setup operations, the following files are
 [ansible_group]: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#inventory-basics-hosts-and-groups
 [ansible_inventory]: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
 [autoscaling]: ../../autoscaling/
-[autoscaling-air-gapped]: ../../autoscaling#autoscaling-an-air-gapped-cluster
+[autoscaling-air]: ../../autoscaling#autoscaling-an-air-gapped-cluster
 [aws_ebs_csi]: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 [calico]: https://www.projectcalico.org/
 [cluster_configuration]: ../../reference/cluster-configuration/
@@ -792,7 +806,7 @@ When the `konvoy deploy` completes its setup operations, the following files are
 [helm]: https://helm.sh/
 [install_docker]: https://www.docker.com/products/docker-desktop
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[kommander_air_gapped_install]: /dkp/kommander/1.4/install-airgapped/
+[kommander_ag_install]: /dkp/kommander/1.4/install-airgapped/
 [keepalived]: https://www.keepalived.org/
 [kibana]: https://www.elastic.co/products/kibana
 [kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/

--- a/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
@@ -61,7 +61,7 @@ The version of Kubernetes Base Addons changed if you use KBA, so you need to cha
 
 If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.20-1.4.4` for kind: ClusterConfiguration.
 
-If you have Dispatch enabled, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-dispatch` to be `configVersion: stable-1.20-1.4.6` for of kind: ClusterConfiguration
+If you have Dispatch enabled, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-dispatch` to be `configVersion: stable-1.20-1.4.6` for kind: ClusterConfiguration
 
 The version of Konvoy is now `v1.8.5`, set `spec.version: v1.8.5` for both of kind: ClusterProvisioner and of kind: ClusterConfiguration.
 

--- a/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
@@ -53,7 +53,7 @@ After the upgrade command completes, you can start using the new Konvoy version.
 
 **You must modify your `cluster.yaml` with these changes when upgrading from a previous Konvoy version:**
 
-It is recommended to upgrade to the newest supported version of Kubernetes. Set `spec.kubernetes.version: 1.20.13` for of kind: ClusterConfiguration.
+It is recommended to upgrade to the newest supported version of Kubernetes. Set `spec.kubernetes.version: 1.20.13` for kind: ClusterConfiguration.
 
 The version of Calico was bumped in Konvoy v1.8.4, from Calico v3.17.3 to v3.20.2. When upgrading, set `spec.containerNetworking.calico.version: v3.20.2` for kind: ClusterConfiguration.
 

--- a/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
@@ -59,7 +59,7 @@ The version of Calico was bumped in Konvoy v1.8.4, from Calico v3.17.3 to v3.20.
 
 The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.20-4.4.0` for of kind: ClusterConfiguration.
 
-If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.20-1.4.4` for of kind: ClusterConfiguration.
+If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.20-1.4.4` for kind: ClusterConfiguration.
 
 If you have Dispatch enabled, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-dispatch` to be `configVersion: stable-1.20-1.4.6` for of kind: ClusterConfiguration
 

--- a/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
@@ -55,7 +55,7 @@ After the upgrade command completes, you can start using the new Konvoy version.
 
 It is recommended to upgrade to the newest supported version of Kubernetes. Set `spec.kubernetes.version: 1.20.13` for of kind: ClusterConfiguration.
 
-The version of Calico got bumped in Konvoy v1.8.5, from Calico v3.17.3 to v3.20.2. You will want to change this in `spec.containerNetworking.calico.version: v3.17.3` for of kind: ClusterConfiguration.
+The version of Calico was bumped in Konvoy v1.8.4, from Calico v3.17.3 to v3.20.2. When upgrading, set `spec.containerNetworking.calico.version: v3.20.2` for kind: ClusterConfiguration.
 
 The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.20-4.4.0` for of kind: ClusterConfiguration.
 

--- a/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
@@ -63,7 +63,7 @@ If you use Kommander, you need to change the `configVersion` for your `configRep
 
 If you have Dispatch enabled, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-dispatch` to be `configVersion: stable-1.20-1.4.6` for kind: ClusterConfiguration
 
-The version of Konvoy is now `v1.8.5`, set `spec.version: v1.8.5` for both of kind: ClusterProvisioner and of kind: ClusterConfiguration.
+The version of Konvoy is now `v1.8.5`, set `spec.version: v1.8.5` for both kind: ClusterProvisioner and kind: ClusterConfiguration.
 
 ```yaml
 kind: ClusterProvisioner

--- a/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
@@ -43,32 +43,32 @@ If you are using a [private Docker registry][docker_registry] for your clusters,
 After you have the available Konvoy versions, you can upgrade your CLI by running the following command:
 
 ```bash
-konvoy image upgrade --version=v1.8.4
-Wrote Konvoy CLI version 'v1.8.4' to '.konvoy/cli_version'
+konvoy image upgrade --version=v1.8.5
+Wrote Konvoy CLI version 'v1.8.5' to '.konvoy/cli_version'
 ```
 
 After the upgrade command completes, you can start using the new Konvoy version.
 
-### Upgrading Konvoy from v1.7.x to v1.8.4
+### Upgrading Konvoy from v1.7.x to v1.8.5
 
 **You must modify your `cluster.yaml` with these changes when upgrading from a previous Konvoy version:**
 
 It is recommended to upgrade to the newest supported version of Kubernetes. Set `spec.kubernetes.version: 1.20.13` for of kind: ClusterConfiguration.
 
-The version of Calico got bumped in Konvoy v1.8.4, from Calico v3.17.3 to v3.20.2. You will want to change this in `spec.containerNetworking.calico.version: v3.17.3` for of kind: ClusterConfiguration.
+The version of Calico got bumped in Konvoy v1.8.5, from Calico v3.17.3 to v3.20.2. You will want to change this in `spec.containerNetworking.calico.version: v3.17.3` for of kind: ClusterConfiguration.
 
-The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.20-4.3.0` for of kind: ClusterConfiguration.
+The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.20-4.4.0` for of kind: ClusterConfiguration.
 
-If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.20-1.4.3` for of kind: ClusterConfiguration.
+If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.20-1.4.4` for of kind: ClusterConfiguration.
 
 If you have Dispatch enabled, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-dispatch` to be `configVersion: stable-1.20-1.4.6` for of kind: ClusterConfiguration
 
-The version of Konvoy is now `v1.8.4`, set `spec.version: v1.8.4` for both of kind: ClusterProvisioner and of kind: ClusterConfiguration.
+The version of Konvoy is now `v1.8.5`, set `spec.version: v1.8.5` for both of kind: ClusterProvisioner and of kind: ClusterConfiguration.
 
 ```yaml
 kind: ClusterProvisioner
 ...
-  version: v1.8.4
+  version: v1.8.5
 ...
 kind: ClusterConfiguration
 apiVersion: konvoy.mesosphere.io/v1beta1
@@ -82,7 +82,7 @@ spec:
   ...
   addons:
     - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-      configVersion: stable-1.20-4.3.0
+      configVersion: stable-1.20-4.4.0
   ...
     - configRepository: https://github.com/mesosphere/kubeaddons-dispatch
       configVersion: stable-1.20-1.4.6
@@ -91,12 +91,12 @@ spec:
           enabled: true
 ...
     - configRepository: https://github.com/mesosphere/kubeaddons-kommander
-      configVersion: stable-1.20-1.4.3
+      configVersion: stable-1.20-1.4.4
       addonsList:
         - name: kommander
           enabled: true
   ...
-  version: v1.8.4
+  version: v1.8.5
 ```
 
 ## Upgrades and Running Workloads

--- a/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
+++ b/pages/dkp/konvoy/1.8/upgrade/upgrade-cli/index.md
@@ -57,7 +57,7 @@ It is recommended to upgrade to the newest supported version of Kubernetes. Set 
 
 The version of Calico was bumped in Konvoy v1.8.4, from Calico v3.17.3 to v3.20.2. When upgrading, set `spec.containerNetworking.calico.version: v3.20.2` for kind: ClusterConfiguration.
 
-The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.20-4.4.0` for of kind: ClusterConfiguration.
+The version of Kubernetes Base Addons changed if you use KBA, so you need to change your `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubernetes-base-addons` to be `spec.addons.configVersion: stable-1.20-4.4.0` for kind: ClusterConfiguration.
 
 If you use Kommander, you need to change the `configVersion` for your `configRepository`: `https://github.com/mesosphere/kubeaddons-kommander` to be `spec.addons.configVersion: stable-1.20-1.4.4` for kind: ClusterConfiguration.
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
@@ -16,7 +16,7 @@ Moving from Konvoy 1.8.x to DKP 2.1.x is not just an upgrade - you are enhancing
 
 The overall process for upgrading the major version to DKP 2.1 has the following high-level steps:
 
--   Upgrade all clusters to [Konvoy 1.8.3](/dkp/konvoy/1.8/release-notes/1.8.3/) or  [Konvoy 1.8.4](/dkp/konvoy/1.8/release-notes/1.8.4/)
+-   Upgrade all clusters to [Konvoy 1.8.3](/dkp/konvoy/1.8/release-notes/1.8.3/), [Konvoy 1.8.4](/dkp/konvoy/1.8/release-notes/1.8.4/), or [Konvoy 1.8.5](/dkp/konvoy/1.8/release-notes/1.8.5/)
 
 -   [Download and install DKP 2.1.0 or 2.1.1](../download)
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
@@ -16,7 +16,7 @@ Follow these steps only if you are upgrading an AWS cluster.
 
 After adopting the cluster, you use this AMI to scale up, or replace a failed instance in the control plane and worker node pools.
 
-<p class="message--note"><strong>NOTE: </strong>Konvoy v1.8.4 uses Kubernetes version 1.20.13 by default. If upgrading from Konvoy v1.8.3, use Kubernetes version 1.20.11 for the below commands.</p>
+<p class="message--note"><strong>NOTE: </strong>Konvoy v1.8.4 and v1.8.5 uses Kubernetes version 1.20.13 by default. If upgrading from Konvoy v1.8.3, use Kubernetes version 1.20.11 for the below commands.</p>
 
 1.  Create the AMI using [Konvoy Image Builder][kib] (you can [download the newest release on GitHub][kib-releases]):
 


### PR DESCRIPTION
## Jira Ticket

N/A

## Description of changes being made
This was mainly upgrading the version for the Konvoy CLI upgrade path.

It looks like there's a lot of changes, but that's mostly linting on the pages I touched.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4137.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
