### PR TITLE
docs: updating links for konv download page

### DIFF
--- a/pages/dkp/kommander/2.2/download/index.md
+++ b/pages/dkp/kommander/2.2/download/index.md
@@ -37,4 +37,4 @@ dkp binary is placed in the local directory, to run:
 ./dkp --help
 ```
 
-You will now see the dkp binary in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+You will now see the `dkp` binary in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.

--- a/pages/dkp/konvoy/2.2/download/index.md
+++ b/pages/dkp/konvoy/2.2/download/index.md
@@ -16,7 +16,7 @@ To download a new version of DKP, you have 2 options:
 
 [button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download DKP[/button]
 
-<p class="message--note"><strong>NOTE: </strong> In DKP 2.2 the Konvoy and Kommander binaries have been merged into a single binary, which you can find by selecting the DKP button above.
+<p class="message--note"><strong>NOTE: </strong> In DKP 2.2, the Konvoy and Kommander binaries have been merged into a single binary, which you can find by selecting the Download DKP button above.
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
 
@@ -37,4 +37,4 @@ dkp binary is placed in the local directory, to run:
 ./dkp --help
 ```
 
-You will now see the `dkp` binary in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+You will now see the `dkp` binary in your working directory. Follow the [Kommander installation instructions](/dkp/kommander/2.2/install/networked) using these binaries, and then [add your license](/dkp/kommander/2.2/licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

Fixing links in the konvoy download page to point to Kommander.
some minor nit to just make the two download pages the same, too.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4299.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
