### PR TITLE
Replace mentions of "Deploy" with "Enable" to reflect UI changes

### DIFF
--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/attach-eks-cluster/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/attach-eks-cluster/index.md
@@ -116,7 +116,7 @@ This procedure requires the following items and configurations:
 
 Now that you have kubeconfig, go to the DKP UI and follow these steps below:
 
-1.  Select a workspace from the **Workspace Selector** in the top navigation bar. 
+1.  From the top menu bar, select your target workspace.
 
 1.  On the Dashboard page, select the **Add Cluster** option in the **Actions** dropdown menu at the top right.
 

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/cluster-no-network-restrictions/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/cluster-no-network-restrictions/index.md
@@ -11,7 +11,7 @@ beta: false
 
 Use this option when you want to attach a cluster that does not require additional access information.
 
-1. Select a workspace from the **Workspace Selector** in the top navigation bar. 
+1. From the top menu bar, select your target workspace.
 
 1. On the Dashboard page, select the **Add Cluster** option in the **Actions** dropdown menu at the top right.
 
@@ -19,7 +19,7 @@ Use this option when you want to attach a cluster that does not require addition
 
 1. Select the **No additional networking restrictions** card.
 
-1. In the **Cluster Configuration** section, paste your kubeconfig file into the field, or select the **Upload kubeconfig File** button to specify the file. 
+1. In the **Cluster Configuration** section, paste your kubeconfig file into the field, or select the **Upload kubeconfig File** button to specify the file.
 
 1. The **Cluster Name** field will automatically populate with the name of the cluster is in the kubeconfig. You can edit this field with the name you want for your cluster.
 

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/cluster-with-network-restrictions/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/cluster-with-network-restrictions/index.md
@@ -13,7 +13,7 @@ Use this option when you want to attach a cluster that is in a DMZ, behind a NAT
 
 <p class="message--note"><strong>NOTE: </strong>If your cluster blocks public access, you may need to make the additional step of allowing certain authorized networks where Docker images are hosted for Konvoy to use your cluster, specifically <code>https://registry-1.docker.io/</code>.</p>
 
-1. Select a workspace from the **Workspace Selector** in the top navigation bar. 
+1. From the top menu bar, select your target workspace.
 
 1. On the Dashboard page, select the **Add Cluster** option in the **Actions** dropdown menu at the top right.
 

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/index.md
@@ -95,26 +95,25 @@ kubectl --kubeconfig $(pwd)/kommander-cluster-admin-config get all --all-namespa
 
 Using the **Add Cluster** option, you can attach an existing Kubernetes or Konvoy cluster directly to Kommander. This enables you to access the multi-cluster management and monitoring benefits that Kommander provides, while keeping your existing cluster on its current provider and infrastructure.
 
-1. Select a workspace from the **Workspace Selector** in the top navigation bar. 
+1.  From the top menu bar, select your target workspace.
 
-1. On the Dashboard page, select the **Add Cluster** option in the **Actions** dropdown menu at the top right.
+1.  On the Dashboard page, select the **Add Cluster** option in the **Actions** dropdown menu at the top right.
 
-1. Select **Attach Cluster**.
+1.  Select **Attach Cluster**.
 
-1. Select the **No additional networking restrictions** card.
+1.  Select the **No additional networking restrictions** card.
 
-1. In the **Cluster Configuration** section, paste your kubeconfig file into the field, or select the **Upload kubeconfig File** button to specify the file. 
+1.  In the **Cluster Configuration** section, paste your kubeconfig file into the field, or select the **Upload kubeconfig File** button to specify the file.
 
 1.  The **Cluster Name** field automatically populates with the name of the cluster is in the kubeconfig. You can edit this field with the name you want for your cluster.
 
-1. The **Context** select list is populated from the kubeconfig. Select the desired context with admin privileges from the **Context** select list.
+1.  The **Context** select list is populated from the kubeconfig. Select the desired context with admin privileges from the **Context** select list.
 
-1. Add labels to classify your cluster as needed.
+1.  Add labels to classify your cluster as needed.
 
-1. Select **Submit** to attach your cluster.
+1.  Select **Submit** to attach your cluster.
 
 Platform applications extend the functionality of Kubernetes and provide ready-to-use logging and monitoring stacks by deploying platform applications when attaching a cluster to Kommander. For more information, refer to [workspace platform applications][workspace_platform_applications].
-
 
 <!---
 ## Accessing your managed clusters using your Kommander administrator credentials

--- a/pages/dkp/kommander/2.2/logging/enable-logging/enable-logging-via-ui/index.md
+++ b/pages/dkp/kommander/2.2/logging/enable-logging/enable-logging-via-ui/index.md
@@ -9,28 +9,29 @@ beta: false
 
 <!-- markdownlint-disable MD030 -->
 
