### PR TITLE
docs: add reference to dkp gpu docs in kaptain install docs

### DIFF
--- a/pages/dkp/kaptain/1.3.0/install/konvoy-dkp/index.md
+++ b/pages/dkp/kaptain/1.3.0/install/konvoy-dkp/index.md
@@ -61,6 +61,7 @@ For cloud installations, scaling out can be limited by resource quotas.
           - name: knative
             enabled: true
     ```
+* For GPU deployment, follow the instructions in [Konvoy GPU documentation][konvoy-gpu].
 
 * Then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons.
 
@@ -87,6 +88,8 @@ For DKP 2.x, ensure the following applications are enabled in Kommander:
     nvidia:  # to enable GPU support
     ...   
   ```
+* For GPU deployment, follow the instructions in [Kommander GPU documentation][kommander-gpu]. 
+
 * Apply the new configuration to Kommander:
   ```
   kommander install --installer-config kommander-config.yaml
@@ -181,5 +184,7 @@ Once all components have been deployed, you can log in to Kaptain:
 [install-spark-dkp2]: /dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/
 [install-spark-konvoy1]: /dkp/kommander/1.4/projects/platform-services/platform-services-catalog/kudo-spark/
 [kommander-install]: /dkp/kommander/latest/install/
+[kommander-gpu]: /dkp/kommander/latest/gpu/
+[konvoy-gpu]: /dkp/konvoy/1.8/gpu/
 [konvoy_deploy_addons]: /dkp/konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
 [kudo_cli]: https://kudo.dev/#get-kudo


### PR DESCRIPTION
port this fix from kaptain docs to live docs: https://github.com/mesosphere/kudo-kubeflow/pull/657

## Jira Ticket
https://jira.d2iq.com/browse/COPS-6863

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4155.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
