### PR TITLE
[DOC][Konvoy 2.2] indentation errors causing procedure numbering in 4 topics

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-capi-vm-image/index.md
@@ -17,15 +17,15 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 
 1. Set the following vSphere environment variables on the bastion VM host:
 
-  ```bash
-  export VSPHERE_SERVER=your_vCenter_APIserver_URL
-  export VSPHERE_USERNAME=your_vCenter_user_name
-  export VSPHERE_PASSWORD=your_vCenter_password
-  ```
+   ```bash
+   export VSPHERE_SERVER=your_vCenter_APIserver_URL
+   export VSPHERE_USERNAME=your_vCenter_user_name
+   export VSPHERE_PASSWORD=your_vCenter_password
+   ```
 
-1.  Copy the base OS image file created in the vSphere Client to your desired location on the bastion VM host, and make a note of the path and file name.
+1. Copy the base OS image file created in the vSphere Client to your desired location on the bastion VM host, and make a note of the path and file name.
 
-1.  Create an `image.yaml` file and add the following variables for vSphere. DKP uses this file and these variables as inputs in the next step.
+1. Create an `image.yaml` file and add the following variables for vSphere. DKP uses this file and these variables as inputs in the next step.
 
    ```yaml
    packer:
@@ -44,12 +44,12 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
      distribution_version: "example_7.9"
    ```
 
-1.  Create a vSphere VM template with the following command:
+1. Create a vSphere VM template with the following command:
 
-    ```bash
-    konvoy-image build path/to/image.yaml /
-      --overrides /path/to/overrides/offline.yaml
-    ```
+   ```bash
+   konvoy-image build path/to/image.yaml /
+     --overrides /path/to/overrides/offline.yaml
+   ```
 
     The DKP image builder uses the values in `image.yaml` and the input base OS image to create a vSphere template that contains the required artifacts needed to create a Kubernetes cluster. Give the file a suitable name using this suggested naming convention: `creator-ova-vsphere-OS-ver-k8sver-unique_identifier`. As an example, the filename you create might resemble `dkp-ova-vsphere-rhel-84-1.21.6-1646938922`.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
@@ -19,17 +19,17 @@ enterprise: false
 
 # Create a StorageClass with a vSphere Datastore
 
-1.   Access the Datastore tab in the vSphere client and select a datastore by name.
+1. Access the Datastore tab in the vSphere client and select a datastore by name.
 
-1.   Copy the URL for that datastore from the information dialog that displays.
+1. Copy the URL for that datastore from the information dialog that displays.
 
-1.   Return to the DKP CLI, and delete the existing `StorageClass` with the commmand:
+1. Return to the DKP CLI, and delete the existing `StorageClass` with the commmand:
 
    ```bash
    kubectl delete storageclass vsphere-raw-block-sc
    ```
 
-1.   Run the following command to create a new StorageClass, supplying the correct values for your environment:
+1. Run the following command to create a new StorageClass, supplying the correct values for your environment:
 
    ```yaml
    cat <<EOF > vsphere-raw-block-sc.yaml
@@ -48,11 +48,11 @@ enterprise: false
 
 ## Explore Nodes and Pods in the New Cluster
 
-1.  List the Nodes with the command:
+1. List the Nodes with the command:
 
-    ```bash
-    kubectl --kubeconfig=${air-gapped_NAME}.conf get nodes
-    ```
+   ```bash
+   kubectl --kubeconfig=${air-gapped_NAME}.conf get nodes
+   ```
 
     <p class="message--note"><strong>NOTE: </strong>It may take a few minutes for the Status to move to <code>Ready</code> while the Pod network is deployed. The Node's Status should change to Ready soon after the <code>calico-node</code> DaemonSet Pods are Ready.</p>
 
@@ -69,7 +69,7 @@ enterprise: false
     d2iq-e2e-air-gapped-1-md-0-74c849dc8c-sqklv   Ready    <none>                 19h   v1.22.8
     ```
 
-1.  List the Pods with the command:
+1. List the Pods with the command:
 
     ```bash
     kubectl --kubeconfig=${air-gapped_NAME}.conf get pods -A

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -15,7 +15,7 @@ You need to create a [base OS image][vsphere-base-os-image] in vSphere before st
 
 Using the base OS image created in a previous procedure, DKP creates the new vSphere template directly on the vCenter server.
 
-1.  Set the following vSphere environment variables on the same machine where DKP is running:
+1. Set the following vSphere environment variables on the same machine where DKP is running:
 
     ```bash
     export VSPHERE_SERVER=your_vCenter_APIserver_URL
@@ -25,7 +25,7 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 
 1. Locate the base OS vSphere template in the vSphere UI client and make a note of the path and file name.
 
-1.  Create an `image.yaml` file and add the following variables for vSphere. DKP uses this file and these variables as inputs in the next step. In the example below, `example_base_OS_template_name` refers to the name of the base OS vSphere template created in a previous step.
+1. Create an `image.yaml` file and add the following variables for vSphere. DKP uses this file and these variables as inputs in the next step. In the example below, `example_base_OS_template_name` refers to the name of the base OS vSphere template created in a previous step.
 
     ```yaml
     packer:
@@ -44,13 +44,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
       distribution_version: "example_7.9"
     ```
 
-1.  Create the vSphere VM template with the following command:
+1. Create the vSphere VM template with the following command:
 
    ```bash
    konvoy-image build path/to/image.yaml
    ```
 
-   The DKP image builder uses the values in `image.yaml` and the input base OS image to create a vSphere template that contains the required artifacts needed to create a Kubernetes cluster. Give the file a suitable name using this suggested naming convention: `creator-ova-vsphere-OS-ver-k8sver-unique_identifier`. As an example, the filename you create might resemble `dkp-ova-vsphere-rhel-84-1.21.6-1646938922`.
+    The DKP image builder uses the values in `image.yaml` and the input base OS image to create a vSphere template that contains the required artifacts needed to create a Kubernetes cluster. Give the file a suitable name using this suggested naming convention: `creator-ova-vsphere-OS-ver-k8sver-unique_identifier`. As an example, the filename you create might resemble `dkp-ova-vsphere-rhel-84-1.21.6-1646938922`.
 
    DKP creates the new vSphere template directly on the vCenter server.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
@@ -25,17 +25,17 @@ Before you start, make sure you have [created a workload cluster][create-new-clu
 
 # Create a StorageClass with a vSphere Datastore
 
-1.   Access the Datastore tab in the vSphere client and select a datastore by name.
+1. Access the Datastore tab in the vSphere client and select a datastore by name.
 
-1.   Copy the URL for that datastore from the information dialog that displays.
+1. Copy the URL for that datastore from the information dialog that displays.
 
-1.   Return to the DKP CLI, and delete the existing `StorageClass` with the commmand:
+1. Return to the DKP CLI, and delete the existing `StorageClass` with the commmand:
 
    ```bash
    kubectl delete storageclass vsphere-raw-block-sc
    ```
 
-1.   Run the following command to create a new StorageClass, supplying the correct values for your environment:
+1. Run the following command to create a new StorageClass, supplying the correct values for your environment:
 
    ```yaml
    cat <<EOF > vsphere-raw-block-sc.yaml


### PR DESCRIPTION
## Jira Ticket

(https://jira.d2iq.com/browse/D2IQ-87699)

## Description of changes being made
Fixed indentation levels in markup to repair numbering in 4 topics, listed in the attached issue. Tested with `npm run dev`until they were right.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4343.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
