### PR TITLE
konvoy: document flag's default change in the next release

### DIFF
--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -28,6 +28,14 @@ This release provides new features and enhancements to improve the user experien
 |**Maximum** | 1.22.x |
 |**Default** | 1.22.8 |
 
+### Deprecations
+
+<p class="message--warning"><strong>WARNING: </strong>Read the deprecations section before upgrading.</p>
+
+#### Flag default changes
+
+The default value for flag `--with-aws-bootstrap-credentials` will be changing from `true` to `false` in version v2.3.0.
+
 ### New features and capabilities
 
 #### Updated Cluster API providers to latest available versions

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -1,16 +1,16 @@
 ---
 layout: layout.pug
 navigationTitle: Release Notes
-title: Konvoy 2.1 Release Notes
+title: Konvoy 2.2 Release Notes
 menuWeight: 10
-excerpt: View release-specific information for Konvoy 2.1
+excerpt: View release-specific information for Konvoy 2.2
 beta: false
 enterprise: false
 ---
 
 <!-- markdownlint-disable MD034 -->
 
-**D2iQ&reg; Konvoy&reg; version 2.1 was released on November 18, 2021.**
+**D2iQ&reg; Konvoy&reg; version 2.2 was released on April 6, 2022.**
 
 [button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
@@ -24,53 +24,39 @@ This release provides new features and enhancements to improve the user experien
 
 | Kubernetes Support | Version |
 | ------------------ | ------- |
-|**Minimum** | 1.21.6 |
-|**Maximum** | 1.21.x |
-|**Default** | 1.21.6 |
+|**Minimum** | 1.22.8 |
+|**Maximum** | 1.22.x |
+|**Default** | 1.22.8 |
 
 ### New features and capabilities
 
-#### DKP Major Version Upgrade
+#### Updated Cluster API providers to latest available versions
 
-Konvoy and Kommander 2.1 represent a major version upgrade that moves forward DKP architecture to give you access to D2iQ's next generation centralized Kubernetes and smart cloud native applications. It incorporates ClusterAPI as a major re-architecture in its management of production Kubernetes clusters. [ClusterAPI](https://cluster-api.sigs.k8s.io/introduction.html), or CAPI, enables declarative creation, configuration, and management of clusters. Declarative mode is a Kubernetes best practice that simplifies lifecycle tasks, making them more consistent and more repeatable. 2.1 enhances your existing clusters to use a new architecture.
+#### Support for provisioning vSphere clusters
 
-#### FIPS Support
+#### Ability to upgrade all components in the cluster
 
-In Konvoy 2.1, customers who require FIPS 140-2 encryption ciphers, have an easier way to validate that specific components and services are FIPS-compliant according to the NIST FIPS 140-2 standard by checking the signatures of the files against a signed signature file. For more information on running FIPS validation commands, see Validate FIPS in Cluster.
+#### Enable etcd encryption in new clusters
 
-For more information on using FIPS with Konvoy, see [FIPS 140-2 Compliance](../fips/)
+#### Distribute the CLI as a single combined binary
 
-#### Diagnostics Bundle
+#### Allow setting docker registry credentials when creating clusters
 
-In DKP 2.1, we provide you a single command for collecting metrics and generating a diagnostic bundle. This allows you to easily upload the bundle to our support team, resulting in less downtime. The diagnostic bundle includes node-level instrumentation around CPU, memory, and disk usage, OS health.
+#### Allow setting HTTP_PROXY settings on all CAPI providers
 
-For more information on creating and sending a Konvoy Diagnostics Bundle, see [Generate a Support Bundle](../troubleshooting/generate-a-support-bundle).
-
-#### Support for NVIDIA 470 Driver
-
-Konvoy 2.1 supports the upgraded Nvidia 470.x driver and DCGM exporter 2.2.9, which enables technology for running DKP on NVIDIA DGX. NVIDIA DGX customers now have a robust Kubernetes platform in Konvoy and Kommander that vastly simplifies the process of getting the infrastructure needed for applications up and running on this powerful hardware platform.
-
-For more information on using Nvidia with Konvoy, see the [GPU](../choose-infrastructure/aws/gpu) documentation.
-
-#### Easier Air-gapped deployments
-
-Konvoy 2.1 comes with an easier way to deploy in an air gapped environment. Rather than one large package that includes the requirements for all air gapped environments, you can now create a smaller package that is specific to your requirements and can fit on a laptop or USB.
-
-#### DKP Licensing through Amazon Marketplace
-
-You can purchase a license for Konvoy or Kommander through the AWS Marketplace, and then add it to Kommander. In the Kommander UI, you can see information such as the license status (valid or expired), the license capacity (number of cores or clusters), and expiration date.
+#### New command to update Azure credentials in running clusters
 
 ### Component updates
 
 The following components have been upgraded to the listed version:
 
-- Calico 3.20
-- AWS EBS CSI 1.4
-- CSI External Snapshotter 4.2.1
-- Azure CSI 1.8.0
+- Calico 3.22
+- AWS EBS CSI 1.5
+- CSI External Snapshotter 5.0.1
+- Azure CSI 1.13.0
 - Local Static Provisioner CSI 2.4.0
-- Cluster Autoscaler 1.21.0
-- Node Feature Discovery 0.8.2
+- Cluster Autoscaler 1.23.0
+- Node Feature Discovery 0.10.1
 - Nvidia Node Feature Discovery 0.4.1
 
 ## Additional resources


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

https://jira.d2iq.com/browse/D2IQ-82128

## Description of changes being made

Document flag `--with-aws-bootstrap-credentials` default change in the next release

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
