### PR TITLE
docs: provision a static local volume

### DIFF
--- a/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
@@ -1,0 +1,128 @@
+---
+layout: layout.pug
+navigationTitle: Provision a static local volume
+title: Provision a static local volume
+menuWeight: 15
+excerpt: Learn how to provision a static local volume for a Konvoy cluster
+beta: false
+enterprise: false
+---
+
+<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
+
+The `localvolumeprovisioner` addon uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
+It does this by watching the `/mnt/disks` folder on each host and creating persistent volumes in the `localvolumeprovisioner` storage class for each disk that it discovers in this folder.
+
+- Persistent volumes with a 'Filesystem' volume-mode are discovered if they are mounted under `/mnt/disks`.
+
+- Persistent volumes with a 'Block' volume-mode are discovered if a symbolic link to the block device is created in `/mnt/disks`.
+
+# Before you begin
+
+Before starting this tutorial, verify the following:
+
+- You have access to a Linux, macOS, or Windows computer with a supported operating system version.
+
+- You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` addon, but have not added any other addons to the cluster yet.
+
+  For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start][quickstart].
+
+  This distinction between provisioning and deployment is important because some addons depend on the storage class provided by the `localvolumeprovisioner` addon and can fail to start if it is not configured yet.
+
+## Provision the cluster and a volume
+
+1. Provision the Kubernetes cluster without deploying addons by running the following command:
+
+    ```bash
+    konvoy provision
+    ```
+
+1. Provision the local volume provisioner to watch for mounts in `/mnt/disks` on each host.
+
+    For example, mount a `tmpfs` volume with `ansible` using the `inventory.yaml` provided by `konvoy` by running the following command:
+
+    ```bash
+    ansible -i inventory.yaml node -m shell -a "mkdir -p /mnt/disks/example-volume && mount -t tmpfs example-volume /mnt/disks/example-volume"
+    ```
+
+1. Deploy the `konvoy` cluster with addons by running the following command:
+
+    ```bash
+    konvoy up
+    ```
+
+    When you run this command, the local volume provisioned detects the `example-volume` volume and adds it as a persistent volume to the `localvolumeprovisioner` storage class.
+
+1. Verify the persistent volume by running the following command:
+
+    ```bash
+    kubectl get pv
+    ```
+
+    The command displays output similar to the following:
+
+    ```sh
+    NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS             REASON   AGE
+    local-pv-4c7fc8ba   3986Mi     RWO            Delete           Available           localvolumeprovisioner            2s
+    ```
+
+1. Claim the persistent volume using PersistentVolumeClaim settings by running the following command:
+
+    ```bash
+    cat <<EOF | kubectl create -f -
+    kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: example-claim
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Mi
+      storageClassName: localvolumeprovisioner
+    EOF
+    ```
+
+1. Reference the persistent volume claim in pods by running the following command:
+
+  ```bash
+  cat <<EOF | kubectl create -f -
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: pod-with-persistent-volume
+  spec:
+    containers:
+      - name: frontend
+        image: nginx
+        volumeMounts:
+          - name: data
+            mountPath: "/var/www/html"
+    volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: example-claim
+  EOF
+  ```
+
+1. Verify the persistent volume claim by running the following command:
+
+    ```bash
+    kubectl get pvc
+    ```
+
+    The command displays output similar to the following:
+
+    ```bash
+    NAME            STATUS   VOLUME              CAPACITY   ACCESS MODES   STORAGECLASS             AGE
+    example-claim   Bound    local-pv-4c7fc8ba   3986Mi     RWO            localvolumeprovisioner   78s
+    $ kubectl get pv
+    NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                   STORAGECLASS             REASON   AGE
+    local-pv-4c7fc8ba   3986Mi     RWO            Delete           Bound       default/example-claim   localvolumeprovisioner            15m
+    ```
+
+Upon deletion of the persistent volume claim, the corresponding persistent volume resource deletes (mandated by the "Delete" reclaim policy), which removes all data on the volume.
+
+[localstorage]:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
+[quickstart]:../../quick-start/

--- a/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
@@ -31,9 +31,9 @@ This distinction between provisioning and deployment is important because some a
 
 1.  Create a pre-provisioned cluster by following the steps outlined [in the choose pre-provisioned infrastructure topic][preprovision].
 
-    Whenever volumes are create on the node machines, the local volume provisioned detects the volume in `/mnt/disks` and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
+    Whenever volumes are created on the machines, the `localvolumeprovisioner` detects the volume in `/mnt/disks` and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
 
-1.  Create some volumes in `/mnt/disks` on each host.
+1.  Create at least one volume in `/mnt/disks` on each host.
 
     For example, mount a `tmpfs` volume:
 

--- a/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
@@ -11,9 +11,9 @@ enterprise: false
 The `localvolumeprovisioner` component uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
 It does this by watching the `/mnt/disks` folder on each host and creating persistent volumes in the `localvolumeprovisioner` storage class for each disk that it discovers in this folder.
 
--   Persistent volumes with a 'Filesystem' volume-mode are discovered if they are mounted under `/mnt/disks`.
+-   Persistent volumes with a 'Filesystem' volume-mode are discovered if you mount them under `/mnt/disks`.
 
--   Persistent volumes with a 'Block' volume-mode are discovered if a symbolic link to the block device is created in `/mnt/disks`.
+-   Persistent volumes with a 'Block' volume-mode are discovered if you create a symbolic link to the block device is created in `/mnt/disks`.
 
 ## Before you begin
 
@@ -21,7 +21,7 @@ Before starting this tutorial, verify the following:
 
 -   You have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
--   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` component, but have not added any other Kommander applications to the cluster yet.
+-   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` platform application, but have not added any other Kommander applications to the cluster yet.
 
 For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start guide][quickstart].
 
@@ -54,7 +54,7 @@ This distinction between provisioning and deployment is important because some a
     local-pv-4c7fc8ba   3986Mi     RWO            Delete           Available           localvolumeprovisioner            2s
     ```
 
