### PR TITLE
docs: adds prereqs from dkp 1.x to 2.2

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -40,7 +40,7 @@ Each worker node should have at least:
    - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
    - Disk usage must be below 85% on the root volume.
 
-If you plan to use local volume provisioning to provide persistent volumes for the workloads, you must mount at least four volumes to the /mnt/disks/ mount point on each node. Each volume must have at least 55 GiB of capacity if the default addon configurations are used.
+If you plan to use local volume provisioning to provide persistent volumes for the workloads, you must mount at least four volumes to the /mnt/disks/ mount point on each node. Each volume must have at least 55 GiB of capacity if you're using default addon configurations.
 
 [prerequisites-airgapped]: ../prerequisites-airgapped
 [bootstrap]: ../bootstrap

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -42,7 +42,7 @@ Each worker node should have at least:
 - Around 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
 - Disk usage must be below 85% on the root volume.
 
-If you plan to use local volume provisioning to provide persistent volumes for the workloads, you must mount at least four volumes to the `/mnt/disks/` mount point on each node. Each volume must have at least 55 GiB of capacity if you are using default addon configurations.
+If you plan to use local volume provisioning to provide persistent volumes for your workloads, you must mount at least four volumes to the `/mnt/disks/` mount point on each node. Each volume must have at least 55 GiB of capacity.
 
 [prerequisites-airgapped]: ../prerequisites-airgapped
 [bootstrap]: ../bootstrap

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -39,7 +39,7 @@ Each worker node should have at least:
 
 - 8 cores
 - 32 GiB memory
-- Approximately 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
+- Around 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
 - Disk usage must be below 85% on the root volume.
 
 If you plan to use local volume provisioning to provide persistent volumes for the workloads, you must mount at least four volumes to the `/mnt/disks/` mount point on each node. Each volume must have at least 55 GiB of capacity if you are using default addon configurations.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -20,5 +20,27 @@ Before you begin using Konvoy, you must have:
 
 When air-gapped, you must follow the steps described in the [air-gapped prerequisites page][prerequisites-airgapped], otherwise [begin creating the bootstrap cluster][bootstrap].
 
+## Control plane nodes
+
+You should have at least three control plane nodes.
+
+Each control plane node should have at least:
+   - 4 cores
+   - 16 GiB memory
+   - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+   - Disk usage must be below 85% on the root volume.
+
+## Worker nodes
+
+You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
+
+Each worker node should have at least:
+   - 8 cores
+   - 32 GiB memory
+   - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+   - Disk usage must be below 85% on the root volume.
+
+If you plan to use local volume provisioning to provide persistent volumes for the workloads, you must mount at least four volumes to the /mnt/disks/ mount point on each node. Each volume must have at least 55 GiB of capacity if the default addon configurations are used.
+
 [prerequisites-airgapped]: ../prerequisites-airgapped
 [bootstrap]: ../bootstrap

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -25,22 +25,24 @@ When air-gapped, you must follow the steps described in the [air-gapped prerequi
 You should have at least three control plane nodes.
 
 Each control plane node should have at least:
-   - 4 cores
-   - 16 GiB memory
-   - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
-   - Disk usage must be below 85% on the root volume.
+
+- 4 cores
+- 16 GiB memory
+- Approximately 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
+- Disk usage must be below 85% on the root volume.
 
 ## Worker nodes
 
 You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
 
 Each worker node should have at least:
-   - 8 cores
-   - 32 GiB memory
-   - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
-   - Disk usage must be below 85% on the root volume.
 
-If you plan to use local volume provisioning to provide persistent volumes for the workloads, you must mount at least four volumes to the /mnt/disks/ mount point on each node. Each volume must have at least 55 GiB of capacity if you're using default addon configurations.
+- 8 cores
+- 32 GiB memory
+- Approximately 80 GiB of free space for the volume used for `/var/lib/kubelet` and `/var/lib/containerd`.
+- Disk usage must be below 85% on the root volume.
+
+If you plan to use local volume provisioning to provide persistent volumes for the workloads, you must mount at least four volumes to the `/mnt/disks/` mount point on each node. Each volume must have at least 55 GiB of capacity if you are using default addon configurations.
 
 [prerequisites-airgapped]: ../prerequisites-airgapped
 [bootstrap]: ../bootstrap


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Copies the on-prem prereqs from dkp to dkp 2

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4347.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
