### PR TITLE
fix invalid markdown crashing vale

### DIFF
--- a/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
+++ b/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
@@ -36,74 +36,86 @@ The amounts depend on the number, complexity, and size of the workloads, as well
 For on-premise installations, horizontal scalability is limited by the overall size of the cluster and quotas therein.
 For cloud installations, scaling out can be limited by resource quotas.
 
-* Ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
-    ```yaml
-    - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-      configVersion: stable-1.20-4.1.0
-      addonsList:
-        - name: istio
-          enabled: true
-        - name: dex
-          enabled: true
-        - name: cert-manager
-          enabled: true
-        - name: prometheus
-          enabled: true
-    ```
+- Ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
 
-* Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies,
-then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons:
   ```yaml
-      - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
-        configVersion: stable-1.20-1.3.0
-        addonsList:
-          - name: knative
-            enabled: true
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
+    configVersion: stable-1.20-4.1.0
+    addonsList:
+      - name: istio
+        enabled: true
+      - name: dex
+        enabled: true
+      - name: cert-manager
+        enabled: true
+      - name: prometheus
+        enabled: true
   ```
 
-* Install the [kubectl-kudo CLI plugin][kudo_cli]
+- Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies,
+  then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons:
 
-* After the Konvoy cluster has been deployed (including Istio and Knative), install KUDO:
+  ```yaml
+  - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
+    configVersion: stable-1.20-1.3.0
+    addonsList:
+      - name: knative
+        enabled: true
+  ```
+
+- Install the [kubectl-kudo CLI plugin][kudo_cli]
+
+- After the Konvoy cluster has been deployed (including Istio and Knative), install KUDO:
+
   ```bash
   kubectl kudo init --wait
   ```
 
-* Download [kubeflow-1.3.0_1.2.0.tgz][download] tarball.
-* Install Kaptain:
-<p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
+- Download [kubeflow-1.3.0_1.2.0.tgz][download] tarball.
+- Install Kaptain:
+  <p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
 
   ```bash
   kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.3.0_1.2.0.tgz
   ```
-* If you would like to inject additional annotations to Kaptain's default gateway `kubeflow-ingressgateway`, you can pass in the service annotations as parameters:
+
+- If you would like to inject additional annotations to Kaptain's default gateway `kubeflow-ingressgateway`, you can pass in the service annotations as parameters:
+
   ```bash
   kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.3.0_1.2.0.tgz -p kubeflowIngressGatewayServiceAnnotations='{"foo": "abc","bar": "xyz"}'
   ```
-* Monitor the installation by running:
+
+- Monitor the installation by running:
   ```bash
   kubectl kudo plan status --instance kaptain  -n kubeflow
   ```
 
 ## Log in to Kaptain
+
 Once all components have been deployed, you can log in to Kaptain:
 
-* Discover the cluster endpoint and copy it to the clipboard.
+- Discover the cluster endpoint and copy it to the clipboard.
   If you are running Kaptain _on-premises_:
+
   ```bash
   kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
   ```
+
   Or if you are running Kaptain on _AWS_:
+
   ```bash
   kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
   ```
-* Get the login credentials from Konvoy to authenticate:
+
+- Get the login credentials from Konvoy to authenticate:
+
   ```bash
   konvoy get ops-portal
   ```
 
 ## Uninstall Kaptain
 