-1.  Claim the persistent volume using PersistentVolumeClaim settings by running the following command:
+1.  Claim the persistent volume using a PersistentVolumeClaim, by running the following command:
 
     ```yaml
     cat <<EOF | kubectl create -f -
@@ -72,7 +72,7 @@ This distinction between provisioning and deployment is important because some a
     EOF
     ```
 
-1.  Reference the persistent volume claim in pods by running the following command:
+1.  Reference the persistent volume claim in a pod by running the following command:
 
     ```yaml
     cat <<EOF | kubectl create -f -
@@ -110,7 +110,7 @@ This distinction between provisioning and deployment is important because some a
     local-pv-4c7fc8ba   3986Mi     RWO            Delete           Bound       default/example-claim   localvolumeprovisioner            15m
     ```
 
-Upon deletion of the persistent volume claim, the corresponding persistent volume resource deletes (mandated by the "Delete" reclaim policy), which removes all data on the volume.
+Upon deletion of the persistent volume claim, the corresponding persistent volume resource uses the "Delete" reclaim policy, which removes all data on the volume.
 
 [localstorage]:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [preprovision]: ../../choose-infrastructure/pre-provisioned

--- a/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-The `localvolumeprovisioner` addon uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
+The `localvolumeprovisioner` component uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
 It does this by watching the `/mnt/disks` folder on each host and creating persistent volumes in the `localvolumeprovisioner` storage class for each disk that it discovers in this folder.
 
 -   Persistent volumes with a 'Filesystem' volume-mode are discovered if they are mounted under `/mnt/disks`.
@@ -21,35 +21,25 @@ Before starting this tutorial, verify the following:
 
 -   You have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
--   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` addon, but have not added any other addons to the cluster yet.
+-   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` component, but have not added any other Kommander applications to the cluster yet.
 
-  For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start guide][quickstart].
+For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start guide][quickstart].
 
-  This distinction between provisioning and deployment is important because some addons depend on the storage class provided by the `localvolumeprovisioner` addon and can fail to start if it is not configured yet.
+This distinction between provisioning and deployment is important because some applications depend on the storage class provided by the `localvolumeprovisioner` component and can fail to start if it is not configured yet.
 
 ### Provision the cluster and a volume
 
