### PR TITLE
docs: changing calico issue to create

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -30,8 +30,8 @@ dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 
 ### Confirming `calico` installation
 
-Before exploring the new cluster further, you will want to confirm your `calico` installation is correct.
-In the default case, Calico will automatically detect the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in our particular nodes and you will need to modify Calico's configuration to use a different method.
+Before exploring the new cluster, confirm your `calico` installation is correct.
+By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in your particular nodes, and you must modify Calico's configuration to use a different method.
 One approach is to use the `interface` method by providing the interface ID to use. For example, let's assume that all your cluster nodes use `ens192` as the interface name, follow the steps outlined in this section to modify Calico configuration.
 
 Get the pods running on your cluster with this command:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -28,11 +28,11 @@ Depending on the cluster size, it will take a few minutes to be created. After t
 dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 ```
 
-### Confirming `calico` installation
+### Verify your Calico installation
 
 Before exploring the new cluster, confirm your `calico` installation is correct.
-By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in your particular nodes, and you must modify Calico's configuration to use a different method.
-One approach is to use the `interface` method by providing the interface ID to use. For example, let's assume that all your cluster nodes use `ens192` as the interface name, follow the steps outlined in this section to modify Calico configuration.
+By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This is not always appropriate for your particular nodes. In that case, you must modify Calico's configuration to use a different method.
+An alternative is to use the `interface` method by providing the interface ID to use. Follow the steps outlined in this section to modify Calico's configuration. In this example, all cluster nodes use `ens192` as the interface name.
 
 Get the pods running on your cluster with this command:
 
@@ -40,7 +40,7 @@ Get the pods running on your cluster with this command:
    kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf
    ```
 
-<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not ready on your cluster, you need to edit the <code>installation</code> file.
+<p class="message--note"><strong>NOTE: </strong>If a <code>calico-node</code> pod is not ready on your cluster, you must edit the <code>installation</code> file.
 </p>
 
 To edit the installation file, run the command:
@@ -59,7 +59,7 @@ Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interfa
          interface: ens192
    ```
 
-After saving the file, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace, if it failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
+Save this file. You may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace if that pod has failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
 
 ## Use the built-in Virtual IP
 
@@ -79,7 +79,7 @@ dkp create cluster preprovisioned \
     --virtual-ip-interface eth1
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Provision on the Flatcar Linux OS
 
@@ -93,7 +93,7 @@ dkp create cluster preprovisioned \
     --os-hint flatcar
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Use an HTTP Proxy
 
@@ -121,7 +121,7 @@ dkp create cluster preprovisioned \
     --worker-no-proxy "127.0.0.1,10.96.0.0/12,192.168.0.0/16,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Use an alternative mirror
 
@@ -145,7 +145,7 @@ dkp create cluster preprovisioned \
     --registry-mirror-url https://registry.example.com
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Use alternate pod or service subnets
 
@@ -205,9 +205,9 @@ In Konvoy, the default pod subnet is 192.168.0.0/16, and the default service sub
 
 When you provision the cluster, the configured pod and service subnets will be applied.
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
-[calico-install]: #confirming-calico-installation
+[calico-install]: #verify-your-calico-installation
 [calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods
 [create-secrets-and-overrides]: ../create-secrets-and-overrides
 [define-control-plane-endpoint]: ../define-control-plane-endpoint

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -31,6 +31,8 @@ dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 ### Confirming `calico` installation
 
 Before exploring the new cluster further, you will want to confirm your `calico` installation is correct.
+In the default case, Calico will automatically detect the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in our particular nodes and you will need to modify Calico's configuration to use a different method.
+One approach is to use the `interface` method by providing the interface ID to use. For example, let's assume that all your cluster nodes use `ens192` as the interface name, follow the steps outlined in this section to modify Calico configuration.
 
 Get the pods running on your cluster with this command:
 
@@ -206,5 +208,6 @@ When you provision the cluster, the configured pod and service subnets will be a
 You will want to confirm your [`calico` installation is correct][calico-install].
 
 [calico-install]: #confirming-calico-installation
+[calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods
 [create-secrets-and-overrides]: ../create-secrets-and-overrides
 [define-control-plane-endpoint]: ../define-control-plane-endpoint

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -28,6 +28,37 @@ Depending on the cluster size, it will take a few minutes to be created. After t
 dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 ```
 
