### PR TITLE
Konvoy 2.2 Release Note: Default update strategy changed to "delete first" for Preprovisioned clusters

### DIFF
--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -55,15 +55,12 @@ The default value for flag `--with-aws-bootstrap-credentials` will be changing f
 #### New command to update Azure credentials in running clusters
 
 ### Fixes and Improvements
+
 #### Default update strategy changed to "delete first" for Preprovisioned clusters
 
-A "create first" update strategy first creates a new machine, then deletes the old one. While this strategy works when
-machine inventory can grow on demand, it does not work if there is a fixed number of machines. Most Preprovisioned
-clusters have a fixed number of machines. To enable updates for Preprovisioned clusters, DKP uses the "delete first"
-update strategy, which first deletes an old machine, then creates a new one.
+A "create first" update strategy first creates a new machine, then deletes the old one. While this strategy works when machine inventory can grow on demand, it does not work if there is a fixed number of machines. Most Preprovisioned clusters have a fixed number of machines. To enable updates for Preprovisioned clusters, DKP uses the "delete first" update strategy, which first deletes an old machine, then creates a new one.
 
-New clusters use the "delete first" strategy by default. Existing clusters are switched to the "delete first" strategy
-whenever their machines are updated with `update controlplane` and `update nodepool`.
+New clusters use the "delete first" strategy by default. Existing clusters are switched to the "delete first" strategy whenever their machines are updated with `update controlplane` and `update nodepool`.
 
 ### Component updates
 

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -54,6 +54,7 @@ The default value for flag `--with-aws-bootstrap-credentials` will be changing f
 
 #### New command to update Azure credentials in running clusters
 
+### Fixes and Improvements
 #### Default update strategy changed to "delete first" for Preprovisioned clusters
 
 A "create first" update strategy first creates a new machine, then deletes the old one. While this strategy works when

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -54,6 +54,13 @@ The default value for flag `--with-aws-bootstrap-credentials` will be changing f
 
 #### New command to update Azure credentials in running clusters
 
+#### Default update strategy changed to "delete first" for Preprovisioned clusters
+
+A "create first" update strategy first creates a new machine, then deletes the old one. While this strategy works when
+machine inventory can grow on demand, it does not work if there is a fixed number of machines. Most Preprovisioned
+clusters have a fixed number of machines. To enable updates for Preprovisioned clusters, DKP uses the "delete first"
+update strategy, which first deletes an old machine, then creates a new one.
+
 ### Component updates
 
 The following components have been upgraded to the listed version:

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -63,7 +63,7 @@ clusters have a fixed number of machines. To enable updates for Preprovisioned c
 update strategy, which first deletes an old machine, then creates a new one.
 
 New clusters use the "delete first" strategy by default. Existing clusters are switched to the "delete first" strategy
-whenever their machines are updated.
+whenever their machines are updated with `update controlplane` and `update nodepool`.
 
 ### Component updates
 

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -62,6 +62,9 @@ machine inventory can grow on demand, it does not work if there is a fixed numbe
 clusters have a fixed number of machines. To enable updates for Preprovisioned clusters, DKP uses the "delete first"
 update strategy, which first deletes an old machine, then creates a new one.
 
+New clusters use the "delete first" strategy by default. Existing clusters are switched to the "delete first" strategy
+whenever their machines are updated.
+
 ### Component updates
 
 The following components have been upgraded to the listed version:


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-78060

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4213.s3-website-us-west-2.amazonaws.com/

## Checklist

- [x] Test all commands and procedures, if applicable.
- [x] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
