### PR TITLE
fix: automated CLI docs didn't remove pages for removed commands

### DIFF
--- a/ci/update-dkp-cli-docs.sh
+++ b/ci/update-dkp-cli-docs.sh
@@ -59,4 +59,5 @@ done
 # copy to the destination directory
 TARGET_DIR=pages$TARGET_PATH
 mkdir -p $TARGET_DIR
+rm -rf $TARGET_DIR/dkp/
 cp -a $TMP_DIR/docs/* $TARGET_DIR/


### PR DESCRIPTION
## Description of changes being made
The script that automatically generates the help pages for the CLI didn't remove pages for commands removed from the CLI. This PR fixes that.