-You can enable the Workspace logging stack to all attached clusters within the Workspace through the UI. If you prefer to deploy the logging stack through `kubectl`, review how you [create AppDeployments to Enable Workspace Logging][create-appdeployment].
+You can enable the Workspace logging stack to all attached clusters within the Workspace through the UI. If you prefer to enable the logging stack with `kubectl`, review how you [create AppDeployments to Enable Workspace Logging][create-appdeployment].
 
-To enable logging in DKP using the UI, follow these steps in Kommander:
+To enable workspace-level logging in DKP using the UI, follow these steps:
 
-1. In the **Global workspace** nav, click on the **Global** dropdown and then select the Workspace you want to deploy for your logging stack.
+1.  From the top menu bar, select your target workspace.
 
-1. In the left rail nav, click on **Applications**.
+1.  Select **Applications** from the sidebar menu.
 
-1. Ensure that cert-manager and Traefik are enabled in the Workspace. Scroll down in the **Applications** page to view the **Foundational** applications section. Confirm that cert-manager and Traefik are deployed.
+1.  Traefik and cert-manager are required to be deployed for the logging stack. Ensure that Traefik is enabled in the Workspace, and cert-manager is enabled or already deployed to the cluster.
 
-1. After validating these applications are deployed, scroll to the **Logging** applications section.
+1.  Scroll to the **Logging** applications section.
 
-1. Click on the three button action menu on the card for MinIO, and click **Deploy**. In this **Deploy Workspace Platform Application** page, you can add a customized configuration for settings that best fit your organization. You can leave the configuration settings unchanged to deploy with default settings.
+1.  Select the three dot button from the bottom-right corner of the card for MinIO, and click **Enable**. On the **Enable Workspace Platform Application** page, you can add a customized configuration for settings that best fit your organization. You can leave the configuration settings unchanged to enable with default settings.
 
-1. Click **Deploy** at the top right of the page.
+1.  Select **Enable** at the top right of the page.
 
-1. Repeat the deployment process for the cards on Grafana Loki, Fluent Bit, Logging Operator, and Grafana Logging.
+1.  Repeat the process for the Grafana Loki, Fluent Bit, Logging Operator, and Grafana Logging applications.
 
-1. You can verify the cluster logging stack installation by waiting until the cards have a Deployed checkmark, or you can [verify the cluster logging stack installation via the CLI][verify-logging-install].
+1.  You can verify the cluster logging stack installation by waiting until the cards have a Deployed checkmark on the [cluster detail page][cluster-applications], or you can [verify the cluster logging stack installation via the CLI][verify-logging-install].
 
-1. Then, you can [view cluster log data][view-log-data].
+1.  Then, you can [view cluster log data][view-log-data].
 
 [create-appdeployment]: ../create-appdeployment-workspace
 [verify-logging-install]: ../verify-cluster-logstack
 [view-log-data]: ../view-cluster-logdata
+[cluster-applications]: ../../../clusters/applications#applications

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
@@ -1,19 +1,17 @@
 ---
 layout: layout.pug
-navigationTitle: Deploy a Custom Application from the Project Catalog
-title: Deploy a Custom Application from the Project Catalog
+navigationTitle: Enable a Custom Application from the Project Catalog
+title: Enable a Custom Application from the Project Catalog
 menuWeight: 50
-excerpt: Deploy a Custom Application from the Project Catalog
+excerpt: Enable a Custom Application from the Project Catalog
 ---
 <!-- markdownlint-disable MD030 -->
 
-After creating a GitRepository, you can either use the DKP UI or the CLI to deploy your custom applications.
+After creating a GitRepository, you can either use the DKP UI or the CLI to enable your custom applications.
 
-## Deploy the application using the DKP UI
+## Enable the application using the DKP UI
 
-Go to the DKP UI to deploy your custom applications:
-
-1.  Select a workspace from the **Workspace Selector** in the top navigation bar.
+1.  From the top menu bar, select your target workspace.
 
 1.  Select **Projects** from the sidebar menu.
 
@@ -23,7 +21,7 @@ Go to the DKP UI to deploy your custom applications:
 
 1.  Select the three dot button from the bottom-right corner of the desired application tile, and then select **Enable**.
 
-1.  Select the version you'd like to enable from the version drop-down, and then select **Enable**. This drop-down will only be visible if there is more than one version available.
+1.  If available, select a version from the drop-down. This drop-down will only be visible if there is more than one version.
 
 1.  (Optional) If you want to override the default configuration values, copy your values content into the text editor under **Configure Service** or just upload your yaml file that contains the values:
 