-* Use the following commands to uninstall Kaptain.
+- Use the following commands to uninstall Kaptain.
   ```bash
   kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
   kubectl delete operatorversions.kudo.dev kubeflow-1.3.0-1.2.0 --namespace kubeflow

--- a/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
+++ b/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
@@ -12,115 +12,118 @@ enterprise: false
 
 Before proceeding, verify that your environment meets the following basic requirements:
 
-- Control plane
-  - min. 3 nodes
-  - min. 4 cores _per node_
-  - min. 200 GiB free disk space _per node_
-  - min. 16 GiB RAM _per node_
-- Workers
-  - min. 6 nodes
-  - min. 8 cores _per node_
-  - min. 200 GiB free disk space _per node_
-  - min. 32 GiB RAM _per node_
-- GPUs (optional)
-  - NVIDIA only
-  - min. 200 GiB free disk space per instance
-  - min. 64 GiB RAM per instance
-  - min. 12 GiB GPU RAM per instance
+-   Control plane
+    - min. 3 nodes
+    - min. 4 cores _per node_
+    - min. 200 GiB free disk space _per node_
+    - min. 16 GiB RAM _per node_
+-   Workers
+    - min. 6 nodes
+    - min. 8 cores _per node_
+    - min. 200 GiB free disk space _per node_
+    - min. 32 GiB RAM _per node_
+-   GPUs (optional)
+    - NVIDIA only
+    - min. 200 GiB free disk space per instance
+    - min. 64 GiB RAM per instance
+    - min. 12 GiB GPU RAM per  instance
 
 Please note that these numbers are for the bare minimum.
 Running any realistic machine learning workloads on Kaptain bumps these requirements for nodes, CPUs, RAM, GPUs, and persistent disk.
-In particular, the number of CPU and/or GPU workers, as well as RAM, must be increased considerably.
-The amounts depend on the number, complexity, and size of the workloads, as well as the amount of metadata and log data stored with each run.
+In particular, the number of CPU, GPU workers, and RAM, must be increased considerably.
+The amounts depend on the number, complexity, and size of the workloads, and the amount of metadata and log data stored with each run.
 
-For on-premise installations, horizontal scalability is limited by the overall size of the cluster and quotas therein.
+For on premise installations, horizontal scalability is limited by the overall size of the cluster and quotas therein.
 For cloud installations, scaling out can be limited by resource quotas.
 
-- Ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
+-   Ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
 
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-    configVersion: stable-1.20-4.1.0
-    addonsList:
-      - name: istio
-        enabled: true
-      - name: dex
-        enabled: true
-      - name: cert-manager
-        enabled: true
-      - name: prometheus
-        enabled: true
-  ```
+    ```yaml
+    - configRepository: https://github.com/mesosphere/kubernetes-base-addons
+      configVersion: stable-1.20-4.1.0
+      addonsList:
+        - name: istio
+          enabled: true
+        - name: dex
+          enabled: true
+        - name: cert-manager
+          enabled: true
+        - name: prometheus
+          enabled: true
+    ```
 
-- Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies,
-  then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons:
+-   Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies, then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons:
 
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
-    configVersion: stable-1.20-1.3.0
-    addonsList:
-      - name: knative
-        enabled: true
-  ```
+    ```yaml
+    - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
+      configVersion: stable-1.20-1.3.0
+      addonsList:
+        - name: knative
+          enabled: true
+    ```
 
-- Install the [kubectl-kudo CLI plugin][kudo_cli]
+-   Install the [kubectl-kudo CLI plugin][kudo_cli]
 
-- After the Konvoy cluster has been deployed (including Istio and Knative), install KUDO:
+-   After the Konvoy cluster has been deployed (including Istio and Knative), install KUDO:
 
-  ```bash
-  kubectl kudo init --wait
-  ```
+    ```bash
+    kubectl kudo init --wait
+    ```
 
-- Download [kubeflow-1.3.0_1.2.0.tgz][download] tarball.
-- Install Kaptain:
-  <p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
+-   Download [kubeflow-1.3.0_1.2.0.tgz][download] tarball.
 
-  ```bash
-  kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.3.0_1.2.0.tgz
-  ```
+-   Install Kaptain:
 
-- If you would like to inject additional annotations to Kaptain's default gateway `kubeflow-ingressgateway`, you can pass in the service annotations as parameters:
+    <p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
 
-  ```bash
-  kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.3.0_1.2.0.tgz -p kubeflowIngressGatewayServiceAnnotations='{"foo": "abc","bar": "xyz"}'
-  ```
+    ```bash
+    kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.3.0_1.2.0.tgz
+    ```
 
-- Monitor the installation by running:
-  ```bash
-  kubectl kudo plan status --instance kaptain  -n kubeflow
-  ```
+-   If you would like to inject additional annotations to Kaptain's default gateway `kubeflow-ingressgateway`, you can pass in the service annotations as parameters:
+
+    ```bash
+    kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.3.0_1.2.0.tgz -p kubeflowIngressGatewayServiceAnnotations='{"foo": "abc","bar": "xyz"}'
+    ```
+
+-   Monitor the installation by running:
+
+    ```bash
+    kubectl kudo plan status --instance kaptain  -n kubeflow
+    ```
 
 ## Log in to Kaptain
 
 Once all components have been deployed, you can log in to Kaptain:
 
-- Discover the cluster endpoint and copy it to the clipboard.
-  If you are running Kaptain _on-premises_:
+-   Discover the cluster endpoint and copy it to the clipboard.
+    If you are running Kaptain _on-premises_:
 
-  ```bash
-  kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
-  ```
+    ```bash
+    kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
+    ```
 
-  Or if you are running Kaptain on _AWS_:
+    Or if you are running Kaptain on _AWS_:
 
-  ```bash
-  kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
-  ```
+    ```bash
+    kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
+    ```
 
-- Get the login credentials from Konvoy to authenticate:
+-   Get the login credentials from Konvoy to authenticate:
 
-  ```bash
-  konvoy get ops-portal
-  ```
+    ```bash
+    konvoy get ops-portal
+    ```
 
 ## Uninstall Kaptain
 
-- Use the following commands to uninstall Kaptain.
-  ```bash
-  kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
-  kubectl delete operatorversions.kudo.dev kubeflow-1.3.0-1.2.0 --namespace kubeflow
-  kubectl delete operators.kudo.dev kubeflow --namespace kubeflow
-  ```
+-   Use the following commands to uninstall Kaptain.
+
+    ```bash
+    kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
+    kubectl delete operatorversions.kudo.dev kubeflow-1.3.0-1.2.0 --namespace kubeflow
+    kubectl delete operators.kudo.dev kubeflow --namespace kubeflow
+    ```
 
 [download]: ../../download/
 [kudo_cli]: https://kudo.dev/#get-kudo

--- a/pages/dkp/kaptain/1.2.0/upgrade/index.md
+++ b/pages/dkp/kaptain/1.2.0/upgrade/index.md
@@ -27,73 +27,72 @@ kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io katib-
 kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io katib-validating-webhook-config
 ```
 
