### PR TITLE
docs: adding export workspace to release notes

### DIFF
--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -115,7 +115,7 @@ If your cluster has `cert-manager` installed, set the namespace for the workspac
 export WORKSPACE_NAMESPACE=<workspace-name-abcd>
 ```
 
-Then create the following yaml file:
+Then, create the following yaml file:
 
 ```yaml
 cat << EOF > cert_manager_root-ca.yaml

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -109,7 +109,13 @@ cert-manager                        cert-manager-cainjector-54f4cc6b5-wbzvr     
 cert-manager                        cert-manager-webhook-7c9588c76-pdxrb                                 1/1     Running   0          5m4s
 ```
 
-If your cluster has `cert-manager` installed, then create the following yaml file:
+If your cluster has `cert-manager` installed, set the namespace for the workspace you attached the cluster in:
+
+```bash
+export WORKSPACE_NAMESPACE=<workspace-name-abcd>
+```
+
+Then create the following yaml file:
 
 ```yaml
 cat << EOF > cert_manager_root-ca.yaml


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

N/A

## Description of changes being made

We tell users to create this yaml file and then apply and patch this stuff, but we don't tell them to set the WORKSPACE_NAMESPACE - 
SO, this fix won't work unless we tell the user to do this thing.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4147.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
