### PR TITLE
[Kommander 2.2] Provide instructions to detach < 2.2 metallb from kommander

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -67,6 +67,8 @@ This section describes how to upgrade your Kommander Management cluster and all 
   
   ```bash
   kubectl -n kommander get pod -l app=metallb
+  
+  ```sh
   NAME                                 READY   STATUS    RESTARTS   AGE
   metallb-controller-d657c8dbb-zlgrk   1/1     Running   0          20m
   metallb-speaker-2gz6p                1/1     Running   0          20m

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -38,8 +38,9 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```bash
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
-  If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.
-
+  
+  <p class="message--note"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a catalog application. If you installed MetalLB on     the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading..</p>
+  
   1. Pause the helm release.
   ```sh
   kubectl -n kommander patch -p='{"spec":{"suspend": true}}' --type=merge helmrelease/metallb

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -38,7 +38,8 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```bash
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
-  
+## Detatch MetalLB from Kommander
+
   <p class="message--important"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
   
   1. Pause the helm release.
@@ -50,17 +51,26 @@ This section describes how to upgrade your Kommander Management cluster and all 
   1. Delete the helm release secret.
   ```bash
   kubectl -n kommander delete secret -l name=metallb,owner=helm
+  ```
+  ```sh 
   secret "sh.helm.release.v1.metallb.v1" deleted
   ```
+  
   1. Delete MetalLB.
   ```bash
   k -n kommander delete appdeployment metallb
+  ```
+  
+  ```sh 
   appdeployment.apps.kommander.d2iq.io "metallb" deleted
   ```
 
   1. Unpause the helm release.
   ```bash
   kubectl -n kommander patch -p='{"spec":{"suspend": false}}' --type=merge helmrelease/metallb
+  ```
+  
+  ```sh 
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```
   This deletes MetalLb from Kommander while leaving the resources running in the cluster.

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -39,7 +39,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
   
-  <p class="message--note"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a catalog application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
+  <p class="message--important"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
   
   1. Pause the helm release.
   ```bash

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -47,7 +47,10 @@ This section describes how to upgrade your Kommander Management cluster and all 
   kubectl -n kommander patch -p='{"spec":{"suspend": true}}' --type=merge helmrelease/metallb
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```
-
+  ```sh
+  helmrelease.helm.toolkit.fluxcd.io/metallb patched
+  ```
+  
   1. Delete the helm release secret.
   ```bash
   kubectl -n kommander delete secret -l name=metallb,owner=helm
@@ -77,6 +80,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   
   ```bash
   kubectl -n kommander get pod -l app=metallb
+  ```
   
   ```sh
   NAME                                 READY   STATUS    RESTARTS   AGE

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -66,7 +66,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   This deletes MetalLb from Kommander while leaving the resources running in the cluster.
   
   ```bash
-  $ kubectl -n kommander get pod -l app=metallb
+  kubectl -n kommander get pod -l app=metallb
   NAME                                 READY   STATUS    RESTARTS   AGE
   metallb-controller-d657c8dbb-zlgrk   1/1     Running   0          20m
   metallb-speaker-2gz6p                1/1     Running   0          20m

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -40,7 +40,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```
 ## Detach MetalLB from Kommander
 
-  <p class="message--important"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
+  <p class="message--important"><strong>IMPORTANT:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
   
   1. Pause the helm release.
   ```bash

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -38,7 +38,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```bash
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
-## Detatch MetalLB from Kommander
+## Detach MetalLB from Kommander
 
   <p class="message--important"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
   

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -48,24 +48,24 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```
 
   1. Delete the helm release secret.
-  ```sh
+  ```bash
   kubectl -n kommander delete secret -l name=metallb,owner=helm
   secret "sh.helm.release.v1.metallb.v1" deleted
   ```
   1. Delete MetalLB.
-  ```sh
+  ```bash
   k -n kommander delete appdeployment metallb
   appdeployment.apps.kommander.d2iq.io "metallb" deleted
   ```
 
   1. Unpause the helm release.
-  ```sh
+  ```bash
   kubectl -n kommander patch -p='{"spec":{"suspend": false}}' --type=merge helmrelease/metallb
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```
   This deletes MetalLb from Kommander while leaving the resources running in the cluster.
   
-  ```sh
+  ```bash
   $ kubectl -n kommander get pod -l app=metallb
   NAME                                 READY   STATUS    RESTARTS   AGE
   metallb-controller-d657c8dbb-zlgrk   1/1     Running   0          20m

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -42,7 +42,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   <p class="message--note"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a catalog application. If you installed MetalLB on     the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading..</p>
   
   1. Pause the helm release.
-  ```sh
+  ```bash
   kubectl -n kommander patch -p='{"spec":{"suspend": true}}' --type=merge helmrelease/metallb
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -39,7 +39,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
   
-  <p class="message--note"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a catalog application. If you installed MetalLB on     the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading..</p>
+  <p class="message--note"><strong>NOTE:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a catalog application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
   
   1. Pause the helm release.
   ```bash


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-86748

## Description of changes being made

Added workaround for MetalLB detachment for users who setup MetalLB prior to 2.2.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4279.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
