### PR TITLE
Update azure SP examples to include parameters required with latest azure CLI

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aks/aks-quickstart/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aks/aks-quickstart/index.md
@@ -28,7 +28,7 @@ Before starting the Konvoy installation, verify that you have:
 1.  Log in to Azure:
 
     ```bash
-    $ az login
+    az login
     ```
 
     ```sh
@@ -55,14 +55,13 @@ Before starting the Konvoy installation, verify that you have:
     <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
     ```bash
-    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy"
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv)
     ```
 
     ```sh
     {
       "appId": "7654321a-1a23-567b-b789-0987b6543a21",
       "displayName": "azure-cli-2021-03-09-23-17-06",
-      "name": "http://azure-cli-2021-03-09-23-17-06",
       "password": "Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C",
       "tenant": "a1234567-b132-1234-1a11-1234a5678b90"
     }

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -55,14 +55,13 @@ Before you begin using Konvoy with Azure, you must:
     <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
     ```bash
-    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy"
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv)
     ```
 
     ```sh
     {
       "appId": "7654321a-1a23-567b-b789-0987b6543a21",
       "displayName": "azure-cli-2021-03-09-23-17-06",
-      "name": "http://azure-cli-2021-03-09-23-17-06",
       "password": "Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C",
       "tenant": "a1234567-b132-1234-1a11-1234a5678b90"
     }

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/azure/quick-start-azure/index.md
@@ -52,14 +52,13 @@ Before starting the Konvoy installation, verify that you have:
     <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
     ```bash
-    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy"
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv)
     ```
 
     ```sh
     {
       "appId": "7654321a-1a23-567b-b789-0987b6543a21",
       "displayName": "azure-cli-2021-03-09-23-17-06",
-      "name": "http://azure-cli-2021-03-09-23-17-06",
       "password": "Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C",
       "tenant": "a1234567-b132-1234-1a11-1234a5678b90"
     }

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aks/aks-quickstart/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aks/aks-quickstart/index.md
@@ -55,14 +55,13 @@ Before starting the Konvoy installation, verify that you have:
     <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
     ```bash
-    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy"
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv)
     ```
 
     ```sh
     {
       "appId": "7654321a-1a23-567b-b789-0987b6543a21",
       "displayName": "azure-cli-2021-03-09-23-17-06",
-      "name": "http://azure-cli-2021-03-09-23-17-06",
       "password": "Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C",
       "tenant": "a1234567-b132-1234-1a11-1234a5678b90"
     }

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -55,14 +55,13 @@ Before you begin using Konvoy with Azure, you must:
     <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
     ```bash
-    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy"
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv)
     ```
 
     ```sh
     {
       "appId": "7654321a-1a23-567b-b789-0987b6543a21",
       "displayName": "azure-cli-2021-03-09-23-17-06",
-      "name": "http://azure-cli-2021-03-09-23-17-06",
       "password": "Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C",
       "tenant": "a1234567-b132-1234-1a11-1234a5678b90"
     }

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -52,14 +52,13 @@ Before starting the Konvoy installation, verify that you have:
     <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
     ```bash
-    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy"
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv)
     ```
 
     ```sh
     {
       "appId": "7654321a-1a23-567b-b789-0987b6543a21",
       "displayName": "azure-cli-2021-03-09-23-17-06",
-      "name": "http://azure-cli-2021-03-09-23-17-06",
       "password": "Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C",
       "tenant": "a1234567-b132-1234-1a11-1234a5678b90"
     }

--- a/pages/dkp/konvoy/2.2/image-builder/create-azure-image/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/create-azure-image/index.md
@@ -56,7 +56,7 @@ Extract the bundle and `cd` into the extracted `konvoy-image-bundle-$VERSION_$OS
     <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
     ```bash
-    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --query "{ client_id: appId, client_secret: password, tenant_id: tenant }"
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv) --query "{ client_id: appId, client_secret: password, tenant_id: tenant }"
     ```
 
     ```sh
@@ -66,6 +66,7 @@ Extract the bundle and `cd` into the extracted `konvoy-image-bundle-$VERSION_$OS
       "tenant_id": "a1234567-b132-1234-1a11-1234a5678b90"
     }
     ```
+
 -   Set the `AZURE_CLIENT_SECRET` environment variable:
 
     ```bash


### PR DESCRIPTION
## Jira Ticket

No ticket, see Slack discussion here:  https://mesosphere.slack.com/archives/CR8GEL5TL/p1649266430322719

## Description of changes being made

The Azure CLI was updated yesterday (5-April-2022) with a breaking change that requires that the --scopes parameter always be specified when creating a service principal.  Previously it was inferred from your subscription if you did not specify it.   All of our Azure login examples in 2.1 and 2.2 were depending on the old behavior, and thus don't work if you try to copy paste them.

I also fixed up the outputs to match the current azure CLI behavior.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4283.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