@@ -31,13 +29,13 @@ Go to the DKP UI to deploy your custom applications:
     someField: someValue
     ```
 
-1.  Once you confirm the details are correct, select the **Enable** button.
+1.  Confirm the details are correct, and then select the **Enable** button.
 
 For all applications, you must provide a display name and an ID which is automatically generated based on what you enter for the display name, unless or until you edit the ID directly. The ID must be compliant with [Kubernetes DNS subdomain name validation rules](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
 
-Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to deploy your custom applications.
+Alternately, you can use the [CLI](#enable-the-application-using-the-cli) to enable your custom applications.
 
-## Deploy the application using the CLI
+## Enable the application using the CLI
 
 1. Set the `PROJECT_NAMESPACE` environment variable to the name of the project's namespace:
 
@@ -45,15 +43,15 @@ Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to dep
     export PROJECT_NAMESPACE=<project_namespace>
     ```
 
-1. Get the list of available applications to deploy using the following command:
+1. Get the list of available applications to enable using the following command:
 
    ```bash
    kubectl get apps -n ${PROJECT_NAMESPACE}
    ```
 
-1. Deploy one of the supported applications from the list with an `AppDeployment` resource.
+1. Enable one of the supported applications from the list with an `AppDeployment` resource.
 
-1. Within the `AppDeployment`, define the `appRef` to specify which `App` will be deployed:
+1. Within the `AppDeployment`, define the `appRef` to specify which `App` will be enabled:
 
    ```yaml
    cat <<EOF | kubectl apply -f -
@@ -70,7 +68,7 @@ Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to dep
 
 <p class="message--note"><strong>NOTE: </strong>The <code>appRef.name</code> must match the app <code>name</code> from the list of available applications.</p>
 
-## Deploy an application with a custom configuration using the CLI
+## Enable an application with a custom configuration using the CLI
 
 1. Provide the name of a `ConfigMap` in the `AppDeployment`, which provides custom configuration on top of the default configuration:
 
@@ -105,11 +103,11 @@ Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to dep
    EOF
    ```
 
-Kommander waits for the `ConfigMap` to be present before deploying the `AppDeployment` to the attached clusters in the Project.
+Kommander waits for the `ConfigMap` to be present before enabling the `AppDeployment` to the attached clusters in the Project.
 
 ## Verify applications
 
-After completing the previous steps, your applications are deployed. Connect to the attached cluster and check the `HelmReleases` to verify the deployments:
+After completing the previous steps, your applications are enabled. Connect to the attached cluster and check the `HelmReleases` to verify the deployments:
 
 ```bash
 kubectl get helmreleases -n ${PROJECT_NAMESPACE}

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
@@ -8,6 +8,7 @@ excerpt: Enable a Custom Application from the Project Catalog
 <!-- markdownlint-disable MD030 -->
 
 After creating a GitRepository, you can either use the DKP UI or the CLI to enable your custom applications.
+<p class="message--important"><strong>IMPORTANT: </strong>From within a project, you can enable applications to deploy. Verify that an application has successfully deployed <a href="#verify-applications">via the CLI</a>.</p>
 
 ## Enable the application using the DKP UI
 

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
@@ -22,7 +22,7 @@ After creating a GitRepository, you can either use the DKP UI or the CLI to enab
 
 1.  Select the three dot button from the bottom-right corner of the desired application tile, and then select **Enable**.
 
-1.  If available, select a version from the drop-down. This drop-down will only be visible if there is more than one version.
+1.  If available, select a version from the drop-down menu. This drop-down menu will only be visible if there is more than one version.
 
 1.  (Optional) If you want to override the default configuration values, copy your values content into the text editor under **Configure Service** or just upload your yaml file that contains the values:
 

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/index.md
@@ -17,7 +17,7 @@ Before upgrading your catalog applications, verify the current and supported ver
 
 Follow these steps to upgrade an application from the DKP UI:
 
-1.  Select a workspace from the **Workspace Selector** in the top navigation bar.
+1.  From the top menu bar, select your target workspace.
 
 1.  Select **Applications** from the sidebar menu.
 

--- a/pages/dkp/kommander/2.2/projects/applications/platform-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/platform-applications/application-deployment/index.md
@@ -99,7 +99,7 @@ Kommander waits for the `ConfigMap` to be present before deploying the `AppDeplo
 
 ## Verify applications
 
