### PR TITLE
Redo: Kommander Installation

### DIFF
--- a/pages/dkp/kommander/2.0/install/networked/index.md
+++ b/pages/dkp/kommander/2.0/install/networked/index.md
@@ -66,9 +66,11 @@ If you are installing Kommander on kind, you must know the following:
     ```
 -->
 
-## Install on Konvoy
+## Install Kommander on Konvoy
 
-Before running the commands below make sure that your `kubectl` configuration is pointing to the cluster you want to install Kommander on by setting the `KUBECONFIG` environment variable to the respective kubeconfig file's location.
+Before running these commands, ensure that your `kubectl` configuration **references the cluster where you want to install Kommander**, otherwise it installs on the bootstrap cluster. Do this by setting the `KUBECONFIG` environment variable [to the appropriate kubeconfig file's location][k8s-access-to-clusters].
+
+<p class="message--note"><strong>NOTE:</strong> An alternative to initializing the KUBECONFIG environment variable as stated earlier is to use the <code>–kubeconfig=cluster_name.conf</code> flag. This ensures that Kommander is installed on the workload cluster.</p>
 
 To install Kommander with http proxy setting enabled, you need to follow the instructions outlined in [enable gatekeeper](../http-proxy#enable-gatekeeper) section before proceeding further. To enable a gatekeeper proxy, you must pass the `values.yaml` you created to the following commands using `--values=values.yaml`
 
@@ -118,7 +120,7 @@ helmrelease.helm.toolkit.fluxcd.io/velero condition met
 
 ## Access Kommander Web UI
 
-When all the `HelmReleases` are ready, use the following command to retrieve the URL for accessing Kommander's Web interface:
+When all the `HelmReleases` are ready, use the following command to retrieve the URL to access Kommander's Web interface:
 
 ```sh
 kubectl -n kommander get svc kommander-traefik -o go-template='https://{{with index .status.loadBalancer.ingress 0}}{{or .hostname .ip}}{{end}}/dkp/kommander/dashboard{{ "\n"}}'
@@ -132,3 +134,4 @@ kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.dat
 
 [konvoy_self_managing]: /dkp/konvoy/2.0/install/advanced/self-managing/
 [bootstrap_cluster]: /dkp/konvoy/2.0/install/advanced/bootstrap/
+[k8s-access-to-clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/

--- a/pages/dkp/kommander/2.1/install/networked/index.md
+++ b/pages/dkp/kommander/2.1/install/networked/index.md
@@ -41,9 +41,11 @@ More information on setting a StorageClass as default can be found at [Changing 
 
 ## Install Kommander on Konvoy
 
-Before running the commands below, ensure that your `kubectl` configuration references the cluster on which you want to install Kommander. You can do this by setting the `KUBECONFIG` environment variable to the appropriate kubeconfig file's location.
+To customize a Kommander installation, see the [configuration page][configuration-kommander] for more details.
 
-<p class="message--note"><strong>NOTE:</strong> See the <a href="../configuration">configuration</a> page for more details on how to customize a Kommander installation.</p>
+Before running the commands below, ensure that your `kubectl` configuration **references the cluster on which you want to install Kommander**, otherwise it will install on the bootstrap cluster. You can do this by setting the `KUBECONFIG` environment variable [to the appropriate kubeconfig file's location][k8s-access-to-clusters].
+
+<p class="message--note"><strong>NOTE:</strong> An alternative to initializing the KUBECONFIG environment variable as stated earlier is to use the <code>–kubeconfig=cluster_name.conf</code> flag. This ensures that Kommander is installed on the workload cluster.</p>
 
 ```sh
 kommander install
@@ -116,3 +118,5 @@ kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.dat
 
 [k8s-change-default-storage-class]: https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
 [download]: ../../download
+[k8s-access-to-clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
+[configuration-kommander]: ../configuration/

--- a/pages/dkp/kommander/2.2/install/networked/index.md
+++ b/pages/dkp/kommander/2.2/install/networked/index.md
@@ -41,9 +41,11 @@ More information on setting a StorageClass as default can be found at [Changing 
 
 ## Install Kommander on Konvoy
 
-Before running the commands below, ensure that your `kubectl` configuration references the cluster on which you want to install Kommander. You can do this by setting the `KUBECONFIG` environment variable to the appropriate kubeconfig file's location.
+To customize a Kommander installation, see the [configuration page][configuration-kommander] for more details.
 
-<p class="message--note"><strong>NOTE:</strong> See the <a href="../configuration">configuration</a> page for more details on how to customize a Kommander installation.</p>
+Before running the commands below, ensure that your `kubectl` configuration **references the cluster on which you want to install Kommander**, otherwise it will install on the bootstrap cluster. You can do this by setting the `KUBECONFIG` environment variable [to the appropriate kubeconfig file's location][k8s-access-to-clusters].
+
+<p class="message--note"><strong>NOTE:</strong> An alternative to initializing the KUBECONFIG environment variable as stated earlier is to use the <code>–kubeconfig=cluster_name.conf</code> flag. This ensures that Kommander is installed on the workload cluster.</p>
 
 ```sh
 kommander install
@@ -115,3 +117,5 @@ kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.dat
 ```
 
 [k8s-change-default-storage-class]: https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class
+[k8s-access-to-clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
+[configuration-kommander]: ../configuration/


### PR DESCRIPTION
Jira: https://jira.d2iq.com/browse/COPS-7039?filter=57924

Redo: Customers are overlooking that kubectl configuration must point to the correct cluster before running the install command. Goal here is to provide with alternatives on how to install Kommander on the correct cluster (and not accidentally installing it on bootstrap cluster).

Preview
You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4150.s3-website-us-west-2.amazonaws.com/
