### PR TITLE
D2IQ-86493 feat: manually attach cluster

### DIFF
--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/manually-attach-cluster/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/manually-attach-cluster/index.md
@@ -1,0 +1,39 @@
+---
+layout: layout.pug
+navigationTitle: Manually attach Cluster created with CLI
+title: Attach a Cluster manually created with CLI
+menuWeight: 50
+excerpt: Attach a Cluster manually created with CLI
+---
+
+When creating a cluster in a Workspace namespace using the DKP CLI it will not be attached automatically. To automatically attach a cluster you can generate the cluster objects using the DKP CLI `--dry-run -o yaml` flags and then using the [Advanced Creation of Konvoy Clusters][create_cluster_advanced].
+
+If the Cluster is created using the CLI it will appear in the UI as it is being Provisioned. It will then be in an Unattached state when Provisioning is completed.
+
+## Manually attach Cluster created with CLI
+
+From the CLI find the `name` of the `Cluster` created so that it can be referenced.
+
+```bash
+$ kubectl -n <workspace_namespace> get clusters
+```
+
+Attach the Cluster by creating a `KommanderCluster` from the CLI.
+
+```yaml
+cat << EOF | kubectl apply -f -
+apiVersion: kommander.mesosphere.io/v1beta1
+kind: KommanderCluster
+metadata:
+  name: <cluster_name>
+  namespace: <workspace_namespace>
+spec:
+  kubeconfigRef:
+    name: <cluster_name>-kubeconfig
+  clusterRef:
+    capiCluster:
+      name: <cluster_name>
+EOF
+```
+
+[create_cluster_advanced]: ../../creating-konvoy-cluster-advanced/

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/manually-attach-cluster/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/manually-attach-cluster/index.md
@@ -6,9 +6,9 @@ menuWeight: 50
 excerpt: Manually attach a cluster that was created with the CLI
 ---
 
-When creating a cluster in a Workspace namespace using the DKP CLI it will not be attached automatically. To automatically attach a cluster you can generate the cluster objects using the DKP CLI `--dry-run -o yaml` flags and then using the [Advanced Creation of Konvoy Clusters][create_cluster_advanced].
+When you create a cluster in a Workspace namespace using the DKP CLI, it does not attach automatically. To automatically attach a cluster, generate the cluster objects using the DKP CLI `--dry-run -o yaml` flags and create a cluster as stated in the [Advanced Creation of Konvoy Clusters][create_cluster_advanced] guide.
 
-If the Cluster is created using the CLI it will appear in the UI as it is being Provisioned. It will then be in an Unattached state when Provisioning is completed.
+However, if you created the cluster using the CLI, you will still need to attach it. You will be able to see the new cluster in the UI while it is being provisioned. Once provisioning is completed, the status will change to Unattached.
 
 ## Manually attach a cluster that was created with the CLI
 

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/manually-attach-cluster/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/manually-attach-cluster/index.md
@@ -1,24 +1,24 @@
 ---
 layout: layout.pug
-navigationTitle: Manually attach Cluster created with CLI
-title: Attach a Cluster manually created with CLI
+navigationTitle: Manually attach a CLI-created cluster 
+title: Manually attach CLI-created cluster
 menuWeight: 50
-excerpt: Attach a Cluster manually created with CLI
+excerpt: Manually attach a cluster that was created with the CLI
 ---
 
 When creating a cluster in a Workspace namespace using the DKP CLI it will not be attached automatically. To automatically attach a cluster you can generate the cluster objects using the DKP CLI `--dry-run -o yaml` flags and then using the [Advanced Creation of Konvoy Clusters][create_cluster_advanced].
 
 If the Cluster is created using the CLI it will appear in the UI as it is being Provisioned. It will then be in an Unattached state when Provisioning is completed.
 
-## Manually attach Cluster created with CLI
+## Manually attach a cluster that was created with the CLI
 
-From the CLI find the `name` of the `Cluster` created so that it can be referenced.
+From the CLI find out the `name` of the created `Cluster` so you can reference it later:
 
 ```bash
 $ kubectl -n <workspace_namespace> get clusters
 ```
 
