### PR TITLE
[Kaptain]: on-prem install & fixing menu weights

### DIFF
--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Deploy Kaptain on DKP 2.x
 title: Deploy Kaptain on DKP 2.x
-menuWeight: 9
+menuWeight: 15
 excerpt: Deploy Kaptain in air-gapped and networked environments
 beta: false
 enterprise: false

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -128,6 +128,9 @@ With Kaptain enabled, connect to the cluster and check the `HelmReleases` to ver
 
 ```bash
 kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}
+```
+
+```sh
 NAME                      AGE     READY   STATUS
 kaptain-1                 3m40s   True    Release reconciliation succeeded
 ```

--- a/pages/dkp/kaptain/2.0.0/install/dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/dkp/index.md
@@ -1,8 +1,8 @@
 ---
 layout: layout.pug
-navigationTitle: Add Kaptain to DKP Catalog Applications
+navigationTitle: Add Kaptain to DKP Catalog Apps
 title: Add Kaptain to DKP Catalog Applications
-menuWeight: 8
+menuWeight: 5
 excerpt: Add Kaptain to DKP Catalog Applications before deploying to clusters.
 beta: false
 enterprise: false
@@ -149,5 +149,5 @@ You have installed Kaptain by adding it to the DKP Catalog applications. The nex
 [konvoy_deploy_addons]: /dkp/konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
 [kudo_cli]: https://kudo.dev/#get-kudo
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
-[dex]: https://docs.d2iq.com/dkp/kaptain/2.0.0/configuration/external-dex/
+[dex]: ../../configuration/external-dex/
 [airgapped_install]: ../air-gapped-dkp/

--- a/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Install on-premises
 title: Install Kaptain on an on-premises cluster
-menuWeight: 9
+menuWeight: 3
 excerpt: Install Kaptain on an on-premises cluster
 beta: false
 enterprise: false
@@ -14,65 +14,10 @@ Kaptain natively supports the installation on an on premise cluster. Before inst
 
 Please note that the IP address of the Kaptain UI will come from the IP address range that is configured in the [MetalLB load balancer][metallb-load-balancer].
 
-### Konvoy 1.x
+## Install Kaptain
 
-The steps to install Kaptain on an on-premises cluster are as follows:
-
-- Follow the [Konvoy On-Premises Installation Guide][konvoy-on-prem] to configure the `cluster.yaml`. An example is shown below.
-
-- Ensure the following base addons that are needed by Kaptain are enabled:
-
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-    configVersion: stable-1.20-4.3.0
-    addonsList:
-      - name: istio
-        enabled: true
-      - name: dex
-        enabled: true
-      - name: cert-manager
-        enabled: true
-      - name: prometheus
-        enabled: true
-  ```
-
-- Ensure the Knative and NFS addons that are needed by Kaptain are enabled:
-  ```yaml
-  - configRepository: https://github.com/mesosphere/kubeaddons-kaptain
-    configVersion: stable-1.20-1.4.0
-    addonsList:
-      - name: knative
-        enabled: true
-  ```
-- Spin up the Konvoy cluster:
-  ```bash
-  konvoy up
-  ```
-
-### DKP 2
-
-For DKP 2.x, ensure the following applications are enabled in Kommander:
-
-```yaml
-  apiVersion: config.kommander.mesosphere.io/v1alpha1
-  kind: Installation
-  apps:
-    ...
-    dex:
-    dex-k8s-authenticator:
-    kube-prometheus-stack:
-    istio:
-    knative:
-    minio-operator:
-    traefik:
-    nvidia:  # to enable GPU support
-    ...
-```
-
-### Install Kaptain
-
-When the Konvoy cluster is ready, [install Kaptain](../konvoy-dkp/).
+When your cluster is ready, [install Kaptain](../) by adding Kaptain to your DKP Catalog Applications and deploying it to your clusters.
 
 [konvoy-on-prem]: /dkp/konvoy/1.8/install/install-onprem/
-[dkp-install]: /dkp/kommander/latest/install/networked/
+[dkp-install]: /dkp/kommander/latest/networking/load-balancing#on-premises
 [metallb-load-balancer]: /dkp/konvoy/1.8/install/install-onprem/#configure-metallb-load-balancing


### PR DESCRIPTION
## Jira Ticket

## Description of changes being made

Updated on-prem section with additional info and linked to the overall install topic for further steps. 
Also fixed the menu-weights of the pages in that folder, so they are shown in a more structured order.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4366.s3-website-us-west-2.amazonaws.com/
