### PR TITLE
[DKP 2.2] Fix Numbering in Kommander/Konvoy Upgrade Docs

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -42,7 +42,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
 ## Detach MetalLB from Kommander
 
   <p class="message--important"><strong>IMPORTANT:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
-  
+
   1. Pause the helm release.
   ```bash
   kubectl -n kommander patch -p='{"spec":{"suspend": true}}' --type=merge helmrelease/metallb
@@ -51,38 +51,38 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```sh
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```
-  
-  1. Delete the helm release secret.
+
+  2. Delete the helm release secret.
   ```bash
   kubectl -n kommander delete secret -l name=metallb,owner=helm
   ```
-  ```sh 
+  ```sh
   secret "sh.helm.release.v1.metallb.v1" deleted
   ```
-  
-  1. Delete MetalLB.
+
+  3. Delete MetalLB.
   ```bash
   k -n kommander delete appdeployment metallb
   ```
-  
-  ```sh 
+
+  ```sh
   appdeployment.apps.kommander.d2iq.io "metallb" deleted
   ```
 
-  1. Unpause the helm release.
+  4. Unpause the helm release.
   ```bash
   kubectl -n kommander patch -p='{"spec":{"suspend": false}}' --type=merge helmrelease/metallb
   ```
-  
-  ```sh 
+
+  ```sh
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```
   This deletes MetalLb from Kommander while leaving the resources running in the cluster.
-  
+
   ```bash
   kubectl -n kommander get pod -l app=metallb
   ```
-  
+
   ```sh
   NAME                                 READY   STATUS    RESTARTS   AGE
   metallb-controller-d657c8dbb-zlgrk   1/1     Running   0          20m

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -53,7 +53,7 @@ If you are running on more than one management cluster (Kommander cluster), you 
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Run the following upgrade command for the CAPI components.
+Run the following upgrade command for the CAPI components.
 
 ```bash
 dkp upgrade capi-components
@@ -80,7 +80,7 @@ Your cluster comes preconfigured with a few different core addons that provide f
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Replace `my-aws-cluster` with the name of the cluster.
+Replace `my-aws-cluster` with the name of the cluster.
 
 ```bash
 export CLUSTER_NAME=my-aws-cluster

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -49,7 +49,7 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Run the following upgrade command for the CAPI components.
+Run the following upgrade command for the CAPI components.
 
 ```bash
 dkp upgrade capi-components
@@ -76,7 +76,7 @@ Your cluster comes preconfigured with a few different core addons that provide f
 
 <p class="message--warning"><strong>IMPORTANT:</strong>If you have more than one essential cluster, ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Replace `my-aws-cluster` with the name of the cluster.
+Replace `my-aws-cluster` with the name of the cluster.
 
 ```bash
 export CLUSTER_NAME=my-aws-cluster
@@ -139,7 +139,7 @@ Waiting for node pool update to finish.
 
 Repeat this step for each additional node pool.
 
-For the overall process for upgrading to the latest version of DKP, refer back to [DKP Upgrade][dkpup] 
+For the overall process for upgrading to the latest version of DKP, refer back to [DKP Upgrade][dkpup]
 
 [dkpup]: /dkp/kommander/2.2/dkp-upgrade/
 [upgradekomm]: ../../upgrade-kommander/

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -42,7 +42,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
 ## Detach MetalLB from Kommander
 
   <p class="message--important"><strong>IMPORTANT:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed  MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
-  
+
   1. Pause the helm release.
   ```bash
   kubectl -n kommander patch -p='{"spec":{"suspend": true}}' --type=merge helmrelease/metallb
@@ -51,38 +51,38 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```sh
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```
-  
-  1. Delete the helm release secret.
+
+  2. Delete the helm release secret.
   ```bash
   kubectl -n kommander delete secret -l name=metallb,owner=helm
   ```
-  ```sh 
+  ```sh
   secret "sh.helm.release.v1.metallb.v1" deleted
   ```
-  
-  1. Delete MetalLB.
+
+  3. Delete MetalLB.
   ```bash
   k -n kommander delete appdeployment metallb
   ```
-  
-  ```sh 
+
+  ```sh
   appdeployment.apps.kommander.d2iq.io "metallb" deleted
   ```
 
