### PR TITLE
docs: sync 2.1 with 2.2 catalog apps docs

### DIFF
--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/kafka/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/kafka/index.md
@@ -14,7 +14,7 @@ After deploying the Kafka operator, create Kafka Clusters by applying a `KafkaCl
 
 ## Example deployment
 
-<p class="message--note"><strong>NOTE: </strong>The Custom Resources must be applied to each attached cluster in a project.</p>
+<p class="message--note"><strong>NOTE: </strong>If you need to manage these custom resources across all clusters in a project, it is recommended you use <a href="../../../../../project-deployments">Project Deployments</a> which enables you to leverage GitOps to deploy the resources. Otherwise, you will need to create the custom resources manually in each cluster.</p>
 
 This example deployment walks you through first deploying a ZooKeeper cluster and then a Kafka cluster in a project namespace. The result of this procedure is a running ZooKeeper cluster and Kafka cluster ready for use in your project's namespace.
 

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
@@ -13,7 +13,7 @@ To run your Spark workloads with Spark Operator, apply the Spark Operator specif
 
 See [Spark Operator API documentation](https://github.com/mesosphere/spark-on-k8s-operator/blob/d2iq-master/docs/api-docs.md) for more details.
 
-<p class="message--note"><strong>NOTE: </strong>The Custom Resources and RBAC resources must be applied to each attached cluster in a project.</p>
+<p class="message--note"><strong>NOTE: </strong>If you need to manage these custom resources and RBAC resources across all clusters in a project, it is recommended you use <a href="../../../../../project-deployments">Project Deployments</a> which enables you to leverage GitOps to deploy the resources. Otherwise, you will need to create the resources manually in each cluster.</p>
 
 ## Prerequisites
 

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/zookeeper/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/zookeeper/index.md
@@ -16,7 +16,7 @@ A [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/
 
 ### Example deployment
 
-<p class="message--note"><strong>NOTE: </strong>The Custom Resources must be applied to each attached cluster in a project.</p>
+<p class="message--note"><strong>NOTE: </strong>If you need to manage these custom resources across all clusters in a project, it is recommended you use <a href="../../../../../project-deployments">Project Deployments</a> which enables you to leverage GitOps to deploy the resources. Otherwise, you will need to create the resources manually in each cluster.</p>
 
 Follow these steps to deploy a ZooKeeper cluster in a project namespace. This procedure results in a running ZooKeeper cluster, ready for use in your project's namespace.
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
There was a small change to the notes in these catalog app pages that wasn't copied over from 2.1 to 2.2, no change in content just syncing things up!

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
