### PR TITLE
docs: note attaching cluster with cert-manager

### DIFF
--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -74,9 +74,9 @@ Consider the additional resource requirements for running the platform services 
 
 ## Attach clusters with an existing cert-manager installation
 
-If you are attaching clusters that already have cert-manager installed, the cert-manager `HelmRelease` provided by Kommander will fail to deploy, due to the existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this failure, it will have no impact on the operation of the cluster.
+If you are attaching clusters that already have cert-manager installed, the cert-manager `HelmRelease` provided by Kommander will fail to deploy, due to the existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this failure. It will have no impact on the operation of the cluster.
 
-<p class="message--note"><strong>NOTE: </strong>Clusters provisioned using `dkp` (Konvoy2 clusters) have cert-manager installed. Kommander's cert-manager `HelmRelease` will fail to deploy on a Konvoy cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>Clusters provisioned using <code>dkp</code> (Konvoy2 clusters) have cert-manager installed. Kommander's cert-manager <code>HelmRelease</code> will fail to deploy on a Konvoy cluster.</p>
 
 [attach_eks_cluster]: ../attach-eks-cluster
 [attach_with_network_restrictions]: ../cluster-with-network-restrictions

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -74,7 +74,7 @@ Consider the additional resource requirements for running the platform services 
 
 ## Attach clusters with an existing cert-manager installation
 
