### PR TITLE
Short upgrade info on Custom Apps

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
@@ -1,0 +1,19 @@
+---
+layout: layout.pug
+navigationTitle: Upgrade Custom Applications
+title: Upgrade Custom Applications
+menuWeight: 60
+excerpt: Verify the compatibility of Custom Applications with the current Kubernetes version
+beta: false
+enterprise: true
+---
+
+We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since there is no expectation of support by D2iQ for Custom Applications, you must upgrade them manually.
+
+<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the [current Kubernetes version][release-notes]. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your cluster’s services will stop running.
+</p>
+
+Once you have ensured your Custom Applications are compatible with the current Kubernetes version, return to the [DKP Upgrade overview][dkp_upgrade] documentation, to review the next steps depending on your environment and license type.
+
+[dkp_upgrade]: ../../dkp-upgrade/
+[release_notes]: ../../release-notes/

--- a/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
@@ -10,7 +10,7 @@ enterprise: true
 
 We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since Custom Applications are not created, maintained or supported by D2iQ, you must upgrade them manually.
 
-<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">Kubernetes version</a> in the new release. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your custom Applications may stop running.
+<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a> href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">Kubernetes version</a> in the new release. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your custom Applications may stop running.
 </p>
 
 Once you have ensured your Custom Applications are compatible with the current Kubernetes version, return to the [DKP Upgrade overview][dkp_upgrade] documentation, to review the next steps depending on your environment and license type.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
@@ -10,7 +10,7 @@ enterprise: true
 
 We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since there is no expectation of support by D2iQ for Custom Applications, you must upgrade them manually.
 
-<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the [current Kubernetes version][release-notes]. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your cluster’s services will stop running.
+<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">current Kubernetes version</a>. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your cluster’s services will stop running.
 </p>
 
 Once you have ensured your Custom Applications are compatible with the current Kubernetes version, return to the [DKP Upgrade overview][dkp_upgrade] documentation, to review the next steps depending on your environment and license type.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
@@ -10,7 +10,7 @@ enterprise: true
 
 We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since Custom Applications are not created, maintained or supported by D2iQ, you must upgrade them manually.
 
-<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">Kubernetes version</a> in the new release. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your custom Applications may stop running.
+<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="../../release-notes/">Kubernetes version</a> in the new release. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your custom Applications may stop running.
 </p>
 
 Once you have ensured your Custom Applications are compatible with the current Kubernetes version, return to the [DKP Upgrade overview][dkp_upgrade] documentation, to review the next steps depending on your environment and license type.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
@@ -10,7 +10,7 @@ enterprise: true
 
 We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since Custom Applications are not created, maintained or supported by D2iQ, you must upgrade them manually.
 
-<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a> href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">Kubernetes version</a> in the new release. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your custom Applications may stop running.
+<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">Kubernetes version</a> in the new release. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your custom Applications may stop running.
 </p>
 
 Once you have ensured your Custom Applications are compatible with the current Kubernetes version, return to the [DKP Upgrade overview][dkp_upgrade] documentation, to review the next steps depending on your environment and license type.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: true
 ---
 
-We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since there is no expectation of support by D2iQ for Custom Applications, you must upgrade them manually.
+We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since Custom Applications are not created, maintained or supported by D2iQ, you must upgrade them manually.
 
 <p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">current Kubernetes version</a>. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your cluster’s services will stop running.
 </p>

--- a/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/custom-apps/index.md
@@ -10,7 +10,7 @@ enterprise: true
 
 We recommend upgrading your Custom Applications to the latest compatible version as soon as possible. Since Custom Applications are not created, maintained or supported by D2iQ, you must upgrade them manually.
 
-<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">current Kubernetes version</a>. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your cluster’s services will stop running.
+<p class="message--warning"><strong>WARNING: </strong>Ensure you validate any Custom Applications you run for compatibility issues against the <a href="https://docs.d2iq.com/dkp/kommander/2.2/release-notes/">Kubernetes version</a> in the new release. If the Custom Application’s version is not compatible with the Kubernetes version, do not continue with the Konvoy upgrade. Otherwise, your custom Applications may stop running.
 </p>
 
 Once you have ensured your Custom Applications are compatible with the current Kubernetes version, return to the [DKP Upgrade overview][dkp_upgrade] documentation, to review the next steps depending on your environment and license type.


### PR DESCRIPTION
## Jira Ticket

No Jira for this one, just a short additional info for operators/users/customers.

## Description of changes being made

Since we want customers to upgrade ALL apps (Platform, Catalog, Custom) before upgrading Konvoy (because of breaking changes due to K8s 1.22), we wanted to make sure they are aware of the consequences. This will be linked in the general DKP Upgrade doc. 


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4215.s3-website-us-west-2.amazonaws.com/