-- Ensure the following base addons that are needed by Kaptain are enabled in your Konvoy cluster:
+-   Ensure the following base addons that are needed by Kaptain are enabled in your Konvoy cluster:
 
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-    configVersion: stable-1.20-4.1.0
-    addonsList:
-      - name: istio
-        enabled: true
-      - name: dex
-        enabled: true
-      - name: cert-manager
-        enabled: true
-      - name: prometheus
-        enabled: true
-  ```
+    ```yaml
+    - configRepository: https://github.com/mesosphere/kubernetes-base-addons
+      configVersion: stable-1.20-4.1.0
+      addonsList:
+        - name: istio
+          enabled: true
+        - name: dex
+          enabled: true
+        - name: cert-manager
+          enabled: true
+        - name: prometheus
+          enabled: true
+    ```
 
-- Ensure the Kaptain addon repository is present in your Konvoy `cluster.yaml`:
+-   Ensure the Kaptain addon repository is present in your Konvoy `cluster.yaml`:
 
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
-    configVersion: stable-1.20-1.3.0
-    addonsList:
-      - name: knative
-        enabled: true
-  ```
+    ```yaml
+    - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
+      configVersion: stable-1.20-1.3.0
+      addonsList:
+        - name: knative
+          enabled: true
+    ```
 
-- [Download][download] the `kubeflow-1.3.0_1.2.0.tgz` tarball from the support website.
+-   [Download][download] the `kubeflow-1.3.0_1.2.0.tgz` tarball from the support website.
 
-- Upgrade Kaptain:
+-   Upgrade Kaptain:
 
-  ```bash
-  kubectl kudo upgrade --instance kaptain --namespace kubeflow ./kubeflow-1.3.0_1.2.0.tgz
-  ```
+    ```bash
+    kubectl kudo upgrade --instance kaptain --namespace kubeflow ./kubeflow-1.3.0_1.2.0.tgz
+    ```
 
-- Monitor the upgrade process by running:
+-   Monitor the upgrade process by running:
 
-  ```bash
-  kubectl kudo plan status --instance kaptain --namespace kubeflow
-  ```
+    ```bash
+    kubectl kudo plan status --instance kaptain --namespace kubeflow
+    ```
 
 After the upgrade completes, log in to Kaptain:
 
-- Discover the cluster endpoint and copy it to the clipboard.
-  If you are running Kaptain _on-premises_, use this command:
+-   Discover the cluster endpoint and copy it to the clipboard.
+    If you are running Kaptain _on-premises_, use this command:
 
-  ```bash
-  kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
-  ```
+    ```bash
+    kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
+    ```
 
-  Or if you are running Kaptain on _AWS_, use this command:
+    Or if you are running Kaptain on _AWS_, use this command:
 
-  ```bash
-  kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
-  ```
+    ```bash
+    kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
+    ```
 
-- Get the login credentials from Konvoy to authenticate:
+-   Get the login credentials from Konvoy to authenticate:
 
-  ```bash
-  konvoy get ops-portal
-  ```
+    ```bash
+    konvoy get ops-portal
+    ```
 
 ## Workloads behavior during the upgrades
 
-- When upgrading from Kaptain version `1.2.0-1.1.0` to `1.2.0` the following workloads do not require stopping and can proceed _without interruption during the upgrade_:
-  Jupyter Notebooks, Training Jobs (`TFJob`, `PyTorchJob`, `MXNetJob`), Katib `Experiments` and `Trials`,
-  and `SparkApplications`), Kubeflow Pipelines.
+-   When upgrading from Kaptain version `1.2.0-1.1.0` to `1.2.0` the following workloads do not require stopping and can proceed _without interruption during the upgrade_:
+    Jupyter Notebooks, Training Jobs (`TFJob`, `PyTorchJob`, `MXNetJob`), Katib `Experiments` and `Trials`,
+    and `SparkApplications`), Kubeflow Pipelines.
 