-If you are attaching clusters that already have cert-manager installed, the cert-manager HelmRelease provided by Kommander will fail to deploy, due to your existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this.
+If you are attaching clusters that already have cert-manager installed, the cert-manager HelmRelease provided by Kommander will fail to deploy, due to the existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this failure, it will have no impact on the operation of the cluster.
 
 [attach_eks_cluster]: ../attach-eks-cluster
 [attach_with_network_restrictions]: ../cluster-with-network-restrictions

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -72,6 +72,10 @@ To attach an existing EKS cluster, refer to the specific information in [Attach 
 Consider the additional resource requirements for running the platform services you want Kommander to manage, and ensure that your existing clusters comply.
 -->
 
+## Attaching existing clusters that has cert-manager installed
+
+If you are attaching clusters that has cert-manager installed, the Kommander provided cert-manager HelmRelease will fail to deploy due to your existing cert-manager installation. As long as the pre-existing cert-manager is functioning as expected, this is safe to ignore.
+
 [attach_eks_cluster]: ../attach-eks-cluster
 [attach_with_network_restrictions]: ../cluster-with-network-restrictions
 [existing-clusters]: ../generate-kubeconfig

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -72,9 +72,9 @@ To attach an existing EKS cluster, refer to the specific information in [Attach 
 Consider the additional resource requirements for running the platform services you want Kommander to manage, and ensure that your existing clusters comply.
 -->
 
-## Attaching existing clusters that has cert-manager installed
+## Attach clusters with an existing cert-manager installation
 
-If you are attaching clusters that has cert-manager installed, the Kommander provided cert-manager HelmRelease will fail to deploy due to your existing cert-manager installation. As long as the pre-existing cert-manager is functioning as expected, this is safe to ignore.
+If you are attaching clusters that already have cert-manager installed, the cert-manager HelmRelease provided by Kommander will fail to deploy, due to your existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this.
 
 [attach_eks_cluster]: ../attach-eks-cluster
 [attach_with_network_restrictions]: ../cluster-with-network-restrictions

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -76,6 +76,8 @@ Consider the additional resource requirements for running the platform services 
 
 If you are attaching clusters that already have cert-manager installed, the cert-manager `HelmRelease` provided by Kommander will fail to deploy, due to the existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this failure, it will have no impact on the operation of the cluster.
 
+<p class="message--note"><strong>NOTE: </strong>Clusters provisioned using `dkp` (Konvoy2 clusters) have cert-manager installed. Kommander's cert-manager `HelmRelease` will fail to deploy on a Konvoy cluster.</p>
+
 [attach_eks_cluster]: ../attach-eks-cluster
 [attach_with_network_restrictions]: ../cluster-with-network-restrictions
 [existing-clusters]: ../generate-kubeconfig

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -74,7 +74,7 @@ Consider the additional resource requirements for running the platform services 
 
 ## Attach clusters with an existing cert-manager installation
 
-If you are attaching clusters that already have cert-manager installed, the cert-manager HelmRelease provided by Kommander will fail to deploy, due to the existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this failure, it will have no impact on the operation of the cluster.
+If you are attaching clusters that already have cert-manager installed, the cert-manager `HelmRelease` provided by Kommander will fail to deploy, due to the existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this failure, it will have no impact on the operation of the cluster.
 
 [attach_eks_cluster]: ../attach-eks-cluster
 [attach_with_network_restrictions]: ../cluster-with-network-restrictions

--- a/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
+++ b/pages/dkp/kommander/2.2/clusters/attach-cluster/requirements-for-attaching/index.md
@@ -76,7 +76,7 @@ Consider the additional resource requirements for running the platform services 
 
 If you are attaching clusters that already have cert-manager installed, the cert-manager `HelmRelease` provided by Kommander will fail to deploy, due to the existing cert-manager installation. As long as the pre-existing cert-manager functions as expected, you can ignore this failure. It will have no impact on the operation of the cluster.
 
-<p class="message--note"><strong>NOTE: </strong>Clusters provisioned using <code>dkp</code> (Konvoy2 clusters) have cert-manager installed. Kommander's cert-manager <code>HelmRelease</code> will fail to deploy on a Konvoy cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>DKP Konvoy clusters already have cert-manager installed, hence Kommander's cert-manager <code>HelmRelease</code> will fail to deploy on a DKP Konvoy cluster.</p>
 
 [attach_eks_cluster]: ../attach-eks-cluster
 [attach_with_network_restrictions]: ../cluster-with-network-restrictions

--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -324,10 +324,6 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
     EOF
     ```
 
-### Attach clusters with an existing cert-manager installation
-
-If you are attaching clusters that already have cert-manager installed, it will take at least 20 minutes for Kommander `HelmReleases` to show up (for example, `traefik`, `kube-prometheus-stack` …) This is due to the implementation of the Kommander prerequisite Job that ensures security during Kommander's roll-out to the incoming attached cluster. The team is looking to address this in a future release.
-
 #### Default update strategy changed to "delete first" for Preprovisioned clusters
 
 A "create first" update strategy first creates a new machine, then deletes the old one. While this strategy works when machine inventory can grow on demand, it does not work if there is a fixed number of machines. Most Preprovisioned clusters have a fixed number of machines. To enable updates for Preprovisioned clusters, DKP uses the "delete first" update strategy, which first deletes an old machine, then creates a new one.

--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -149,29 +149,37 @@ spec:
             usernameClaim: email
 [...]
 ```
+
 ### Spark operator failure workaround
 
 Upgrading catalog applications using Spark Operator can fail when running `dkp upgrade catalogapp` due to the operator not starting. If this occurs, use the following workaround:
 
-1. Run the `dkp upgrade catalogapp` command.
-1. Monitor the failure of `spark-operator`.
-1. Get the workspace namespace name and export it.
-   ```bash
-   export WORKSPACE_NAMESPACE=<SPARK_OPERATOR_WS_NS>
-   ```
-1. Export the spark-operator AppDeployment name.
+1.  Run the `dkp upgrade catalogapp` command.
+1.  Monitor the failure of `spark-operator`.
+1.  Get the workspace namespace name and export it.
+
+    ```bash
+    export WORKSPACE_NAMESPACE=<SPARK_OPERATOR_WS_NS>
+    ```
+
+1.  Export the spark-operator AppDeployment name.
+
     ```bash
     # e.g., this value can be spark-operator-1
     export SPARK_APPD_NAME=$(kubectl get appdeployment -n $WORKSPACE_NAMESPACE -o jsonpath='{range .items[*]} {.metadata.name}{"\n"}{end}' | grep spark)
     ```
-1. Export the service account name of your `spark-operator`.
+
+1.  Export the service account name of your `spark-operator`.
+
     ```bash
     # if your provided values override, please look it up in that ConfigMap
     # this is the default value defined in spark-operator-1.1.6-d2iq-defaults ConfigMap
     export SPARK_OPERATOR_SERVICE_ACCOUNT=spark-operator-service-account
     ```
-1. Run the following command.
-   ```bash
+
+1.  Run the following command.
+
+    ```bash
     kubectl apply -f - <<EOF
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -318,7 +326,7 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
 
 ### Attach clusters with an existing cert-manager installation
 
-If you are attaching clusters that already have cert-manager installed, it will take at least 20 minutes for Kommander `HelmReleases` to show up(for example, traefik, kube-prometheus-stack..) This is due to the implementation of the Kommander prerequisite Job that ensures security during Kommander's roll-out to the incoming attached cluster. The team is looking to address this in a future release.
+If you are attaching clusters that already have cert-manager installed, it will take at least 20 minutes for Kommander `HelmReleases` to show up (for example, `traefik`, `kube-prometheus-stack` …) This is due to the implementation of the Kommander prerequisite Job that ensures security during Kommander's roll-out to the incoming attached cluster. The team is looking to address this in a future release.
 
 #### Default update strategy changed to "delete first" for Preprovisioned clusters
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -315,6 +315,11 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
     namespace: $WORKSPACE_NAMESPACE
     EOF
     ```
+
+### Attach clusters with an existing cert-manager installation
+
+If you are attaching clusters that already have cert-manager installed, it will take at least 20 minutes for Kommander `HelmReleases` to show up(for example, traefik, kube-prometheus-stack..) This is due to the implementation of the Kommander prerequisite Job that ensures security during Kommander's roll-out to the incoming attached cluster. The team is looking to address this in a future release.
+
 #### Default update strategy changed to "delete first" for Preprovisioned clusters
 
 A "create first" update strategy first creates a new machine, then deletes the old one. While this strategy works when machine inventory can grow on demand, it does not work if there is a fixed number of machines. Most Preprovisioned clusters have a fixed number of machines. To enable updates for Preprovisioned clusters, DKP uses the "delete first" update strategy, which first deletes an old machine, then creates a new one.


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

Added a note to mention about attaching clusters that has cert-manager installed. This is a known issue since 2.1 and it is not as harmful as it looks on the surface.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
