### PR TITLE
prepare beta to only show konvoy

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "DO_NOT_BUILD": []
   },
   "beta": {
-    "DO_NOT_BUILD": []
+    "DO_NOT_BUILD": ["dkp/kommander/2.2/**"]
   },
   "production": {
     "DO_NOT_BUILD": ["dkp/kommander/2.2/**", "dkp/konvoy/2.2/**"]


### PR DESCRIPTION
Change the config json beta branch settings so that when we merge main
into beta, we will only show 2.2 stuff for Konvoy

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
