### PR TITLE
Konvoy 2.1: Update dkp-diagnose download URL from v0.3.2 to v0.4.1

### DIFF
--- a/pages/dkp/konvoy/2.1/troubleshooting/generate-a-support-bundle/index.md
+++ b/pages/dkp/konvoy/2.1/troubleshooting/generate-a-support-bundle/index.md
@@ -15,13 +15,13 @@ Follow these instructions to generate a support bundle with data collected for t
 
 Before generating a support bundle, verify that you have:
 
-- An AMD64-based Linux or MacOS machine with a supported version of the operating system.
+- An AMD64-based Linux or macOS machine with a supported version of the operating system.
 - A running Kubernetes cluster.
-- `dkp-diagnose` command for [MacOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux] for collecting the support bundle.
+- `dkp-diagnose` command for [macOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux] for collecting the support bundle.
 
 ## Download dkp-diagnose
 
-1.  To download and extract the `dkp-diagnose` binary for [MacOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux]
+1.  To download and extract the `dkp-diagnose` binary for [macOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux]
 
     For Linux:
 
@@ -199,13 +199,13 @@ The fallback collector runs a bash script over SSH and copies the collected data
 
 Redactors are supported and are in the same format as the main `dkp-diagnose` command. Per node collection timeouts are supported using the `--timeout` parameter.
 
-[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
-[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
-[troubleshoot-collectors]: https://troubleshoot.sh/docs/collect/all/
 [clusterInfo-collector]: https://troubleshoot.sh/docs/collect/cluster-info/
 [clusterResources-collector]: https://troubleshoot.sh/docs/collect/cluster-resources/
 [configMap-collector]: https://troubleshoot.sh/docs/collect/configmap/
-[secrets-collector]: https://troubleshoot.sh/docs/collect/secret/
-[logs-collector]: https://troubleshoot.sh/docs/collect/logs/
 [copyFromHost-collector]: https://troubleshoot.sh/docs/collect/copy-from-host/
+[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
+[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
 [exec-collector]: https://troubleshoot.sh/docs/collect/exec/
+[logs-collector]: https://troubleshoot.sh/docs/collect/logs/
+[secrets-collector]: https://troubleshoot.sh/docs/collect/secret/
+[troubleshoot-collectors]: https://troubleshoot.sh/docs/collect/all/

--- a/pages/dkp/konvoy/2.1/troubleshooting/generate-a-support-bundle/index.md
+++ b/pages/dkp/konvoy/2.1/troubleshooting/generate-a-support-bundle/index.md
@@ -26,13 +26,13 @@ Before generating a support bundle, verify that you have:
     For Linux:
 
     ```sh
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
     For macOS:
 
     ```sh
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
 1.  Add the binary to your PATH:
@@ -199,8 +199,8 @@ The fallback collector runs a bash script over SSH and copies the collected data
 
 Redactors are supported and are in the same format as the main `dkp-diagnose` command. Per node collection timeouts are supported using the `--timeout` parameter.
 
-[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_darwin_amd64.tar.gz
-[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_linux_amd64.tar.gz
+[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
+[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
 [troubleshoot-collectors]: https://troubleshoot.sh/docs/collect/all/
 [clusterInfo-collector]: https://troubleshoot.sh/docs/collect/cluster-info/
 [clusterResources-collector]: https://troubleshoot.sh/docs/collect/cluster-resources/

--- a/pages/dkp/konvoy/2.2/troubleshooting/generate-a-support-bundle/index.md
+++ b/pages/dkp/konvoy/2.2/troubleshooting/generate-a-support-bundle/index.md
@@ -15,24 +15,24 @@ Follow these instructions to generate a support bundle with data collected for t
 
 Before generating a support bundle, verify that you have:
 
-- An AMD64-based Linux or MacOS machine with a supported version of the operating system.
+- An AMD64-based Linux or macOS machine with a supported version of the operating system.
 - A running Kubernetes cluster.
-- `dkp-diagnose` command for [MacOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux] for collecting the support bundle.
+- `dkp-diagnose` command for [macOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux] for collecting the support bundle.
 
 ## Download dkp-diagnose
 
-1.  To download and extract the `dkp-diagnose` binary for [MacOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux]
+1.  To download and extract the `dkp-diagnose` binary for [macOS][dkp-diagnostics-darwin] or [Linux][dkp-diagnostics-linux]
 
     For Linux:
 
     ```sh
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
     For macOS:
 
     ```sh
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
 1.  Add the binary to your PATH:
@@ -199,13 +199,13 @@ The fallback collector runs a bash script over SSH and copies the collected data
 
 Redactors are supported and are in the same format as the main `dkp-diagnose` command. Per node collection timeouts are supported using the `--timeout` parameter.
 
-[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_darwin_amd64.tar.gz
-[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.3.2_linux_amd64.tar.gz
-[troubleshoot-collectors]: https://troubleshoot.sh/docs/collect/all/
 [clusterInfo-collector]: https://troubleshoot.sh/docs/collect/cluster-info/
 [clusterResources-collector]: https://troubleshoot.sh/docs/collect/cluster-resources/
 [configMap-collector]: https://troubleshoot.sh/docs/collect/configmap/
-[secrets-collector]: https://troubleshoot.sh/docs/collect/secret/
-[logs-collector]: https://troubleshoot.sh/docs/collect/logs/
 [copyFromHost-collector]: https://troubleshoot.sh/docs/collect/copy-from-host/
+[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
+[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
 [exec-collector]: https://troubleshoot.sh/docs/collect/exec/
+[logs-collector]: https://troubleshoot.sh/docs/collect/logs/
+[secrets-collector]: https://troubleshoot.sh/docs/collect/secret/
+[troubleshoot-collectors]: https://troubleshoot.sh/docs/collect/all/


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Update download URL of the dkp-diagnose CLI to the latest version, v0.4.1.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4156.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