-[breaking-changes]: #breaking-changes
 [download]: ../download
 [install]: ../install

--- a/pages/dkp/kaptain/1.2.0/upgrade/index.md
+++ b/pages/dkp/kaptain/1.2.0/upgrade/index.md
@@ -15,7 +15,7 @@ Upgrade the existing Kaptain installation to a newer version.
 Before you begin, ensure you have:
 
 - Kaptain 1.2.0–1.1.0 installed on a Konvoy cluster.
-- The existing cluster meets the criteria listed in the [installation documentation][install]. 
+- The existing cluster meets the criteria listed in the [installation documentation][install].
 
 ## Upgrade Kaptain
 
@@ -27,61 +27,73 @@ kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io katib-
 kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io katib-validating-webhook-config
 ```
 
-* Ensure the following base addons that are needed by Kaptain are enabled in your Konvoy cluster:
-    ```yaml
-    - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-      configVersion: stable-1.20-4.1.0
-      addonsList:
-        - name: istio
-          enabled: true
-        - name: dex
-          enabled: true
-        - name: cert-manager
-          enabled: true
-        - name: prometheus
-          enabled: true
-    ```
+- Ensure the following base addons that are needed by Kaptain are enabled in your Konvoy cluster:
 
-* Ensure the Kaptain addon repository is present in your Konvoy `cluster.yaml`:
   ```yaml
-      - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
-        configVersion: stable-1.20-1.3.0
-        addonsList:
-          - name: knative
-            enabled: true
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
+    configVersion: stable-1.20-4.1.0
+    addonsList:
+      - name: istio
+        enabled: true
+      - name: dex
+        enabled: true
+      - name: cert-manager
+        enabled: true
+      - name: prometheus
+        enabled: true
   ```
 
-* [Download][download] the `kubeflow-1.3.0_1.2.0.tgz` tarball from the support website.
-* Upgrade Kaptain:
+- Ensure the Kaptain addon repository is present in your Konvoy `cluster.yaml`:
+
+  ```yaml
+  - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
+    configVersion: stable-1.20-1.3.0
+    addonsList:
+      - name: knative
+        enabled: true
+  ```
+
+- [Download][download] the `kubeflow-1.3.0_1.2.0.tgz` tarball from the support website.
+
+- Upgrade Kaptain:
+
   ```bash
   kubectl kudo upgrade --instance kaptain --namespace kubeflow ./kubeflow-1.3.0_1.2.0.tgz
   ```
-* Monitor the upgrade process by running:
+
+- Monitor the upgrade process by running:
+
   ```bash
   kubectl kudo plan status --instance kaptain --namespace kubeflow
   ```
 
 After the upgrade completes, log in to Kaptain:
 
-* Discover the cluster endpoint and copy it to the clipboard.
+- Discover the cluster endpoint and copy it to the clipboard.
   If you are running Kaptain _on-premises_, use this command:
+
   ```bash
   kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
   ```
+
   Or if you are running Kaptain on _AWS_, use this command:
+
   ```bash
   kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
   ```
-* Get the login credentials from Konvoy to authenticate:
+
+- Get the login credentials from Konvoy to authenticate:
+
   ```bash
   konvoy get ops-portal
   ```
 
 ## Workloads behavior during the upgrades
-* When upgrading from Kaptain version `1.2.0-1.1.0` to `1.2.0` the following workloads do not require stopping and can proceed _without interruption during the upgrade_:
+
+- When upgrading from Kaptain version `1.2.0-1.1.0` to `1.2.0` the following workloads do not require stopping and can proceed _without interruption during the upgrade_:
   Jupyter Notebooks, Training Jobs (`TFJob`, `PyTorchJob`, `MXNetJob`), Katib `Experiments` and `Trials`,
   and `SparkApplications`), Kubeflow Pipelines.
-  
+
 [breaking-changes]: #breaking-changes
 [download]: ../download
 [install]: ../install

--- a/pages/dkp/kaptain/1.3.0/install/konvoy-dkp/index.md
+++ b/pages/dkp/kaptain/1.3.0/install/konvoy-dkp/index.md
@@ -38,41 +38,48 @@ For cloud installations, scaling out can be limited by resource quotas.
 
 ## Prerequisites for Konvoy 1.x
 
-* When installing on Konvoy 1.x, ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
-    ```yaml
-      - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-        configVersion: stable-1.20-4.1.0
-        addonsList:
-          - name: istio
-            enabled: true
-          - name: dex
-            enabled: true
-          - name: cert-manager
-            enabled: true
-          - name: prometheus
-            enabled: true
-    ```
+- When installing on Konvoy 1.x, ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
 
-* Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies:
-    ```yaml
-      - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
-        configVersion: stable-1.20-1.4.0
-        addonsList:
-          - name: knative
-            enabled: true
-    ```
-* For GPU deployment, follow the instructions in [Konvoy GPU documentation][konvoy-gpu].
+  ```yaml
+  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
+    configVersion: stable-1.20-4.1.0
+    addonsList:
+      - name: istio
+        enabled: true
+      - name: dex
+        enabled: true
+      - name: cert-manager
+        enabled: true
+      - name: prometheus
+        enabled: true
+  ```
 
-* Then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons.
+- Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies:
+
+  ```yaml
+  - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
+    configVersion: stable-1.20-1.4.0
+    addonsList:
+      - name: knative
+        enabled: true
+  ```
+
+- For GPU deployment, follow the instructions in [Konvoy GPU documentation][konvoy-gpu].
+
+- Then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons.
 
 ## Prerequisites for DKP 2.x
 
 For DKP 2.x, ensure the following applications are enabled in Kommander:
-* Use the existing Kommander configuration file, or initialize the default one:  
+
+- Use the existing Kommander configuration file, or initialize the default one:
+
   ```
   kommander install --init > kommander-config.yaml
   ```
-* Ensure the following applications are enabled in the config:
+
+- Ensure the following applications are enabled in the config:
+
   ```yaml
   apiVersion: config.kommander.mesosphere.io/v1alpha1
   kind: Installation
