### PR TITLE
[kommander] Move ws upgrade section to correct ws page instead of project

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -159,7 +159,7 @@ You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the
 [EKS]: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
 [pre_provisioned]: ../../../../konvoy/2.2/choose-infrastructure/pre-provisioned/upgrade/control-plane/
 [k8s_access_to_clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
-[upgrade_workspaces]: ../../projects/applications/platform-applications#upgrade-platform-applications-from-the-cli
+[upgrade_workspaces]: ../../workspaces/applications/platform-applications#upgrade-platform-applications-from-the-cli
 [release_notes]: ../../release-notes/
 [konvoy_upgrade]: ../upgrade-konvoy/
 [load_images]: ../../install/air-gapped#load-the-docker-images-into-your-docker-registry

--- a/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
@@ -50,6 +50,6 @@ To use the CLI to enable or disable applications, see [Application Deployment](.
 
 ## Upgrade Platform applications from the CLI
 
-Platform Applications within a Project are automatically upgraded when the Workspace the Project belongs to is upgraded. See [Upgrading Workspace Platform Applications][upgrade_workspaces] for more information on how to upgrade these applications.
+Platform Applications within a Project are automatically upgraded when the Workspace that a Project belongs to is upgraded. See [Upgrading Workspace Platform Applications][upgrade_workspaces] for more information on how to upgrade these applications.
 
 [upgrade_workspaces]: ../../workspaces/applications/platform-applications#upgrade-platform-applications-from-the-cli

--- a/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/projects/applications/platform-applications/index.md
@@ -50,13 +50,6 @@ To use the CLI to enable or disable applications, see [Application Deployment](.
 
 ## Upgrade Platform applications from the CLI
 
-The [DKP upgrade](../../../dkp-upgrade) process deploys and upgrades Platform applications as a bundle for each cluster or workspace. For the management cluster or workspace, DKP upgrade handles all Platform applications; no other steps are necessary to upgrade the Platform application bundle. However, for managed or attached clusters or workspaces, you MUST manually upgrade the Platform applications bundle with the following command.
+Platform Applications within a Project are automatically upgraded when the Workspace the Project belongs to is upgraded. See [Upgrading Workspace Platform Applications][upgrade_workspaces] for more information on how to upgrade these applications.
 
-<p class="message--warning"><strong>WARNING: </strong>If you are upgrading your Platform applications as part of the <a href="../../../dkp-upgrade">DKP upgrade</a>, upgrade your Platform applications on any additional Workspaces before proceeding with the Konvoy upgrade. Some applications in the previous release are not compatible with the <a href="../../../release-notes/">Kubernetes version</a> of this release, and upgrading Kubernetes is part of the DKP Konvoy upgrade process.
-</p>
-
-Upgrade all platform applications in the given workspace and its projects to the same version as platform applications running on the management cluster:
-
-```bash
-dkp upgrade workspace WORKSPACE_NAME [--dry-run] [flags]
-```
+[upgrade_workspaces]: ../../workspaces/applications/platform-applications#upgrade-platform-applications-from-the-cli

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
@@ -59,3 +59,16 @@ The following table describes the list of platform applications that are deploye
 <p class="message--note"><strong>NOTE: </strong>Kommander automatically manages the deployment of <code>traefik-forward-auth</code> and <code>kube-oidc-proxy</code> when clusters are attached to the workspace. These applications are not shown in the DKP UI.</p>
 
 <p class="message--note"><strong>NOTE: </strong>Applications are enabled in DKP and then deployed to attached clusters. To confirm that your enabled application has successfully deployed, you should <a href="../platform-applications/application-deployment#verify-applications">verify via the CLI</a>.</p>
+
+## Upgrade Platform applications from the CLI
+
+The [DKP upgrade](../../../dkp-upgrade) process deploys and upgrades Platform applications as a bundle for each cluster or workspace. For the management cluster or workspace, DKP upgrade handles all Platform applications; no other steps are necessary to upgrade the Platform application bundle. However, for managed or attached clusters or workspaces, you MUST manually upgrade the Platform applications bundle with the following command.
+
+<p class="message--warning"><strong>WARNING: </strong>If you are upgrading your Platform applications as part of the <a href="../../../dkp-upgrade">DKP upgrade</a>, upgrade your Platform applications on any additional Workspaces before proceeding with the Konvoy upgrade. Some applications in the previous release are not compatible with the <a href="../../../release-notes/">Kubernetes version</a> of this release, and upgrading Kubernetes is part of the DKP Konvoy upgrade process.
+</p>
+
+Upgrade all platform applications in the given workspace and its projects to the same version as platform applications running on the management cluster:
+
+```bash
+dkp upgrade workspace WORKSPACE_NAME [--dry-run] [flags]
+```

--- a/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/platform-applications/index.md
@@ -62,12 +62,12 @@ The following table describes the list of platform applications that are deploye
 
 ## Upgrade Platform applications from the CLI
 
-The [DKP upgrade](../../../dkp-upgrade) process deploys and upgrades Platform applications as a bundle for each cluster or workspace. For the management cluster or workspace, DKP upgrade handles all Platform applications; no other steps are necessary to upgrade the Platform application bundle. However, for managed or attached clusters or workspaces, you MUST manually upgrade the Platform applications bundle with the following command.
+The [DKP upgrade](../../../dkp-upgrade) process deploys and upgrades Platform applications as a bundle for each cluster or workspace. For the Management Cluster or workspace, DKP upgrade handles all Platform applications; no other steps are necessary to upgrade the Platform application bundle. However, for managed or attached clusters or workspaces, you MUST manually upgrade the Platform applications bundle with the following command.
 
 <p class="message--warning"><strong>WARNING: </strong>If you are upgrading your Platform applications as part of the <a href="../../../dkp-upgrade">DKP upgrade</a>, upgrade your Platform applications on any additional Workspaces before proceeding with the Konvoy upgrade. Some applications in the previous release are not compatible with the <a href="../../../release-notes/">Kubernetes version</a> of this release, and upgrading Kubernetes is part of the DKP Konvoy upgrade process.
 </p>
 
-Upgrade all platform applications in the given workspace and its projects to the same version as platform applications running on the management cluster:
+Use this command to upgrade all platform applications in the given workspace and its projects to the same version as platform applications running on the management cluster:
 
 ```bash
 dkp upgrade workspace WORKSPACE_NAME [--dry-run] [flags]


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
I was browsing our upgrade docs and saw that the upgrade workspace section was put under a Projects page. I've moved it to Workspace platform apps page where it should be.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