-1.  Provision the Kubernetes cluster without deploying addons by running the following command:
+1.  Create a pre-provisioned cluster by following the steps outlined [in the choose pre-provisioned infrastructure topic][preprovision].
+
+    Whenever volumes are create on the node machines, the local volume provisioned detects the volume in `/mnt/disks` and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
+
+1.  Create some volumes in `/mnt/disks` on each host.
+
+    For example, mount a `tmpfs` volume:
 
     ```bash
-    konvoy provision
+    mkdir -p /mnt/disks/example-volume && mount -t tmpfs example-volume /mnt/disks/example-volume
     ```
-
-1.  Provision the local volume provisioner to watch for mounts in `/mnt/disks` on each host.
-
-    For example, mount a `tmpfs` volume with `ansible` using the `inventory.yaml` provided by `konvoy` by running the following command:
-
-    ```bash
-    ansible -i inventory.yaml node -m shell -a "mkdir -p /mnt/disks/example-volume && mount -t tmpfs example-volume /mnt/disks/example-volume"
-    ```
-
-1.  Deploy the `konvoy` cluster with addons by running the following command:
-
-    ```bash
-    konvoy up
-    ```
-
-    When you run this command, the local volume provisioned detects the `example-volume` volume and adds it as a persistent volume to the `localvolumeprovisioner` storage class.
 
 1.  Verify the persistent volume by running the following command:
 
@@ -123,4 +113,5 @@ Before starting this tutorial, verify the following:
 Upon deletion of the persistent volume claim, the corresponding persistent volume resource deletes (mandated by the "Delete" reclaim policy), which removes all data on the volume.
 
 [localstorage]:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
+[preprovision]: ../../choose-infrastructure/pre-provisioned
 [quickstart]:../../choose-infrastructure/aws/quick-start-aws/

--- a/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
@@ -13,7 +13,7 @@ It does this by watching the `/mnt/disks` folder on each host and creating persi
 
 -   Persistent volumes with a 'Filesystem' volume-mode are discovered if you mount them under `/mnt/disks`.
 
--   Persistent volumes with a 'Block' volume-mode are discovered if you create a symbolic link to the block device is created in `/mnt/disks`.
+-   Persistent volumes with a 'Block' volume-mode are discovered if you create a symbolic link to the block device in `/mnt/disks`.
 
 ## Before you begin
 
@@ -31,7 +31,7 @@ This distinction between provisioning and deployment is important because some a
 
 1.  Create a pre-provisioned cluster by following the steps outlined [in the choose pre-provisioned infrastructure topic][preprovision].
 
-    Whenever volumes are created on the machines, the `localvolumeprovisioner` detects the volume in `/mnt/disks` and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
+    As volumes are created/mounted on the nodes, the local volume provisioner detects each volume in the `/mnt/disks` directory and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
 
 1.  Create at least one volume in `/mnt/disks` on each host.
 

--- a/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
@@ -8,36 +8,34 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
-
 The `localvolumeprovisioner` addon uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
 It does this by watching the `/mnt/disks` folder on each host and creating persistent volumes in the `localvolumeprovisioner` storage class for each disk that it discovers in this folder.
 
-- Persistent volumes with a 'Filesystem' volume-mode are discovered if they are mounted under `/mnt/disks`.
+-   Persistent volumes with a 'Filesystem' volume-mode are discovered if they are mounted under `/mnt/disks`.
 
-- Persistent volumes with a 'Block' volume-mode are discovered if a symbolic link to the block device is created in `/mnt/disks`.
+-   Persistent volumes with a 'Block' volume-mode are discovered if a symbolic link to the block device is created in `/mnt/disks`.
 
-# Before you begin
+## Before you begin
 
 Before starting this tutorial, verify the following:
 
-- You have access to a Linux, macOS, or Windows computer with a supported operating system version.
+-   You have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
-- You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` addon, but have not added any other addons to the cluster yet.
+-   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` addon, but have not added any other addons to the cluster yet.
 
-  For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start][quickstart].
+  For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start guide][quickstart].
 
   This distinction between provisioning and deployment is important because some addons depend on the storage class provided by the `localvolumeprovisioner` addon and can fail to start if it is not configured yet.
 
-## Provision the cluster and a volume
+### Provision the cluster and a volume
 
