### PR TITLE
docs: updating fips manifest file links

### DIFF
--- a/pages/dkp/konvoy/2.2/fips/validate-fips-in-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/fips/validate-fips-in-cluster/index.md
@@ -14,12 +14,14 @@ You can use the FIPS validation tool to verify that specific components and serv
 
 You need to download an appropriate, signed signature file before you run validation. Use the links in the table that follows to obtain a valid file:
 
-|EL version | Kubernetes version | Manifest URL                |
-|-----------|--------------------|-----------------------------|
-| 7         | v1.21.3            | [v1.21.3 EL 7 Manifest][1-21-3-fips-manifest-7] |
-| 8         | v1.21.3            | [v1.21.3 EL 8 Manifest][1-21-3-fips-manifest-8] |
+|EL version | Kubernetes version | Manifest URL                                    |
+|-----------|--------------------|-------------------------------------------------|
+| 7         | v1.22.8            | [v1.22.8 EL 7 Manifest][1-22-8-fips-manifest-7] |
+| 8         | v1.22.8            | [v1.22.8 EL 8 Manifest][1-22-8-fips-manifest-8] |
 | 7         | v1.21.6            | [v1.21.6 EL 7 Manifest][1-21-6-fips-manifest-7] |
 | 8         | v1.21.6            | [v1.21.6 EL 8 Manifest][1-21-6-fips-manifest-8] |
+| 7         | v1.21.3            | [v1.21.3 EL 7 Manifest][1-21-3-fips-manifest-7] |
+| 8         | v1.21.3            | [v1.21.3 EL 8 Manifest][1-21-3-fips-manifest-8] |
 
 ## Run FIPS validation
 
@@ -74,3 +76,5 @@ In this case, the validation tool checks the cluster using the existing signatur
 [1-21-3-fips-manifest-8]: https://kubernetes-fips.s3.us-east-2.amazonaws.com/tool/manifests/v1.21.6/manifest-rhel8.json.asc
 [1-21-6-fips-manifest-7]: https://kubernetes-fips.s3.us-east-2.amazonaws.com/tool/manifests/v1.21.6/manifest-rhel7.json.asc
 [1-21-6-fips-manifest-8]: https://kubernetes-fips.s3.us-east-2.amazonaws.com/tool/manifests/v1.21.6/manifest-rhel8.json.asc
+[1-22-8-fips-manifest-7]: https://downloads.d2iq.com/dkp/fips/v1.22.8/manifest-rhel7.json.asc
+[1-22-8-fips-manifest-8]: https://downloads.d2iq.com/dkp/fips/v1.22.8/manifest-rhel8.json.asc


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

updating links to fips manifest files

I kept 1.21.xx files in there for this release - but, probably take them out in 2.3

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
