### PR TITLE
Adding Kaptain info in Kommander docs

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -243,7 +243,8 @@ Tensorboard(|s)
 Tensorflow
 TensorFlow
 (thanos|Thanos)
-Toree
+toolkit(|s)
+Toolkit(|s)
 tqdm
 (traefik|Traefik)
 triaging

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/kaptain/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/kaptain/index.md
@@ -8,7 +8,7 @@ excerpt: Information about Kaptain
 
 ## Overview
 
-Kaptain is a DKP platform application that allows data scientists to extract value from data immediately by providing a familiar environment for development and all the technologies needed to deploy and scale models in production. To find out more about Kaptain, refer to the [Kaptain documentation][kaptain].
+Kaptain is a DKP catalog application that allows data scientists to implement machine learning models from Jupyter notebooks with KubeFlow. Kaptain packages together many key libraries and toolkits needed to deploy models at scale. To find out more about Kaptain, refer to the [Kaptain documentation][kaptain].
 
 ## Install
 

--- a/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/kaptain/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/kaptain/index.md
@@ -1,0 +1,18 @@
+---
+layout: layout.pug
+navigationTitle: Kaptain
+title: Kaptain
+menuWeight: 30
+excerpt: Information about Kaptain
+---
+
+## Overview
+
+Kaptain is a DKP platform application that allows data scientists to extract value from data immediately by providing a familiar environment for development and all the technologies needed to deploy and scale models in production. To find out more about Kaptain, refer to the [Kaptain documentation][kaptain].
+
+## Install
+
+To install this DKP catalog application, refer to the [Install Kaptain][install_kap] documentation.
+
+[kaptain]: ../../../../../../../kaptain/2.0.0/introducing/
+[install_kap]: ../../../../../../../kaptain/2.0.0/install/


### PR DESCRIPTION
## Jira Ticket
No Jira, but https://github.com/mesosphere/dcos-docs-site/pull/4362#discussion_r853221337

## Description of changes being made
Adding a page under DKP Catalog applications referencing Kaptain (since it is now a dkp catalog app).

## Preview
http://docs-d2iq-com-pr-4371.s3-website-us-west-2.amazonaws.com/

