### PR TITLE
[DOC][Konvoy 2.2] vSphere - removed checksum.txt from download list

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-When installing Konvoy for a project, line-of-business, or enterprise, the first step is to determine the infrastructure on which you want to deploy.
+When installing DKP Konvoy for a project, line-of-business, or enterprise, the first step is to determine the infrastructure on which you want to deploy.
 
 The infrastructure you select then determines the specific requirements for a successful installation.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/bootstrap/index.md
@@ -27,7 +27,7 @@ DKP Konvoy deploys all cluster lifecycle services to a bootstrap cluster, which 
 1.  Create a bootstrap cluster with the command:
 
     ```bash
-    ./dkp create bootstrap --kubeconfig $HOME/.kube/config
+    dkp create bootstrap --kubeconfig $HOME/.kube/config
     ```
 
     The output resembles this example:
@@ -73,7 +73,7 @@ DKP Konvoy deploys all cluster lifecycle services to a bootstrap cluster, which 
 1.  Refresh the credentials used by the vSphere provider at any time, using the command:
 
     ```bash
-    ./dkp update bootstrap credentials vsphere
+    dkp update bootstrap credentials vsphere
     ```
 
 Next, you can create a [new vSphere Kubernetes cluster][new-cluster].

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
@@ -18,15 +18,15 @@ When creating an air-gapped vSphere cluster, the bastion VM hosts the installati
 
 1.  Find and record the bastion VM's IP or host name.
 
-1.  [Download][download] the following required Konvoy binaries and installation bundles directly to the bastion host, or transfer them using your environment's approved methods:
+1.  [Download][download] the following required DKP Konvoy binaries and installation bundles appropriate for your environment directly to the bastion host, or transfer them using your environment's approved methods:
 
-    - konvoy_v2.2.0_darwin_amd64.tar.gz
+    - dkp_v2.2.0_darwin_amd64.tar.gz
 
-    - konvoy_v2.2.0_linux_amd64.tar.gz
+    - dkp_v2.2.0_linux_amd64.tar.gz
 
-    - konvoy_image_bundle_v2.2.0_linux_amd64.tar.gz (air-gapped) - This bundle contains air-gapped images that you must push to a registry.)
+    - dkp_image_bundle_v2.2.0_linux_amd64.tar.gz (air-gapped) - This bundle contains air-gapped images that you must push to a registry.)
 
-    - konvoy-bootstrap_v2.2.0.tar (air-gapped) - This bundle contains the KIND bootstrap image to load with the `docker load` command when you create the bootstrap cluster in a later step.
+    - dkp-bootstrap_v2.2.0.tar (air-gapped) - This bundle contains the KIND bootstrap image to load with the `docker load` command when you create the bootstrap cluster in a later step.
 
 1.  Use your credentials to SSH into the bastion VM host with the command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
@@ -20,8 +20,6 @@ When creating an air-gapped vSphere cluster, the bastion VM hosts the installati
 
 1.  [Download][download] the following required Konvoy binaries and installation bundles directly to the bastion host, or transfer them using your environment's approved methods:
 
