### PR TITLE
docs: fixing yaml and spelling for linter

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -54,6 +54,7 @@ D2iQ
 daemonsets
 Datadog
 Datastax
+(Datastore|datastore)
 DC/OS
 dcos
 declaratively

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/explore/index.md
@@ -17,22 +17,22 @@ enterprise: false
     dkp get kubeconfig -c ${air-gapped_NAME} > ${air-gapped_NAME}.conf
     ```
 
-# Create a StorageClass with a vSphere Datastore
+## Create a StorageClass with a vSphere Datastore
 
-1. Access the Datastore tab in the vSphere client and select a datastore by name.
+1.  Access the Datastore tab in the vSphere client and select a datastore by name.
 
-1. Copy the URL for that datastore from the information dialog that displays.
+1.  Copy the URL of that datastore from the information dialog that displays.
 
-1. Return to the DKP CLI, and delete the existing `StorageClass` with the commmand:
+1.  Return to the DKP CLI, and delete the existing `StorageClass` with the command:
 
-   ```bash
-   kubectl delete storageclass vsphere-raw-block-sc
-   ```
+    ```bash
+    kubectl delete storageclass vsphere-raw-block-sc
+    ```
 
-1. Run the following command to create a new StorageClass, supplying the correct values for your environment:
+1.  Run the following command to create a new StorageClass, supplying the correct values for your environment:
 
-   ```yaml
-   cat <<EOF > vsphere-raw-block-sc.yaml
+    ```yaml
+    cat <<EOF > vsphere-raw-block-sc.yaml
     kind: StorageClass
     apiVersion: storage.k8s.io/v1
     metadata:
@@ -44,15 +44,15 @@ enterprise: false
       datastoreurl: "<url>"
     volumeBindingMode: WaitForFirstConsumer
     EOF
-   ```
+    ```
 
 ## Explore Nodes and Pods in the New Cluster
 
-1. List the Nodes with the command:
+1.  List the Nodes with the command:
 
-   ```bash
-   kubectl --kubeconfig=${air-gapped_NAME}.conf get nodes
-   ```
+    ```bash
+    kubectl --kubeconfig=${air-gapped_NAME}.conf get nodes
+    ```
 
     <p class="message--note"><strong>NOTE: </strong>It may take a few minutes for the Status to move to <code>Ready</code> while the Pod network is deployed. The Node's Status should change to Ready soon after the <code>calico-node</code> DaemonSet Pods are Ready.</p>
 
@@ -69,7 +69,7 @@ enterprise: false
     d2iq-e2e-air-gapped-1-md-0-74c849dc8c-sqklv   Ready    <none>                 19h   v1.22.8
     ```
 
-1. List the Pods with the command:
+1.  List the Pods with the command:
 
     ```bash
     kubectl --kubeconfig=${air-gapped_NAME}.conf get pods -A
@@ -138,4 +138,4 @@ enterprise: false
 
 When you are ready, [delete your cluster and clean up your environment][delete].
 
-[delete]: ../delete/
+[delete]: ../../delete

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
@@ -23,22 +23,22 @@ Before you start, make sure you have [created a workload cluster][create-new-clu
     dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
     ```
 
-# Create a StorageClass with a vSphere Datastore
+## Create a StorageClass with a vSphere Datastore
 
-1. Access the Datastore tab in the vSphere client and select a datastore by name.
+1.  Access the Datastore tab in the vSphere client and select a datastore by name.
 
-1. Copy the URL for that datastore from the information dialog that displays.
+1.  Copy the URL of that datastore from the information dialog that displays.
 
-1. Return to the DKP CLI, and delete the existing `StorageClass` with the commmand:
+1.  Return to the DKP CLI, and delete the existing `StorageClass` with the command:
 
-   ```bash
-   kubectl delete storageclass vsphere-raw-block-sc
-   ```
+    ```bash
+    kubectl delete storageclass vsphere-raw-block-sc
+    ```
 
-1. Run the following command to create a new StorageClass, supplying the correct values for your environment:
+1.  Run the following command to create a new StorageClass, supplying the correct values for your environment:
 
-   ```yaml
-   cat <<EOF > vsphere-raw-block-sc.yaml
+    ```yaml
+    cat <<EOF > vsphere-raw-block-sc.yaml
     kind: StorageClass
     apiVersion: storage.k8s.io/v1
     metadata:
@@ -50,7 +50,7 @@ Before you start, make sure you have [created a workload cluster][create-new-clu
       datastoreurl: "<url>"
     volumeBindingMode: WaitForFirstConsumer
     EOF
-   ```
+    ```
 
 ## Explore Nodes and Pods in the New Cluster
 


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

Some spelling that got caught by linters, fixing a link, and there was some yaml allignment/linting stuff.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4350.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
