### PR TITLE
removing hiding of 2.2 for GA

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,6 @@
     "DO_NOT_BUILD": ["dkp/kommander/2.2/**"]
   },
   "production": {
-    "DO_NOT_BUILD": ["dkp/kommander/2.2/**", "dkp/konvoy/2.2/**"]
+    "DO_NOT_BUILD": ["dkp/kommander/2.3/**", "dkp/konvoy/2.3/**"]
   }
 }

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "DO_NOT_BUILD": []
   },
   "beta": {
-    "DO_NOT_BUILD": ["dkp/kommander/2.2/**"]
+    "DO_NOT_BUILD": []
   },
   "production": {
     "DO_NOT_BUILD": ["dkp/kommander/2.3/**", "dkp/konvoy/2.3/**"]

--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ MS.metadata({
   dcosCNDocsLatest: "2.1",
   dcosDocsLatest: "2.2",
   dispatchDocsLatest: "1.4",
-  kommanderDocsLatest: "2.1",
-  konvoyDocsLatest: "2.1",
+  kommanderDocsLatest: "2.2",
+  konvoyDocsLatest: "2.2",
   kaptainDocsLatest: "1.3.0",
   Utils,
 });

--- a/s3config.json
+++ b/s3config.json
@@ -7,9 +7,9 @@
   },
   "RoutingRules": [
     { "Condition": { "KeyPrefixEquals": "mesosphere/dcos/latest/" },                                           "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/2.2/", "HttpRedirectCode": "307" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/konvoy/latest/" },                                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/konvoy/2.1/", "HttpRedirectCode": "307" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/konvoy/latest/" },                                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/konvoy/2.2/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/dispatch/latest/" },                                              "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/dispatch/1.4/", "HttpRedirectCode": "307" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/2.1/", "HttpRedirectCode": "307" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/2.2/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/kaptain/latest/" },                                               "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kaptain/1.3.0/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/kubeflow/" },                                                     "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kaptain/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "mesosphere/dcos/services/cassandra/latest/" },                        "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/services/cassandra/2.9.0-3.11.6/", "HttpRedirectCode": "307" } },


### PR DESCRIPTION
Signed-off-by: Casie Oxford <coxford@d2iq.com>

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

No JIRA for this. 

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4266.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