-1. Provision the Kubernetes cluster without deploying addons by running the following command:
+1.  Provision the Kubernetes cluster without deploying addons by running the following command:
 
     ```bash
     konvoy provision
     ```
 
-1. Provision the local volume provisioner to watch for mounts in `/mnt/disks` on each host.
+1.  Provision the local volume provisioner to watch for mounts in `/mnt/disks` on each host.
 
     For example, mount a `tmpfs` volume with `ansible` using the `inventory.yaml` provided by `konvoy` by running the following command:
 
@@ -45,7 +43,7 @@ Before starting this tutorial, verify the following:
     ansible -i inventory.yaml node -m shell -a "mkdir -p /mnt/disks/example-volume && mount -t tmpfs example-volume /mnt/disks/example-volume"
     ```
 
-1. Deploy the `konvoy` cluster with addons by running the following command:
+1.  Deploy the `konvoy` cluster with addons by running the following command:
 
     ```bash
     konvoy up
@@ -53,7 +51,7 @@ Before starting this tutorial, verify the following:
 
     When you run this command, the local volume provisioned detects the `example-volume` volume and adds it as a persistent volume to the `localvolumeprovisioner` storage class.
 
-1. Verify the persistent volume by running the following command:
+1.  Verify the persistent volume by running the following command:
 
     ```bash
     kubectl get pv
@@ -66,9 +64,9 @@ Before starting this tutorial, verify the following:
     local-pv-4c7fc8ba   3986Mi     RWO            Delete           Available           localvolumeprovisioner            2s
     ```
 
-1. Claim the persistent volume using PersistentVolumeClaim settings by running the following command:
+1.  Claim the persistent volume using PersistentVolumeClaim settings by running the following command:
 
-    ```bash
+    ```yaml
     cat <<EOF | kubectl create -f -
     kind: PersistentVolumeClaim
     apiVersion: v1
@@ -84,29 +82,29 @@ Before starting this tutorial, verify the following:
     EOF
     ```
 
-1. Reference the persistent volume claim in pods by running the following command:
+1.  Reference the persistent volume claim in pods by running the following command:
 
-  ```bash
-  cat <<EOF | kubectl create -f -
-  apiVersion: v1
-  kind: Pod
-  metadata:
-    name: pod-with-persistent-volume
-  spec:
-    containers:
-      - name: frontend
-        image: nginx
-        volumeMounts:
-          - name: data
-            mountPath: "/var/www/html"
-    volumes:
-      - name: data
-        persistentVolumeClaim:
-          claimName: example-claim
-  EOF
-  ```
+    ```yaml
+    cat <<EOF | kubectl create -f -
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod-with-persistent-volume
+    spec:
+      containers:
+        - name: frontend
+          image: nginx
+          volumeMounts:
+            - name: data
+              mountPath: "/var/www/html"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: example-claim
+    EOF
+    ```
 
-1. Verify the persistent volume claim by running the following command:
+1.  Verify the persistent volume claim by running the following command:
 
     ```bash
     kubectl get pvc
@@ -114,7 +112,7 @@ Before starting this tutorial, verify the following:
 
     The command displays output similar to the following:
 
-    ```bash
+    ```sh
     NAME            STATUS   VOLUME              CAPACITY   ACCESS MODES   STORAGECLASS             AGE
     example-claim   Bound    local-pv-4c7fc8ba   3986Mi     RWO            localvolumeprovisioner   78s
     $ kubectl get pv
@@ -125,4 +123,4 @@ Before starting this tutorial, verify the following:
 Upon deletion of the persistent volume claim, the corresponding persistent volume resource deletes (mandated by the "Delete" reclaim policy), which removes all data on the volume.
 
 [localstorage]:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
-[quickstart]:../../quick-start/
+[quickstart]:../../choose-infrastructure/aws/quick-start-aws/

