### PR TITLE
docs: Restructure upgrade path table

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/index.md
@@ -11,11 +11,6 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
 
 ## Supported upgrade paths
 
-|**Display Icon** | **Service** |
-|---------- | ------- |
-| ⚫ | Supported |
-| ◯ | Not Supported |
-
 <table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
    <caption>DKP Upgrade Paths</caption>
    <tr>
@@ -32,31 +27,31 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
    </tr>
    <tr>
     <th>1.8.4</th>
-    <td Align = "center">⚫</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">◯</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">No</td>
    </tr>
    <tr>
     <th>1.8.5</th>
-    <td Align = "center">◯</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">◯</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">No</td>
    </tr>
    <tr>
     <th>2.1.0</th>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">⚫</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">No</td>
+    <td Align = "center">Yes</td>
    </tr>
    <tr>
     <th>2.1.1</th>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">⚫</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">Yes</td>
    </tr>
   </table>
 

--- a/pages/dkp/kommander/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/index.md
@@ -9,16 +9,56 @@ beta: false
 
 The DKP upgrade represents an important step of your environment's lifecycle, as it ensures that you are up-to-date with the latest features and can benefit from the most recent improvements, enhanced cluster management, and better performance. This section describes how to upgrade your networked, air-gapped, or on-prem environment to the latest version of DKP.
 
-## Upgrade paths
+## Supported upgrade paths
 
-Verified upgrade paths are as follows:
+|**Display Icon** | **Service** |
+|---------- | ------- |
+| ⚫ | Supported |
+| ◯ | Not Supported |
 
-| From Version | To Version |       |       |
-| :----------: | :--------: | :---: | :---: |
-|    1.8.4     |   1.8.5    | 2.1.0 | 2.1.1 |
-|    1.8.5     |   2.1.0    | 2.1.1 |       |
-|    2.1.0     |   2.2.0    |       |       |
-|    2.1.1     |   2.2.0    |       |       |
+<table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
+   <caption>DKP Upgrade Paths</caption>
+   <tr>
+    <th Rowspan = "20" Align = "center"><strong>Upgrade<br>From</strong></th>
+   <tr>
+    <th></th>
+    <th Colspan = "20" Align = "center"><strong>Upgrade To</strong></th>
+   </tr>
+    <th></th>
+    <th Align = "center">1.8.5</th>
+    <th Align = "center">2.1.0</th>
+    <th Align = "center">2.1.1</th>
+    <th Align = "center">2.2.0</th>
+   </tr>
+   <tr>
+    <th>1.8.4</th>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.8.5</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>2.1.0</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>2.1.1</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+   </tr>
+  </table>
 
 ## Understand the upgrade process
 

--- a/pages/dkp/kommander/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/index.md
@@ -34,23 +34,23 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
    </tr>
    <tr>
     <th>1.8.5</th>
-    <td Align = "center">N/A</td>
+    <td Align = "center"></td>
     <td Align = "center">Yes</td>
     <td Align = "center">Yes</td>
     <td Align = "center">No</td>
    </tr>
    <tr>
     <th>2.1.0</th>
-    <td Align = "center">N/A</td>
-    <td Align = "center">N/A</td>
+    <td Align = "center"></td>
+    <td Align = "center"></td>
     <td Align = "center">No</td>
     <td Align = "center">Yes</td>
    </tr>
    <tr>
     <th>2.1.1</th>
-    <td Align = "center">N/A</td>
-    <td Align = "center">N/A</td>
-    <td Align = "center">N/A</td>
+    <td Align = "center"></td>
+    <td Align = "center"></td>
+    <td Align = "center"></td>
     <td Align = "center">Yes</td>
    </tr>
   </table>

--- a/pages/dkp/kommander/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/index.md
@@ -11,49 +11,12 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
 
 ## Supported upgrade paths
 
