### PR TITLE
backport 2.1.1: documents custom cert federation workaround

### DIFF
--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -165,6 +165,34 @@ kubectl patch certificate -n $WORKSPACE_NAMESPACE kommander-traefik --type='merg
 
 `cert-manager` HelmRelease will fail to deploy due to your existing `cert-manager` installation. This is expected and can be ignored.
 
+### Kommander Cluster with custom SSL certificate
+
+After attaching a cluster, the management cluster should deploy apps to managed clusters.
+If the management cluster was initialized using a custom SSL certificate, the managed cluster will fail cloning the manager's service repository. Check the status of the federated git repository resource to see the error:
+
+```sh
+kubectl get gitrepo -n kommander-flux management --kubeconfig MANAGED-KUBECONFIG
+[..]
+unable to clone 'https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander': Get "https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander/info/refs?service=git-upload-pack": x509: certificate signed by unknown authority
+[..]
+```
+
+The deployment fails because the managed cluster uses the wrong CA certificate to verify access to the management cluster's git repository. Solve this issue by patching the `gitserver-ca` secret within the `kommander-flux` namespace on the managed cluster with the CA certificate stored in the `kommander-traefik-certificate` secret within the `kommander` namespace on the management cluster.
+
+```sh
+kubectl --kubeconfig=MANAGED_KUBECONFIG patch secret -n kommander-flux gitserver-ca -p '{"data":{"caFile":"'$(kubectl --kubeconfig=MANAGER_KUBECONFIG get secret -n kommander kommander-traefik-certificate -o go-template='{{index .data "ca.crt"}}')'"}}'
+```
+
+You may need to trigger a reconciliation of the flux controller on the managed cluster if you do not want to wait for its regular interval to occur. Use the [`flux` CLI utility][flux-cli]:
+
+```sh
+flux reconcile -n kommander-flux source git management --kubeconfig MANAGED_KUBECONFIG
+► annotating GitRepository management in kommander-flux namespace
+✔ GitRepository annotated
+◎ waiting for GitRepository reconciliation
+✔ fetched revision main/GIT_HASH
+```
+
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->
@@ -173,5 +201,6 @@ For more information about working with native Kubernetes, see the [Kubernetes d
 
 [kubernetes-doc]: https://kubernetes.io/docs/home/
 [attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
-[konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
+[konvoy-self-managed]: ../../choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
 [project-custom-applications-git-repo]: ../../projects/applications/catalog-applications/custom-applications/add-create-git-repo
+[flux-cli]: https://fluxcd.io/docs/installation/

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -39,7 +39,7 @@ For more information, see [DKP catalog applications](../../workspaces/applicatio
 - Corrected an issue where the `PreprovisionedInventory` object and SSH key secret were not moved to the target cluster when making the cluster self-managing.(COPS-7079)
 - When Kommander installation is complete, you can open the Kommander dashboard and access the username and password credentials by running:
 
-```sh
+```bash
 kommander open dashboard
 ```
 
@@ -103,7 +103,7 @@ If your cluster does not have `cert-manager` installed, the output will be empty
 
 If your cluster has `cert-manager` installed, the output resembles this example:
 
-```bash
+```sh
 cert-manager                        cert-manager-848f547974-crl47                                        1/1     Running   0          5m5s
 cert-manager                        cert-manager-cainjector-54f4cc6b5-wbzvr                              1/1     Running   0          5m5s
 cert-manager                        cert-manager-webhook-7c9588c76-pdxrb                                 1/1     Running   0          5m4s
@@ -152,7 +152,7 @@ EOF
 
 Next, apply this file to your cluster you are attaching to Kommander:
 
-```sh
+```bash
 kubectl apply -f cert_manager_root-ca.yaml
 ```
 
@@ -170,7 +170,7 @@ kubectl patch certificate -n $WORKSPACE_NAMESPACE kommander-traefik --type='merg
 After attaching a cluster, the management cluster should deploy apps to managed clusters.
 If the management cluster was initialized using a custom SSL certificate, the managed cluster will fail cloning the manager's service repository. Check the status of the federated git repository resource to see the error:
 
-```sh
+```bash
 kubectl get gitrepo -n kommander-flux management --kubeconfig MANAGED-KUBECONFIG
 [..]
 unable to clone 'https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander': Get "https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kommander/info/refs?service=git-upload-pack": x509: certificate signed by unknown authority
@@ -179,7 +179,7 @@ unable to clone 'https://MANAGER_INGRESS_ADDRESS/dkp/kommander/git/kommander/kom
 
 The deployment fails because the managed cluster uses the wrong CA certificate to verify access to the management cluster's git repository. Solve this issue by patching the `gitserver-ca` secret within the `kommander-flux` namespace on the managed cluster with the CA certificate stored in the `kommander-traefik-certificate` secret within the `kommander` namespace on the management cluster.
 
-```sh
+```bash
 kubectl --kubeconfig=MANAGED_KUBECONFIG patch secret -n kommander-flux gitserver-ca -p '{"data":{"caFile":"'$(kubectl --kubeconfig=MANAGER_KUBECONFIG get secret -n kommander kommander-traefik-certificate -o go-template='{{index .data "ca.crt"}}')'"}}'
 ```
 
@@ -201,6 +201,6 @@ For more information about working with native Kubernetes, see the [Kubernetes d
 
 [kubernetes-doc]: https://kubernetes.io/docs/home/
 [attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
-[konvoy-self-managed]: ../../choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
+[konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster
 [project-custom-applications-git-repo]: ../../projects/applications/catalog-applications/custom-applications/add-create-git-repo
 [flux-cli]: https://fluxcd.io/docs/installation/


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-84968

## Description of changes being made
Backport minus first sentence. We agreed to remove it in https://github.com/mesosphere/dcos-docs-site/pull/4138.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4142.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