-    - konvoy_v2.2.0_checksums.txt
-
     - konvoy_v2.2.0_darwin_amd64.tar.gz
 
     - konvoy_v2.2.0_linux_amd64.tar.gz

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
@@ -65,8 +65,6 @@ Before you start, make sure you have [created a workload cluster][create-new-clu
     The output resembles the following example:
 
     ```sh
-        The output resembles this example:
-
     NAME                                       STATUS   ROLES                  AGE   VERSION
     d2iq-e2e-cluster-1-control-plane-7llgd     Ready    control-plane,master   20h   v1.22.8
     d2iq-e2e-cluster-1-control-plane-vncbl     Ready    control-plane,master   19h   v1.22.8

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/index.md
@@ -14,6 +14,8 @@ The overall process for configuring vSphere and DKP together includes the follow
 
 1.   Configure vSphere to provide the needed elements, described in the [Prerequisites][prerequisites].
 
+1.   Create a bastion VM host if you are using an air-gapped environment.
+
 1.   Create a base OS image.
 
 1.   Create a CAPI VM image that uses the base OS image and adds the needed Kubernetes cluster components.
@@ -21,6 +23,8 @@ The overall process for configuring vSphere and DKP together includes the follow
 1.   Create a bootstrap cluster.
 
 1.   Create a new DKP cluster on vSphere.
+
+1.   Make the cluster self-managing.
 
 1.   Explore the cluster and perform other functions as needed.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/metal-lb/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/metal-lb/index.md
@@ -37,7 +37,7 @@ data:
 EOF
 ```
 
-Once complete, run the following `kubectl` command.
+When complete, run the following `kubectl` command.
 
 ```sh
 kubectl apply -f metallb-conf.yaml
@@ -76,7 +76,8 @@ data:
       - 192.168.10.0/24
 EOF
 ```
-Once complete, run the following `kubectl` command.
+
+When complete, run the following `kubectl` command:
 
 ```sh
 kubectl apply -f metallb-conf.yaml

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/new/index.md
@@ -40,7 +40,7 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 1.  Generate the Kubernetes cluster objects by copying and editing this command to include the correct values, including the VM template name you assigned in the previous procedure:
 
     ```bash
-    konvoy create cluster vsphere \
+    dkp create cluster vsphere \
       --cluster-name ${CLUSTER_NAME} \
       --network <NETWORK_NAME> \
       --control-plane-endpoint-host <xxx.yyy.zzz.000> \

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/nodepools/create/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/nodepools/create/index.md
@@ -55,9 +55,7 @@ kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/example created
  ✓ Creating default/example nodepool resources
 ```
 
-This example uses default values for brevity. Use flags to define %%% parm1, parm2, and other properties.
-
-Advanced users can use a combination of the `--dry-run` and `--output=yaml` flags to get a complete set of node pool objects to modify locally or store in version control.
+This example uses default values for brevity. Advanced users can use a combination of the `--dry-run` and `--output=yaml` flags to get a complete set of node pool objects to modify locally or store in version control.
 
 [makeselfmanaged]: ../../self-managed/
 [createnewcluster]: ../../new/

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/replace-node/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/replace-node/index.md
@@ -11,7 +11,7 @@ menuWeight: 90
 
 Before you begin, you must:
 
-- [Create a workload cluster][createnewcluster].
+- [Create a workload cluster][createnewcluster] or [create an air-gapped workload cluster][createnewairgappedcluster].
 
 - [Make the new cluster self-managed][selfmanaged].
 
@@ -74,7 +74,7 @@ In certain situations, you may want to delete a worker node and have [Cluster AP
     d2iq-e2e-cluster-1-md-0   d2iq-e2e-cluster-1   4          3       4         1             ScalingUp   20h   v1.22.8
     ```
 
-    There exist 4 replicas, but only 3 are ready. One replica is unavailable, and the `ScalingUp` phase means a new Machine is being created.
+    In this example, there exist 4 replicas, but only 3 are ready. One replica is unavailable, and the `ScalingUp` phase means a new Machine is being created.
 
 1.  Identify the replacement Machine using this command:
 
@@ -110,5 +110,6 @@ In certain situations, you may want to delete a worker node and have [Cluster AP
 --->
 
 [createnewcluster]: ../new
+[createnewairgappedcluster]: ../air-gapped/new/
 [selfmanaged]: ../self-managed
 [capi_book]: https://cluster-api.sigs.k8s.io/


### PR DESCRIPTION
## Jira Ticket

(https://jira.d2iq.com/browse/D2IQ-87508)

## Description of changes being made
Craig noted in a Slack DM that I needed to remove the bullet point about checksum.txt from the "Create a Bastion VM Host" topic in Choose infrastructure --> vSphere --> Air-gapped, and I forgot to do it as part of the larger PR. Done now.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4296.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
