### PR TITLE
docs: fixed links for vspehere

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
@@ -14,21 +14,21 @@ Before you start this procedure, ensure that you complete the [Prerequisites][pr
 ## Create a vSphere Bastion VM Host Template
 When creating an air-gapped vSphere cluster, the bastion VM hosts the installation DKP Konvoy bundles and images, and the Docker registry, needed to create and operate your vSphere cluster. The bastion VM must have access to the vSphere API Server (vCenter Server).
 
-1.  Create a bastion VM host template for the cluster nodes to use within the air-gapped network. This bastion VM host also needs access to a Docker registry in lieu of an Internet connection for pulling Docker images. The recommended template naming pattern is `../folder-name/dkp-e2e-bastion-template' or similar.
+1.  Create a bastion VM host template for the cluster nodes to use within the air-gapped network. This bastion VM host also needs access to a Docker registry in lieu of an Internet connection for pulling Docker images. The recommended template naming pattern is `../folder-name/dkp-e2e-bastion-template` or similar.
 
 1.  Find and record the bastion VM's IP or host name.
 
 1.  Download the required Konvoy binaries and installation bundles directly to the bastion host, or transfer them using your environment's approved methods:
 
-    - [downloads.mesosphere.io/konvoy/konvoy_v2.2.0-rc.1_checksums.txt][http://downloads.mesosphere.io/konvoy/konvoy_v2.2.0-beta.1_checksums.txt]
+    - [downloads.mesosphere.io/konvoy/konvoy_v2.2.0-rc.1_checksums.txt](http://downloads.mesosphere.io/konvoy/konvoy_v2.2.0-beta.1_checksums.txt)
 
-    - [downloads.mesosphere.io/konvoy/konvoy_v2.2.0-rc.1_darwin_amd64.tar.gz][http://downloads.mesosphere.io/konvoy/konvoy_v2.2.0-beta.1_darwin_amd64.tar.gz]
+    - [downloads.mesosphere.io/konvoy/konvoy_v2.2.0-rc.1_darwin_amd64.tar.gz](http://downloads.mesosphere.io/konvoy/konvoy_v2.2.0-beta.1_darwin_amd64.tar.gz)
 
-    - [downloads.mesosphere.io/konvoy/konvoy_v2.2.0-rc.1_linux_amd64.tar.gz][http://downloads.mesosphere.io/konvoy/konvoy_v2.2.0-beta.1_linux_amd64.tar.gz]
+    - [downloads.mesosphere.io/konvoy/konvoy_v2.2.0-rc.1_linux_amd64.tar.gz](http://downloads.mesosphere.io/konvoy/konvoy_v2.2.0-beta.1_linux_amd64.tar.gz)
 
-    - [downloads.mesosphere.io/konvoy/airgapped/v2.2.0-rc.1/konvoy_image_bundle_v2.2.0-rc.1_linux_amd64.tar.gz][http://downloads.mesosphere.io/konvoy/airgapped/v2.2.0-beta.1/konvoy_image_bundle_v2.2.0-beta.1_linux_amd64.tar.gz] (This bundle contains air-gapped images that you must push to a registry.)
+    - [downloads.mesosphere.io/konvoy/airgapped/v2.2.0-rc.1/konvoy_image_bundle_v2.2.0-rc.1_linux_amd64.tar.gz](http://downloads.mesosphere.io/konvoy/airgapped/v2.2.0-beta.1/konvoy_image_bundle_v2.2.0-beta.1_linux_amd64.tar.gz) (This bundle contains air-gapped images that you must push to a registry.)
 
-    - [downloads.mesosphere.io/konvoy/airgapped/v2.2.0-rc.1/konvoy-bootstrap_v2.2.0-rc.1.tar][http://downloads.mesosphere.io/konvoy/airgapped/v2.2.0-beta.1/konvoy-bootstrap_v2.2.0-beta.1.tar] (This bundle contains the KIND bootstrap image to load with the `docker load` command when you create the bootstrap cluster in a later step.)
+    - [downloads.mesosphere.io/konvoy/airgapped/v2.2.0-rc.1/konvoy-bootstrap_v2.2.0-rc.1.tar](http://downloads.mesosphere.io/konvoy/airgapped/v2.2.0-beta.1/konvoy-bootstrap_v2.2.0-beta.1.tar) (This bundle contains the KIND bootstrap image to load with the `docker load` command when you create the bootstrap cluster in a later step.)
 
 1.  Use your credentials to SSH into the bastion VM host with the command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
@@ -13,13 +13,13 @@ enterprise: false
 
 1.  Fetch the kubeconfig file with the command:
 
-    ```sh
+    ```bash
     dkp get kubeconfig -c ${air-gapped_NAME} > ${air-gapped_NAME}.conf
     ```
 
 1.  List the Nodes with the command:
 
-    ```sh
+    ```bash
     kubectl --kubeconfig=${air-gapped_NAME}.conf get nodes
     ```
 
@@ -27,6 +27,7 @@ enterprise: false
 
     The output resembles this example:
 
+    ```sh
     NAME                                         STATUS   ROLES                  AGE   VERSION
     d2iq-e2e-air-gapped-1-control-plane-7llgd     Ready    control-plane,master   20h   v1.22.8
     d2iq-e2e-air-gapped-1-control-plane-vncbl     Ready    control-plane,master   19h   v1.22.8
@@ -39,7 +40,7 @@ enterprise: false
 
 1.  List the Pods with the command:
 
-    ```sh
+    ```bash
     kubectl --kubeconfig=${air-gapped_NAME}.conf get pods -A
     ```
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/bootstrap/index.md
@@ -123,14 +123,15 @@ When the bootstrap cluster is running, you are ready to [create a new cluster][c
 
     Konvoy defines the selectors and sets the correct labels on the Cluster objects. For a more detailed explanation of how ClusterResourceSets work, see the [Extension Proposal][clusterresourceset_cape]. --->
 
-[install_docker]: https://docs.docker.com/get-docker/
-[install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[capv]: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere
-[kind]: https://github.com/kubernetes-sigs/kind
-[capi_book]: https://cluster-api.sigs.k8s.io/
-[capi]: https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.20/
-[kcp]: https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.20/controlplane/kubeadm
+[calico]: https://projectcalico.docs.tigera.io/about/about-calico
 [cabpk]: https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.20/bootstrap/kubeadm
+[capi]: https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.20/
+[capi_book]: https://cluster-api.sigs.k8s.io/
+[capv]: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere
 [clusterresourceset_cape]: https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20200220-cluster-resource-set.md
 [create-capi-image]: ../create-capi-vm-image/
 [create-cluster]: ../new/
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[kcp]: https://github.com/kubernetes-sigs/cluster-api/tree/v0.3.20/controlplane/kubeadm
+[kind]: https://github.com/kubernetes-sigs/kind

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-base-os-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-base-os-image/index.md
@@ -13,7 +13,7 @@ Creating a base OS image from DVD ISO files is a one-time process. Building a ba
 
 Refer to the vCenter and vSphere Client documentation for details.
 
-The next step is to [create a vSphere VM template][create-vsphere-template] that contains the CAPI and Kubernetes objects.]
+The next step is to [create a vSphere VM template][create-vsphere-template] that contains the CAPI and Kubernetes objects.
 
 [vsphere-doc-base-image]: https://docs.vmware.com/en/VMware-vSphere/index.html
 [create-vsphere-template]: ../create-capi-vm-image/

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/index.md
@@ -20,4 +20,4 @@ After creating the base image, the DKP image builder uses it to create a CAPI-en
 
 To get started, fulfill the [prerequisites][prerequisites].
 
-[prerequisites]: /prerequisites
+[prerequisites]: prerequisites

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/nodepools/cluster-autoscaler/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/nodepools/cluster-autoscaler/index.md
@@ -99,6 +99,6 @@ Run the following steps to enable Cluster Autoscaler:
 
 1.  Cluster Autoscaler starts to scale down the number of Worker Nodes after the default timeout of 10 minutes.
 
-[bootstraplifecycle]: ../../advanced/bootstrap
-[createnewcluster]: ../../advanced/new
-[selfmanagedcluster]: ../../advanced/self-managed
+[bootstraplifecycle]: ../../bootstrap
+[createnewcluster]: ../../new
+[selfmanagedcluster]: ../../self-managed

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/self-managed/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/self-managed/index.md
@@ -15,7 +15,7 @@ Before starting, ensure you create a workload cluster as described in [Create a 
 
 1.  Deploy cluster lifecycle services on the workload cluster:
 
-        ```bash
+    ```bash
     dkp create capi-components --kubeconfig ${CLUSTER_NAME}.conf
     ```
 


### PR DESCRIPTION
## Jira Ticket

N/A

## Description of changes being made
Just went through some of the documentation for vsphere, and noticed some links weren't there/maybe weren't even published at the time some topics were created. Just fixed them here.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4245.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
