### PR TITLE
docs: rename konvoy cluster to dkp

### DIFF
--- a/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.1/storage/static-local-volume/index.md
@@ -21,7 +21,7 @@ Before starting this tutorial, verify the following:
 
 -   You have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
--   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` platform application, but have not added any other Kommander applications to the cluster yet.
+-   You have a provisioned `dkp` cluster that uses the `localvolumeprovisioner` platform application, but have not added any other Kommander applications to the cluster yet.
 
 For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start guide][quickstart].
 

--- a/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
+++ b/pages/dkp/konvoy/2.2/storage/static-local-volume/index.md
@@ -21,7 +21,7 @@ Before starting this tutorial, verify the following:
 
 -   You have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
--   You have a provisioned `konvoy` cluster that uses the `localvolumeprovisioner` platform application, but have not added any other Kommander applications to the cluster yet.
+-   You have a provisioned `dkp` cluster that uses the `localvolumeprovisioner` platform application, but have not added any other Kommander applications to the cluster yet.
 
 For this tutorial, you **do not deploy** using all the default settings as described in the [Quick start guide][quickstart].
 


### PR DESCRIPTION
## Jira Ticket

Following up on this edit. Deepak advised:

> There is no more konvoy or kommander cluster. They all are DKP clusters. 

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4190.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
