### PR TITLE
chore: adding gitea lowercase in accept words

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -86,7 +86,7 @@ Fluentd
 gapped 
 (gcr|GCR)
 (Gensim|gensim)
-Gitea
+(Gitea|gitea)
 (gitops|GitOps)
 (Goboring|goboring)
 (Golang|golang)


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

fixes broken linter
It'll be good to have gitea both ways, because sometimes it shows up in configs like this (i.e.: lowercase)

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4360.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