--- a/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
@@ -1,0 +1,128 @@
+---
+layout: layout.pug
+navigationTitle: Provision a static local volume
+title: Provision a static local volume
+menuWeight: 15
+excerpt: Learn how to provision a static local volume for a Konvoy cluster
+beta: false
+enterprise: false
+---
+
+<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
+
+The `localvolumeprovisioner` addon uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
+It does this by watching the `/mnt/disks` folder on each host and creating persistent volumes in the `localvolumeprovisioner` storage class for each disk that it discovers in this folder.
+
+- Persistent volumes with a 'Filesystem' volume-mode are discovered if they are mounted under `/mnt/disks`.
+
+- Persistent volumes with a 'Block' volume-mode are discovered if a symbolic link to the block device is created in `/mnt/disks`.
+
+# Before you begin
+
+Before starting this tutorial, verify the following:
+
+- You have access to a Linux, macOS, or Windows computer with a supported operating system version.
+
+- You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` addon, but have not added any other addons to the cluster yet.
+
+  For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start][quickstart].
+
+  This distinction between provisioning and deployment is important because some addons depend on the storage class provided by the `localvolumeprovisioner` addon and can fail to start if it is not configured yet.
+
+## Provision the cluster and a volume
+
+1. Provision the Kubernetes cluster without deploying addons by running the following command:
+
+    ```bash
+    konvoy provision
+    ```
+
+1. Provision the local volume provisioner to watch for mounts in `/mnt/disks` on each host.
+
+    For example, mount a `tmpfs` volume with `ansible` using the `inventory.yaml` provided by `konvoy` by running the following command:
+
+    ```bash
+    ansible -i inventory.yaml node -m shell -a "mkdir -p /mnt/disks/example-volume && mount -t tmpfs example-volume /mnt/disks/example-volume"
+    ```
+
+1. Deploy the `konvoy` cluster with addons by running the following command:
+
+    ```bash
+    konvoy up
+    ```
+
+    When you run this command, the local volume provisioned detects the `example-volume` volume and adds it as a persistent volume to the `localvolumeprovisioner` storage class.
+
+1. Verify the persistent volume by running the following command:
+
+    ```bash
+    kubectl get pv
+    ```
+
+    The command displays output similar to the following:
+
+    ```sh
+    NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS             REASON   AGE
+    local-pv-4c7fc8ba   3986Mi     RWO            Delete           Available           localvolumeprovisioner            2s
+    ```
+
+1. Claim the persistent volume using PersistentVolumeClaim settings by running the following command:
+
+    ```bash
+    cat <<EOF | kubectl create -f -
+    kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: example-claim
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Mi
+      storageClassName: localvolumeprovisioner
+    EOF
+    ```
+
+1. Reference the persistent volume claim in pods by running the following command:
+
+  ```bash
+  cat <<EOF | kubectl create -f -
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: pod-with-persistent-volume
+  spec:
+    containers:
+      - name: frontend
+        image: nginx
+        volumeMounts:
+          - name: data
+            mountPath: "/var/www/html"
+    volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: example-claim
+  EOF
+  ```
+
+1. Verify the persistent volume claim by running the following command:
+
+    ```bash
+    kubectl get pvc
+    ```
+
+    The command displays output similar to the following:
+
+    ```bash
+    NAME            STATUS   VOLUME              CAPACITY   ACCESS MODES   STORAGECLASS             AGE
+    example-claim   Bound    local-pv-4c7fc8ba   3986Mi     RWO            localvolumeprovisioner   78s
+    $ kubectl get pv
+    NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                   STORAGECLASS             REASON   AGE
+    local-pv-4c7fc8ba   3986Mi     RWO            Delete           Bound       default/example-claim   localvolumeprovisioner            15m
+    ```
+
+Upon deletion of the persistent volume claim, the corresponding persistent volume resource deletes (mandated by the "Delete" reclaim policy), which removes all data on the volume.
+
+[localstorage]:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
+[quickstart]:../../quick-start/

--- a/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
@@ -8,52 +8,40 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
-
-The `localvolumeprovisioner` addon uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
+The `localvolumeprovisioner` component uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
 It does this by watching the `/mnt/disks` folder on each host and creating persistent volumes in the `localvolumeprovisioner` storage class for each disk that it discovers in this folder.
 
 -   Persistent volumes with a 'Filesystem' volume-mode are discovered if you mount them under `/mnt/disks`.
 
 -   Persistent volumes with a 'Block' volume-mode are discovered if you create a symbolic link to the block device is created in `/mnt/disks`.
 
-# Before you begin
+## Before you begin
 
 Before starting this tutorial, verify the following:
 
-- You have access to a Linux, macOS, or Windows computer with a supported operating system version.
+-   You have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
 -   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` platform application, but have not added any other Kommander applications to the cluster yet.
 
