### PR TITLE
fix: align ca cert example for kubetunnel

### DIFF
--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/cluster-with-network-restrictions/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/cluster-with-network-restrictions/index.md
@@ -19,7 +19,7 @@ Use this option when you want to attach a cluster that is in a DMZ, behind a NAT
 
 1. Select the **Cluster has networking restrictions** card to display the configuration page.
 
-    <!--- ![Add Cluster Networking Options](/dkp/kommander/1.4/img/cluster-has-networking-restrictions.png) --->
+<!--- ![Add Cluster Networking Options](/dkp/kommander/1.4/img/cluster-has-networking-restrictions.png) --->
 
 1. Enter the **Cluster Name** of the cluster you're attaching and select a **Workspace** from the dropdown list (if entering the **Add Cluster** menu from the Global workspace).
 
@@ -35,11 +35,11 @@ Use this option when you want to attach a cluster that is in a DMZ, behind a NAT
 
 1. If you have not attached this cluster before, you must create a new secret in the **Root CA Certificate** drop down menu. To do this in your Konvoy management cluster, view your base64 encoded Kubernetes secret values to copy and paste into the **Root CA Certificate** field:
 
-    ```bash
-    echo $(kubectl get secret -n kommander kommander-bootstrap-root-ca -o=go-template='{{index .data "tls.crt"}}')
-    ```
+   ```bash
+   echo $(kubectl get secret -n cert-manager kommander-ca -o=go-template='{{index .data "tls.crt"}}')
+   ```
 
-    Otherwise, select from the list of available Secrets.
+   Otherwise, select from the list of available Secrets.
 
    <!--- ![Network Cluster Configuration](/dkp/kommander/1.4/img/attach-network-restrict-cluster-tunnel-config.png) --->
 


### PR DESCRIPTION
the existing example command was no longer accurate. The one from the
tunnel-cli docs was correct. I updated the UI example to match the cli
documentation.

At somepoint we may want to reconsider have 2 pages to document connecting a cluster with a tunnel, one for cli and one for UI. this is confusing and prone to get out of sync.

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4235.s3-website-us-west-2.amazonaws.com/dkp/kommander/2.2/clusters/attach-cluster/cluster-with-network-restrictions/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
