### PR TITLE
docs: documents custom cert federation workaround

### DIFF
--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -170,7 +170,7 @@ kubectl apply -f cert_manager_root-ca.yaml
 
 Once complete, continue to [attach your cluster][attach-cluster] to Kommander.
 
-You should expect to see that cert-manager will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
+Your cert-manager will fail to deploy due to your existing `cert-manager` installation. This behavior is expected and can be ignored.
 
 ### Kommander Cluster with custom SSL certificate
 

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -172,6 +172,33 @@ Once complete, continue to [attach your cluster][attach-cluster] to Kommander.
 
 You should expect to see that cert-manager will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
 
+### Kommander Cluster with custom SSL certificate
+
+When attaching a cluster, it is expected that the managed cluster was deploying apps as federated by the management cluster.
+If the management cluster was initialised using a custom SSL certificate, the managed cluster may fail cloning the managers’ service repository. You may need to check the status of the federated GIT repository resource to see the error;
+
+```
+kubectl get gitrepo -A --kubeconfig MANAGED-KUBECONFIG
+[..]
+unable to clone 'https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander': Get "https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander/info/refs?service=git-upload-pack": x509: certificate signed by unknown authority
+[..]
+```
+
+The deployment fails because the managed cluster uses the wrong CA certificate to verify access to the management clusters’ GIT repository. For working around this issue we need to patch the `gitserver-ca` secret within the `kommander-flux` namespace on the managed cluster with the CA certificate as stored in the `kommander-traefik-certificate` secret within the `kommander`namespace on the management cluster.
+
+```
+kubectl --kubeconfig=MANAGED_KUBECONFIG patch secret -n kommander-flux gitserver-ca -p '{"data":{"caFile":"'$(kubectl --kubeconfig=MANAGER_KUBECONFIG get secret -n kommander kommander-traefik-certificate -o go-template='{{index .data "ca.crt"}}')'"}}'
+```
+
+You may need to trigger a reconciliation of the flux controller on the managed cluster if you do not want to wait for its regular interval to occur. Use the `flux` CLI utility -  https://fluxcd.io/docs/installation/ ;
+```
+flux reconcile -n kommander-flux source git management --kubeconfig MANAGED_KUBECONFIG
+► annotating GitRepository management in kommander-flux namespace
+✔ GitRepository annotated
+◎ waiting for GitRepository reconciliation
+✔ fetched revision main/GIT_HASH
+```
+
 ### Additional resources
 
 <!-- Add links to external documentation as needed -->

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -190,7 +190,8 @@ The deployment fails because the managed cluster uses the wrong CA certificate t
 kubectl --kubeconfig=MANAGED_KUBECONFIG patch secret -n kommander-flux gitserver-ca -p '{"data":{"caFile":"'$(kubectl --kubeconfig=MANAGER_KUBECONFIG get secret -n kommander kommander-traefik-certificate -o go-template='{{index .data "ca.crt"}}')'"}}'
 ```
 
-You may need to trigger a reconciliation of the flux controller on the managed cluster if you do not want to wait for its regular interval to occur. Use the `flux` CLI utility -  https://fluxcd.io/docs/installation/ ;
+You may need to trigger a reconciliation of the flux controller on the managed cluster if you do not want to wait for its regular interval to occur. Use the [`flux` CLI utility][flux-cli]:
+
 ```
 flux reconcile -n kommander-flux source git management --kubeconfig MANAGED_KUBECONFIG
 ► annotating GitRepository management in kommander-flux namespace