-The applications are now deployed. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
+The applications are now enabled. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
 
 ```bash
 kubectl get helmreleases -n ${PROJECT_NAMESPACE}

--- a/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
@@ -14,6 +14,8 @@ Review the [project application service resource requirements](./platform-applic
 
 When deploying and upgrading applications, platform applications come as a bundle; they are tested as a single unit and you must deploy or upgrade them in a single process, for each workspace. This means all clusters in a workspace have the same set and versions of platform applications deployed.
 
+<p class="message--important"><strong>IMPORTANT: </strong>From within a project, you can enable applications to deploy. Verify that an application has successfully deployed <a href="../platform-applications/application-deployment#verify-applications">via the CLI</a>.</p>
+
 ## Enable applications in a project using the DKP UI
 
 1.  From the top menu bar, select your target workspace.

--- a/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
@@ -16,7 +16,7 @@ When deploying and upgrading applications, platform applications come as a bundl
 
 ## Enable applications in a project using the DKP UI
 
-1.  Select a workspace from the **Workspace Selector** in the top navigation bar.
+1.  From the top menu bar, select your target workspace.
 
 1.  Select **Projects** from the sidebar menu.
 

--- a/pages/dkp/kommander/2.2/projects/project-configmaps/index.md
+++ b/pages/dkp/kommander/2.2/projects/project-configmaps/index.md
@@ -15,7 +15,7 @@ For a full reference to the concept, consult the Kubernetes documentation on the
 
 The below Project ConfigMap form can be navigated to by:
 
-1.  Select a workspace from the **Workspace Selector** in the top navigation bar.
+1.  From the top menu bar, select your target workspace.
 
 1.  Select **Projects** from the sidebar menu.
 

--- a/pages/dkp/kommander/2.2/projects/project-deployments/continuous-delivery/index.md
+++ b/pages/dkp/kommander/2.2/projects/project-deployments/continuous-delivery/index.md
@@ -87,7 +87,7 @@ status:
 ...
 ```
 
-If there are errors creating the manifests, those events are populated in the status field of the `GitopsRepository` resource on the management cluster and/or the `GitRepository` and `Kustomization` resources on the attached cluster(s).
+If there are errors creating the manifests, those events are populated in the status field of the `GitopsRepository` resource on the management cluster, the `GitRepository` and `Kustomization` resources on the attached cluster(s), or both.
 
 ## Suspend GitOps Source
 
@@ -95,7 +95,7 @@ There may be times when you need to suspend the auto-sync between the GitOps rep
 
 To Suspend the GitOps Source from the DKP UI:
 
-1.  Select a workspace from the **Workspace Selector** in the top navigation bar.
+1.  From the top menu bar, select your target workspace.
 
 1.  Select **Projects** from the sidebar menu.
 

--- a/pages/dkp/kommander/2.2/projects/project-deployments/view-helm-releases/index.md
+++ b/pages/dkp/kommander/2.2/projects/project-deployments/view-helm-releases/index.md
@@ -9,7 +9,7 @@ excerpt: View Helm Releases for Continuous Deployments
 
 In addition to viewing the current GitOps Sources, you can also view the current Helm Releases that have been deployed.
 
-1.  Select a workspace from the **Workspace Selector** in the top navigation bar.
+1.  From the top menu bar, select your target workspace.
 
 1.  Select **Projects** from the sidebar menu.
 

--- a/pages/dkp/kommander/2.2/projects/project-network-policies/index.md
+++ b/pages/dkp/kommander/2.2/projects/project-network-policies/index.md
@@ -39,7 +39,7 @@ This section also contains the **Pod Selector** fields for selecting pods using 
 The **Policy Types** selections help to define the type of Network Policy you are creating:
 
 - **Default** - automatically includes ingress, and egress is set only if the network policy defines egress rules.
-- **Ingress** - this policy applies to ingress traffic for the selected pods, namespaces using the options you define below, or both.
+- **Ingress** - this policy applies to ingress traffic for the selected pods, to namespaces using the options you define below, or both.
 - **Egress** - this policy applies to egress traffic for the selected pods, namespaces using the options you define below, or both.
 
 If the Default policy type is too rigid or does not offer what you need, you can select the Ingress or Egress type, or both, and explicitly define the policy with the options that follow. For example, if you do not want this policy to apply to ingress traffic, you would select only Egress, and then define the policy.

--- a/pages/dkp/kommander/2.2/projects/project-network-policies/index.md
+++ b/pages/dkp/kommander/2.2/projects/project-network-policies/index.md
@@ -40,7 +40,7 @@ The **Policy Types** selections help to define the type of Network Policy you ar
 
 - **Default** - automatically includes ingress, and egress is set only if the network policy defines egress rules.
 - **Ingress** - this policy applies to ingress traffic for the selected pods, to namespaces using the options you define below, or both.