@@ -86,15 +93,18 @@ For DKP 2.x, ensure the following applications are enabled in Kommander:
     minio-operator:
     traefik:
     nvidia:  # to enable GPU support
-    ...   
+    ...
   ```
-* For GPU deployment, follow the instructions in [Kommander GPU documentation][kommander-gpu]. 
 
-* Apply the new configuration to Kommander:
+- For GPU deployment, follow the instructions in [Kommander GPU documentation][kommander-gpu].
+
+- Apply the new configuration to Kommander:
+
   ```
   kommander install --installer-config kommander-config.yaml
   ```
-Check [Kommander installation documentation][kommander-install] for more information.
+
+  Check [Kommander installation documentation][kommander-install] for more information.
 
 <p class="message--note"><strong>NOTE: </strong>Starting from the 1.3 release, Spark Operator is no longer installed by default with Kaptain.</p>
 
@@ -102,27 +112,32 @@ In case you need to run Spark jobs on Kubernetes using Spark Operator, it needs 
 Use the following instructions to install Spark Operator from Kommander Catalog for your target platform:
 [Konvoy 1.x][install-spark-konvoy1] or [DKP 2.x][install-spark-dkp2]
 
-
 ## Install Kaptain
-* Install the [kubectl-kudo CLI plugin][kudo_cli]
 
-* After the Konvoy cluster has been deployed (including Istio and KNative), install KUDO:
+- Install the [kubectl-kudo CLI plugin][kudo_cli]
+
+- After the Konvoy cluster has been deployed (including Istio and KNative), install KUDO:
+
   ```bash
   kubectl kudo init --wait
   ```
 
-* Download [kubeflow-1.4.0_1.3.0.tgz][download] tarball.
+- Download [kubeflow-1.4.0_1.3.0.tgz][download] tarball.
 <p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
 
-* Set required configuration based on the target platform:
-  * When installing on Konvoy 1.x, add the following configuration to `parameters.yaml` file:
+- Set required configuration based on the target platform:
+
+  - When installing on Konvoy 1.x, add the following configuration to `parameters.yaml` file:
+
   ```bash
   cat >> parameters.yaml << END
   dkpPlatformVersion: 1
   installMinioOperator: true
   END
   ```
-* When installing on DKP 2.x, add the following configuration to `parameters.yaml` file:
+
+- When installing on DKP 2.x, add the following configuration to `parameters.yaml` file:
+
   ```bash
   # set the OIDC Provider CA bundle
   OIDC_PROVIDER_CA_BUNDLE=$(kubectl get secret kommander-traefik-certificate -n kommander -o jsonpath="{.data.ca\.crt}")
