### PR TITLE
[Kaptain] Separate uninstall topic

### DIFF
--- a/install/konvoy-dkp/index.md
+++ b/install/konvoy-dkp/index.md
@@ -170,15 +170,6 @@ Once all components have been deployed, you can log in to Kaptain:
     kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}'
     ```
 
-## Uninstall Kaptain
-
-* Use the following commands to uninstall Kaptain.
-  ```bash
-  kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
-  kubectl delete operatorversions.kudo.dev kubeflow-1.4.0-1.3.0 --namespace kubeflow
-  kubectl delete operators.kudo.dev kubeflow --namespace kubeflow
-  ```
-
 [download]: ../../download/
 [install-spark-dkp2]: /dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/
 [install-spark-konvoy1]: /dkp/kommander/1.4/projects/platform-services/platform-services-catalog/kudo-spark/

--- a/pages/dkp/kaptain/2.0.0/install/uninstall/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/uninstall/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 ## Uninstall Kaptain
 
--   Use the following commands to uninstall Kaptain.
+-   Use the following commands to uninstall Kaptain:
 
     ```bash
     kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait

--- a/pages/dkp/kaptain/2.0.0/install/uninstall/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/uninstall/index.md
@@ -1,0 +1,19 @@
+---
+layout: layout.pug
+navigationTitle: Uninstall Kaptain
+title: Uninstall Kaptain
+menuWeight: 80
+excerpt: Uninstall Kaptain
+beta: false
+enterprise: false
+---
+
+## Uninstall Kaptain
+
+-   Use the following commands to uninstall Kaptain.
+
+    ```bash
+    kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
+    kubectl delete operatorversions.kudo.dev kubeflow-1.4.0-1.3.0 --namespace kubeflow
+    kubectl delete operators.kudo.dev kubeflow --namespace kubeflow
+    ```


### PR DESCRIPTION
## Description of changes being made

Copied this over from https://docs.d2iq.com/dkp/kaptain/1.3.0/install/konvoy-dkp/#uninstall-kaptain since we wanted to have an 'Uninstall' topic on its own and in a separate place. 
Please check if these steps are still valid for 2.0 and all environment setups (air-gapped, on-prem, networked) 

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

