### PR TITLE
Remove kudo commands from troubleshooting

### DIFF
--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-dkp/index.md
@@ -88,7 +88,6 @@ Use the following instructions to install Spark Operator from Kommander Catalog 
 
 [install-kaptain]: ../konvoy-dkp/
 [install-spark-dkp2]: /dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/
-[install-spark-konvoy1]: /dkp/kommander/1.4/projects/platform-services/platform-services-catalog/kudo-spark/
 [kommander-install]: /dkp/kommander/2.1/install/air-gapped/
 [konvoy-air-gap]: /dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/
 [konvoy_deploy_addons]: /dkp/konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade

--- a/pages/dkp/kaptain/2.0.0/install/dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/dkp/index.md
@@ -92,11 +92,11 @@ For cloud installations, scaling out can be limited by resource quotas.
 In case you need to run Spark jobs on Kubernetes using Spark Operator, it needs to be installed separately.
 Use the following instructions to install Spark Operator from Kommander Catalog [DKP 2.x][install-spark-dkp2]
 
-## Add Kaptain to your DKP Catalog Applications via CLI 
+## Add Kaptain to your DKP Catalog Applications via CLI
 
-If you installed DKP with Kaptain as a workspace application in the Kommander installation file, you do not need to create a Git Repository for Kaptain. 
+If you installed DKP with Kaptain as a workspace application in the Kommander installation file, you do not need to create a Git Repository for Kaptain.
 
-If you added Kaptain after installing DKP, you must make it available by creating a Git Repository. Use the CLI to create the GitRepository resource and add a new repository. 
+If you added Kaptain after installing DKP, you must make it available by creating a Git Repository. Use the CLI to create the GitRepository resource and add a new repository.
 
 ### Create a Git repository for Kaptain
 
@@ -111,11 +111,11 @@ If you added Kaptain after installing DKP, you must make it available by creatin
     metadata:
       name: kaptain-catalog-applications
       namespace: ${WORKSPACE_NAMESPACE}
-      labels: 
+      labels:
         kommander.d2iq.io/gitrepository-type: catalog
     spec:
       interval: 1m0s
-      ref: 
+      ref:
         tag: v2.0.0
       timeout: 20s
       url: https://github.com/mesosphere/kaptain-catalog-applications
@@ -137,13 +137,14 @@ If you added Kaptain after installing DKP, you must make it available by creatin
 
 ## Deploy Kaptain on selected workspaces
 
-You have now added Kaptain to your DKP Catalog applications. The next step is to enable and deploy Kaptain on all clusters in a selected workspace. For this, refer to [Deploy Kaptain][deploy] instructions. 
+You have now added Kaptain to your DKP Catalog applications. The next step is to enable and deploy Kaptain on all clusters in a selected workspace. For this, refer to [Deploy Kaptain][deploy] instructions.
 
 [download]: ../../download/
-[install-spark-dkp2]: /dkp/kommander/latest/workspaces/applications/catalog-applications/dkp-applications/spark-operator/
+[install-spark-dkp2]: /dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/
 [kommander-install]: /dkp/kommander/latest/install/
 [kommander-gpu]: /dkp/kommander/latest/gpu/
-[kudo_cli]: https://kudo.dev/#get-kudo
+[konvoy-gpu]: /dkp/konvoy/1.8/gpu/
+[konvoy_deploy_addons]: /dkp/konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [dex]: ../../configuration/external-dex/
 [airgapped_install]: ../air-gapped-dkp/

--- a/pages/dkp/kaptain/2.0.0/secrets-management/index.md
+++ b/pages/dkp/kaptain/2.0.0/secrets-management/index.md
@@ -44,7 +44,6 @@ kube-public       Active   108m
 kube-system       Active   108m
 kubeaddons        Active   107m
 kubeflow          Active   66m
-kudo-system       Active   64m
 ```
 
 ### Step 2 - Create a secret in Kubeflow tenant's namespace

--- a/pages/dkp/kaptain/2.0.0/troubleshooting/index.md
+++ b/pages/dkp/kaptain/2.0.0/troubleshooting/index.md
@@ -8,12 +8,12 @@ beta: false
 enterprise: false
 ---
 
-## Kaptain and KUDO
+## Kaptain
 
-To print the status of the Kaptain operator instance:
+To print the status of the Kaptain helm installation:
 
 ```bash
-kubectl kudo plan status -n kubeflow --instance kaptain
+helm status kaptain
 ```
 
 To show deployments and pods in the Kaptain operator instance:
@@ -25,13 +25,6 @@ kubectl get pods -n kubeflow
 
 kubectl describe pod <pod_name> -n kubeflow
 ```
-
-To print the logs from the KUDO controller:
-
-```bash
-kubectl logs -n kudo-system kudo-controller-manager-0 -f
-```
-
 
 ## Konvoy
 
@@ -521,7 +514,6 @@ Kaptain includes:
   - MinIO Operator 4.0.3
   - MinIO RELEASE.2021-03-01T04-20-55Z
 - kubectl 1.21
-- Kudobuilder 0.19.0
 - Kaniko 1.3.0
 - TensorFlow Serving 1.14.0
 - ONNX server 0.5.1


### PR DESCRIPTION
## Jira Ticket

[D2IQ-87584](https://jira.d2iq.com/browse/D2IQ-87584)

## Description of changes being made

Remove kudo references from troubleshooting.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4367.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