-  1. Unpause the helm release.
+  4. Unpause the helm release.
   ```bash
   kubectl -n kommander patch -p='{"spec":{"suspend": false}}' --type=merge helmrelease/metallb
   ```
-  
-  ```sh 
+
+  ```sh
   helmrelease.helm.toolkit.fluxcd.io/metallb patched
   ```
   This deletes MetalLb from Kommander while leaving the resources running in the cluster.
-  
+
   ```bash
   kubectl -n kommander get pod -l app=metallb
   ```
-  
+
   ```sh
   NAME                                 READY   STATUS    RESTARTS   AGE
   metallb-controller-d657c8dbb-zlgrk   1/1     Running   0          20m

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -53,7 +53,7 @@ If you are running on more than one management cluster (Kommander cluster), you 
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Run the following upgrade command for the CAPI components.
+Run the following upgrade command for the CAPI components.
 
 ```bash
 dkp upgrade capi-components
@@ -76,11 +76,11 @@ To install the core addons, DKP relies on the `ClusterResourceSet` [Cluster API 
 
 <p class="message--warning"><strong>WARNING:</strong> If you have modified any of the <code>clusterResourceSet</code> definitions, these changes will <strong>not</strong> be preserved when running the command <code>dkp upgrade addons</code>. You must use the <code>--dry-run -o yaml</code> options to save the new configuration to a file and remake the same changes upon each upgrade.</p>
 
-Your cluster comes preconfigured with a few different core addons that provide functionality to your cluster upon creation. These include: CSI, CNI, Cluster Autoscaler, and Node Feature Discovery. New versions of DKP may come pre-bundled with newer versions of these addons. Perform the following steps to update these addons. If you have any additional managed clusters, you will need to upgrade the core addons and Kubernetes version for each one. 
+Your cluster comes preconfigured with a few different core addons that provide functionality to your cluster upon creation. These include: CSI, CNI, Cluster Autoscaler, and Node Feature Discovery. New versions of DKP may come pre-bundled with newer versions of these addons. Perform the following steps to update these addons. If you have any additional managed or attached clusters, you will need to upgrade the core addons and Kubernetes version for each one.
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Replace `my-aws-cluster` with the name of the cluster.
+Replace `my-aws-cluster` with the name of the cluster.
 
 ```bash
 export CLUSTER_NAME=my-aws-cluster
@@ -109,7 +109,7 @@ Once complete, begin upgrading the Kubernetes version.
 
 ## Upgrade the Kubernetes version
 
-When upgrading the Kubernetes version of a cluster, first upgrade the control plane and then the node pools. If you have any additional managed clusters, you will need to upgrade the core addons and Kubernetes version for each one.
+When upgrading the Kubernetes version of a cluster, first upgrade the control plane and then the node pools. If you have any additional managed or attached clusters, you will need to upgrade the core addons and Kubernetes version for each one.
 
 <p class="message--note"><strong>NOTE:</strong> If an AMI was specified when initially creating a cluster, you must build a new one with <a href="/dkp/konvoy/2.2/image-builder/">Konvoy Image Builder</a> and pass it with <code>--ami</code>.
 
@@ -142,7 +142,7 @@ Waiting for node pool update to finish.
 ```
 Repeat this step for each additional node pool.
 
-If you have any additional management or managed clusters, review the [DKP Upgrade][dkpup] documentation for next steps.
+For the overall process for upgrading to the latest version of DKP, refer back to [DKP Upgrade][dkpup]
 
 [dkpup]: ../../
 [upgradekomm]: ../../upgrade-kommander/

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -50,7 +50,7 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Run the following upgrade command for the CAPI components.
+Run the following upgrade command for the CAPI components.
 
 ```bash
 dkp upgrade capi-components
@@ -77,7 +77,7 @@ Your cluster comes preconfigured with a few different core addons that provide f
 
 <p class="message--warning"><strong>IMPORTANT:</strong>If you have more than one essential cluster, ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1. Replace `my-aws-cluster` with the name of the cluster.
+Replace `my-aws-cluster` with the name of the cluster.
 
 ```bash
 export CLUSTER_NAME=my-aws-cluster


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-87506

## Description of changes being made

- Fixed lack of sequential numbering in Detaching MetalLB section of Kommander Upgrade doc
- Removed single step numbering in both Enterprise/Essential upgrade docs in both Konvoy and Kommander repos

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4294.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
