### PR TITLE
More locations about clusters for AKS per Dev

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aks/aks-quickstart/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aks/aks-quickstart/index.md
@@ -23,6 +23,8 @@ Before starting the Konvoy installation, verify that you have:
 - [kubectl][install_kubectl] for interacting with the running cluster.
 - A valid Azure account [used to sign in with the Azure CLI][azure_credentials].
 
+<p class="message--warning"><strong>WARNING: </strong>Pivoting is not supported in AKS.</p>
+
 ## Configure AKS prerequisites
 
 1.  Log in to Azure:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aks/aks-quickstart/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aks/aks-quickstart/index.md
@@ -157,6 +157,8 @@ export CLUSTER_NAME=aks-example
 	cluster.cluster.x-k8s.io/aks-example condition met
 	```
 
+<p class="message--warning"><strong>WARNING: </strong>Pivoting is not supported in AKS.</p>
+
 ## Explore the new Kubernetes cluster
 
 1.  Fetch the kubeconfig file:


### PR DESCRIPTION
## Jira Ticket

This is related to a previously closed JIRA ticket 4254 and COPS 7231.  Konvoy team requested the information regarding AKS not supporting self-managed clusters be added to the section of docs in Quick Start, not just under Advanced tab where we added it in previous Jira 4254.


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4357.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