-  For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start][quickstart].
+For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start guide][quickstart].
 
-  This distinction between provisioning and deployment is important because some addons depend on the storage class provided by the `localvolumeprovisioner` addon and can fail to start if it is not configured yet.
+This distinction between provisioning and deployment is important because some applications depend on the storage class provided by the `localvolumeprovisioner` component and can fail to start if it is not configured yet.
 
-## Provision the cluster and a volume
+### Provision the cluster and a volume
 
-1. Provision the Kubernetes cluster without deploying addons by running the following command:
+1.  Create a pre-provisioned cluster by following the steps outlined [in the choose pre-provisioned infrastructure topic][preprovision].
 
-    ```bash
-    konvoy provision
-    ```
+    Whenever volumes are created on the machines, the `localvolumeprovisioner` detects the volume in `/mnt/disks` and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
 
-1. Provision the local volume provisioner to watch for mounts in `/mnt/disks` on each host.
+1.  Create at least one volume in `/mnt/disks` on each host.
 
-    For example, mount a `tmpfs` volume with `ansible` using the `inventory.yaml` provided by `konvoy` by running the following command:
+    For example, mount a `tmpfs` volume:
 
     ```bash
-    ansible -i inventory.yaml node -m shell -a "mkdir -p /mnt/disks/example-volume && mount -t tmpfs example-volume /mnt/disks/example-volume"
+    mkdir -p /mnt/disks/example-volume && mount -t tmpfs example-volume /mnt/disks/example-volume
     ```
 
-1. Deploy the `konvoy` cluster with addons by running the following command:
-
-    ```bash
-    konvoy up
-    ```
-
-    When you run this command, the local volume provisioned detects the `example-volume` volume and adds it as a persistent volume to the `localvolumeprovisioner` storage class.
-
-1. Verify the persistent volume by running the following command:
+1.  Verify the persistent volume by running the following command:
 
     ```bash
     kubectl get pv
@@ -68,7 +56,7 @@ Before starting this tutorial, verify the following:
 
 1.  Claim the persistent volume using a PersistentVolumeClaim, by running the following command:
 
-    ```bash
+    ```yaml
     cat <<EOF | kubectl create -f -
     kind: PersistentVolumeClaim
     apiVersion: v1
@@ -84,29 +72,29 @@ Before starting this tutorial, verify the following:
     EOF
     ```
 
-1. Reference the persistent volume claim in a pod by running the following command:
+1.  Reference the persistent volume claim in a pod by running the following command:
 
-  ```bash
-  cat <<EOF | kubectl create -f -
-  apiVersion: v1
-  kind: Pod
-  metadata:
-    name: pod-with-persistent-volume
-  spec:
-    containers:
-      - name: frontend
-        image: nginx
-        volumeMounts:
-          - name: data
-            mountPath: "/var/www/html"
-    volumes:
-      - name: data
-        persistentVolumeClaim:
-          claimName: example-claim
-  EOF
-  ```
+    ```yaml
+    cat <<EOF | kubectl create -f -
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: pod-with-persistent-volume
+    spec:
+      containers:
+        - name: frontend
+          image: nginx
+          volumeMounts:
+            - name: data
+              mountPath: "/var/www/html"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: example-claim
+    EOF
+    ```
 