-- **Egress** - this policy applies to egress traffic for the selected pods, namespaces using the options you define below, or both.
+- **Egress** - this policy applies to egress traffic for the selected pods, to namespaces using the options you define below, or both.
 
 If the Default policy type is too rigid or does not offer what you need, you can select the Ingress or Egress type, or both, and explicitly define the policy with the options that follow. For example, if you do not want this policy to apply to ingress traffic, you would select only Egress, and then define the policy.
 

--- a/pages/dkp/kommander/2.2/projects/project-network-policies/index.md
+++ b/pages/dkp/kommander/2.2/projects/project-network-policies/index.md
@@ -39,10 +39,10 @@ This section also contains the **Pod Selector** fields for selecting pods using 
 The **Policy Types** selections help to define the type of Network Policy you are creating:
 
 - **Default** - automatically includes ingress, and egress is set only if the network policy defines egress rules.
-- **Ingress** - this policy applies to ingress traffic for the selected pods and/or namespaces using the options you define below.
-- **Egress** - this policy applies to egress traffic for the selected pods and/or namespaces using the options you define below.
+- **Ingress** - this policy applies to ingress traffic for the selected pods, namespaces using the options you define below, or both.
+- **Egress** - this policy applies to egress traffic for the selected pods, namespaces using the options you define below, or both.
 
-If the Default policy type is too rigid or does not offer what you need, you can select the Ingress and/or Egress type and explicitly define the policy with the options that follow. For example, if you do not want this policy to apply to ingress traffic, you would select only Egress, and then define the policy.
+If the Default policy type is too rigid or does not offer what you need, you can select the Ingress or Egress type, or both, and explicitly define the policy with the options that follow. For example, if you do not want this policy to apply to ingress traffic, you would select only Egress, and then define the policy.
 
 To deny all ingress traffic, select the **Ingress** option here and then leave the ingress rules empty.
 
@@ -52,13 +52,13 @@ To deny all egress traffic, select the **Egress** option here and then leave the
 
 Ingress rules use a combination of **Port** / **Protocol** and **Source** to define the incoming traffic allowed to some or all of the pods in this namespace.
 
-The options under **Sources: From** enable you to define a source either by using the pod selector or by defining an IP block. When using the pod selector method, you can define the namespace, and/or the pods within that namespace.
+The options under **Sources: From** enable you to define a source either by using the pod selector or by defining an IP block. When using the pod selector method, you can define the namespace, the pods within that namespace, or both.
 
 **Namespaces** - Selecting a namespace in an ingress rule source permits the pods selected by the pod selector, in your selected namespaces, to receive incoming traffic that meets the other defined criteria. If you have not selected any pods, the rule permits traffic from all pods in the selected namespaces.
 
 **Pods** - This option selects specific Pods which should be allowed as ingress sources or egress destinations. If you have not selected any namespaces in the namespace selector, this option selects all matching pods in the project namespace. Otherwise, this option selects all matching pods in the selected namespaces.
 
-There also are options to select all namespaces and/or all pods.
+There also are options to select all namespaces, all pods, or both.
 
 When defining ingress rules using the IP Block method, you define a CIDR and exception conditions. CIDR stands for Classless Inter-Domain Routing and is an IP standard for creating unique network and device identifiers. When grouped together so that they share an initial sequence of bits in their binary representation, the range of addresses creates a CIDR block. The block identity is in an IPv4-like notation including a dotted-decimal address, followed by a slash, then a colon and a number from 0 through 32, for example, 127.0.26.33:31.
 
@@ -72,7 +72,7 @@ Egress rules use a similar combination of options to define the outgoing traffic
 
 To navigate to your project's Network Policy page:
 
-1. Select a workspace from the **Workspace Selector** in the top navigation bar.
+1. From the top menu bar, select your target workspace.
 1. Select **Projects** from the sidebar menu.
 1. Select your project from the list.
 1. Select the **Network Policy** tab.

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/application-deployment/index.md
@@ -35,7 +35,7 @@ Follow these steps to enable your catalog applications from the DKP UI:
 
 1.  Select the three dot button from the bottom-right corner of the desired application tile, and then select **Enable**.
 
-1.  If available, select a version from the drop-down. This drop-down will only be visible if there is more than one version.
+1.  If available, select a version from the drop-down menu. This drop-down menu will only be visible if there is more than one version.
 
 1.  (Optional) If you want to override the default configuration values, copy your customized values into the text editor under **Configure Service** or upload your yaml file that contains the values:
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/application-deployment/index.md
@@ -23,6 +23,7 @@ export WORKSPACE_NAMESPACE=<workspace_namespace>
 ```
 
 After creating a GitRepository, use either the DKP UI or the CLI to enable your catalog applications.
+<p class="message--important"><strong>IMPORTANT: </strong>From within a workspace, you can enable applications to deploy. Verify that an application has successfully deployed <a href="#verify-applications">via the CLI</a>.</p>
 
 ## Enable the application using the DKP UI
 
@@ -115,7 +116,7 @@ Kommander waits for the `ConfigMap` to be present before deploying the `AppDeplo
 
 ## Verify applications
 