-Attach the Cluster by creating a `KommanderCluster` from the CLI.
+Attach the cluster by creating a `KommanderCluster`:
 
 ```yaml
 cat << EOF | kubectl apply -f -

--- a/pages/dkp/kommander/2.2/clusters/index.md
+++ b/pages/dkp/kommander/2.2/clusters/index.md
@@ -25,22 +25,23 @@ A cluster card's status line displays both the current status and the version of
 
 The status list includes these values:
 
-| Status         | Description                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Pending        | This is the initial state when a cluster is created or connected.                                                          |
-| Pending Setup  | The cluster has networking restrictions that require additional setup, and is not yet connected or attached.               |
-| Loading Data   | The cluster has been added to Kommander and we are fetching details about the cluster. This is the status before `Active`. |
-| Active         | The cluster is connected to API server.                                                                                    |
-| Provisioning\* | The cluster is being created on your cloud provider. This process may take some time.                                      |
-| Provisioned\*  | The cluster's infrastructure has been created and configured.                                                              |
-| Joining        | The cluster is being joined to the management cluster for federation.                                                      |
-| Joined         | The join process is done, and waiting for the first data from the cluster to arrive.                                       |
-| Deleting\*     | The cluster and its resources are being removed from your cloud provider. This process may take some time.                 |
-| Error          | There has been an error connecting to the cluster or retrieving data from the cluster.                                     |
-| Join Failed    | This status can appear when kubefed does not have permission to create entities in the target cluster.                     |
-| Unjoining      | Kubefed is cleaning up after itself, removing all installed resources on the target cluster.                               |
-| Unjoined       | The cluster has been disconnected from the management cluster.                                                             |
-| Unjoin Failed  | The Unjoin from kubefed failed or there is some other error with deleting or disconnecting.                                |
+| Status         | Description                                                                                                                                                                                                 |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pending        | This is the initial state when a cluster is created or connected.                                                                                                                                           |
+| Pending Setup  | The cluster has networking restrictions that require additional setup, and is not yet connected or attached.                                                                                                |
+| Loading Data   | The cluster has been added to Kommander and we are fetching details about the cluster. This is the status before `Active`.                                                                                  |
+| Active         | The cluster is connected to API server.                                                                                                                                                                     |
+| Provisioning\* | The cluster is being created on your cloud provider. This process may take some time.                                                                                                                       |
+| Provisioned\*  | The cluster's infrastructure has been created and configured.                                                                                                                                               |
+| Joining        | The cluster is being joined to the management cluster for federation.                                                                                                                                       |
+| Joined         | The join process is done, and waiting for the first data from the cluster to arrive.                                                                                                                        |
+| Deleting\*     | The cluster and its resources are being removed from your cloud provider. This process may take some time.                                                                                                  |
+| Error          | There has been an error connecting to the cluster or retrieving data from the cluster.                                                                                                                      |
+| Join Failed    | This status can appear when kubefed does not have permission to create entities in the target cluster.                                                                                                      |
+| Unjoining      | Kubefed is cleaning up after itself, removing all installed resources on the target cluster.                                                                                                                |
+| Unjoined       | The cluster has been disconnected from the management cluster.                                                                                                                                              |
+| Unjoin Failed  | The Unjoin from kubefed failed or there is some other error with deleting or disconnecting.                                                                                                                 |
+| Unattached\*   | The cluster was manually created and the infrastructure is created and configured. But the cluster not attached, review the [manually attach cluster][manually_attach_cluster] page to resolve this status. |
 
 <p class="message--note"><strong>*</strong>These statuses only appear on Managed clusters.</p>
 
@@ -85,6 +86,6 @@ For an attached cluster, you can only edit labels assigned to that cluster.
 ![Edit an Attached Cluster](/dkp/kommander/2.1/img/edit-cluster-attached-1-1-0.png)
 
 [k8s_docs]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-
 [workspace_platform_applications]: ../workspaces/applications/platform-applications/
 [platform_applications_req]: ../workspaces/applications/platform-applications/platform-service-requirements/
+[manually_attach_cluster]: ./attach-cluster/manually-attach-cluster/

--- a/pages/dkp/kommander/2.2/clusters/index.md
+++ b/pages/dkp/kommander/2.2/clusters/index.md
@@ -41,7 +41,7 @@ The status list includes these values:
 | Unjoining      | Kubefed is cleaning up after itself, removing all installed resources on the target cluster.                                                                                                                |
 | Unjoined       | The cluster has been disconnected from the management cluster.                                                                                                                                              |
 | Unjoin Failed  | The Unjoin from kubefed failed or there is some other error with deleting or disconnecting.                                                                                                                 |
-| Unattached\*   | The cluster was manually created and the infrastructure is created and configured. But the cluster not attached, review the [manually attach cluster][manually_attach_cluster] page to resolve this status. |
+| Unattached\*   | The cluster was created manually and the infrastructure has been created and configured. However, the cluster is not attached. Review the [Manually attach a CLI-created cluster][manually_attach_cluster] page to resolve this status. |
 
 <p class="message--note"><strong>*</strong>These statuses only appear on Managed clusters.</p>
 


### PR DESCRIPTION
Adding the new `Unattached` status to the Cluster status table and a new page with instructions on how to manually attach a cluster that was manually created with the DKP CLI. 

There is a feature in 2.3 that will auto-attach these clusters and these docs will become obsolete then, but for 2.2 we want to provide a way to resolve the "Unattached" status correctly.

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[D2IQ-86493](https://jira.d2iq.com/browse/D2IQ-86493)

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4202.s3-website-us-west-2.amazonaws.com/

## Checklist

- [x] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
