### PR TITLE
docs: A few fixes for 2.1.1 airgapped docs

### DIFF
--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -116,7 +116,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 Set the `VERSION` environment variable to the version of Kommander you want to install, for example:
 
 ```bash
-export VERSION=v2.1.0
+export VERSION=v2.1.1
 ```
 
 ### Load the Docker images into your Docker registry
@@ -143,7 +143,7 @@ export VERSION=v2.1.0
 
     while read -r IMAGE; do
         echo "Processing ${IMAGE}"
-        REGISTRY_IMAGE="$(echo "${IMAGE}" | sed -E "s@^(quay|gcr|ghcr|docker).io@${REGISTRY_URL}@")"
+        REGISTRY_IMAGE="$(echo "${IMAGE}" | sed -E "s@^(quay|gcr|ghcr|docker|k8s.gcr).io@${REGISTRY_URL}@")"
         docker tag "${IMAGE}" "${REGISTRY_IMAGE}"
         docker push "${REGISTRY_IMAGE}"
     done < <(tar xfO "${AIRGAPPED_TAR_FILE}" "index.json" | grep -oP '(?<="io.containerd.image.name":").*?(?=",)')


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
ran into some small errors in 2.1.1 airgapped docs while running through the docs

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
