### PR TITLE
Platform Application versions for 2.2

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/supported-platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/supported-platform-applications/index.md
@@ -1,0 +1,93 @@
+---
+layout: layout.pug
+navigationTitle: Supported Platform Applications
+title: Supported Platform Applications
+menuWeight: 60
+excerpt: Upgrade Platform applications
+beta: false
+---
+ 
+<!-- markdownlint-disable MD0013 MD030 MD034 -->
+
+Upgrading to DKP 2.2 adapts your Platform Applications to the following versions:
+
+| Platform Application in 2.x | Platform Application in 2.2 |
+| --- | --- |
+|  |  |
+| cert-manager-setup | cert-manager-setup |
+| https://mesosphere.github.io/charts/stable/index.yaml | https://mesosphere.github.io/charts/stable/index.yaml |
+| 0.2.7 | 0.2.7 |
+|  |  |
+| kubernetes-dashboard | kubernetes-dashboard |
+| https://kubernetes.github.io/dashboard/index.yaml | https://kubernetes.github.io/dashboard/index.yaml |
+|  |  |
+| dex | dex |
+| https://mesosphere.github.io/charts/stable/index.yaml | https://mesosphere.github.io/charts/stable/index.yaml |
+|  |  |
+|  |  |
+| 2.9.2 | 2.9.10 |
+|  |  |
+| dex-k8s-authenticator | dex-k8s-authenticator |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 1.2.8 | 1.2.8 |
+|  |  |
+| external-dns | external-dns |
+| https://mesosphere.github.io/charts/stable/index.yaml | https://mesosphere.github.io/charts/stable/index.yaml |
+| 2.20.5 | 2.20.5 |
+|  |  |
+| fluent-bit | fluent-bit |
+| https://fluent.github.io/helm-charts | https://fluent.github.io/helm-charts |
+| 0.7.13 | 0.16.2 |
+|  |  |
+| gatekeeper | gatekeeper |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 0.6.7 | 0.6.8 |
+|  |  |
+| istio | istio |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 1.9.1 | 1.9.1 |
+|  |  |
+| jaeger-operator | jaeger-operator |
+| https://jaegertracing.github.io/helm-charts/ | https://jaegertracing.github.io/helm-charts/ |
+| 2.19.0 | 2.21.0 |
+|  |  |
+| kiali-operator | kiali-operator |
+| https://kiali.org/helm-charts/ | https://kiali.org/helm-charts/ |
+| 1.29.1 | 1.29.0 |
+|  |  |
+| kube-oidc-proxy | kube-oidc-proxy |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 0.2.3 | 0.2.5 |
+|  |  |
+| metallb | metallb |
+| https://mesosphere.github.io/charts/stable/index.yaml | https://mesosphere.github.io/charts/stable/index.yaml |
+| 0.12.2 | 0.12.2 |
+|  |  |
+| nvidia | nvidia |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 0.3.5 | 0.4.2 |
+|  |  |
+| kube-prometheus-stack | kube-prometheus-stack |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 15.4.5 | 17.2.1 |
+|  |  |
+| prometheus-adapter | prometheus-adapter |
+| https://prometheus-community.github.io/helm-charts | https://prometheus-community.github.io/helm-charts |
+| 2.11.1 | 2.11.1 |
+|  |  |
+| reloader | reloader |
+| https://stakater.github.io/stakater-charts | https://stakater.github.io/stakater-charts |
+| v0.0.85 | v0.0.99 |
+|  |  |
+| traefik | traefik |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://helm.traefik.io/traefik |
+| 1.88.0 | 10.3.0 |
+|  |  |
+| traefik-forward-auth | traefik-forward-auth |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 0.3.0 | 0.3.2 |
+|  |  |
+| velero | velero |
+| https://mesosphere.github.io/charts/staging/index.yaml | https://mesosphere.github.io/charts/staging/index.yaml |
+| 3.1.1 | 3.1.3 |
+|  |  |


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-86153?filter=57924

## Description of changes being made
Want to point to Platform Application versions in 2.1.x and 2.2 for operators to be able to review prior to upgrade. Just copying the file and adapting the text a bit, eng will take care of adding the correct versions. 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4186.s3-website-us-west-2.amazonaws.com/
