### PR TITLE
konvoy: use kubectl create because of large ConfigMaps

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -133,7 +133,7 @@ enterprise: false
 1.  Create the cluster from the objects.
 
     ```sh
-    kubectl apply -f ${CLUSTER_NAME}.yaml
+    kubectl create -f ${CLUSTER_NAME}.yaml
     ```
 
     ```sh

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/clusterconfig/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/awsgovcloud/clusterconfig/index.md
@@ -91,7 +91,7 @@ enterprise: false
 1.  Apply the cluster configuration.
 
     ```sh
-    kubectl apply -f cluster-sbx.yaml
+    kubectl create -f cluster-sbx.yaml
     ```
 
 1.  Monitor the Kubernetes cluster deployment.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/new/index.md
@@ -112,7 +112,7 @@ enterprise: false
 1.  Create the cluster from the objects.
 
     ```sh
-    kubectl apply -f ${CLUSTER_NAME}.yaml
+    kubectl create -f ${CLUSTER_NAME}.yaml
     ```
 
     ```sh

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/eks/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/eks/advanced/new/index.md
@@ -50,7 +50,7 @@ Before you start, make sure you have completed the steps in [Bootstrap][bootstra
 1.  Create the cluster from the objects.
 
     ```sh
-    kubectl apply -f ${CLUSTER_NAME}.yaml
+    kubectl create -f ${CLUSTER_NAME}.yaml
     ```
 
     ```sh


### PR DESCRIPTION
When using kubectl apply, the whole ConfigMap will be stuffed into an annotation thats too long.

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4179.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
