### PR TITLE
Fixing some links to direct to specific headers

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -98,10 +98,10 @@ You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the
 [EKS]: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
 [pre_provisioned]: ../../../../konvoy/2.2/choose-infrastructure/pre-provisioned/upgrade/control-plane/
 [k8s_access_to_clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
-[upgrade_workspaces]: ../../projects/applications/platform-applications
+[upgrade_workspaces]: ../../projects/applications/platform-applications#upgrade-platform-applications-from-the-cli
 [release_notes]: ../../release-notes/
 [konvoy_upgrade]: ../upgrade-konvoy/
-[load_images]: ../../install/air-gapped/
+[load_images]: ../../install/air-gapped#load-the-docker-images-into-your-docker-registry
 [dkp_upgrade]: ../../dkp-upgrade/
-[load_images_catalog]: ../../install/air-gapped/catalog/
+[load_images_catalog]: ../../install/air-gapped/catalog#load-the-docker-images-into-your-docker-registry
 [backup]: ../../backup-and-restore#back-up-on-demand


### PR DESCRIPTION
## Description of changes being made

Some links were directing to a page/topic instead of directing to a specific heading/sections.  

### Preview
http://docs-d2iq-com-pr-4275.s3-website-us-west-2.amazonaws.com/