+### Confirming `calico` installation
+
+Before exploring the new cluster further, you will want to confirm your `calico` installation is correct.
+
+Get the pods running on your cluster with this command:
+
+   ```bash
+   kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf
+   ```
+
+<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not ready on your cluster, you need to edit the <code>installation</code> file.
+</p>
+
+To edit the installation file, run the command:
+
+   ```bash
+   kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf
+   ```
+
+Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interface: ens192`, and save the file:
+
+   ```yaml
+   spec:
+     calicoNetwork:
+     ...
+       nodeAddressAutodetectionV4:
+         interface: ens192
+   ```
+
+After saving the file, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace, if it failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
+
 ## Use the built-in Virtual IP
 
 As explained in [Define the Control Plane Endpoint][define-control-plane-endpoint], we recommend using an external load balancer for the control plane endpoint, but provide a built-in virtual IP when an external load balancer is not available. To use the virtual IP, add these flags to the `create cluster` command:
@@ -46,6 +77,8 @@ dkp create cluster preprovisioned \
     --virtual-ip-interface eth1
 ```
 
+You will want to confirm your [`calico` installation is correct][calico-install].
+
 ## Provision on the Flatcar Linux OS
 
 When provisioning onto the Flatcar Container Linux distribution, you must instruct the bootstrap cluster to make some changes related to the installation paths. To accomplish this, add the `--os-hint flatcar` flag to the above `create cluster` command.
@@ -57,6 +90,8 @@ dkp create cluster preprovisioned \
     --cluster-name ${CLUSTER_NAME} \
     --os-hint flatcar
 ```
+
+You will want to confirm your [`calico` installation is correct][calico-install].
 
 ## Use an HTTP Proxy
 
@@ -84,6 +119,8 @@ dkp create cluster preprovisioned \
     --worker-no-proxy "127.0.0.1,10.96.0.0/12,192.168.0.0/16,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
 ```
 
+You will want to confirm your [`calico` installation is correct][calico-install].
+
 ## Use an alternative mirror
 
 To apply Docker registry configurations during the create operation, add the appropriate flags to the `create cluster` command:
@@ -105,6 +142,8 @@ dkp create cluster preprovisioned \
     --registry-mirror-cacert /tmp/registry.pem \
     --registry-mirror-url https://registry.example.com
 ```
+
+You will want to confirm your [`calico` installation is correct][calico-install].
 
 ## Use alternate pod or service subnets
 
@@ -164,5 +203,8 @@ In Konvoy, the default pod subnet is 192.168.0.0/16, and the default service sub
 
 When you provision the cluster, the configured pod and service subnets will be applied.
 
-[define-control-plane-endpoint]: ../define-control-plane-endpoint
+You will want to confirm your [`calico` installation is correct][calico-install].
+
+[calico-install]: #confirming-calico-installation
 [create-secrets-and-overrides]: ../create-secrets-and-overrides
+[define-control-plane-endpoint]: ../define-control-plane-endpoint

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -22,27 +22,6 @@ Before setting the cluster to manage itself, explore your cluster with this comm
    kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf
    ```
 
-<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not ready on your cluster, you need to edit the <code>installation</code> file.
-</p>
-
-To edit the installation file, run the command:
-
-   ```sh
-   kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf
-   ```
-
-Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interface: ens192`, and save the file:
-
-   ```sh
-   spec:
-     calicoNetwork:
-     ...
-       nodeAddressAutodetectionV4:
-         interface: ens192
-   ```
-
-After saving the file, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace, if it failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
-
 ## Make the new Kubernetes cluster manage itself
 
 1.  Deploy cluster lifecycle services on the workload cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -30,8 +30,8 @@ dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 
 ### Confirming `calico` installation
 
-Before exploring the new cluster further, you will want to confirm your `calico` installation is correct.
-In the default case, Calico will automatically detect the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in our particular nodes and you will need to modify Calico's configuration to use a different method.
+Before exploring the new cluster, confirm your `calico` installation is correct.
+By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in your particular nodes, and you must modify Calico's configuration to use a different method.
 One approach is to use the `interface` method by providing the interface ID to use. For example, let's assume that all your cluster nodes use `ens192` as the interface name, follow the steps outlined in this section to modify Calico configuration.
 
 Get the pods running on your cluster with this command:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -31,6 +31,8 @@ dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 ### Confirming `calico` installation
 
 Before exploring the new cluster further, you will want to confirm your `calico` installation is correct.
+In the default case, Calico will automatically detect the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in our particular nodes and you will need to modify Calico's configuration to use a different method.
+One approach is to use the `interface` method by providing the interface ID to use. For example, let's assume that all your cluster nodes use `ens192` as the interface name, follow the steps outlined in this section to modify Calico configuration.
 
 Get the pods running on your cluster with this command:
 
@@ -206,5 +208,6 @@ When you provision the cluster, the configured pod and service subnets will be a
 You will want to confirm your [`calico` installation is correct][calico-install].
 
 [calico-install]: #confirming-calico-installation
+[calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods
 [create-secrets-and-overrides]: ../create-secrets-and-overrides
 [define-control-plane-endpoint]: ../define-control-plane-endpoint

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -28,11 +28,11 @@ Depending on the cluster size, it will take a few minutes to be created. After t
 dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 ```
 
