### PR TITLE
Update index.md

### DIFF
--- a/pages/dkp/kommander/2.2/install/configuration/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/index.md
@@ -28,6 +28,7 @@ After the initial deployment of Kommander, you can find the application Helm Cha
 kubectl get helmreleases <application> -o yaml -n kommander
 ```
 
+
 ### Inline configuration (using values)
 
 In this example, you configure the `centralized-grafana` application with resource limits by defining the Helm Chart values in the Kommander configuration file.
@@ -80,7 +81,7 @@ apps:
 Add the `--installer-config` flag to the `kommander install` command to use a custom configuration file. To reconfigure applications, you can also run this command after the initial installation.
 
 ```bash
-dkp install kommander --installer-config kommander.yaml
+dkp install kommander --installer-config kommander.yaml --kubeconfig <cluster-kubeconfig>
 ```
 
 When completed, you can [verify your installation](../networked#verify-installation).


### PR DESCRIPTION
These instructions assume that the operator has already set their default kubeconfig file to the kubeconfig for the target install cluster.  Recommend adding the `--kubeconfig <cluster-kubeconfig`to prevent them from installing Kommander on their bootstrap cluster or another unintended cluster.

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
