### PR TITLE
docs: replacing kommander cli with dkp

### DIFF
--- a/pages/dkp/kommander/2.2/gpu/kommander-config/index.md
+++ b/pages/dkp/kommander/2.2/gpu/kommander-config/index.md
@@ -43,7 +43,7 @@ To enable Nvidia GPU support when installing Kommander, perform the following st
 1. Create an installation configuration file:
 
     ```bash
-    kommander install --init > install.yaml
+    dkp install kommander --init > install.yaml
     ```
 
 1. Append the following to the apps section in the `install.yaml` file to enable Nvidia platform services.
@@ -56,10 +56,8 @@ To enable Nvidia GPU support when installing Kommander, perform the following st
 1. Install Kommander, using the configuration file you created:
 
     ```bash
-    kommander install --installer-config ./install.yaml
+    dkp install kommander --installer-config ./install.yaml
     ```
-
-
 
 ## Disable Nvidia Platform Service on Kommander
 

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -28,7 +28,7 @@ Before installing, ensure you have:
 -   A [configuration file][kommander-config] that you will adapt to your needs using the steps outlined in this topic. Make sure to create that file using the following command:
 
   ```bash
-  kommander install --init --airgapped > install.yaml
+  dkp install kommander --init --airgapped > install.yaml
   ```
 
 -   All the prerequisites covered in [air-gapped Konvoy installation][air-gap-before-you-begin].
@@ -42,14 +42,14 @@ Create the charts bundle with the Kommander CLI or downloaded along with the Kom
 Execute this command to create the charts bundle:
 
    ```bash
-   kommander create chart-bundle
+   dkp create chart-bundle
    ```
 
 Kommander creates `charts-bundle.tar.gz`.
 Optionally, specify the output using the `-o` parameter:
 
    ```bash
-   kommander create chart-bundle -o [name of the output file]
+   dkp create chart-bundle -o [name of the output file]
    ```
 
 ### Kommander's internal Helm repository
@@ -58,25 +58,25 @@ The Kommander charts bundle is pushed to Kommander's internal Helm repository.
 To inspect the contents:
 
    ```bash
-   kommander get charts
+   dkp get charts
    ```
 
 Individual charts can be removed using:
 
    ```bash
-   kommander delete chart [chartName] [chartVersion]
+   dkp delete chart [chartName] [chartVersion]
    ```
 
 It is possible to push new charts as well:
 
    ```bash
-   kommander push chart [chartTarball]
+   dkp push chart [chartTarball]
    ```
 
 Or push a new bundle:
 
    ```bash
-   kommander push chart-bundle [chartsTarball]
+   dkp push chart-bundle [chartsTarball]
    ```
 
 Check the built-in help text for each command for more information.
@@ -231,7 +231,7 @@ It may take a while to push all the images to your image registry, depending on 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
-    kommander install --installer-config ./install.yaml \
+    dkp install kommander --installer-config ./install.yaml \
     --kommander-applications-repository kommander-applications-v2.2.0.tar.gz \
     --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz \
     --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -26,7 +26,7 @@ Before installing, ensure you have:
 -   A [configuration file][kommander-config] that you will adapt to your needs using the steps outlined in this topic. Make sure to create that file using the following command:
 
   ```bash
-  kommander install --init --airgapped > install.yaml
+  dkp install kommander --init --airgapped > install.yaml
   ```
 
 -   All the prerequisites covered in [air-gapped Konvoy installation][air-gap-before-you-begin].
@@ -36,18 +36,18 @@ Before installing, ensure you have:
 ### Kommander charts bundle
 
 The charts bundle is a gzipped Tar archive containing Helm charts, which are required during Kommander installation.
-Create the charts bundle with the Kommander CLI or downloaded along with the Kommander CLI.
+Create the charts bundle with the DKP CLI or downloaded along with the DKP CLI.
 Execute this command to create the charts bundle:
 
    ```bash
-   kommander create chart-bundle
+   dkp create chart-bundle
    ```
 
 Kommander creates `charts-bundle.tar.gz`.
 Optionally, specify the output using the `-o` parameter:
 
    ```bash
-   kommander create chart-bundle -o [name of the output file]
+   dkp create chart-bundle -o [name of the output file]
    ```
 
 ### Kommander's internal Helm repository
@@ -56,25 +56,25 @@ The Kommander charts bundle is pushed to Kommander's internal Helm repository.
 To inspect the contents:
 
    ```bash
-   kommander get charts
+   dkp get charts
    ```
 
 Individual charts can be removed using:
 
    ```bash
-   kommander delete chart [chartName] [chartVersion]
+   dkp delete chart [chartName] [chartVersion]
    ```
 
 It is possible to push new charts as well:
 
    ```bash
-   kommander push chart [chartTarball]
+   dkp push chart [chartTarball]
    ```
 
 Or push a new bundle:
 
    ```bash
-   kommander push chart-bundle [chartsTarball]
+   dkp push chart-bundle [chartsTarball]
    ```
 
 Check the built-in help text for each command for more information.