-### Confirming `calico` installation
+### Verify your Calico installation
 
 Before exploring the new cluster, confirm your `calico` installation is correct.
-By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This may not be appropriate in your particular nodes, and you must modify Calico's configuration to use a different method.
-One approach is to use the `interface` method by providing the interface ID to use. For example, let's assume that all your cluster nodes use `ens192` as the interface name, follow the steps outlined in this section to modify Calico configuration.
+By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This is not always appropriate for your particular nodes. In that case, you must modify Calico's configuration to use a different method.
+An alternative is to use the `interface` method by providing the interface ID to use. Follow the steps outlined in this section to modify Calico's configuration. In this example, all cluster nodes use `ens192` as the interface name.
 
 Get the pods running on your cluster with this command:
 
@@ -40,7 +40,7 @@ Get the pods running on your cluster with this command:
    kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf
    ```
 
-<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not ready on your cluster, you need to edit the <code>installation</code> file.
+<p class="message--note"><strong>NOTE: </strong>If a <code>calico-node</code> pod is not ready on your cluster, you must edit the <code>installation</code> file.
 </p>
 
 To edit the installation file, run the command:
@@ -59,7 +59,7 @@ Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interfa
          interface: ens192
    ```
 
-After saving the file, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace, if it failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
+Save this file. You may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace if that pod has failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
 
 ## Use the built-in Virtual IP
 
@@ -79,7 +79,7 @@ dkp create cluster preprovisioned \
 --virtual-ip-interface eth1
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Provision on the Flatcar Linux OS
 
@@ -93,7 +93,7 @@ dkp create cluster preprovisioned \
 --os-hint flatcar
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Use an HTTP Proxy
 
@@ -121,7 +121,7 @@ dkp create cluster preprovisioned \
 --worker-no-proxy "127.0.0.1,10.96.0.0/12,192.168.0.0/16,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Use an alternative mirror
 
@@ -145,7 +145,7 @@ dkp create cluster preprovisioned \
 --registry-mirror-url https://registry.example.com
 ```
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
 ## Use alternate pod or service subnets
 
@@ -205,9 +205,9 @@ In Konvoy, the default pod subnet is 192.168.0.0/16, and the default service sub
 
 When you provision the cluster, the configured pod and service subnets will be applied.
 
-You will want to confirm your [`calico` installation is correct][calico-install].
+Confirm that your [Calico installation is correct][calico-install].
 
-[calico-install]: #confirming-calico-installation
+[calico-install]: #verify-your-calico-installation
 [calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods
 [create-secrets-and-overrides]: ../create-secrets-and-overrides
 [define-control-plane-endpoint]: ../define-control-plane-endpoint

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -28,6 +28,37 @@ Depending on the cluster size, it will take a few minutes to be created. After t
 dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
 ```
 
+### Confirming `calico` installation
+
+Before exploring the new cluster further, you will want to confirm your `calico` installation is correct.
+
+Get the pods running on your cluster with this command:
+
+   ```bash
+   kubectl get pods -A --kubeconfig ${CLUSTER_NAME}.conf
+   ```
+
+<p class="message--note"><strong>NOTE: </strong>If you see a <code>calico-node</code> pod not ready on your cluster, you need to edit the <code>installation</code> file.
+</p>
+
+To edit the installation file, run the command:
+
+   ```bash
+   kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf
+   ```
+
+Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interface: ens192`, and save the file:
+
+   ```yaml
+   spec:
+     calicoNetwork:
+     ...
+       nodeAddressAutodetectionV4:
+         interface: ens192
+   ```
+
+After saving the file, you may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace, if it failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
+
 ## Use the built-in Virtual IP
 
 As explained in [Define the Control Plane Endpoint][define-control-plane-endpoint], we recommend using an external load balancer for the control plane endpoint, but provide a built-in virtual IP when an external load balancer is not available. To use the virtual IP, add these flags to the `create cluster` command:
@@ -41,10 +72,12 @@ As explained in [Define the Control Plane Endpoint][define-control-plane-endpoin
 
 ```shell
 dkp create cluster preprovisioned \