@@ -131,49 +146,65 @@ Use the following instructions to install Spark Operator from Kommander Catalog 
   oidcProviderBase64CaBundle: ${OIDC_PROVIDER_CA_BUNDLE}
   END
   ```
-* Install Kaptain:
+
+- Install Kaptain:
+
   ```bash
   kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace \
     ./kubeflow-1.4.0_1.3.0.tgz \
     -P parameters.yaml
   ```
-* If you would like to inject additional annotations to Kaptain's default `kubeflow-ingressgateway` `Gateway`, you can pass in the service annotations as parameters:
+
+- If you would like to inject additional annotations to Kaptain's default `kubeflow-ingressgateway` `Gateway`, you can pass in the service annotations as parameters:
+
   ```bash
   kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace \
     ./kubeflow-1.4.0_1.3.0.tgz \
     -P parameters.yaml \
     -p kubeflowIngressGatewayServiceAnnotations='{"foo": "abc","bar": "xyz"}'
   ```
-* Monitor the installation by running:
+
+- Monitor the installation by running:
+
   ```bash
   kubectl kudo plan status --instance kaptain -n kubeflow
   ```
 
 ## Log in to Kaptain
+
 Once all components have been deployed, you can log in to Kaptain:
 
-* Discover the cluster endpoint and copy it to the clipboard.
+- Discover the cluster endpoint and copy it to the clipboard.
   If you are running Kaptain _on-premises_:
+
   ```bash
   kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
   ```
+
   Or if you are running Kaptain on _AWS_:
+
   ```bash
   kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
   ```
-* Get the login credentials from Konvoy to authenticate:
-  * For Konvoy 1.x:
+
+- Get the login credentials from Konvoy to authenticate:
+
+  - For Konvoy 1.x:
+
     ```bash
     konvoy get ops-portal
     ```
-  * For DKP 2.x:
+
+  - For DKP 2.x:
+
     ```
     kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}')
     ```
 
 ## Uninstall Kaptain
 
-* Use the following commands to uninstall Kaptain.
+- Use the following commands to uninstall Kaptain.
+
   ```bash
   kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
   kubectl delete operatorversions.kudo.dev kubeflow-1.4.0-1.3.0 --namespace kubeflow

--- a/pages/dkp/kaptain/1.3.0/install/konvoy-dkp/index.md
+++ b/pages/dkp/kaptain/1.3.0/install/konvoy-dkp/index.md
@@ -12,99 +12,99 @@ enterprise: false
 
 Before proceeding, verify that your environment meets the following basic requirements:
 
-- Control plane
-  - min. 3 nodes
-  - min. 4 cores _per node_
-  - min. 200 GiB free disk space _per node_
-  - min. 16 GiB RAM _per node_
-- Workers
-  - min. 6 nodes
-  - min. 8 cores _per node_
-  - min. 200 GiB free disk space _per node_
-  - min. 32 GiB RAM _per node_
-- GPUs (optional)
-  - NVIDIA only
-  - min. 200 GiB free disk space per instance
-  - min. 64 GiB RAM per instance
-  - min. 12 GiB GPU RAM per instance
+-   Control plane
+    - min. 3 nodes
+    - min. 4 cores _per node_
+    - min. 200 GiB free disk space _per node_
+    - min. 16 GiB RAM _per node_
+-   Workers
+    - min. 6 nodes
+    - min. 8 cores _per node_
+    - min. 200 GiB free disk space _per node_
+    - min. 32 GiB RAM _per node_
+-   GPUs (optional)
+    - NVIDIA only
+    - min. 200 GiB free disk space per instance
+    - min. 64 GiB RAM per instance
+    - min. 12 GiB GPU RAM per instance
 
 Please note that these numbers are for the bare minimum.
 Running any real world machine learning workloads on Kaptain bumps these requirements for nodes, CPUs, RAM, GPUs, and persistent disks.
-In particular, the number of CPU and/or GPU workers, as well as RAM, must be increased considerably.
-The amounts depend on the number, complexity, and size of the workloads, as well as the amount of metadata and log data stored with each run.
+In particular, the number of CPU, GPU workers, and RAM, must be increased considerably.
+The amounts depend on the number, complexity, and size of the workloads, and the amount of metadata and log data stored with each run.
 
-For on-premise installations, horizontal scalability is limited by the overall size of the cluster and quotas therein.
+For on premise installations, horizontal scalability is limited by the overall size of the cluster and quotas therein.
 For cloud installations, scaling out can be limited by resource quotas.
 
 ## Prerequisites for Konvoy 1.x
 
