### PR TITLE
setupRBAC_Jira78938

### DIFF
--- a/pages/dkp/konvoy/1.6/access-authentication/install-rbac/index.md
+++ b/pages/dkp/konvoy/1.6/access-authentication/install-rbac/index.md
@@ -107,7 +107,7 @@ You need certain software configurations and settings before you start this proc
 1. Verify the token authenticates for the Service Account. Describe the secret, using your own secret name, using the following command:
 
     ```bash
-    kubect describe secret <secret-name>
+    kubectl describe secret <secret-name>
     ```
 
     The output from the commands should look like the following:
@@ -132,7 +132,7 @@ You need certain software configurations and settings before you start this proc
 1. Add the token as an environment variable. Having it as an environment variable reduces copying and pasting token operations. Use the following command:
 
     ```bash
-    export TOKEN=$(kubectl get secret john-sa-token-rq4ls -o=jsonpath="{.data.token}" | base64 -d -i -)
+    export TOKEN=$(kubectl get secret <secret name> -o=jsonpath="{.data.token}" | base64 -d -i -)
     ```
 
 1. Review your kubeconfig file. Notice the file defines 1 user and 1 cluster. Use the following command:
@@ -306,7 +306,7 @@ You need certain software configurations and settings before you start this proc
     kubectl get pods
     ```
 
-1. Confirm you can use the token to make http calls to the Kubernetes api. Use the following command:
+1. Confirm you can use the token to make HTTP calls to the Kubernetes API. Use the following command:
 
     ```bash
     curl -H "Authorization: Bearer $TOKEN" https://api.cluster-address/api/v1/pods -k

--- a/pages/dkp/konvoy/1.7/access-authentication/install-rbac/index.md
+++ b/pages/dkp/konvoy/1.7/access-authentication/install-rbac/index.md
@@ -107,7 +107,7 @@ You need certain software configurations and settings before you start this proc
 1. Verify the token authenticates for the Service Account. Describe the secret, using your own secret name, using the following command:
 
     ```bash
-    kubect describe secret <secret-name>
+    kubectl describe secret <secret-name>
     ```
 
     The output from the commands should look like the following:
@@ -132,7 +132,7 @@ You need certain software configurations and settings before you start this proc
 1. Add the token as an environment variable. Having it as an environment variable reduces copying and pasting token operations. Use the following command:
 
     ```bash
-    export TOKEN=$(kubectl get secret john-sa-token-rq4ls -o=jsonpath="{.data.token}" | base64 -d -i -)
+    export TOKEN=$(kubectl get secret <secret name> -o=jsonpath="{.data.token}" | base64 -d -i -)
     ```
 
 1. Review your kubeconfig file. Notice the file defines 1 user and 1 cluster. Use the following command:
@@ -306,7 +306,7 @@ You need certain software configurations and settings before you start this proc
     kubectl get pods
     ```
 
-1. Confirm you can use the token to make http calls to the Kubernetes api. Use the following command:
+1. Confirm you can use the token to make HTTP calls to the Kubernetes API. Use the following command:
 
     ```bash
     curl -H "Authorization: Bearer $TOKEN" https://api.cluster-address/api/v1/pods -k

--- a/pages/dkp/konvoy/1.8/access-authentication/install-rbac/index.md
+++ b/pages/dkp/konvoy/1.8/access-authentication/install-rbac/index.md
@@ -22,7 +22,7 @@ You need certain software configurations and settings before you start this proc
 
 - Install and configure `kubectl` and [`kubectx`](https://github.com/ahmetb/kubectx).
 
-- Access to a Kubernetes cluster with Authorization mode as `RBAC`. Refer to this [link](https://docs.d2iq.com/mesosphere/dcos/services/kubernetes/2.7.0-1.18.6/operations/authn-and-authz/#rbac) for information.
+- Access to a Kubernetes cluster with Authorization mode as `RBAC`. Refer to this [link](https://docs.d2iq.com/mesosphere/dcos/services/kubernetes/2.7.0-1.18.6/operations/authn-and-authz/#rbac) for information. (Also see the [Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#authorization-modules) site)
 
 - Vim or some other text editor.
 
@@ -107,7 +107,7 @@ You need certain software configurations and settings before you start this proc
 1. Verify the token authenticates for the Service Account. Describe the secret, using your own secret name, using the following command:
 
     ```bash
-    kubect describe secret <secret-name>
+    kubectl describe secret <secret-name>
     ```
 
     The output from the commands should look like the following:
@@ -132,7 +132,7 @@ You need certain software configurations and settings before you start this proc
 1. Add the token as an environment variable. Having it as an environment variable reduces copying and pasting token operations. Use the following command:
 
     ```bash
-    export TOKEN=$(kubectl get secret john-sa-token-rq4ls -o=jsonpath="{.data.token}" | base64 -d -i -)
+    export TOKEN=$(kubectl get secret <secret name> -o=jsonpath="{.data.token}" | base64 -d -i -)
     ```
 
 1. Review your kubeconfig file. Notice the file defines 1 user and 1 cluster. Use the following command:

--- a/pages/dkp/konvoy/1.8/access-authentication/install-rbac/index.md
+++ b/pages/dkp/konvoy/1.8/access-authentication/install-rbac/index.md
@@ -306,7 +306,7 @@ You need certain software configurations and settings before you start this proc
     kubectl get pods
     ```
 
-1. Confirm you can use the token to make http calls to the Kubernetes api. Use the following command:
+1. Confirm you can use the token to make HTTP calls to the Kubernetes API. Use the following command:
 
     ```bash
     curl -H "Authorization: Bearer $TOKEN" https://api.cluster-address/api/v1/pods -k


### PR DESCRIPTION
## Jira Ticket

Setup RBAC with Konvoy
(https://jira.d2iq.com/browse/D2IQ-78938)

Wrong command

kubect describe secret <secret-name>
Missing letter 'l' in the command 'kubectl'.

3. About Step 6 - The following command is not clear/detailed:

export TOKEN=$(kubectl get secret john-sa-token-rq4ls -o=jsonpath="{.data.token}" | base64 -d -i -)
The part 'john-sa-token-rq4ls' is individual. My suggestion:

export TOKEN=$(kubectl get secret <secret-name> -o=jsonpath="{.data.token}" | base64 -d -i -)


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
