### PR TITLE
docs: replace metallb with istio in the WS config override example

### DIFF
--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/application-deployment/index.md
@@ -42,11 +42,11 @@ Review the [list of available applications](../../platform-applications#workspac
     apiVersion: apps.kommander.d2iq.io/v1alpha2
     kind: AppDeployment
     metadata:
-      name: cert-manager
+      name: istio
       namespace: ${WORKSPACE_NAMESPACE}
     spec:
       appRef:
-        name: cert-manager-1.7.1
+        name: istio-1.11.6
         kind: ClusterApp
     EOF
     ```
@@ -64,14 +64,14 @@ Review the [list of available applications](../../platform-applications#workspac
     apiVersion: apps.kommander.d2iq.io/v1alpha2
     kind: AppDeployment
     metadata:
-      name: metallb
+      name: istio
       namespace: ${WORKSPACE_NAMESPACE}
     spec:
       appRef:
-        name: metallb-0.12.3
+        name: istio-1.11.6
         kind: ClusterApp
       configOverrides:
-        name: metallb-overrides-attached
+        name: istio-overrides-attached
     EOF
     ```
 
@@ -83,15 +83,17 @@ Review the [list of available applications](../../platform-applications#workspac
     kind: ConfigMap
     metadata:
       namespace: ${WORKSPACE_NAMESPACE}
-      name: metallb-overrides-attached
+      name: istio-overrides-attached
     data:
       values.yaml: |
-        configInline:
-          address-pools:
-          - name: default
-            protocol: layer2
-            addresses:
-            - 172.17.255.150-172.17.255.199
+        operator:
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
     EOF
     ```
 
@@ -102,9 +104,14 @@ Kommander waits for the `ConfigMap` to be present before deploying the `AppDeplo
 The applications are now enabled. Connect to the attached cluster and check the `HelmReleases` to verify the deployment:
 
 ```bash
-kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}
+kubectl get helmreleases istio -n ${WORKSPACE_NAMESPACE} -w
+```
+
+You should eventually see the `HelmRelease` marked as `Ready`:
+
+```sh
 NAMESPACE               NAME        READY   STATUS                             AGE
-workspace-test-vjsfq    metallb     True    Release reconciliation succeeded   7m3s
+workspace-test-vjsfq    istio       True    Release reconciliation succeeded   7m3s
 ```
 
 <p class="message--note"><strong>NOTE: </strong>Some of the supported applications have dependencies on other applications. See <a href="../platform-application-dependencies">Workspace Platform Application Dependencies</a> for that table.</p>

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
@@ -33,7 +33,7 @@ The following table describes the list of platform applications that are deploye
 | cert-manager-1.7.1            | cert-manager          | True                |
 | external-dns-6.1.8            | external-dns          | False               |
 | fluent-bit-0.19.20            | fluent-bit            | False               |
-| gatekeeper-3.7.0              | gatekeeper            | True               |
+| gatekeeper-3.7.0              | gatekeeper            | True                |
 | grafana-logging-6.22.0        | grafana-logging       | False               |
 | grafana-loki-0.33.2           | grafana-loki          | False               |
 | istio-1.11.6                  | istio                 | False               |

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
@@ -33,7 +33,7 @@ The following table describes the list of platform applications that are deploye
 | cert-manager-1.7.1            | cert-manager          | True                |
 | external-dns-6.1.8            | external-dns          | False               |
 | fluent-bit-0.19.20            | fluent-bit            | False               |
-| gatekeeper-3.7.0              | gatekeeper            | False               |
+| gatekeeper-3.7.0              | gatekeeper            | True               |
 | grafana-logging-6.22.0        | grafana-logging       | False               |
 | grafana-loki-0.33.2           | grafana-loki          | False               |
 | istio-1.11.6                  | istio                 | False               |
@@ -44,7 +44,6 @@ The following table describes the list of platform applications that are deploye
 | kubecost-0.23.3               | kubecost              | True                |
 | kubernetes-dashboard-5.1.1    | kubernetes-dashboard  | True                |
 | logging-operator-3.17.2       | logging-operator      | False               |
-| metallb-0.12.3                | metallb               | False               |
 | minio-operator-4.4.10         | minio-operator        | False               |
 | nvidia-0.4.4                  | nvidia                | False               |
 | prometheus-adapter-2.17.1     | prometheus-adapter    | True                |


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Start in 2.2, MetalLB is planned to be moved out of Kommander. This PR removes some references to MetalLB and replaces one of the examples with istio. 

There are still a lot of remaining MetalLB docs that need to be removed or moved to the Konvoy documentation but I don't think any MetalLB documentation for konvoy exists yet so I didn't remove them in this PR. 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