-The applications are now deployed. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
+The applications are now enabled. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
 
 ```bash
 kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/application-deployment/index.md
@@ -22,19 +22,19 @@ Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace'
 export WORKSPACE_NAMESPACE=<workspace_namespace>
 ```
 
-After creating a GitRepository, use either the DKP UI or the CLI to deploy your catalog applications.
+After creating a GitRepository, use either the DKP UI or the CLI to enable your catalog applications.
 
-## Deploy the application using the DKP UI
+## Enable the application using the DKP UI
 
-Follow these steps to deploy your catalog applications from the DKP UI:
+Follow these steps to enable your catalog applications from the DKP UI:
 
-1.  Select the desired **Workspace**
+1.  From the top menu bar, select your target workspace.
 
-1.  Select **Applications** on the left navigation bar to browse the available applications from your configured repositories.
+1.  Select **Applications** from the sidebar menu to browse the available applications from your configured repositories.
 
-1.  Select your desired application.
+1.  Select the three dot button from the bottom-right corner of the desired application tile, and then select **Enable**.
 
-1.  Select the version you'd like to deploy from the version drop-down, and then select Deploy. The `Deploy Workspace Catalog Application` page is displayed.
+1.  If available, select a version from the drop-down. This drop-down will only be visible if there is more than one version.
 
 1.  (Optional) If you want to override the default configuration values, copy your customized values into the text editor under **Configure Service** or upload your yaml file that contains the values:
 
@@ -42,19 +42,19 @@ Follow these steps to deploy your catalog applications from the DKP UI:
     someField: someValue
     ```
 
-1.  Confirm the details are correct, and then select the `Deploy` button.
+1.  Confirm the details are correct, and then select the **Enable** button.
 
 For all applications, you must provide a display name and an ID which is automatically generated based on what you enter for the display name, unless or until you edit the ID directly. The ID must be compliant with [Kubernetes DNS subdomain name validation rules](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
 
-Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to deploy your catalog applications.
+Alternately, you can use the [CLI](#enable-the-application-using-the-cli) to enable your catalog applications.
 
-## Deploy the application using the CLI
+## Enable the application using the CLI
 
 See [workspace catalog applications](/dkp/kommander/2.2/workspaces/applications/catalog-applications/#workspace-catalog-applications) for the list of available applications that you can deploy on the attached cluster.
 
-1.  Deploy a supported application to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
+1.  Enable a supported application to deploy to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
 
-1.  Within the `AppDeployment`, define the `appRef` to specify which `App` to deploy:
+1.  Within the `AppDeployment`, define the `appRef` to specify which `App` to enable:
 
     ```yaml
     cat <<EOF | kubectl apply -f -