@@ -207,5 +208,6 @@ For more information about working with native Kubernetes, see the [Kubernetes d
 
 [kubernetes-doc]: https://kubernetes.io/docs/home/
 [attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
-[konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
+[konvoy-self-managed]: /../../choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
 [project-custom-applications-git-repo]: ../../projects/applications/catalog-applications/custom-applications/add-create-git-repo
+[flux-cli]: https://fluxcd.io/docs/installation/

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -10,7 +10,7 @@ beta: false
 
 **D2iQ&reg; Kommander&reg; version 2.1.0 was released on November 19, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Kommander[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-ucs/articles/4409215222932-Product-Downloads"]Download Kommander[/button]
 
 To get started with Kommander, [download](../../download/) and [install](../../install/) the latest version of Kommander.
 
@@ -36,7 +36,7 @@ For more information on provisioning from Kommander, see [Managing Clusters](../
 
 #### Kommander Continuous Deployment
 
-Kommander 2.1 now supports continuous delivery/deployment using Flux, which is designed for Kubernetes and supports multi-cluster and multi-tenant use cases. Configure Kommander Projects with GitOps-based Continuous Deployments using FluxCD, which enables canary and A/B deployments, as well as roll-back. Kommander now uses a completely declarative approach, where what you define for production is what you get, without the need to monitor and manually intervene when something goes wrong.
+Kommander 2.1 now supports continuous delivery/deployment using Flux, which is designed for Kubernetes and supports multi-cluster and multi-tenant use cases. Configure Kommander Projects with GitOps-based Continuous Deployments using FluxCD, which enables canary and A/B deployments, and roll-back. Kommander now uses a completely declarative approach, where what you define for production is what you get, without the need to monitor and manually intervene when something goes wrong.
 
 For more information on setting up continuous deployment using Flux, see [Continuous Deployment](../../projects/project-deployments/continuous-delivery).
 
@@ -175,24 +175,24 @@ Your cert-manager will fail to deploy due to your existing `cert-manager` instal
 ### Kommander Cluster with custom SSL certificate
 
 When attaching a cluster, it is expected that the managed cluster was deploying apps as federated by the management cluster.
-If the management cluster was initialised using a custom SSL certificate, the managed cluster will fail cloning the managers’ service repository. Check the status of the federated git repository resource to see the error:
+If the management cluster was initialised using a custom SSL certificate, the managed cluster will fail cloning the manager's service repository. Check the status of the federated git repository resource to see the error:
 
-```
+```sh
 kubectl get gitrepo -n kommander-flux management --kubeconfig MANAGED-KUBECONFIG
 [..]
 unable to clone 'https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander': Get "https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander/info/refs?service=git-upload-pack": x509: certificate signed by unknown authority
 [..]
 ```
 
-The deployment fails because the managed cluster uses the wrong CA certificate to verify access to the management clusters’ git repository. Solve this issue by patching the `gitserver-ca` secret within the `kommander-flux` namespace on the managed cluster with the CA certificate stored in the `kommander-traefik-certificate` secret within the `kommander`namespace on the management cluster.
+The deployment fails because the managed cluster uses the wrong CA certificate to verify access to the management cluster's git repository. Solve this issue by patching the `gitserver-ca` secret within the `kommander-flux` namespace on the managed cluster with the CA certificate stored in the `kommander-traefik-certificate` secret within the `kommander` namespace on the management cluster.
 
-```
+```sh
 kubectl --kubeconfig=MANAGED_KUBECONFIG patch secret -n kommander-flux gitserver-ca -p '{"data":{"caFile":"'$(kubectl --kubeconfig=MANAGER_KUBECONFIG get secret -n kommander kommander-traefik-certificate -o go-template='{{index .data "ca.crt"}}')'"}}'
 ```
 
 You may need to trigger a reconciliation of the flux controller on the managed cluster if you do not want to wait for its regular interval to occur. Use the [`flux` CLI utility][flux-cli]:
 
-```
+```sh
 flux reconcile -n kommander-flux source git management --kubeconfig MANAGED_KUBECONFIG
 ► annotating GitRepository management in kommander-flux namespace
 ✔ GitRepository annotated

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -174,7 +174,7 @@ Your cert-manager will fail to deploy due to your existing `cert-manager` instal
 
 ### Kommander Cluster with custom SSL certificate
 
-When attaching a cluster, it is expected that the managed cluster was deploying apps as federated by the management cluster.
+After attaching a cluster, the management cluster should deploy apps to managed clusters.
 If the management cluster was initialized using a custom SSL certificate, the managed cluster will fail cloning the manager's service repository. Check the status of the federated git repository resource to see the error:
 
 ```sh

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -175,16 +175,16 @@ You should expect to see that cert-manager will fail to deploy due to your exist
 ### Kommander Cluster with custom SSL certificate
 
 When attaching a cluster, it is expected that the managed cluster was deploying apps as federated by the management cluster.
-If the management cluster was initialised using a custom SSL certificate, the managed cluster may fail cloning the managers’ service repository. You may need to check the status of the federated GIT repository resource to see the error;
+If the management cluster was initialised using a custom SSL certificate, the managed cluster will fail cloning the managers’ service repository. Check the status of the federated git repository resource to see the error:
 
 ```
-kubectl get gitrepo -A --kubeconfig MANAGED-KUBECONFIG
+kubectl get gitrepo -n kommander-flux management --kubeconfig MANAGED-KUBECONFIG
 [..]
 unable to clone 'https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander': Get "https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander/info/refs?service=git-upload-pack": x509: certificate signed by unknown authority
 [..]
 ```
 
-The deployment fails because the managed cluster uses the wrong CA certificate to verify access to the management clusters’ GIT repository. For working around this issue we need to patch the `gitserver-ca` secret within the `kommander-flux` namespace on the managed cluster with the CA certificate as stored in the `kommander-traefik-certificate` secret within the `kommander`namespace on the management cluster.
+The deployment fails because the managed cluster uses the wrong CA certificate to verify access to the management clusters’ git repository. Solve this issue by patching the `gitserver-ca` secret within the `kommander-flux` namespace on the managed cluster with the CA certificate stored in the `kommander-traefik-certificate` secret within the `kommander`namespace on the management cluster.
 
 ```
 kubectl --kubeconfig=MANAGED_KUBECONFIG patch secret -n kommander-flux gitserver-ca -p '{"data":{"caFile":"'$(kubectl --kubeconfig=MANAGER_KUBECONFIG get secret -n kommander kommander-traefik-certificate -o go-template='{{index .data "ca.crt"}}')'"}}'

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -175,7 +175,7 @@ Your cert-manager will fail to deploy due to your existing `cert-manager` instal
 ### Kommander Cluster with custom SSL certificate
 
 When attaching a cluster, it is expected that the managed cluster was deploying apps as federated by the management cluster.
-If the management cluster was initialised using a custom SSL certificate, the managed cluster will fail cloning the manager's service repository. Check the status of the federated git repository resource to see the error:
+If the management cluster was initialized using a custom SSL certificate, the managed cluster will fail cloning the manager's service repository. Check the status of the federated git repository resource to see the error:
 
 ```sh
 kubectl get gitrepo -n kommander-flux management --kubeconfig MANAGED-KUBECONFIG

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -10,7 +10,7 @@ beta: false
 
 **D2iQ&reg; Kommander&reg; version 2.1.0 was released on November 19, 2021.**
 
-[button color="purple" href="https://support.d2iq.com/hc/en-ucs/articles/4409215222932-Product-Downloads"]Download Kommander[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Kommander[/button]
 
 To get started with Kommander, [download](../../download/) and [install](../../install/) the latest version of Kommander.
 

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -208,6 +208,6 @@ For more information about working with native Kubernetes, see the [Kubernetes d
 
 [kubernetes-doc]: https://kubernetes.io/docs/home/
 [attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
-[konvoy-self-managed]: /../../choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
+[konvoy-self-managed]: ../../choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
 [project-custom-applications-git-repo]: ../../projects/applications/catalog-applications/custom-applications/add-create-git-repo
 [flux-cli]: https://fluxcd.io/docs/installation/


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-84968

## Description of changes being made
Documents workaround for custom SSL certificate validation failure of managed cluster in the Kommander 2.1.0 release notes. Needs porting to 2.1.1 release notes as well.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [x] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
