### PR TITLE
docs: adding default for azure and aws

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,6 +19,8 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
+If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 ## AWS prerequisites
 
 Before you begin using Konvoy with AWS, you must:
@@ -31,7 +33,8 @@ Before you begin using Konvoy with AWS, you must:
     export AWS_PROFILE=<profile>
     ```
 
+[iampolicies]: ../../iam-policies
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
-[iampolicies]: ../../iam-policies
+[supported-systems]: ../../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,7 +19,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 ## AWS prerequisites
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -17,9 +17,14 @@ Before you begin using Konvoy, you must have:
 - [kubectl][install_kubectl] for interacting with the running cluster.
 - A valid AWS account with [credentials configured][aws_credentials].
 
-<p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
+<p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</p>
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+
+<p class="message--note"><strong>NOTE: </strong>
+Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
+We suggest using <a href="../../../../image-builder/create-ami/">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations.
+</p>
 
 ## AWS prerequisites
 
@@ -33,8 +38,9 @@ Before you begin using Konvoy with AWS, you must:
     export AWS_PROFILE=<profile>
     ```
 
+[aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 [iampolicies]: ../../iam-policies
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
-[aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+[kib_create_ami]: ../../../../image-builder/create-ami/
 [supported-systems]: ../../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -22,8 +22,7 @@ Before you begin using Konvoy, you must have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
-Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
-We suggest using <a href="../../../../image-builder/create-ami/">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations.
+The AMI images used in the default configuration work, but they are not recommended for production workloads.  We suggest using the <a href="../../../../image-builder/create-ami/">Konvoy Image Builder to create a custom AMI</a> for production workloads.
 </p>
 
 ## AWS prerequisites

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
@@ -42,7 +42,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 1.  Create a Kubernetes cluster:
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
@@ -44,6 +44,11 @@ Before starting the Konvoy installation, verify that you have:
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
+<p class="message--note"><strong>NOTE: </strong>
+Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
+We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.
+</p>
+
 1.  Create a Kubernetes cluster:
 
     ```sh
@@ -160,7 +165,9 @@ To understand how this process works step by step, you can follow the workflow i
 
 [advanced]: ../advanced/
 [advanced_delete]: ../advanced/delete/
+[aws_advanced]: ../advanced
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.htm
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[kib_create_ami]: ../../../image-builder/create-ami
 [supported-systems]: ../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
@@ -42,6 +42,8 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
+If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 1.  Create a Kubernetes cluster:
 
     ```sh
@@ -161,3 +163,4 @@ To understand how this process works step by step, you can follow the workflow i
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.htm
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[supported-systems]: ../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -19,6 +19,8 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
+If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 ## Azure prerequisites
 
 Before you begin using Konvoy with Azure, you must:
@@ -81,6 +83,7 @@ Before you begin using Konvoy with Azure, you must:
 When you completed, move on to the [Bootstrap][bootstrap] section.
 
 [bootstrap]: ../bootstrap
+[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
-[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
+[supported-systems]: ../../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -19,7 +19,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
@@ -79,6 +79,8 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
+If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 1.  Give your cluster a name suitable for your environment:
 
     ```sh
@@ -165,6 +167,7 @@ The kubeconfig file is written to your local directory and you can now explore t
     --self-managed
     ```
 
+[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
-[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
+[supported-systems]: ../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
@@ -79,7 +79,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,6 +19,8 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
+If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 ## AWS prerequisites
 
 Before you begin using Konvoy with AWS, you must:
@@ -37,7 +39,8 @@ Before you begin using Konvoy with AWS, you must:
     export AWS_PROFILE=<profile>
     ```
 
-[install_docker]: https://docs.docker.com/get-docker/
-[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 [iampolicies]: ../../iam-policies
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[supported-systems]: ../../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,7 +19,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 ## AWS prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -17,9 +17,14 @@ Before you begin using Konvoy, you must have:
 - [kubectl][install_kubectl] for interacting with the running cluster.
 - A valid AWS account with [credentials configured][aws_credentials].
 
-<p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
+<p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</p>
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+
+<p class="message--note"><strong>NOTE: </strong>
+Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
+We suggest using <a href="../../../../image-builder/create-ami/">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations.
+</p>
 
 ## AWS prerequisites
 
@@ -43,4 +48,5 @@ Before you begin using Konvoy with AWS, you must:
 [iampolicies]: ../../iam-policies
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[kib_create_ami]: ../../../../image-builder/create-ami/
 [supported-systems]: ../../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,7 +48,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 1.  Create a Kubernetes cluster:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,6 +48,8 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
+If you create a cluster on AWS using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 1.  Create a Kubernetes cluster:
 
     ```sh
@@ -167,3 +169,4 @@ To understand how this process works step by step, you can follow the workflow i
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.htm
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[supported-systems]: ../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -50,6 +50,11 @@ Before starting the Konvoy installation, verify that you have:
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
+<p class="message--note"><strong>NOTE: </strong>
+Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
+We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.
+</p>
+
 1.  Create a Kubernetes cluster:
 
     ```sh
@@ -166,7 +171,9 @@ To understand how this process works step by step, you can follow the workflow i
 
 [advanced]: ../advanced/
 [advanced_delete]: ../advanced/delete/
+[aws_advanced]: ../advanced
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.htm
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[kib_create_ami]: ../../../image-builder/create-ami
 [supported-systems]: ../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -19,6 +19,8 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
+If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 ## Azure prerequisites
 
 Before you begin using Konvoy with Azure, you must:
@@ -80,7 +82,8 @@ Before you begin using Konvoy with Azure, you must:
 
 When you completed, move on to the [Bootstrap][bootstrap] section.
 
+[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
 [bootstrap]: ../bootstrap
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
-[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
+[supported-systems]: ../../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -19,7 +19,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -79,6 +79,8 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
+If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+
 1.  Give your cluster a name suitable for your environment:
 
     ```sh
@@ -165,6 +167,7 @@ The kubeconfig file is written to your local directory and you can now explore t
     --self-managed
     ```
 
+[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
-[azure_credentials]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/book/src/topics/getting-started.md#prerequisites
+[supported-systems]: ../../../supported-operating-systems

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -79,7 +79,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you create a cluster on Azure using DKP's default settings without any edits to any configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 1.  Give your cluster a name suitable for your environment:
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

Not a fix, per se, but definitely addresses some concerns @fatz brought up here:
[D2IQ-84974](https://jira.d2iq.com/browse/D2IQ-84974)
[D2IQ-84973](https://jira.d2iq.com/browse/D2IQ-84973)

## Description of changes being made

Adding a note to say what OS image is being used and what all is included in the defaults when doing quickstart.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4146.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