@@ -214,7 +214,7 @@ It may take a while to push all the images to your image registry, depending on 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
-    kommander install --installer-config ./install.yaml \
+    dkp install kommander --installer-config ./install.yaml \
     --kommander-applications-repository kommander-applications-v2.2.0.tar.gz \
     --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz
     ```

--- a/pages/dkp/kommander/2.2/install/configuration/custom-domain/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/custom-domain/index.md
@@ -21,10 +21,10 @@ kind: Installation
 clusterHostname: mycluster.domain.dom
 ```
 
-This configuration can be used when installing or reconfiguring Kommander by passing it to the `kommander install` command:
+This configuration can be used when installing or reconfiguring Kommander by passing it to the `dkp install kommander` command:
 
 ```bash
-kommander install --installer-config <config_file.yaml>
+dkp install kommander --installer-config <config_file.yaml>
 ```
 
 Soon after the command completes, obtain the cluster ingress IP address or hostname using the following command:

--- a/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
@@ -30,10 +30,10 @@ catalog:
           tag: v2.2.0
 ```
 
-Use this configuration when installing or reconfiguring Kommander by passing it to the `kommander install` command:
+Use this configuration when installing or reconfiguring Kommander by passing it to the `dkp install kommander` command:
 
 ```bash
-kommander install --installer-config <config_file.yaml>
+dkp install kommander --installer-config <config_file.yaml>
 ```
 
 <p class="message--note"><strong>NOTE: </strong>When configuring the catalog repository post-upgrade, run <code>kommander install --init > install.yaml</code> and update it accordingly with any custom configuration. This ensures you are using the proper default configuration values for the new Kommander version.</p>
@@ -73,8 +73,8 @@ When running in air-gapped environments, update the configuration by replacing `
 
     <p class="message--note"><strong>NOTE: </strong>When configuring the catalog repository post-upgrade, run <code>kommander install --init > install.yaml</code> and update it accordingly with any custom configuration. This ensures you are using the proper default configuration values for the new Kommander version.</p>
 
-1.  Use this configuration when installing or reconfiguring Kommander by passing it to the `kommander install` command:
+1.  Use this configuration when installing or reconfiguring Kommander by passing it to the `dkp install kommander` command:
 
     ```bash
-    kommander install --installer-config <config_file.yaml>
+    dkp install kommander --installer-config <config_file.yaml>
     ```

--- a/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
@@ -45,12 +45,12 @@ If the proxy is working for HTTP and HTTPS, respectively, the `curl` command ret
 
 Gatekeeper acts as a [Kubernetes mutating webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook). You can use this to mutate the Pod resources with `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.
 
-Kommander installs with a dedicated CLI.
+Kommander installs with the DKP CLI.
 
 1.  Create (if necessary) and update the Kommander installation configuration file. If one does not already exist, then create it using the following commands:
 
     ```bash
-    ./kommander install --init > install.yaml
+    ./dkp install kommander --init > install.yaml
     ```
 
 1. Append the `apps` section in `install.yaml` with the following values to enable Gatekeeper and configure it to add HTTP proxy settings to the pods.
@@ -83,7 +83,7 @@ Kommander installs with a dedicated CLI.
 1. Install Kommander using the above configuration file:
 
     ```bash
-    ./kommander install --installer-config ./install.yaml
+    ./dkp install kommander --installer-config ./install.yaml
     ```
 
 # Configure Workspace (or Project) in which you want to use proxy

--- a/pages/dkp/kommander/2.2/install/configuration/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/index.md
@@ -15,7 +15,7 @@ You can configure Kommander during the initial installation, and also post-insta
 To begin configuring Kommander, run the following command to initialize a default configuration file:
 
 ```bash
-kommander install --init > kommander.yaml
+dkp install kommander --init > kommander.yaml
 ```
 
 ## Configuring applications
@@ -80,7 +80,7 @@ apps:
 Add the `--installer-config` flag to the `kommander install` command to use a custom configuration file. To reconfigure applications, you can also run this command after the initial installation.
 
 ```bash
-kommander install --installer-config kommander.yaml
+dkp install kommander --installer-config kommander.yaml
 ```
 
 When completed, you can [verify your installation](../networked#verify-installation).

--- a/pages/dkp/kommander/2.2/install/networked/index.md
+++ b/pages/dkp/kommander/2.2/install/networked/index.md
@@ -48,7 +48,7 @@ Before running the commands below, ensure that your `kubectl` configuration **re
 <p class="message--note"><strong>NOTE:</strong> An alternative to initializing the KUBECONFIG environment variable as stated earlier is to use the <code>–kubeconfig=cluster_name.conf</code> flag. This ensures that Kommander is installed on the workload cluster.</p>
 
 ```bash
-kommander install
+dkp install kommander
 ```
 
 ## Verify installation
@@ -99,7 +99,7 @@ helmrelease.helm.toolkit.fluxcd.io/velero condition met
 When all the `HelmReleases` are ready, use the following command to open the Kommander dashboard in your browser:
 
 ```bash
-kommander open dashboard
+dkp open dashboard
 ```
 
 This command opens the URL of the Kommander web interface in your default browser, and prints the username and password in the CLI.


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

in 2.2 and above, there is no longer a dedicated kommander-cli - this has all been folded into the DKP cli. Therefore, these commands in the documentation need to be updated as well.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4252.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
