### PR TITLE
chore: update airgapped kommander install commands

### DIFF
--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -40,41 +40,41 @@ Create the charts bundle with the Kommander CLI or downloaded along with the Kom
 Execute this command to create the charts bundle:
 
    ```bash
-   kommander helmmirror create bundle
+   kommander create chart-bundle
    ```
 
 Kommander creates `charts-bundle.tar.gz`.
 Optionally, specify the output using the `-o` parameter:
 
    ```bash
-   kommander helmmirror create bundle -o [name of the output file]
+   kommander create chart-bundle -o [name of the output file]
    ```
 
 ### Kommander's internal Helm repository
 
-The Kommander charts bundle is uploaded to Kommander's internal Helm repository.
+The Kommander charts bundle is pushed to Kommander's internal Helm repository.
 To inspect the contents:
 
    ```bash
-   kommander helmmirror get charts
+   kommander get charts
    ```
 
 Individual charts can be removed using:
 
    ```bash
-   kommander helmmirror delete chart [chartName] [chartVersion]
+   kommander delete chart [chartName] [chartVersion]
    ```
 
-It is possible to upload new charts as well:
+It is possible to push new charts as well:
 
    ```bash
-   kommander helmmirror upload chart [chartTarball]
+   kommander push chart [chartTarball]
    ```
 
-Or upload a new bundle:
+Or push a new bundle:
 
    ```bash
-   kommander helmmirror upload bundle [chartsTarball]
+   kommander push chart-bundle [chartsTarball]
    ```
 
 Check the built-in help text for each command for more information.
@@ -197,7 +197,7 @@ export VERSION=v2.2.0
     done < <(tar xfO "${AIRGAPPED_TAR_FILE}" "index.json" | grep -oP '(?<="io.containerd.image.name":").*?(?=",)')
     ```
 
-Based on the network latency between the environment of script execution and the docker registry, this can take a while to upload all the images to your image registry.
+Based on the network latency between the environment of script execution and the docker registry, this can take a while to push all the images to your image registry.
 
 ## Install on Konvoy
 


### PR DESCRIPTION
## Jira Ticket
JIRA: https://jira.d2iq.com/browse/D2IQ-86447

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
We've restructured some commands in the kommnader-cli and the `helmmirror` subcommands were moved to other places.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
