### PR TITLE
feat: new badge style for tech previews

### DIFF
--- a/layouts/partials/content.pug
+++ b/layouts/partials/content.pug
@@ -15,6 +15,8 @@ main.content
           p.badge.badge--content-header.badge--preview PREVIEW
         if experimental
           p.badge.badge--content-header.badge--experimental EXPERIMENTAL
+        if techPreview
+          p.badge.badge--content-header.badge--techPreview TECH PREVIEW
       if excerpt
         h4.content__header-description!= excerpt
       include ../components/content-actions.pug

--- a/scss/shortcodes/_badge.scss
+++ b/scss/shortcodes/_badge.scss
@@ -1,68 +1,67 @@
 .badge {
-    display: inline-block;
-    font-size: 0.9rem;
-    font-weight: 400;
-    padding: 0;
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 400;
+  padding: 0;
+  color: $color-grey;
+  border: 1px solid $color-grey;
+  border-radius: 3px;
+  padding: 0.5rem 0.7rem 0.5rem 0.7rem;
+  margin: 0.5rem 0;
+  line-height: 1;
+  text-transform: uppercase;
+  &__container {
+    display: block;
+    &--inline {
+      display: inline;
+    }
+  }
+  &-shortcode-container {
+    position: relative;
+  }
+  &--shortcode {
+    margin: 0;
+  }
+  &--content-header {
+    margin: 0.75rem 1rem 0;
+    white-space: nowrap;
+  }
+  &--oss {
     color: $color-grey;
     border: 1px solid $color-grey;
-    border-radius: 3px;
-    padding: 0.5rem 0.7rem 0.5rem 0.7rem;
-    margin: 0.5rem 0;
-    line-height: 1;
-    text-transform: uppercase;
-    &__container {
-        // position: relative;
-        display: block;
-        &--inline {
-            display: inline;
-        }
-    }
-    &-shortcode-container {
-        position: relative;
-    }
-    &--shortcode {
-        margin: 0;
-        /*
-    + * {
-      margin-top: 0;
-    }
-    */
-    }
-    &--content-header {
-        margin: 0.75rem 1rem 0;
-        white-space: nowrap;
-    }
-    &--oss {
-        color: $color-grey;
-        border: 1px solid $color-grey;
-    }
-    &--community {
-        color: $color-grey;
-        border: 1px solid $color-grey;
-    }
-    &--enterprise {
-        color: $color-purple-d3;
-        border: 1px solid $color-purple-d3;
-    }
-    &--beta {
-        color: $color-pink;
-        border: 1px solid $color-pink;
-    }
-    &--preview {
-        color: $color-pink;
-        border: 1px solid $color-pink;
-    }
-    &--experimental {
-        color: $color-pink;
-        border: 1px solid $color-pink;
-    }
-    &--small {
-        font-size: 0.7rem;
-        padding: 0.4rem 0.6rem 0.3rem 0.6rem;
-    }
-    &--inline {
-        display: inline-block;
-    }
+  }
+  &--community {
+    color: $color-grey;
+    border: 1px solid $color-grey;
+  }
+  &--enterprise {
+    color: $color-purple-d3;
+    border: 1px solid $color-purple-d3;
+  }
+  &--beta {
+    color: $color-pink;
+    border: 1px solid $color-pink;
+  }
+  &--preview {
+    color: $color-pink;
+    border: 1px solid $color-pink;
+  }
+  &--experimental {
+    color: $color-pink;
+    border: 1px solid $color-pink;
+  }
+  &--small {
+    font-size: 0.7rem;
+    padding: 0.4rem 0.6rem 0.3rem 0.6rem;
+  }
+  &--inline {
+    display: inline-block;
+  }
+  &--techPreview {
+    background-color: $color-grey-medium;
+    color: $color-dark;
+    border: 1px solid $color-grey-medium;
+  }
 }
 
 h1,
@@ -71,9 +70,9 @@ h3,
 h4,
 h5,
 h6 {
-    display: flex;
-    align-items: center;
-    .badge {
-        margin-left: 0.5rem;
-    }
+  display: flex;
+  align-items: center;
+  .badge {
+    margin-left: 0.5rem;
+  }
 }

--- a/shortcodes/index.js
+++ b/shortcodes/index.js
@@ -5,10 +5,12 @@ const Yaml = require("js-yaml");
 ///////////////////////////////////////////////////////////////////////////////
 //                                  HELPERS                                  //
 ///////////////////////////////////////////////////////////////////////////////
-const badge = (style, label) => (buf, { size = "large", type = "block" }) =>
-  buf
-    ? `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--${style}">${label}</span>`
-    : `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--${style}">${label}</span></span>`;
+const badge =
+  (style, label) =>
+  (buf, { size = "large", type = "block" }) =>
+    buf
+      ? `${buf} <span class="badge badge--shortcode badge--${size} badge--${type} badge--${style}">${label}</span>`
+      : `<span class="badge__container badge__container--${type}"><span class="badge badge--shortcode badge--${size} badge--${type} badge--${style}">${label}</span></span>`;
 
 const capitalize = (string) => string.charAt(0).toUpperCase() + string.slice(1);
 
@@ -25,6 +27,7 @@ const shortcodes = {
   experimental: badge("experimental", "Experimental"),
   oss: badge("oss", "Open Source"),
   preview: badge("preview", "Preview"),
+  techPreview: badge("techPreview", "Tech Preview"),
 
   button: (buf, { href, color = "purple" }) => {
     const btn = `<button type="button" class="btn btn--${color} btn--large">${buf.toUpperCase()}</button>`;


### PR DESCRIPTION
## Jira Ticket

Created a new badge button style for tech previews. The badge should be filled with a medium grey color with dark text that says "TECH PREVIEW". 

Cleaned up some old comments in the code and prettier formatted the spacing on the badge style. I noticed there are some scss files with 2 spaces and some files with 4 spaces.

<img width="1431" alt="Screen Shot 2022-03-24 at 5 03 28 PM" src="https://user-images.githubusercontent.com/34781875/160019881-30c23f1c-b33e-4339-9743-220d96e8372b.png">


<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4209.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