-1. Verify the persistent volume claim by running the following command:
+1.  Verify the persistent volume claim by running the following command:
 
     ```bash
     kubectl get pvc
@@ -114,7 +102,7 @@ Before starting this tutorial, verify the following:
 
     The command displays output similar to the following:
 
-    ```bash
+    ```sh
     NAME            STATUS   VOLUME              CAPACITY   ACCESS MODES   STORAGECLASS             AGE
     example-claim   Bound    local-pv-4c7fc8ba   3986Mi     RWO            localvolumeprovisioner   78s
     $ kubectl get pv
@@ -125,4 +113,5 @@ Before starting this tutorial, verify the following:
 Upon deletion of the persistent volume claim, the corresponding persistent volume resource uses the "Delete" reclaim policy, which removes all data on the volume.
 
 [localstorage]:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
-[quickstart]:../../quick-start/
+[preprovision]: ../../choose-infrastructure/pre-provisioned
+[quickstart]:../../choose-infrastructure/aws/quick-start-aws/

--- a/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
@@ -13,9 +13,9 @@ enterprise: false
 The `localvolumeprovisioner` addon uses the [local volume static provisioner][localstorage] to manage persistent volumes for pre-allocated disks.
 It does this by watching the `/mnt/disks` folder on each host and creating persistent volumes in the `localvolumeprovisioner` storage class for each disk that it discovers in this folder.
 
-- Persistent volumes with a 'Filesystem' volume-mode are discovered if they are mounted under `/mnt/disks`.
+-   Persistent volumes with a 'Filesystem' volume-mode are discovered if you mount them under `/mnt/disks`.
 
-- Persistent volumes with a 'Block' volume-mode are discovered if a symbolic link to the block device is created in `/mnt/disks`.
+-   Persistent volumes with a 'Block' volume-mode are discovered if you create a symbolic link to the block device is created in `/mnt/disks`.
 
 # Before you begin
 
@@ -23,7 +23,7 @@ Before starting this tutorial, verify the following:
 
 - You have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
-- You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` addon, but have not added any other addons to the cluster yet.
+-   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` platform application, but have not added any other Kommander applications to the cluster yet.
 
   For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start][quickstart].
 
@@ -66,7 +66,7 @@ Before starting this tutorial, verify the following:
     local-pv-4c7fc8ba   3986Mi     RWO            Delete           Available           localvolumeprovisioner            2s
     ```
 
-1. Claim the persistent volume using PersistentVolumeClaim settings by running the following command:
+1.  Claim the persistent volume using a PersistentVolumeClaim, by running the following command:
 
     ```bash
     cat <<EOF | kubectl create -f -
@@ -84,7 +84,7 @@ Before starting this tutorial, verify the following:
     EOF
     ```
 
-1. Reference the persistent volume claim in pods by running the following command:
+1. Reference the persistent volume claim in a pod by running the following command:
 
   ```bash
   cat <<EOF | kubectl create -f -
@@ -122,7 +122,7 @@ Before starting this tutorial, verify the following:
     local-pv-4c7fc8ba   3986Mi     RWO            Delete           Bound       default/example-claim   localvolumeprovisioner            15m
     ```
 
-Upon deletion of the persistent volume claim, the corresponding persistent volume resource deletes (mandated by the "Delete" reclaim policy), which removes all data on the volume.
+Upon deletion of the persistent volume claim, the corresponding persistent volume resource uses the "Delete" reclaim policy, which removes all data on the volume.
 
 [localstorage]:https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 [quickstart]:../../quick-start/

--- a/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
@@ -13,7 +13,7 @@ It does this by watching the `/mnt/disks` folder on each host and creating persi
 
 -   Persistent volumes with a 'Filesystem' volume-mode are discovered if you mount them under `/mnt/disks`.
 
--   Persistent volumes with a 'Block' volume-mode are discovered if you create a symbolic link to the block device is created in `/mnt/disks`.
+-   Persistent volumes with a 'Block' volume-mode are discovered if you create a symbolic link to the block device in `/mnt/disks`.
 
 ## Before you begin
 
@@ -31,7 +31,7 @@ This distinction between provisioning and deployment is important because some a
 
 1.  Create a pre-provisioned cluster by following the steps outlined [in the choose pre-provisioned infrastructure topic][preprovision].
 
-    Whenever volumes are created on the machines, the `localvolumeprovisioner` detects the volume in `/mnt/disks` and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
+    As volumes are created/mounted on the nodes, the local volume provisioner detects each volume in the `/mnt/disks` directory and adds it as a persistent volume with the `localvolumeprovisioner` storage class.
 
 1.  Create at least one volume in `/mnt/disks` on each host.
 


### PR DESCRIPTION
Closes D2IQ-78946

We'd like to transfer the information found here [Provision a static local volume](https://docs.d2iq.com/dkp/konvoy/1.8/storage/static-local-volume/)
into 2.1/2.2 docs.

There may be some updates here requested by the Konvoy team, and we can collaborate on this PR to make those changes. 

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-78946

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4163.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