-<table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
-   <caption>DKP Upgrade Paths</caption>
-   <tr>
-    <th Rowspan = "20" Align = "center"><strong>Upgrade<br>From</strong></th>
-   <tr>
-    <th></th>
-    <th Colspan = "20" Align = "center"><strong>Upgrade To</strong></th>
-   </tr>
-    <th></th>
-    <th Align = "center">1.8.5</th>
-    <th Align = "center">2.1.0</th>
-    <th Align = "center">2.1.1</th>
-    <th Align = "center">2.2.0</th>
-   </tr>
-   <tr>
-    <th>1.8.4</th>
-    <td Align = "center">Yes</td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">No</td>
-   </tr>
-   <tr>
-    <th>1.8.5</th>
-    <td Align = "center"></td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">No</td>
-   </tr>
-   <tr>
-    <th>2.1.0</th>
-    <td Align = "center"></td>
-    <td Align = "center"></td>
-    <td Align = "center">No</td>
-    <td Align = "center">Yes</td>
-   </tr>
-   <tr>
-    <th>2.1.1</th>
-    <td Align = "center"></td>
-    <td Align = "center"></td>
-    <td Align = "center"></td>
-    <td Align = "center">Yes</td>
-   </tr>
-  </table>
+| From Version | To Version |       |       |
+| :----------: | :--------: | :---: | :---: |
+|    1.8.4     |   1.8.5    | 2.1.0 | 2.1.1 |
+|    1.8.5     |   2.1.0    | 2.1.1 |       |
+|    2.1.0     |   2.2.0    |       |       |
+|    2.1.1     |   2.2.0    |       |       |
 
 ## Understand the upgrade process
 

--- a/pages/dkp/kommander/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/index.md
@@ -13,12 +13,12 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
 
 Verified upgrade paths are as follows:
 
-| To    | From | 1.8.4 | 1.8.5 | 2.1.0 | 2.1.1 |
-|-------|------|:-----:|:-----:|:-----:|:-----:|
-| 1.8.5 |      | Yes   |       |       |       |
-| 2.1.0 |      | Yes   | Yes   |       |       |
-| 2.1.1 |      | Yes   | Yes   | No    |       |
-| 2.2.0 |      | No    | No    | Yes   | Yes   |
+| From Version | To Version |       |       |
+| :----------: | :--------: | :---: | :---: |
+|    1.8.4     |   1.8.5    | 2.1.0 | 2.1.1 |
+|    1.8.5     |   2.1.0    | 2.1.1 |       |
+|    2.1.0     |   2.2.0    |       |       |
+|    2.1.1     |   2.2.0    |       |       |
 
 ## Understand the upgrade process
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
@@ -11,11 +11,6 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
 
 ## Supported upgrade paths
 
-|**Display Icon** | **Service** |
-|---------- | ------- |
-| ⚫ | Supported |
-| ◯ | Not Supported |
-
 <table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
    <caption>DKP Upgrade Paths</caption>
    <tr>
@@ -32,31 +27,31 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
    </tr>
    <tr>
     <th>1.8.4</th>
-    <td Align = "center">⚫</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">◯</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">No</td>
    </tr>
    <tr>
     <th>1.8.5</th>
-    <td Align = "center">◯</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">⚫</td>
-    <td Align = "center">◯</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">Yes</td>
+    <td Align = "center">No</td>
    </tr>
    <tr>
     <th>2.1.0</th>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">⚫</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">No</td>
+    <td Align = "center">Yes</td>
    </tr>
    <tr>
     <th>2.1.1</th>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">◯</td>
-    <td Align = "center">⚫</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">N/A</td>
+    <td Align = "center">Yes</td>
    </tr>
   </table>
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
@@ -9,17 +9,16 @@ beta: false
 
 The DKP upgrade represents an important step of your environment's lifecycle, as it ensures that you are up-to-date with the latest features and can benefit from the most recent improvements, enhanced cluster management, and better performance. This section describes how to upgrade your networked, air-gapped, or on-prem environment to the latest version of DKP.
 
-
 ## Upgrade paths
 
 Verified upgrade paths are as follows:
 
-| To    | From | 1.8.4 | 1.8.5 | 2.1.0 | 2.1.1 |
-|-------|------|:-----:|:-----:|:-----:|:-----:|
-| 1.8.5 |      | Yes   |       |       |       |
-| 2.1.0 |      | Yes   | Yes   |       |       |
-| 2.1.1 |      | Yes   | Yes   | No    |       |
-| 2.2.0 |      | No    | No    | Yes   | Yes   |
+| From Version | To Version |       |       |
+| :----------: | :--------: | :---: | :---: |
+|    1.8.4     |   1.8.5    | 2.1.0 | 2.1.1 |
+|    1.8.5     |   2.1.0    | 2.1.1 |       |
+|    2.1.0     |   2.2.0    |       |       |
+|    2.1.1     |   2.2.0    |       |       |
 
 ## Understand the upgrade process
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
@@ -9,16 +9,56 @@ beta: false
 
 The DKP upgrade represents an important step of your environment's lifecycle, as it ensures that you are up-to-date with the latest features and can benefit from the most recent improvements, enhanced cluster management, and better performance. This section describes how to upgrade your networked, air-gapped, or on-prem environment to the latest version of DKP.
 
-## Upgrade paths
+## Supported upgrade paths
 