@@ -74,7 +74,7 @@ See [workspace catalog applications](/dkp/kommander/2.2/workspaces/applications/
 
 <p class="message--note"><strong>NOTE: </strong>The <code>appRef.name</code> must match the app <code>name</code> from the list of available catalog applications.</p>
 
-## Deploy an application with a custom configuration using the CLI
+## Enable an application with a custom configuration using the CLI
 
 1.  Provide the name of a `ConfigMap` in the `AppDeployment`, which provides custom configuration on top of the default configuration:
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
@@ -9,6 +9,7 @@ excerpt: Enable a Custom Application from the Workspace Catalog
 <!-- markdownlint-disable MD030 -->
 
 After creating a GitRepository, you can either use the DKP UI or the CLI to enable your custom applications.
+<p class="message--important"><strong>IMPORTANT: </strong>From within a workspace, you can enable applications to deploy. Verify that an application has successfully deployed <a href="#verify-applications">via the CLI</a>.</p>
 
 ## Enable the application using the DKP UI
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
@@ -1,42 +1,38 @@
 ---
 layout: layout.pug
-navigationTitle: Deploy a Custom Application from the Workspace Catalog
-title: Deploy a Custom Application from the Workspace Catalog
+navigationTitle: Enable a Custom Application from the Workspace Catalog
+title: Enable a Custom Application from the Workspace Catalog
 menuWeight: 50
 beta: false
-excerpt: Deploy a Custom Application from the Workspace Catalog
+excerpt: Enable a Custom Application from the Workspace Catalog
 ---
 <!-- markdownlint-disable MD030 -->
 
-After creating a GitRepository, you can either use the DKP UI or the CLI to deploy your custom applications.
+After creating a GitRepository, you can either use the DKP UI or the CLI to enable your custom applications.
 
-## Deploy the application using the DKP UI
+## Enable the application using the DKP UI
 
-Go to the DKP UI to deploy your custom applications:
+1.  From the top menu bar, select your target workspace.
 
-1. Select **Workspace** > **Workspace**
+1.  Select **Applications** from the sidebar menu to browse the available applications from your configured repositories.
 
-1. Select your workspace from the list.
+1.  Select the three dot button from the bottom-right corner of the desired application tile, and then select **Enable**.
 
-1. Select **Applications** on the top navigation bar to browse the available applications from your configured repositories.
+1.  If available, select a version from the drop-down. This drop-down will only be visible if there is more than one version.
 
-1. Select your desired application.
+1.  (Optional) If you want to override the default configuration values, copy your customized values into the text editor under **Configure Service** or upload your yaml file that contains the values:
 
-1. Select the version you'd like to deploy from the version drop-down, and then select Deploy. The `Deploy Workspace Custom Application` page is displayed.
+    ```yaml
+    someField: someValue
+    ```
 
-1. (Optional) If you want to override the default configuration values, copy your values content into the text editor under **Configure Service** or just upload your yaml file that contains the values:
-
-   ```yaml
-   someField: someValue
-   ```
-
-1. Once you confirm the details are correct, click the `Deploy` button.
+1.  Confirm the details are correct, and then select the **Enable** button.
 
 For all applications, you must provide a display name and an ID which is automatically generated based on what you enter for the display name, unless or until you edit the ID directly. The ID must be compliant with [Kubernetes DNS subdomain name validation rules](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
 
-Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to deploy your custom applications.
+Alternately, you can use the [CLI](#enable-the-application-using-the-cli) to enable your custom applications.
 
-## Deploy the application using the CLI
+## Enable the application using the CLI
 
 1. Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace's namespace:
 
@@ -44,7 +40,7 @@ Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to dep
     export WORKSPACE_NAMESPACE=<workspace_namespace>
     ```
 
-1. Get the list of available applications to deploy using the following command:
+1. Get the list of available applications to enable using the following command:
 
    ```bash
    kubectl get apps -n ${WORKSPACE_NAMESPACE}
@@ -52,7 +48,7 @@ Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to dep
 
 1. Deploy one of the supported applications from the list with an `AppDeployment` resource.
 
-1. Within the `AppDeployment`, define the `appRef` to specify which `App` will be deployed:
+1. Within the `AppDeployment`, define the `appRef` to specify which `App` will be enabled:
 
    ```yaml
    cat <<EOF | kubectl apply -f -
@@ -69,7 +65,7 @@ Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to dep
 
 <p class="message--note"><strong>NOTE: </strong>The <code>appRef.name</code> must match the app <code>name</code> from the list of available applications.</p>
 
-## Deploy an application with a custom configuration using the CLI
+## Enable an application with a custom configuration using the CLI
 
 1. Provide the name of a `ConfigMap` in the `AppDeployment`, which provides custom configuration on top of the default configuration:
 
@@ -104,11 +100,11 @@ Alternately, you can use the [CLI](#deploy-the-application-using-the-cli) to dep
    EOF
    ```
 
-Kommander waits for the `ConfigMap` to be present before deploying the `AppDeployment` to the attached clusters in the Workspace.
+Kommander waits for the `ConfigMap` to be present before enabling the `AppDeployment` to the attached clusters in the Workspace.
 
 ## Verify applications
 
-After completing the previous steps, your applications are deployed. Connect to the attached cluster and check the `HelmReleases` to verify the deployments:
+After completing the previous steps, your applications are enabled. Connect to the attached cluster and check the `HelmReleases` to verify the deployments:
 
 ```bash
 kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/custom-applications/deploy-custom-app/index.md
@@ -19,7 +19,7 @@ After creating a GitRepository, you can either use the DKP UI or the CLI to enab
 
 1.  Select the three dot button from the bottom-right corner of the desired application tile, and then select **Enable**.
 
-1.  If available, select a version from the drop-down. This drop-down will only be visible if there is more than one version.
+1.  If available, select a version from the drop-down menu. This drop-down menu will only be visible if there is more than one version.
 
 1.  (Optional) If you want to override the default configuration values, copy your customized values into the text editor under **Configure Service** or upload your yaml file that contains the values:
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
@@ -9,8 +9,8 @@ excerpt: Deploy applications to attached clusters using the CLI
 
 <!-- markdownlint-disable MD004 MD040 -->
 
-This topic describes how to use the CLI to deploy an application to attached clusters within a workspace.
-To use the DKP UI to deploy applications, see [Customize a workspace's applications](../../platform-applications#customize-a-workspaces-applications).
+This topic describes how to use the CLI to enable an application to deploy to attached clusters within a workspace.
+To use the DKP UI to enable applications, see [Customize a workspace's applications](../../platform-applications#customize-a-workspaces-applications).
 
 See [Workspace Platform Applications](../../platform-applications#workspace-platform-applications) for a list of all applications and those that are enabled by default.
 
@@ -27,13 +27,13 @@ Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace'
 export WORKSPACE_NAMESPACE=<workspace_namespace>
 ```
 
-## Deploy the application
+## Enable the application
 
-The list of available applications that can be deployed on the attached cluster can be found [in this documentation](../../platform-applications#workspace-platform-applications).
+The list of available applications that can be enabled to deploy to the attached cluster can be found [in this documentation](../../platform-applications#workspace-platform-applications).
 
-1.  Deploy a supported application to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
+1.  Enable a supported application to deploy to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
 
-1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be deployed:
+1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be enabled:
 
     ```yaml
     cat <<EOF | kubectl apply -f -
@@ -53,7 +53,7 @@ The list of available applications that can be deployed on the attached cluster 
 
 <p class="message--note"><strong>NOTE: </strong>The <code>appRef.name</code> must match the app <code>name</code> from the list of available applications.</p>
 
-## Deploy an application with a custom configuration
+## Enable an application with a custom configuration
 
 1.  Provide the name of a `ConfigMap` in the `AppDeployment`, which provides custom configuration on top of the default configuration:
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
@@ -27,6 +27,8 @@ Set the `WORKSPACE_NAMESPACE` environment variable to the name of the workspace'
 export WORKSPACE_NAMESPACE=<workspace_namespace>
 ```
 
+<p class="message--important"><strong>IMPORTANT: </strong>From the CLI, you can enable applications to deploy in the workspace. Verify that an application has successfully deployed <a href="#verify-applications">via the CLI</a>.</p>
+
 ## Enable the application
 
 The list of available applications that can be enabled to deploy to the attached cluster can be found [in this documentation](../../platform-applications#workspace-platform-applications).
@@ -97,7 +99,7 @@ Kommander waits for the `ConfigMap` to be present before deploying the `AppDeplo
 
 ## Verify applications
 
-The applications are now deployed. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
+The applications are now enabled. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
 
 ```bash
 kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
@@ -31,7 +31,7 @@ export WORKSPACE_NAMESPACE=<workspace_namespace>
 
 ## Enable the application
 
-The list of available applications that can be enabled to deploy to the attached cluster can be found [in this documentation](../../platform-applications#workspace-platform-applications).
+Review the [list of available applications](../../platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.
 
 1.  Enable a supported application to deploy to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
@@ -14,9 +14,11 @@ Review the [workspace platform application resource requirements](./platform-app
 
 ### Customize a workspace's applications
 
-You can customize the applications that are deployed to a workspace's clusters using the DKP UI. Access the applications page by going to the specific workspace, then opening the **Applications** page from the sidebar menu.
+You can customize the applications that are deployed to a workspace's clusters using the DKP UI:
 
-This takes you to the **Applications** page which displays all applications that can be deployed or uninstalled.
+1.  From the top menu bar, select your target workspace.
+
+1.  Select **Applications** from the sidebar menu to browse all applications that can be deployed or uninstalled.
 
 To use the CLI to deploy or uninstall applications, see [Application Deployment](./application-deployment)
 
@@ -56,3 +58,5 @@ The following table describes the list of platform applications that are deploye
 <p class="message--note"><strong>NOTE: </strong>Only a single deployment of <code>traefik</code> per cluster is supported.</p>
 
 <p class="message--note"><strong>NOTE: </strong>Kommander automatically manages the deployment of <code>traefik-forward-auth</code> and <code>kube-oidc-proxy</code> when clusters are attached to the workspace. These applications are not shown in the DKP UI.</p>
+
+<p class="message--note"><strong>NOTE: </strong>Applications are enabled in DKP and then deployed to attached clusters. To confirm that your enabled application has successfully deployed, you should <a href="../platform-applications/application-deployment#verify-applications">verify via the CLI</a>.</p>


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-86815
https://jira.d2iq.com/browse/D2IQ-87258

## Description of changes being made

The wording has now changed in the UI so that you "Enable" an application, rather than "Deploy". We need to update the docs to reflect this change. 

I've also updated some of the instructions to make them a little bit clearer.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4274.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
