### PR TITLE
docs: just updating dkp output for capi comps

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/self-managed/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/self-managed/index.md
@@ -23,9 +23,7 @@ Before you start, make sure you have created a workload cluster, as described in
     ```
 
     ```sh
-    ✓ Upgrading CAPI components
-    ✓ Waiting for CAPI components to be upgraded
-    ✓ Initializing new CAPI components
+    ✓ Initializing new CAPI components 
     ```
 
 1.  Move the Cluster API objects from the bootstrap to the workload cluster:
@@ -88,8 +86,8 @@ Before you start, make sure you have created a workload cluster, as described in
 
 <p class="message--note"><strong>NOTE: </strong>Be aware of these limitations in the current release of Konvoy.</p>
 
-- Konvoy supports moving only one set of cluster objects from the bootstrap cluster to the workload cluster, or vice-versa.
-- Konvoy only supports moving all namespaces in the cluster; Konvoy does not support migration of individual namespaces.
+- DKP supports moving only one set of cluster objects from the bootstrap cluster to the workload cluster, or vice-versa.
+- DKP only supports moving all namespaces in the cluster; DKP does not support migration of individual namespaces.
 
 [pivot]: https://cluster-api.sigs.k8s.io/reference/glossary.html?highlight=pivot#pivot
 [createthecluster]: ../create-cluster


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

Really small potatoes, but just updating the output to be current with what I noticed when running these steps

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4374.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
