### PR TITLE
docs: Update spark permissions

### DIFF
--- a/pages/dkp/kommander/2.1/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
+++ b/pages/dkp/kommander/2.1/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
@@ -47,6 +47,12 @@ Follow these steps:
         - apiGroups: [""]
           resources: ["services"]
           verbs: ["*"]
+        - apiGroups: [""]
+          resources: ["configmaps"]
+          verbs: ["*"]
+        - apiGroups: [""]
+          resources: ["persistentvolumeclaims"]
+          verbs: ["*"]
         ---
         apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding

--- a/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/catalog-applications/dkp-applications/custom-resources-workspace-catalog/spark/index.md
@@ -47,6 +47,12 @@ Follow these steps:
         - apiGroups: [""]
           resources: ["services"]
           verbs: ["*"]
+        - apiGroups: [""]
+          resources: ["configmaps"]
+          verbs: ["*"]
+        - apiGroups: [""]
+          resources: ["persistentvolumeclaims"]
+          verbs: ["*"]
         ---
         apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
While testing spark operator, I found some missing permissions from the docs that were added in 1.1.17 and also some missing permissions for spark 3.1.

New chart (1.1.17):

The PVC permission was added due to a bug when using a specific spark configuration, so I added it to both 2.1 and 2.2.
https://github.com/mesosphere/spark-on-k8s-operator/blob/d2iq-master/charts/spark-operator-chart/templates/spark-rbac.yaml#L22-L33

Spark 3.1 requires some ConfigMap permissions:

https://github.com/mesosphere/spark-on-k8s-operator/blob/spark-operator-chart-1.1.6/charts/spark-operator-chart/templates/spark-rbac.yaml#L22-L27

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
