### PR TITLE
docs: removes note on an outdated limitation

### DIFF
--- a/pages/dkp/kommander/2.2/install/configuration/custom-domain/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/custom-domain/index.md
@@ -62,8 +62,6 @@ ingressCertificate:
 
 Kommander can be configured to automatically issue a trusted certificate for the configured custom domain and renew it before expiration.
 
-<p class="message--important"><strong>IMPORTANT: </strong>This feature is currently only supported for the management cluster. Kommander does not currently support attaching clusters that use ACME certs. </p>
-
 ### Let's encrypt
 
 In this section, we will walk you through how to set up a Let’s Encrypt certificate for the cluster ingress. This would allow most browsers to validate the certificate for the cluster when the users try to log into the ops portal.


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/D2IQ-86818

## Description of changes being made
Removes limitation that we are fixing right now around the use of ACME on managed clusters. 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
