### PR TITLE
Update kaptain 2.0 version policy

### DIFF
--- a/pages/dkp/kaptain/2.0.0/version-policy/index.md
+++ b/pages/dkp/kaptain/2.0.0/version-policy/index.md
@@ -15,7 +15,7 @@ D2iQ recommends that you install the newest Kaptain version available to stay up
 
 ## Supported DKP Versions
 
-Kaptain 2.0.0 runs on DKP 2.1.2 and newer and can be installed as a workspace catalog application.
+You can deploy Kaptain 2.0.0 on DKP 2.1.2 and later versions as a DKP workspace catalog application.
 
 ## Experimental Status
 

--- a/pages/dkp/kaptain/2.0.0/version-policy/index.md
+++ b/pages/dkp/kaptain/2.0.0/version-policy/index.md
@@ -9,21 +9,16 @@ enterprise: false
 ---
 
 D2iQ supports `N-2` of the latest `MAJOR.MINOR` release of Kaptain.
-With the GA release of Kaptain 1.3.0, support continues for Kaptain 1.3, 1.2, and 1.1, including all patch releases. Support for Kaptain 1.0 expires.
+With the GA release of Kaptain 2.0.0, support continues for Kaptain 1.3, and 1.2, including all patch releases. Support for Kaptain 1.1 expires.
 
 D2iQ recommends that you install the newest Kaptain version available to stay up to date with the latest features and bug fixes.
 
-## Supported Konvoy Versions
+## Supported DKP Versions
 
-Kaptain 1.3.0 runs on DKP 2.1.1, Konvoy 1.7 and 1.8.
-
-## Supported Kommander Versions
-
-Kaptain 1.3.0 cannot be installed from Kommander or as an add on.
-
-Note that it is possible to use [Kommander's Dex instance](../configuration/external-dex) for authenticating users in Kaptain.
+Kaptain 2.0.0 runs on DKP 2.1.2 and newer and can be installed as a workspace catalog application.
 
 ## Experimental Status
+
 "Experimental" means software, features, functionality, sample configurations, or other speculative content that is still under exploration, development, or testing by D2iQ. Experimental components carry no guarantee of eventual release as GA and therefore must not be used in Production Environments. Experimental components qualify for limited, Severity 4 support only and may be discontinued at any time, with or without notice.
 
 Since Experimental components are not intended for Production Environment use, D2iQ cannot assume any responsibility for errors occurring during their use in Production. We can offer only these services in a commercially-reasonable manner, based on the availability of relevant subject matter experts (SMEs):
@@ -34,22 +29,21 @@ Advice on preventing and recovering from failures and troubleshooting, as availa
 Support for Experimental components is provided on a Standard level, Severity 4 basis only.
 
 ## Istio Support Status
+
 Istio is a required prerequisite for Kaptain.
 Istio usage is only supported in conjunction with Kaptain and the configurations delivered as part of Kaptain.
 All other usage of [experimental]Istio[/experimental] is considered experimental.
 
-## Support for KUDO - Cassandra, Kafka & Spark
-### Support Definition - Secondary Support
-Secondary support covers support for the base technology of platform service, which is Cassandra, Kafka, and Spark, and additionally support for the KUDO-based operator of the mentioned platform services.
+## Secondary Support for Cassandra, Kafka & Spark
 
-*Base Technology refers to Cassandra, Kafka, and Spark.
+<p class="message--note"><strong>Secondary Support Definition:</strong> Secondary support covers support for the base technology of platform service, which is Cassandra, Kafka, and Spark.</p>
 
-|Type|Scope Example|Support Offered|
-|:---|:---|:---|
-|Configuration|* Guidance for base technology and DKP interoperability configuration questions and troubleshooting for different components of the DKP platform. <br> * No support for base technology's configuration that is unrelated to its integration with DKP. <br>  * No support for performance issues with the base technology.|Supported with Severity 4 support terms|
-|Failure Assistance|* Assistance with installation, and upgrade, failures of the service. <br> * Assistance with service failures due to platform issues. For example: Konvoy, Kommander, KUDO. <br> * No assistance for base technology's failures that is unrelated to its integration with DKP.|  Supported with Severity 3 & 4 support terms|
-|Bug Fixes|* Bug fixes for service integration with DKP.<br>  * Upstream bug fixes to identified issues in the base technology. (Cassandra, Kafka, Spark) on a best effort basis.<br> * No guarantee that changes to upstream will be accepted.<br> * No commitment to maintaining forks of upstream.|Supported with Severity 3 & 4 support terms|
-|Documentation Errors|* Documentation fixes for life cycle management of services and integration with DKP.<br> * Issue or PR submitted to correct any incorrect upstream documentation in base technology. (Cassandra, Kafka, Spark) on a best effort basis.<br> * No guarantee that changes will be accepted.|Supported with Severity 4 support terms|
+| Type                 | Scope Example                                                                                                                                                                                                                                                                                                              | Support Offered                             |
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------ |
+| Configuration        | _ Guidance for base technology and DKP interoperability configuration questions and troubleshooting for different components of the DKP platform. <br> _ No support for base technology's configuration that is unrelated to its integration with DKP. <br> \* No support for performance issues with the base technology. | Supported with Severity 4 support terms     |
+| Failure Assistance   | _ Assistance with installation, and upgrade, failures of the service. <br> _ Assistance with service failures due to DKP platform issues. <br> \* No assistance for base technology's failures that is unrelated to its integration with DKP.                                                                              | Supported with Severity 3 & 4 support terms |
+| Bug Fixes            | _ Bug fixes for service integration with DKP.<br> _ Upstream bug fixes to identified issues in the base technology. (Cassandra, Kafka, Spark) on a best effort basis.<br> _ No guarantee that changes to upstream will be accepted.<br> _ No commitment to maintaining forks of upstream.                                  | Supported with Severity 3 & 4 support terms |
+| Documentation Errors | _ Documentation fixes for life cycle management of services and integration with DKP.<br> _ Issue or PR submitted to correct any incorrect upstream documentation in base technology. (Cassandra, Kafka, Spark) on a best effort basis.<br> \* No guarantee that changes will be accepted.                                 | Supported with Severity 4 support terms     |
 
 ## Standard Level & Severity Definitions
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-87586

## Description of changes being made

Updated version policy to reflect Kaptain 2.0 helm and DKP based deployment. I've basicly made this up thinking its the best change to be done, but not sure if we need some other people to have a look? support matrix is important I guess..

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4377.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
