### PR TITLE
docs: updated centralized grafana clusterrole name

### DIFF
--- a/pages/dkp/kommander/2.2/operations/access-control/rbac/index.md
+++ b/pages/dkp/kommander/2.2/operations/access-control/rbac/index.md
@@ -104,18 +104,18 @@ Roles have been created for granting access to the dashboard and select applicat
 | kommander-dashboard | dkp-kommander-view                           | /dkp/kommander/dashboard/\*          | read                |
 | kommander-dashboard | dkp-kommander-edit                           | /dkp/kommander/dashboard/\*          | read, write         |
 | kommander-dashboard | dkp-kommander-admin                          | /dkp/kommander/dashboard/\*          | read, write, delete |
-| alertmanager        | kube-prometheus-stack-dkp-alertmanager-view  | /dkp/alertmanager/\*                 | read                |
-| alertmanager        | kube-prometheus-stack-dkp-alertmanager-edit  | /dkp/alertmanager/\*                 | read, write         |
-| alertmanager        | kube-prometheus-stack-dkp-alertmanager-admin | /dkp/alertmanager/\*                 | read, write, delete |
-| centralized-grafana | centralized-grafana-dkp-grafana-view  | /dkp/kommander/monitoring/grafana/\* | read                |
-| centralized-grafana | centralized-grafana-dkp-grafana-edit  | /dkp/kommander/monitoring/grafana/\* | read, write         |
-| centralized-grafana | centralized-grafana-dkp-grafana-admin | /dkp/kommander/monitoring/grafana/\* | read, write, delete |
+| alertmanager        | dkp-kube-prometheus-stack-alertmanager-view  | /dkp/alertmanager/\*                 | read                |
+| alertmanager        | dkp-kube-prometheus-stack-alertmanager-edit  | /dkp/alertmanager/\*                 | read, write         |
+| alertmanager        | dkp-kube-prometheus-stack-alertmanager-admin | /dkp/alertmanager/\*                 | read, write, delete |
+| centralized-grafana | dkp-centralized-grafana-grafana-view  | /dkp/kommander/monitoring/grafana/\* | read                |
+| centralized-grafana | dkp-centralized-grafana-grafana-edit  | /dkp/kommander/monitoring/grafana/\* | read, write         |
+| centralized-grafana | dkp-centralized-grafana-grafana-admin | /dkp/kommander/monitoring/grafana/\* | read, write, delete |
 | centralized-kubecost | dkp-centralized-kubecost-view  | /dkp/kommander/kubecost/\* | read                |
 | centralized-kubecost | dkp-centralized-kubecost-edit  | /dkp/kommander/kubecost/\* | read, write         |
 | centralized-kubecost | dkp-centralized-kubecost-admin | /dkp/kommander/kubecost/\* | read, write, delete |
-| grafana             | kube-prometheus-stack-dkp-grafana-view       | /dkp/grafana/\*                      | read                |
-| grafana             | kube-prometheus-stack-dkp-grafana-edit       | /dkp/grafana/\*                      | read, write         |
-| grafana             | kube-prometheus-stack-dkp-grafana-admin      | /dkp/grafana/\*                      | read, write, delete |
+| grafana             | dkp-kube-prometheus-stack-grafana-view       | /dkp/grafana/\*                      | read                |
+| grafana             | dkp-kube-prometheus-stack-grafana-edit       | /dkp/grafana/\*                      | read, write         |
+| grafana             | dkp-kube-prometheus-stack-grafana-admin      | /dkp/grafana/\*                      | read, write, delete |
 | grafana-logging     | dkp-grafana-logging-view                             | /dkp/logging/grafana/\*              | read                |
 | grafana-logging     | dkp-grafana-logging-edit                             | /dkp/logging/grafana/\*              | read, write         |
 | grafana-logging     | dkp-grafana-logging-admin                            | /dkp/logging/grafana/\*              | read, write, delete |
@@ -125,9 +125,9 @@ Roles have been created for granting access to the dashboard and select applicat
 | kubernetes-dashboard | dkp-kubernetes-dashboard-view       | /dkp/kubernetes/\*                      | read                |
 | kubernetes-dashboard | dkp-kubernetes-dashboard-edit       | /dkp/kubernetes/\*                      | read, write         |
 | kubernetes-dashboard | dkp-kubernetes-dashboard-admin      | /dkp/kubernetes/\*                      | read, write, delete |
-| prometheus          | kube-prometheus-stack-dkp-prometheus-view    | /dkp/prometheus/\*                   | read                |
-| prometheus          | kube-prometheus-stack-dkp-prometheus-edit    | /dkp/prometheus/\*                   | read, write         |
-| prometheus          | kube-prometheus-stack-dkp-prometheus-admin   | /dkp/prometheus/\*                   | read, write, edit   |
+| prometheus          | dkp-kube-prometheus-stack-prometheus-view    | /dkp/prometheus/\*                   | read                |
+| prometheus          | dkp-kube-prometheus-stack-prometheus-edit    | /dkp/prometheus/\*                   | read, write         |
+| prometheus          | dkp-kube-prometheus-stack-prometheus-admin   | /dkp/prometheus/\*                   | read, write, edit   |
 | traefik             | dkp-traefik-view                             | /dkp/traefik/\*                      | read                |
 | traefik             | dkp-traefik-edit                             | /dkp/traefik/\*                      | read, edit          |
 | traefik             | dkp-traefik-admin                            | /dkp/traefik/\*                      | read, edit, delete  |

--- a/pages/dkp/kommander/2.2/operations/access-control/rbac/index.md
+++ b/pages/dkp/kommander/2.2/operations/access-control/rbac/index.md
@@ -107,9 +107,9 @@ Roles have been created for granting access to the dashboard and select applicat
 | alertmanager        | kube-prometheus-stack-dkp-alertmanager-view  | /dkp/alertmanager/\*                 | read                |
 | alertmanager        | kube-prometheus-stack-dkp-alertmanager-edit  | /dkp/alertmanager/\*                 | read, write         |
 | alertmanager        | kube-prometheus-stack-dkp-alertmanager-admin | /dkp/alertmanager/\*                 | read, write, delete |
-| centralized-grafana | dkp-centralized-grafana-view  | /dkp/kommander/monitoring/grafana/\* | read                |
-| centralized-grafana | dkp-centralized-grafana-edit  | /dkp/kommander/monitoring/grafana/\* | read, write         |
-| centralized-grafana | dkp-centralized-grafana-admin | /dkp/kommander/monitoring/grafana/\* | read, write, delete |
+| centralized-grafana | centralized-grafana-dkp-grafana-view  | /dkp/kommander/monitoring/grafana/\* | read                |
+| centralized-grafana | centralized-grafana-dkp-grafana-edit  | /dkp/kommander/monitoring/grafana/\* | read, write         |
+| centralized-grafana | centralized-grafana-dkp-grafana-admin | /dkp/kommander/monitoring/grafana/\* | read, write, delete |
 | centralized-kubecost | dkp-centralized-kubecost-view  | /dkp/kommander/kubecost/\* | read                |
 | centralized-kubecost | dkp-centralized-kubecost-edit  | /dkp/kommander/kubecost/\* | read, write         |
 | centralized-kubecost | dkp-centralized-kubecost-admin | /dkp/kommander/kubecost/\* | read, write, delete |


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-84281

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

I made a change in kommander applications: https://github.com/mesosphere/kommander-applications/pull/239/files#r828297086 

To the user, the names of the clusterroles of centralized grafana are changed, but the expected behavior of these roles remain the same.


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4180.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