-Verified upgrade paths are as follows:
+|**Display Icon** | **Service** |
+|---------- | ------- |
+| ⚫ | Supported |
+| ◯ | Not Supported |
 
-| From Version | To Version |       |       |
-| :----------: | :--------: | :---: | :---: |
-|    1.8.4     |   1.8.5    | 2.1.0 | 2.1.1 |
-|    1.8.5     |   2.1.0    | 2.1.1 |       |
-|    2.1.0     |   2.2.0    |       |       |
-|    2.1.1     |   2.2.0    |       |       |
+<table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
+   <caption>DKP Upgrade Paths</caption>
+   <tr>
+    <th Rowspan = "20" Align = "center"><strong>Upgrade<br>From</strong></th>
+   <tr>
+    <th></th>
+    <th Colspan = "20" Align = "center"><strong>Upgrade To</strong></th>
+   </tr>
+    <th></th>
+    <th Align = "center">1.8.5</th>
+    <th Align = "center">2.1.0</th>
+    <th Align = "center">2.1.1</th>
+    <th Align = "center">2.2.0</th>
+   </tr>
+   <tr>
+    <th>1.8.4</th>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>1.8.5</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">⚫</td>
+    <td Align = "center">◯</td>
+   </tr>
+   <tr>
+    <th>2.1.0</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+   </tr>
+   <tr>
+    <th>2.1.1</th>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">◯</td>
+    <td Align = "center">⚫</td>
+   </tr>
+  </table>
 
 ## Understand the upgrade process
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
@@ -34,23 +34,23 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
    </tr>
    <tr>
     <th>1.8.5</th>
-    <td Align = "center">N/A</td>
+    <td Align = "center"></td>
     <td Align = "center">Yes</td>
     <td Align = "center">Yes</td>
     <td Align = "center">No</td>
    </tr>
    <tr>
     <th>2.1.0</th>
-    <td Align = "center">N/A</td>
-    <td Align = "center">N/A</td>
+    <td Align = "center"></td>
+    <td Align = "center"></td>
     <td Align = "center">No</td>
     <td Align = "center">Yes</td>
    </tr>
    <tr>
     <th>2.1.1</th>
-    <td Align = "center">N/A</td>
-    <td Align = "center">N/A</td>
-    <td Align = "center">N/A</td>
+    <td Align = "center"></td>
+    <td Align = "center"></td>
+    <td Align = "center"></td>
     <td Align = "center">Yes</td>
    </tr>
   </table>

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
@@ -11,49 +11,12 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
 
 ## Supported upgrade paths
 
-<table style="border-collapse: collapse;" Border = "1" Cellpadding = "5" Cellspacing = "5">
-   <caption>DKP Upgrade Paths</caption>
-   <tr>
-    <th Rowspan = "20" Align = "center"><strong>Upgrade<br>From</strong></th>
-   <tr>
-    <th></th>
-    <th Colspan = "20" Align = "center"><strong>Upgrade To</strong></th>
-   </tr>
-    <th></th>
-    <th Align = "center">1.8.5</th>
-    <th Align = "center">2.1.0</th>
-    <th Align = "center">2.1.1</th>
-    <th Align = "center">2.2.0</th>
-   </tr>
-   <tr>
-    <th>1.8.4</th>
-    <td Align = "center">Yes</td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">No</td>
-   </tr>
-   <tr>
-    <th>1.8.5</th>
-    <td Align = "center"></td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">Yes</td>
-    <td Align = "center">No</td>
-   </tr>
-   <tr>
-    <th>2.1.0</th>
-    <td Align = "center"></td>
-    <td Align = "center"></td>
-    <td Align = "center">No</td>
-    <td Align = "center">Yes</td>
-   </tr>
-   <tr>
-    <th>2.1.1</th>
-    <td Align = "center"></td>
-    <td Align = "center"></td>
-    <td Align = "center"></td>
-    <td Align = "center">Yes</td>
-   </tr>
-  </table>
+| From Version | To Version |       |       |
+| :----------: | :--------: | :---: | :---: |
+|    1.8.4     |   1.8.5    | 2.1.0 | 2.1.1 |
+|    1.8.5     |   2.1.0    | 2.1.1 |       |
+|    2.1.0     |   2.2.0    |       |       |
+|    2.1.1     |   2.2.0    |       |       |
 
 ## Understand the upgrade process
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
I was reading through the docs and the table was hard for me to understand at first glance. My mind wants to read the table from left to right so i can find my current version and see all the versions I can upgrade to. I would like to have a different table format but that would require using an HTML table instead of markdown :(. 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4308.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
