### PR TITLE
[DOC][Konvoy 2.2] vSphere - added new StorageClass procedure to the air-gapped workflow

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
@@ -9,13 +9,44 @@ beta: false
 enterprise: false
 ---
 
-## Explore the new Kubernetes air-gapped cluster
+## Get the kubeconfig file for the new Kubernetes cluster
 
 1.  Fetch the kubeconfig file with the command:
 
     ```bash
     dkp get kubeconfig -c ${air-gapped_NAME} > ${air-gapped_NAME}.conf
     ```
+
+# Create a StorageClass with a vSphere Datastore
+
+1.   Access the Datastore tab in the vSphere client and select a datastore by name.
+
+1.   Copy the URL for that datastore from the information dialog that displays.
+
+1.   Return to the DKP CLI, and delete the existing `StorageClass` with the commmand:
+
+   ```bash
+   kubectl delete storageclass vsphere-raw-block-sc
+   ```
+
+1.   Run the following command to create a new StorageClass, supplying the correct values for your environment:
+
+   ```yaml
+   cat <<EOF > vsphere-raw-block-sc.yaml
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+      name: vsphere-raw-block-sc
+    provisioner: csi.vsphere.vmware.com
+    parameters:
+      datastoreurl: "<url>"
+    volumeBindingMode: WaitForFirstConsumer
+    EOF
+   ```
+
+## Explore Nodes and Pods in the New Cluster
 
 1.  List the Nodes with the command:
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[<!-- Link to JIRA ticket -->](https://jira.d2iq.com/browse/D2IQ-87168)

## Description of changes being made
Realized that I did not copy the new StorageClass procedure to the air-gapped workflow in PR 4243, so doing that now.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4285.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