-- When installing on Konvoy 1.x, ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
+-   When installing on Konvoy 1.x, ensure the following Kubernetes base addons that are needed by Kaptain are enabled:
 
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-    configVersion: stable-1.20-4.1.0
-    addonsList:
-      - name: istio
-        enabled: true
-      - name: dex
-        enabled: true
-      - name: cert-manager
-        enabled: true
-      - name: prometheus
-        enabled: true
-  ```
+    ```yaml
+    - configRepository: https://github.com/mesosphere/kubernetes-base-addons
+      configVersion: stable-1.20-4.1.0
+      addonsList:
+        - name: istio
+          enabled: true
+        - name: dex
+          enabled: true
+        - name: cert-manager
+          enabled: true
+        - name: prometheus
+          enabled: true
+    ```
 
-- Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies:
+-   Add the Kaptain addon repository to your Konvoy `cluster.yaml` to install Kaptain dependencies:
 
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
-    configVersion: stable-1.20-1.4.0
-    addonsList:
-      - name: knative
-        enabled: true
-  ```
+    ```yaml
+    - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
+      configVersion: stable-1.20-1.4.0
+      addonsList:
+        - name: knative
+          enabled: true
+    ```
 
-- For GPU deployment, follow the instructions in [Konvoy GPU documentation][konvoy-gpu].
+-   For GPU deployment, follow the instructions in [Konvoy GPU documentation][konvoy-gpu].
 
-- Then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons.
+-   Then follow the [Konvoy documentation][konvoy_deploy_addons] to deploy the addons.
 
 ## Prerequisites for DKP 2.x
 
 For DKP 2.x, ensure the following applications are enabled in Kommander:
 
-- Use the existing Kommander configuration file, or initialize the default one:
+-   Use the existing Kommander configuration file, or initialize the default one:
 
-  ```
-  kommander install --init > kommander-config.yaml
-  ```
+    ```bash
+    kommander install --init > kommander-config.yaml
+    ```
 
-- Ensure the following applications are enabled in the config:
+-   Ensure the following applications are enabled in the config:
 
-  ```yaml
-  apiVersion: config.kommander.mesosphere.io/v1alpha1
-  kind: Installation
-  apps:
-    ...
-    dex:
-    dex-k8s-authenticator:
-    kube-prometheus-stack:
-    istio:
-    knative:
-    minio-operator:
-    traefik:
-    nvidia:  # to enable GPU support
-    ...
-  ```
+    ```yaml
+    apiVersion: config.kommander.mesosphere.io/v1alpha1
+    kind: Installation
+    apps:
+      ...
+      dex:
+      dex-k8s-authenticator:
+      kube-prometheus-stack:
+      istio:
+      knative:
+      minio-operator:
+      traefik:
+      nvidia:  # to enable GPU support
+      ...
+    ```
 
-- For GPU deployment, follow the instructions in [Kommander GPU documentation][kommander-gpu].
+-   For GPU deployment, follow the instructions in [Kommander GPU documentation][kommander-gpu].
 
-- Apply the new configuration to Kommander:
+-   Apply the new configuration to Kommander:
 
-  ```
-  kommander install --installer-config kommander-config.yaml
-  ```
+    ```bash
+    kommander install --installer-config kommander-config.yaml
+    ```
 
-  Check [Kommander installation documentation][kommander-install] for more information.
+    Check [Kommander installation documentation][kommander-install] for more information.
 
 <p class="message--note"><strong>NOTE: </strong>Starting from the 1.3 release, Spark Operator is no longer installed by default with Kaptain.</p>
 
@@ -114,102 +114,103 @@ Use the following instructions to install Spark Operator from Kommander Catalog 
 
 ## Install Kaptain
 
-- Install the [kubectl-kudo CLI plugin][kudo_cli]
+-   Install the [kubectl-kudo CLI plugin][kudo_cli]
 
-- After the Konvoy cluster has been deployed (including Istio and KNative), install KUDO:
+-   After the Konvoy cluster has been deployed (including Istio and KNative), install KUDO:
 
-  ```bash
-  kubectl kudo init --wait
-  ```
+    ```bash
+    kubectl kudo init --wait
+    ```
 
-- Download [kubeflow-1.4.0_1.3.0.tgz][download] tarball.
-<p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
+-   Download [kubeflow-1.4.0_1.3.0.tgz][download] tarball.
 
-- Set required configuration based on the target platform:
+    <p class="message--note"><strong>NOTE: </strong>Starting with Kaptain 1.2.0, automatic profile creation on initial login is now disabled by default. See <a href="../../user-management">User Management</a> for more details.</p>
 
-  - When installing on Konvoy 1.x, add the following configuration to `parameters.yaml` file:
+-   Set required configuration based on the target platform:
 
-  ```bash
-  cat >> parameters.yaml << END
-  dkpPlatformVersion: 1
-  installMinioOperator: true
-  END
-  ```
+    - When installing on Konvoy 1.x, add the following configuration to `parameters.yaml` file:
 
