### PR TITLE
docs: Add info about DKP catalog apps git repo archive

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -47,23 +47,27 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
 1.  Use the DKP CLI to upgrade Kommander and all the Platform Applications in the Management Cluster:
 
-    For air-gapped:
+    -   For air-gapped:
 
-    ```bash
-    dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
-    ```
+        ```bash
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
+        ```
 
-    For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
+    -   For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
-    ```bash
-    dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
-    ```
+        ```bash
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
+        ```
 
-    For non air-gapped:
+        After the upgrade, follow the [DKP Catalog Applications configuration page](../../install/configuration/enterprise-catalog#air-gapped-catalog-configuration) to update the Git repository.
 
-    ```bash
-    dkp upgrade kommander 
-    ```
+    -   For non air-gapped:
+
+        ```bash
+        dkp upgrade kommander
+        ```
+
+        If you have DKP Catalog Applications deployed, follow the [DKP Catalog Applications configuration page](../../install/configuration/enterprise-catalog#configure-a-default-enterprise-catalog) to update the Git repository after the upgrade.
 
     An output similar to this appears:
 
@@ -72,6 +76,7 @@ Before running the following command, ensure that your `dkp` configuration **ref
     ✓ Ensuring upgrading conditions are met
     ✓ Ensuring application definitions are updated
     ✓ Ensuring helm-mirror implementation is migrated to chartmuseum
+    ...
     ```
 
 1.  If the upgrade fails, run the following command to get more information on the upgrade process:

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -13,12 +13,6 @@ This section describes how to upgrade your Kommander Management cluster and all 
 
 ## Prerequisites
 
--   Set the `VERSION` environment variable to the version of Kommander you are upgrading to, for example:
-
-    ```bash
-    export VERSION=v2.2.0
-    ```
-
 -   [Download][download_binary] and install the latest DKP CLI binary on your computer.
 -   Ensure you are on DKP version 2.1 or 2.1.1 and Kubernetes version 1.21.
 -   If you have attached clusters, ensure they are on Kubernetes versions 1.19, 1.20 or 1.21. To upgrade your Kubernetes version, refer to the appropriate documentation for your environment: [AKS][AKS], [AWS][AWS], [Azure][Azure], [EKS][EKS], [pre-provisioned][pre_provisioned].
@@ -30,19 +24,19 @@ This section describes how to upgrade your Kommander Management cluster and all 
   Download the Kommander application definitions:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications-${VERSION}.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
   ```
   
   Download the Kommander charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-kommander-charts-bundle-${VERSION}.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
   ```
   
   If you have any DKP Catalog Applications, download the DKP Catalog Application charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
 
 ## Upgrade Kommander
@@ -51,24 +45,18 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
 <p class="message--note"><strong>NOTE:</strong> As stated earlier, an alternative to initializing the KUBECONFIG environment variable is to use the <code>–kubeconfig=cluster_name.conf</code> flag. This ensures that Kommander upgrades on the workload cluster.</p>
 
-1.  Set the `VERSION` environment variable to the version of Kommander you are upgrading to (if you have not already), for example:
-
-    ```bash
-    export VERSION=v2.2.0
-    ```
-
 1.  Use the DKP CLI to upgrade Kommander and all the Platform Applications in the Management Cluster:
 
     -   For air-gapped:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz --kommander-applications-repository kommander-applications-${VERSION}.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
         ```
 
     -   For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz --kommander-applications-repository kommander-applications-${VERSION}.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
         ```
 
         After the upgrade, follow the [DKP Catalog Applications configuration page](../../install/configuration/enterprise-catalog#air-gapped-catalog-configuration) to update the Git repository.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -24,7 +24,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   Download the Kommander application definitions:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications_v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
   ```
   
   Download the Kommander charts bundle:
@@ -50,13 +50,13 @@ Before running the following command, ensure that your `dkp` configuration **ref
     -   For air-gapped:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
         ```
 
     -   For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
         ```
 
         After the upgrade, follow the [DKP Catalog Applications configuration page](../../install/configuration/enterprise-catalog#air-gapped-catalog-configuration) to update the Git repository.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -13,6 +13,12 @@ This section describes how to upgrade your Kommander Management cluster and all 
 
 ## Prerequisites
 
+-   Set the `VERSION` environment variable to the version of Kommander you are upgrading to, for example:
+
+    ```bash
+    export VERSION=v2.2.0
+    ```
+
 -   [Download][download_binary] and install the latest DKP CLI binary on your computer.
 -   Ensure you are on DKP version 2.1 or 2.1.1 and Kubernetes version 1.21.
 -   If you have attached clusters, ensure they are on Kubernetes versions 1.19, 1.20 or 1.21. To upgrade your Kubernetes version, refer to the appropriate documentation for your environment: [AKS][AKS], [AWS][AWS], [Azure][Azure], [EKS][EKS], [pre-provisioned][pre_provisioned].
@@ -24,19 +30,19 @@ This section describes how to upgrade your Kommander Management cluster and all 
   Download the Kommander application definitions:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications-${VERSION}.tar.gz"
   ```
   
   Download the Kommander charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-kommander-charts-bundle-${VERSION}.tar.gz"
   ```
   
   If you have any DKP Catalog Applications, download the DKP Catalog Application charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz"
   ```
 
 ## Upgrade Kommander
@@ -45,18 +51,24 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
 <p class="message--note"><strong>NOTE:</strong> As stated earlier, an alternative to initializing the KUBECONFIG environment variable is to use the <code>–kubeconfig=cluster_name.conf</code> flag. This ensures that Kommander upgrades on the workload cluster.</p>
 
+1.  Set the `VERSION` environment variable to the version of Kommander you are upgrading to (if you have not already), for example:
+
+    ```bash
+    export VERSION=v2.2.0
+    ```
+
 1.  Use the DKP CLI to upgrade Kommander and all the Platform Applications in the Management Cluster:
 
     -   For air-gapped:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz --kommander-applications-repository kommander-applications-${VERSION}.tar.gz
         ```
 
     -   For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz --kommander-applications-repository kommander-applications-${VERSION}.tar.gz
         ```
 
         After the upgrade, follow the [DKP Catalog Applications configuration page](../../install/configuration/enterprise-catalog#air-gapped-catalog-configuration) to update the Git repository.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -50,13 +50,13 @@ Before running the following command, ensure that your `dkp` configuration **ref
     For air-gapped:
 
     ```bash
-    dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v.2.2.0.tar.gz --kommander-applications-repository kommander-applications_v.2.2.0.tar.gz
+    dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
     ```
 
     For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
     ```bash
-    dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v.2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v.2.2.0.tar.gz
+    dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v2.2.0.tar.gz
     ```
 
     For non air-gapped:

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -53,6 +53,12 @@ Before running the following command, ensure that your `dkp` configuration **ref
     dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v.2.2.0.tar.gz --kommander-applications-repository kommander-applications_v.2.2.0.tar.gz
     ```
 
+    For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
+
+    ```bash
+    dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v.2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications_v.2.2.0.tar.gz
+    ```
+
     For non air-gapped:
 
     ```bash

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -221,7 +221,7 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications_${VERSION}.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications-${VERSION}.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
@@ -240,7 +240,7 @@ It may take a while to push all the images to your image registry, depending on 
 
     ```bash
     kommander install --installer-config ./install.yaml \
-    --kommander-applications-repository kommander-applications_${VERSION}.tar.gz \
+    --kommander-applications-repository kommander-applications-${VERSION}.tar.gz \
     --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz \
     --charts-bundle dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz
     ```

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -216,6 +216,8 @@ It may take a while to push all the images to your image registry, depending on 
               service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     ```
 
+1.  Follow the steps on the [Configure an Enterprise catalog](../../configuration/enterprise-catalog#air-gapped-catalog-configuration) page.
+
 1.  Download the Kommander application definitions:
 
     ```bash
@@ -239,8 +241,8 @@ It may take a while to push all the images to your image registry, depending on 
     ```bash
     kommander install --installer-config ./install.yaml \
     --kommander-applications-repository kommander-applications_${VERSION}.tar.gz \
-    --charts-bundle dkp-kommander-charts-bundle_${VERSION}.tar.gz \
-    --charts-bundle dkp-catalog-applications-charts-bundle_${VERSION}.tar.gz
+    --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz \
+    --charts-bundle dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz
     ```
 
 1.  [Verify your installation](../../networked#verify-installation).

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -161,26 +161,18 @@ MetalLB also supports [advanced BGP configuration][metallb_config].
 
 See [Kommander Load Balancing][kommander-load-balancing] for more information.
 
-### Determine the installation version
-
-Set the `VERSION` environment variable to the version of Kommander you want to install, for example:
-
-```bash
-export VERSION=v2.2.0
-```
-
 ### Load the Docker images into your Docker registry
 
 1.  Download the Kommander image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-image-bundle-${VERSION}.tar.gz" -O kommander-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
     ```
 
 1.  Download the [DKP catalog applications][dkp_catalog_applications] image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-image-bundle-${VERSION}.tar.gz" -O catalog-applications-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-image-bundle-v2.2.0.tar.gz" -O catalog-applications-image-bundle.tar.gz
     ```
 
 1.  Place the bundles in a location where you can load and push the images to your private Docker registry.
@@ -221,28 +213,28 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications-${VERSION}.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-kommander-charts-bundle-${VERSION}.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
     ```
 
 1.  Download the [DKP catalog applications][dkp_catalog_applications] chart bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
     kommander install --installer-config ./install.yaml \
-    --kommander-applications-repository kommander-applications-${VERSION}.tar.gz \
-    --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz \
-    --charts-bundle dkp-catalog-applications-charts-bundle-${VERSION}.tar.gz
+    --kommander-applications-repository kommander-applications-v2.2.0.tar.gz \
+    --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz \
+    --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz
     ```
 
 1.  [Verify your installation](../../networked#verify-installation).

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -210,7 +210,7 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications_${VERSION}.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications-${VERSION}.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
@@ -223,7 +223,7 @@ It may take a while to push all the images to your image registry, depending on 
 
     ```bash
     kommander install --installer-config ./install.yaml \
-    --kommander-applications-repository kommander-applications_${VERSION}.tar.gz \
+    --kommander-applications-repository kommander-applications-${VERSION}.tar.gz \
     --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz
     ```
 

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -159,20 +159,12 @@ MetalLB also supports [advanced BGP configuration][metallb_config].
 
 See [Kommander Load Balancing][kommander-load-balancing] for more information.
 
-### Determine the installation version
-
-Set the `VERSION` environment variable to the version of Kommander you want to install, for example:
-
-```bash
-export VERSION=v2.2.0
-```
-
 ### Load the Docker images into your Docker registry
 
 1.  Download the image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-image-bundle-${VERSION}.tar.gz" -O kommander-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
     ```
 
 1.  Place the bundle in a location where you can load and push the images to your private Docker registry.
@@ -210,21 +202,21 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/kommander-applications-${VERSION}.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-kommander-charts-bundle-${VERSION}.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
     kommander install --installer-config ./install.yaml \
-    --kommander-applications-repository kommander-applications-${VERSION}.tar.gz \
-    --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz
+    --kommander-applications-repository kommander-applications-v2.2.0.tar.gz \
+    --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz
     ```
 
 1.  [Verify your installation](../networked#verify-installation).

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -224,7 +224,7 @@ It may take a while to push all the images to your image registry, depending on 
     ```bash
     kommander install --installer-config ./install.yaml \
     --kommander-applications-repository kommander-applications_${VERSION}.tar.gz \
-    --charts-bundle dkp-kommander-charts-bundle_${VERSION}.tar.gz
+    --charts-bundle dkp-kommander-charts-bundle-${VERSION}.tar.gz
     ```
 
 1.  [Verify your installation](../networked#verify-installation).

--- a/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
@@ -48,10 +48,16 @@ The following section describes each label:
 
 When running in air-gapped environments, update the configuration by replacing `gitRepositorySpec` with the `path` field pointing to a local path of the DKP catalog applications git repository.
 
+1. Set the `VERSION` environment variable to the version of Kommander, for example:
+
+```bash
+export VERSION=v2.2.0
+```
+
 1. Download the DKP catalog application Git repository archive:
 
 ```bash
-wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-${VERSION}.tar.gz"
+wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-${VERSION}.tar.gz" -O dkp-catalog-applications.tar.gz
 ```
 
 1. Update the Kommander configuration file with:
@@ -66,5 +72,5 @@ catalog:
         kommander.d2iq.io/project-default-catalog-repository: "true"
         kommander.d2iq.io/workspace-default-catalog-repository: "true"
         kommander.d2iq.io/gitapps-gitrepository-type: "dkp"
-      path: ./dkp-catalog-applications
+      path: ./dkp-catalog-applications.tar.gz
 ```

--- a/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
@@ -36,6 +36,8 @@ Use this configuration when installing or reconfiguring Kommander by passing it 
 kommander install --installer-config <config_file.yaml>
 ```
 
+<p class="message--note"><strong>NOTE: </strong>When configuring the catalog repository post-upgrade, run <code>kommander install --init > install.yaml</code> and update it accordingly with any custom configuration. This ensures you are using the proper default configuration values for the new Kommander version.</p>
+
 The following section describes each label:
 
 | Label  |  Description |
@@ -74,6 +76,8 @@ When running in air-gapped environments, update the configuration by replacing `
             kommander.d2iq.io/gitapps-gitrepository-type: "dkp"
           path: ./dkp-catalog-applications.tar.gz
     ```
+
+    <p class="message--note"><strong>NOTE: </strong>When configuring the catalog repository post-upgrade, run <code>kommander install --init > install.yaml</code> and update it accordingly with any custom configuration. This ensures you are using the proper default configuration values for the new Kommander version.</p>
 
 1.  Use this configuration when installing or reconfiguring Kommander by passing it to the `kommander install` command:
 

--- a/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
@@ -46,13 +46,15 @@ The following section describes each label:
 
 ### Air-gapped Catalog Configuration
 
-When running in air-gapped environments, update the configuration by replacing `gitRepositorySpec` with the `path` field pointing to a local path of the catalog git repository folder, for example:
+When running in air-gapped environments, update the configuration by replacing `gitRepositorySpec` with the `path` field pointing to a local path of the DKP catalog applications git repository.
+
+1. Download the DKP catalog application Git repository archive:
 
 ```bash
-git clone https://github.com/mesosphere/dkp-catalog-applications
+wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-${VERSION}.tar.gz"
 ```
 
-And then:
+1. Update the Kommander configuration file with:
 
 ```yaml
 apiVersion: config.kommander.mesosphere.io/v1alpha1

--- a/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
@@ -50,16 +50,10 @@ The following section describes each label:
 
 When running in air-gapped environments, update the configuration by replacing `gitRepositorySpec` with the `path` field pointing to a local path of the DKP catalog applications git repository.
 
-1.  Set the `VERSION` environment variable to the version of Kommander, for example:
-
-    ```bash
-    export VERSION=v2.2.0
-    ```
-
 1.  Download the DKP catalog application Git repository archive:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-${VERSION}.tar.gz" -O dkp-catalog-applications.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-v2.2.0.tar.gz" -O dkp-catalog-applications.tar.gz
     ```
 
 1.  Update the Kommander configuration file with:

--- a/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
@@ -48,29 +48,35 @@ The following section describes each label:
 
 When running in air-gapped environments, update the configuration by replacing `gitRepositorySpec` with the `path` field pointing to a local path of the DKP catalog applications git repository.
 
-1. Set the `VERSION` environment variable to the version of Kommander, for example:
+1.  Set the `VERSION` environment variable to the version of Kommander, for example:
 
-```bash
-export VERSION=v2.2.0
-```
+    ```bash
+    export VERSION=v2.2.0
+    ```
 
-1. Download the DKP catalog application Git repository archive:
+1.  Download the DKP catalog application Git repository archive:
 
-```bash
-wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-${VERSION}.tar.gz" -O dkp-catalog-applications.tar.gz
-```
+    ```bash
+    wget "https://downloads.d2iq.com/dkp/${VERSION}/dkp-catalog-applications-${VERSION}.tar.gz" -O dkp-catalog-applications.tar.gz
+    ```
 
-1. Update the Kommander configuration file with:
+1.  Update the Kommander configuration file with:
 
-```yaml
-apiVersion: config.kommander.mesosphere.io/v1alpha1
-kind: Installation
-catalog:
-  repositories:
-    - name: dkp-catalog-applications
-      labels:
-        kommander.d2iq.io/project-default-catalog-repository: "true"
-        kommander.d2iq.io/workspace-default-catalog-repository: "true"
-        kommander.d2iq.io/gitapps-gitrepository-type: "dkp"
-      path: ./dkp-catalog-applications.tar.gz
-```
+    ```yaml
+    apiVersion: config.kommander.mesosphere.io/v1alpha1
+    kind: Installation
+    catalog:
+      repositories:
+        - name: dkp-catalog-applications
+          labels:
+            kommander.d2iq.io/project-default-catalog-repository: "true"
+            kommander.d2iq.io/workspace-default-catalog-repository: "true"
+            kommander.d2iq.io/gitapps-gitrepository-type: "dkp"
+          path: ./dkp-catalog-applications.tar.gz
+    ```
+
+1.  Use this configuration when installing or reconfiguring Kommander by passing it to the `kommander install` command:
+
+    ```bash
+    kommander install --installer-config <config_file.yaml>
+    ```


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
This PR adds some additional information about upgrading with catalog applications installed and also updates some configuration steps to download a new git repo archive that will be available in 2.2.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
