### PR TITLE
docs: fix excerpts and links for cluster mgmt

### DIFF
--- a/pages/dkp/kommander/2.0/clusters/applications/index.md
+++ b/pages/dkp/kommander/2.0/clusters/applications/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Cluster Applications
 title: Cluster Applications
 menuWeight: 10
-excerpt:
+excerpt: A guide for applications installed on your cluster
 ---
 
 ## Applications

--- a/pages/dkp/kommander/2.0/clusters/management-cluster/index.md
+++ b/pages/dkp/kommander/2.0/clusters/management-cluster/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Management Cluster
 title: Management Cluster
 menuWeight: 7
-excerpt:
+excerpt: A guide to the Management Cluster
 ---
 
 When you install Kommander, the host cluster is attached in the Kommander Workspace as the Management Cluster. This allows the Management Cluster to be included in [Projects](../../projects/)<!-- and enables the management of its [Platform Services](../../workspaces/workspace-platform-services/) from the Kommander Workspace-->.

--- a/pages/dkp/kommander/2.1/clusters/applications/index.md
+++ b/pages/dkp/kommander/2.1/clusters/applications/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Cluster Applications
 title: Cluster Applications
 menuWeight: 50
-excerpt:
+excerpt: A guide for applications installed on your cluster
 ---
 
 ## Applications

--- a/pages/dkp/kommander/2.1/clusters/management-cluster/index.md
+++ b/pages/dkp/kommander/2.1/clusters/management-cluster/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Management Cluster
 title: Management Cluster
 menuWeight: 40
-excerpt:
+excerpt: A guide for the Management Cluster and the Management Cluster Workspace
 ---
 
 When you install Kommander, the host cluster is attached in the **Management Cluster Workspace** as the **Management Cluster**, called **Management Cluster** in the Global workspace dashboard and **Kommander Host** inside the Management Cluster Workspace. This allows the Management Cluster to be included in [Projects](../../projects/) and enables the management of its [Platform Applications](../../workspaces/applications/platform-applications/) from the Management Cluster Workspace.

--- a/pages/dkp/kommander/2.2/clusters/applications/index.md
+++ b/pages/dkp/kommander/2.2/clusters/applications/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Cluster Applications
 title: Cluster Applications
 menuWeight: 50
-excerpt:
+excerpt: A guide for applications installed on your cluster
 ---
 
 ## Application Dashboards
@@ -30,5 +30,5 @@ Cluster applications can have one of the following statuses:
 
 Review the [workspace application resource requirements][application_req] to ensure that the attached clusters have sufficient resources. For more information on applications and how to customize them, see [workspace applications][workspace_applications].
 
-[workspace_applications]: ../../workspaces/applications/platform-applications/
-[application_req]: ../../workspaces/applications/platform-applications/platform-service-requirements/
+[workspace_applications]: ../../workspaces/applications/platform-applications
+[application_req]: ../../workspaces/applications/platform-applications/platform-service-requirements

--- a/pages/dkp/kommander/2.2/clusters/management-cluster/index.md
+++ b/pages/dkp/kommander/2.2/clusters/management-cluster/index.md
@@ -3,10 +3,10 @@ layout: layout.pug
 navigationTitle: Management Cluster
 title: Management Cluster
 menuWeight: 40
-excerpt:
+excerpt: A guide for the Management Cluster and the Management Cluster Workspace
 ---
 
-When you install Kommander, the host cluster is attached in the **Management Cluster Workspace** as the **Management Cluster**, called **Management Cluster** in the Global workspace dashboard and **Kommander Host** inside the Management Cluster Workspace. This allows the Management Cluster to be included in [Projects](../../projects/) and enables the management of its [Platform Applications](../..workspaces./applications/platform-applications/) from the Management Cluster Workspace.
+When you install Kommander, the host cluster is attached in the **Management Cluster Workspace** as the **Management Cluster**, called **Management Cluster** in the Global workspace dashboard and **Kommander Host** inside the Management Cluster Workspace. This allows the Management Cluster to be included in [Projects](../../projects/) and enables the management of its [Platform Applications](../../workspaces/applications/platform-applications/) from the Management Cluster Workspace.
 
 <p class="message--note"><strong>NOTE: </strong>Do not attach a cluster in the "Management Cluster Workspace" workspace. This workspace is reserved for your Kommander Management cluster only.</p>
 


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

This page didn't have an excerpt and is just pulling the rest of the content from the page, looking weird in the UI on the parent page in the cards at the bottom.
also had a broken link in there.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
