### PR TITLE
Moving downloads to all be on d2iq.com

### DIFF
--- a/.github/styles/Vocab/Docs/reject.txt
+++ b/.github/styles/Vocab/Docs/reject.txt
@@ -2,3 +2,5 @@ on-premise[^s]
 add-on
 D2IQ
 airgapped
+downloads.mesosphere.io
+downloads.mesosphere.com

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/fairing/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/fairing/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/katib/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/pipelines/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/sdk/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/sdk/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/mxnet/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/mxnet/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/pytorch/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/spark/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/spark/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/tensorflow/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.0.0/tutorials/training/tensorflow/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.0.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/fairing/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/fairing/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/katib/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/pipelines/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/sdk/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/sdk/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/mxnet/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/mxnet/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/pytorch/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/spark/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/spark/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/tensorflow/index.md
+++ b/pages/dkp/kaptain/1.2.0-1.1.0/tutorials/training/tensorflow/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kudo-kubeflow/d2iq-tutorials-1.2.0-1.1.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>Please note that these notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/fairing/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/fairing/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/katib/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/pipelines/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/sdk/pytorch/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/sdk/pytorch/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/sdk/tensorflow/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/training/mxnet/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/training/mxnet/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/training/pytorch/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/training/spark/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/training/spark/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kaptain/1.2.0/tutorials/training/tensorflow/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/training/tensorflow/index.md
@@ -9,9 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run
-<code>curl -L https://downloads.mesosphere.io/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
+<code>curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.2.0.tar.gz | tar xz</code>
 from a Jupyter Notebook Terminal running in your Kaptain installation.
 </p>
 <p class="message--note"><strong>NOTE: </strong>These notebook tutorials have been built for and

--- a/pages/dkp/kommander/2.0/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.0/install/air-gapped/index.md
@@ -37,7 +37,7 @@ export VERSION=v2.0.0
 1. Download the `kommander-image-bundle.tar.gz` file.
 
     ```bash
-    wget "https://downloads.mesosphere.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
+    wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
     ```
 
 1. Place the bundle into a location where you can load and push the images to your private Docker registry.

--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -216,7 +216,7 @@ Based on the network latency between the environment of script execution and the
 1.  Download and extract the `kommander-applications` bundle.
 
     ```bash
-    mkdir kommander-applications && wget https://downloads.mesosphere.com/dkp/kommander-applications_${VERSION}.tar.gz -O - | tar xvzf - -C kommander-applications --strip-components 1
+    mkdir kommander-applications && wget https://downloads.d2iq.com/dkp/kommander-applications_${VERSION}.tar.gz -O - | tar xvzf - -C kommander-applications --strip-components 1
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:

--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -124,7 +124,7 @@ export VERSION=v2.1.0
 1.  Download the image bundle file:
 
     ```bash
-    wget "https://downloads.mesosphere.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
+    wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
     ```
 
 1.  Place the bundle in a location where you can load and push the images to your private Docker registry.

--- a/pages/dkp/konvoy/2.1/troubleshooting/generate-a-support-bundle/index.md
+++ b/pages/dkp/konvoy/2.1/troubleshooting/generate-a-support-bundle/index.md
@@ -26,13 +26,13 @@ Before generating a support bundle, verify that you have:
     For Linux:
 
     ```bash
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
     For macOS:
 
     ```bash
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
 1.  Add the binary to your PATH:
@@ -203,8 +203,8 @@ Redactors are supported and are in the same format as the main `dkp-diagnose` co
 [clusterResources-collector]: https://troubleshoot.sh/docs/collect/cluster-resources/
 [configMap-collector]: https://troubleshoot.sh/docs/collect/configmap/
 [copyFromHost-collector]: https://troubleshoot.sh/docs/collect/copy-from-host/
-[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
-[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
+[dkp-diagnostics-darwin]: https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
+[dkp-diagnostics-linux]: https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
 [exec-collector]: https://troubleshoot.sh/docs/collect/exec/
 [logs-collector]: https://troubleshoot.sh/docs/collect/logs/
 [secrets-collector]: https://troubleshoot.sh/docs/collect/secret/

--- a/pages/dkp/konvoy/2.2/troubleshooting/generate-a-support-bundle/index.md
+++ b/pages/dkp/konvoy/2.2/troubleshooting/generate-a-support-bundle/index.md
@@ -26,13 +26,13 @@ Before generating a support bundle, verify that you have:
     For Linux:
 
     ```bash
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
     For macOS:
 
     ```bash
-    mkdir dkp-diagnose && curl -sL https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
+    mkdir dkp-diagnose && curl -sL https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz | tar -xz -C ./dkp-diagnose/
     ```
 
 1.  Add the binary to your PATH:
@@ -203,8 +203,8 @@ Redactors are supported and are in the same format as the main `dkp-diagnose` co
 [clusterResources-collector]: https://troubleshoot.sh/docs/collect/cluster-resources/
 [configMap-collector]: https://troubleshoot.sh/docs/collect/configmap/
 [copyFromHost-collector]: https://troubleshoot.sh/docs/collect/copy-from-host/
-[dkp-diagnostics-darwin]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
-[dkp-diagnostics-linux]: https://downloads.mesosphere.io/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
+[dkp-diagnostics-darwin]: https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_darwin_amd64.tar.gz
+[dkp-diagnostics-linux]: https://downloads.d2iq.com/dkp/dkp-diagnose_v0.4.1_linux_amd64.tar.gz
 [exec-collector]: https://troubleshoot.sh/docs/collect/exec/
 [logs-collector]: https://troubleshoot.sh/docs/collect/logs/
 [secrets-collector]: https://troubleshoot.sh/docs/collect/secret/


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

All the download links are moving from mesosphere.io to d2iq.com

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
