### PR TITLE
[Konvoy 2.2] Document any manual steps needed for metallb configuration

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -76,30 +76,6 @@ data:
       addresses:
       - 192.168.10.0/24
 ```
-If you installed MetalLB with the MetalLB Operator, the addresspool configuration happens via the AddressPool CRD:
-
-```sh
-apiVersion: metallb.io/v1beta1
-kind: BGPPeer
-metadata:
-  name: peer-sample1
-  namespace: metallb-system
-spec:
-  peerAddress: 10.0.0.1
-  peerASN: 64501
-  myASN: 64500
-  routerID: 10.10.10.10
-  peerPort: 1
-  holdTime: "180s"
-  keepaliveTime: "180s"
-  sourceAddress: "1.1.1.1"
-  password: "test"
-  nodeSelectors:
-  - matchExpressions:
-    - key: kubernetes.io/hostname
-      operator: In
-      values: [hostA, hostB]
-```
 Once complete, run the following `kubectl` command.
 
 ```sh

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -9,7 +9,6 @@ enterprise: false
 ---
 ## Prerequisites
 
-* If you installed MetalLB using Helm, you will need to change the namespace of the config map to match the namespace in which MetalLB was deployed, and change the name of the config map from config to metallb.    
 
 Choose one of the following two protocols you want to use to announce service IPs, either Layer 2 or BGP configurations.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -1,0 +1,119 @@
+---
+layout: layout.pug
+navigationTitle: Configure MetalLB
+title: Configure MetalLB
+menuWeight: 90
+excerpt: Create a MetalLB configmap for your pre-provisioned infrastructure.
+beta: false
+enterprise: false
+---
+## Prerequisites
+
+* If you installed MetalLB using Helm, you will need to change the namespace of the config map to match the namespace in which MetalLB was deployed, and change the name of the config map from config to metallb.    
+
+Choose one of the following two protocols you want to use to announce service IPs, either Layer 2 or BGP configurations.
+
+## Layer 2 configuration
+
+Layer 2 mode is the simplest to configure: in many cases, you don’t need any protocol-specific configuration, only IP addresses.
+
+Layer 2 mode does not require the IPs to be bound to the network interfaces of your worker nodes. It works by responding to ARP requests on your local network directly, to give the machine’s MAC address to clients.
+
+For example, the following configuration gives MetalLB control over IPs from 192.168.1.240 to 192.168.1.250, and configures Layer 2 mode:
+
+<p class="message--note"><strong>NOTE:</strong>The following values are generic, enter your specific values into the fields where applicable.</p>
+
+```sh
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.1.240-192.168.1.250
+```
+If you installed MetalLB with the MetalLB Operator, the addresspool configuration happens via the AddressPool CRD:
+
+```sh
+apiVersion: metallb.io/v1beta1
+kind: AddressPool
+metadata:
+  name: addresspool-sample1
+  namespace: metallb-system
+spec:
+  protocol: layer2
+  addresses:
+    - 172.18.0.100-172.18.0.255
+```
+
+Once complete, run the following `kubectl` command.
+
+```sh
+kubectl apply -f <metallb-config-file>
+```
+
+## BGP Configuration
+
+For a basic configuration featuring one BGP router and one IP address range, you need 4 pieces of information:
+
+* The router IP address that MetalLB should connect to,
+* The router’s AS number,
+* The AS number MetalLB should use,
+* An IP address range expressed as a CIDR prefix.
+
+As an example, if you want to give MetalLB the range 192.168.10.0/24 and AS number 64500, and connect it to a router at 10.0.0.1 with AS number 64501, your configuration will look like:
+
+<p class="message--note"><strong>NOTE:</strong>The following values are generic, enter your specific values into the fields where applicable.</p>
+
+```sh
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    peers:
+    - peer-address: 10.0.0.1
+      peer-asn: 64501
+      my-asn: 64500
+    address-pools:
+    - name: default
+      protocol: bgp
+      addresses:
+      - 192.168.10.0/24
+```
+If you installed MetalLB with the MetalLB Operator, the addresspool configuration happens via the AddressPool CRD:
+
+```sh
+apiVersion: metallb.io/v1beta1
+kind: BGPPeer
+metadata:
+  name: peer-sample1
+  namespace: metallb-system
+spec:
+  peerAddress: 10.0.0.1
+  peerASN: 64501
+  myASN: 64500
+  routerID: 10.10.10.10
+  peerPort: 1
+  holdTime: "180s"
+  keepaliveTime: "180s"
+  sourceAddress: "1.1.1.1"
+  password: "test"
+  nodeSelectors:
+  - matchExpressions:
+    - key: kubernetes.io/hostname
+      operator: In
+      values: [hostA, hostB]
+```
+Once complete, run the following `kubectl` command.
+
+```sh
+kubectl apply -f <metallb-config-file>
+```

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -40,7 +40,7 @@ data:
 Once complete, run the following `kubectl` command.
 
 ```sh
-kubectl apply -f <metallb-config-file>
+kubectl apply -f metallb-conf.yaml
 ```
 
 ## BGP Configuration

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -37,19 +37,6 @@ data:
       addresses:
       - 192.168.1.240-192.168.1.250
 ```
-If you installed MetalLB with the MetalLB Operator, the addresspool configuration happens via the AddressPool CRD:
-
-```sh
-apiVersion: metallb.io/v1beta1
-kind: AddressPool
-metadata:
-  name: addresspool-sample1
-  namespace: metallb-system
-spec:
-  protocol: layer2
-  addresses:
-    - 172.18.0.100-172.18.0.255
-```
 
 Once complete, run the following `kubectl` command.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Configure MetalLB
 title: Configure MetalLB
-menuWeight: 80
+menuWeight: 82
 excerpt: Create a MetalLB configmap for your pre-provisioned infrastructure.
 beta: false
 enterprise: false

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -59,6 +59,7 @@ As an example, if you want to give MetalLB the range 192.168.10.0/24 and AS numb
 <p class="message--note"><strong>NOTE:</strong>The following values are generic, enter your specific values into the fields where applicable.</p>
 
 ```sh