-- When installing on DKP 2.x, add the following configuration to `parameters.yaml` file:
+    ```bash
+    cat >> parameters.yaml << END
+    dkpPlatformVersion: 1
+    installMinioOperator: true
+    END
+    ```
 
-  ```bash
-  # set the OIDC Provider CA bundle
-  OIDC_PROVIDER_CA_BUNDLE=$(kubectl get secret kommander-traefik-certificate -n kommander -o jsonpath="{.data.ca\.crt}")
+-   When installing on DKP 2.x, add the following configuration to `parameters.yaml` file:
 
-  cat >> parameters.yaml << END
-  oidcProviderBase64CaBundle: ${OIDC_PROVIDER_CA_BUNDLE}
-  END
-  ```
+    ```bash
+    # set the OIDC Provider CA bundle
+    OIDC_PROVIDER_CA_BUNDLE=$(kubectl get secret kommander-traefik-certificate -n kommander -o jsonpath="{.data.ca\.crt}")
+  
+    cat >> parameters.yaml << END
+    oidcProviderBase64CaBundle: ${OIDC_PROVIDER_CA_BUNDLE}
+    END
+    ```
 
-- Install Kaptain:
+-   Install Kaptain:
 
-  ```bash
-  kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace \
-    ./kubeflow-1.4.0_1.3.0.tgz \
-    -P parameters.yaml
-  ```
+    ```bash
+    kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace \
+      ./kubeflow-1.4.0_1.3.0.tgz \
+      -P parameters.yaml
+    ```
 
-- If you would like to inject additional annotations to Kaptain's default `kubeflow-ingressgateway` `Gateway`, you can pass in the service annotations as parameters:
+-   If you would like to inject additional annotations to Kaptain's default `kubeflow-ingressgateway` `Gateway`, you can pass in the service annotations as parameters:
 
-  ```bash
-  kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace \
-    ./kubeflow-1.4.0_1.3.0.tgz \
-    -P parameters.yaml \
-    -p kubeflowIngressGatewayServiceAnnotations='{"foo": "abc","bar": "xyz"}'
-  ```
+    ```bash
+    kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace \
+      ./kubeflow-1.4.0_1.3.0.tgz \
+      -P parameters.yaml \
+      -p kubeflowIngressGatewayServiceAnnotations='{"foo": "abc","bar": "xyz"}'
+    ```
 
-- Monitor the installation by running:
+-   Monitor the installation by running:
 
-  ```bash
-  kubectl kudo plan status --instance kaptain -n kubeflow
-  ```
+    ```bash
+    kubectl kudo plan status --instance kaptain -n kubeflow
+    ```
 
 ## Log in to Kaptain
 
 Once all components have been deployed, you can log in to Kaptain:
 
-- Discover the cluster endpoint and copy it to the clipboard.
-  If you are running Kaptain _on-premises_:
+-   Discover the cluster endpoint and copy it to the clipboard.
+    If you are running Kaptain _on-premises_:
 
-  ```bash
-  kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
-  ```
+    ```bash
+    kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}") && echo "https://${kf_uri}"
+    ```
 
-  Or if you are running Kaptain on _AWS_:
+    Or if you are running Kaptain on _AWS_:
 
-  ```bash
-  kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
-  ```
+    ```bash
+    kf_uri=$(kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") && echo "https://${kf_uri}"
+    ```
 
-- Get the login credentials from Konvoy to authenticate:
+-   Get the login credentials from Konvoy to authenticate:
 
-  - For Konvoy 1.x:
+    - For Konvoy 1.x:
 
     ```bash
     konvoy get ops-portal
     ```
 
-  - For DKP 2.x:
+    - For DKP 2.x:
 
-    ```
+    ```bash
     kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}')
     ```
 
 ## Uninstall Kaptain
 
-- Use the following commands to uninstall Kaptain.
+-   Use the following commands to uninstall Kaptain.
 
-  ```bash
-  kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
-  kubectl delete operatorversions.kudo.dev kubeflow-1.4.0-1.3.0 --namespace kubeflow
-  kubectl delete operators.kudo.dev kubeflow --namespace kubeflow
-  ```
+    ```bash
+    kubectl kudo uninstall --instance kaptain --namespace kubeflow --wait
+    kubectl delete operatorversions.kudo.dev kubeflow-1.4.0-1.3.0 --namespace kubeflow
+    kubectl delete operators.kudo.dev kubeflow --namespace kubeflow
+    ```
 
 [download]: ../../download/
 [install-spark-dkp2]: /dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/


### PR DESCRIPTION
seems like a missing blank line above a codeblock in a list crashes vale, it is invalid markdown so its sorta ok, but it should post a error instead of just crashing.. nvm, this PR should fix it.


## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4359.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