-    --cluster-name ${CLUSTER_NAME} \
-    --control-plane-endpoint-host 196.168.1.10 \
-    --virtual-ip-interface eth1
+--cluster-name ${CLUSTER_NAME} \
+--control-plane-endpoint-host 196.168.1.10 \
+--virtual-ip-interface eth1
 ```
+
+You will want to confirm your [`calico` installation is correct][calico-install].
 
 ## Provision on the Flatcar Linux OS
 
@@ -54,9 +87,11 @@ When provisioning onto the Flatcar Container Linux distribution, you must instru
 
 ```shell
 dkp create cluster preprovisioned \
-    --cluster-name ${CLUSTER_NAME} \
-    --os-hint flatcar
+--cluster-name ${CLUSTER_NAME} \
+--os-hint flatcar
 ```
+
+You will want to confirm your [`calico` installation is correct][calico-install].
 
 ## Use an HTTP Proxy
 
@@ -75,14 +110,16 @@ If you require HTTP proxy configurations, you can apply them during the `create`
 
 ```shell
 dkp create cluster preprovisioned \
-    --cluster-name ${CLUSTER_NAME} \
-    --control-plane-http-proxy http://proxy.example.com:8080 \
-    --control-plane-https-proxy https://proxy.example.com:8080 \
-    --control-plane-no-proxy "127.0.0.1,10.96.0.0/12,192.168.0.0/16,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local" \
-    --worker-http-proxy http://proxy.example.com:8080 \
-    --worker-https-proxy https://proxy.example.com:8080 \
-    --worker-no-proxy "127.0.0.1,10.96.0.0/12,192.168.0.0/16,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
+--cluster-name ${CLUSTER_NAME} \
+--control-plane-http-proxy http://proxy.example.com:8080 \
+--control-plane-https-proxy https://proxy.example.com:8080 \
+--control-plane-no-proxy "127.0.0.1,10.96.0.0/12,192.168.0.0/16,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local" \
+--worker-http-proxy http://proxy.example.com:8080 \
+--worker-https-proxy https://proxy.example.com:8080 \
+--worker-no-proxy "127.0.0.1,10.96.0.0/12,192.168.0.0/16,kubernetes,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local"
 ```
+
+You will want to confirm your [`calico` installation is correct][calico-install].
 
 ## Use an alternative mirror
 
@@ -101,10 +138,12 @@ When the cluster is up and running, you can deploy and test workloads.
 
 ```shell
 dkp create cluster preprovisioned \
-    --cluster-name ${CLUSTER_NAME} \
-    --registry-mirror-cacert /tmp/registry.pem \
-    --registry-mirror-url https://registry.example.com
+--cluster-name ${CLUSTER_NAME} \
+--registry-mirror-cacert /tmp/registry.pem \
+--registry-mirror-url https://registry.example.com
 ```
+
+You will want to confirm your [`calico` installation is correct][calico-install].
 
 ## Use alternate pod or service subnets
 
@@ -164,5 +203,8 @@ In Konvoy, the default pod subnet is 192.168.0.0/16, and the default service sub
 
 When you provision the cluster, the configured pod and service subnets will be applied.
 
-[define-control-plane-endpoint]: ../define-control-plane-endpoint
+You will want to confirm your [`calico` installation is correct][calico-install].
+
+[calico-install]: #confirming-calico-installation
 [create-secrets-and-overrides]: ../create-secrets-and-overrides
+[define-control-plane-endpoint]: ../define-control-plane-endpoint


### PR DESCRIPTION
makes more sense to be here rather than on the
self manage section
also what if someone does not want to make the
cluster self managed

## Jira Ticket

n/a

## Description of changes being made

This was brought to our attention - where this would make most sense to be on the create page.
Also, I added this as a link to the other different flavors of preprov create, because there are many flavors, and don't want it to get missed by users creating these diff types of clusters.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4153.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