+cat << EOF > metallb-conf.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -75,6 +76,7 @@ data:
       protocol: bgp
       addresses:
       - 192.168.10.0/24
+EOF
 ```
 Once complete, run the following `kubectl` command.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Configure MetalLB
 title: Configure MetalLB
-menuWeight: 90
+menuWeight: 80
 excerpt: Create a MetalLB configmap for your pre-provisioned infrastructure.
 beta: false
 enterprise: false

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -7,8 +7,6 @@ excerpt: Create a MetalLB configmap for your pre-provisioned infrastructure.
 beta: false
 enterprise: false
 ---
-## Prerequisites
-
 
 Choose one of the following two protocols you want to use to announce service IPs, either Layer 2 or BGP configurations.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -79,5 +79,5 @@ data:
 Once complete, run the following `kubectl` command.
 
 ```sh
-kubectl apply -f <metallb-config-file>
+kubectl apply -f metallb-conf.yaml
 ```

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/index.md
@@ -23,6 +23,7 @@ For example, the following configuration gives MetalLB control over IPs from 192
 <p class="message--note"><strong>NOTE:</strong>The following values are generic, enter your specific values into the fields where applicable.</p>
 
 ```sh
+cat << EOF > metallb-conf.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +36,7 @@ data:
       protocol: layer2
       addresses:
       - 192.168.1.240-192.168.1.250
+EOF
 ```
 
 Once complete, run the following `kubectl` command.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/metal-lb/index.md
@@ -1,0 +1,83 @@
+---
+layout: layout.pug
+navigationTitle: Configure MetalLB
+title: Configure MetalLB
+menuWeight: 78
+excerpt: Create a MetalLB configmap for your pre-provisioned infrastructure.
+beta: false
+enterprise: false
+---
+
+Choose one of the following two protocols you want to use to announce service IPs, either Layer 2 or BGP configurations.
+
+## Layer 2 configuration
+
+Layer 2 mode is the simplest to configure: in many cases, you don’t need any protocol-specific configuration, only IP addresses.
+
+Layer 2 mode does not require the IPs to be bound to the network interfaces of your worker nodes. It works by responding to ARP requests on your local network directly, to give the machine’s MAC address to clients.
+
+For example, the following configuration gives MetalLB control over IPs from 192.168.1.240 to 192.168.1.250, and configures Layer 2 mode:
+
+<p class="message--note"><strong>NOTE:</strong>The following values are generic, enter your specific values into the fields where applicable.</p>
+
+```sh
+cat << EOF > metallb-conf.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.1.240-192.168.1.250
+EOF
+```
+
+Once complete, run the following `kubectl` command.
+
+```sh
+kubectl apply -f metallb-conf.yaml
+```
+
+## BGP Configuration
+
+For a basic configuration featuring one BGP router and one IP address range, you need 4 pieces of information:
+
+* The router IP address that MetalLB should connect to,
+* The router’s AS number,
+* The AS number MetalLB should use,
+* An IP address range expressed as a CIDR prefix.
+
+As an example, if you want to give MetalLB the range 192.168.10.0/24 and AS number 64500, and connect it to a router at 10.0.0.1 with AS number 64501, your configuration will look like:
+
+<p class="message--note"><strong>NOTE:</strong>The following values are generic, enter your specific values into the fields where applicable.</p>
+
+```sh
+cat << EOF > metallb-conf.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    peers:
+    - peer-address: 10.0.0.1
+      peer-asn: 64501
+      my-asn: 64500
+    address-pools:
+    - name: default
+      protocol: bgp
+      addresses:
+      - 192.168.10.0/24
+EOF
+```
+Once complete, run the following `kubectl` command.
+
+```sh
+kubectl apply -f metallb-conf.yaml
+```

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/metal-lb/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Configure MetalLB
 title: Configure MetalLB
 menuWeight: 78
-excerpt: Create a MetalLB configmap for your pre-provisioned infrastructure.
+excerpt: Create a MetalLB configmap for your vSphere infrastructure.
 beta: false
 enterprise: false
 ---


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-86750

## Description of changes being made

New MetalLB config page for pre-provisioned

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4269.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
