### PR TITLE
Re-generate tutorials and chart configuration docs

### DIFF
--- a/pages/dkp/kaptain/2.0.0/configuration/index.md
+++ b/pages/dkp/kaptain/2.0.0/configuration/index.md
@@ -31,13 +31,13 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | ingress.namespace | string | `"kaptain-ingress"` | Namespace to install Kaptain Ingress resources |
 | core.enabled | bool | `true` |  |
 | core.namespace | string | `"kubeflow"` |  |
-| core.notebook.defaultImage | string | `"mesosphere/kubeflow-dev:b66cecc3-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0"` | Default image to use when creating a new notebook server |
-| core.notebook.images[0] | string | `"mesosphere/kubeflow-dev:b66cecc3-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0"` | JupyterLab with Tensorflow, Spark and Horovod pre-installed |
-| core.notebook.images[1] | string | `"mesosphere/kubeflow-dev:c15bf3fa-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu"` | JupyterLab with Tensorflow, CUDA, Spark and Horovod pre-installed with GPU support |
-| core.notebook.images[2] | string | `"mesosphere/kubeflow-dev:22caa41c-jupyter-spark-3.0.0-horovod-0.24.2-pytorch-1.11.0"` | JupyterLab with Pytorch, Spark and Horovod pre-installed |
-| core.notebook.images[3] | string | `"mesosphere/kubeflow-dev:d431dd5f-jupyter-spark-3.0.0-horovod-0.24.2-pytorch-1.11.0-gpu"` | JupyterLab with Pytorch, CUDA, Spark and Horovod pre-installed with GPU support |
-| core.notebook.images[4] | string | `"mesosphere/kubeflow-dev:44625480-jupyter-spark-3.0.0-horovod-0.24.2-mxnet-1.9.0"` | JupyterLab with MXNet, Spark and Horovod pre-installed |
-| core.notebook.images[5] | string | `"mesosphere/kubeflow-dev:e6c6aec9-jupyter-spark-3.0.0-horovod-0.24.2-mxnet-1.9.0-gpu"` | JupyterLab with Tensorflow, CUDA, Spark and Horovod pre-installed with GPU support |
+| core.notebook.defaultImage | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0"` | Default image to use when creating a new notebook server |
+| core.notebook.images[0] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0"` | JupyterLab with Tensorflow, Spark and Horovod pre-installed |
+| core.notebook.images[1] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu"` | JupyterLab with Tensorflow, CUDA, Spark and Horovod pre-installed with GPU support |
+| core.notebook.images[2] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-pytorch-1.11.0"` | JupyterLab with Pytorch, Spark and Horovod pre-installed |
+| core.notebook.images[3] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-pytorch-1.11.0-gpu"` | JupyterLab with Pytorch, CUDA, Spark and Horovod pre-installed with GPU support |
+| core.notebook.images[4] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-mxnet-1.9.0"` | JupyterLab with MXNet, Spark and Horovod pre-installed |
+| core.notebook.images[5] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-mxnet-1.9.0-gpu"` | JupyterLab with MXNet, CUDA, Spark and Horovod pre-installed with GPU support |
 | core.notebook.tolerationGroups | list | `[]` | Pod toleration group configurations for Notebook servers |
 | core.notebook.affinityConfig | list | `[]` | Pod affinity configurations for Notebook servers |
 | core.notebook.enableCulling | bool | `false` | Enables scale down idling notebooks to freeing up the allocated resources. |
@@ -77,7 +77,6 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | core.db.backup.region | string | `""` | Backup bucket region name for the MySQL cluster |
 | core.db.backup.secretName | string | `""` | Name of the secret with access credentials for the MySQL cluster backup bucket |
 | core.db.backup.endpointUrl | string | `""` | Custom endpoint URL for the MySQL cluster backup bucket |
-| core.db.backup.restoreSource | string | `""` | Full path to the backup folder, for example `s3://mysql-store-backup/kaptain-mysql-store-2021-04-05-21:47:24-full` |
 | core.minio.serverPools | int | `1` | Number of MinIO server pools |
 | core.minio.servers | int | `2` | Number of MinIO server pods to deploy in the pool |
 | core.minio.volumesPerServer | int | `2` | Number of Persistent Volume Claims to generate for each MinIO server pod in the pool |

--- a/pages/dkp/kaptain/2.0.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/katib/index.md
@@ -166,7 +166,7 @@ The following YAML file describes an `Experiment` object:
 
 
 ```python
-%env IMAGE mesosphere/kubeflow-dev:51d57053-mnist-tensorflow-2.8.0-gpu
+%env IMAGE mesosphere/kubeflow:2.0.0-mnist-tensorflow-2.8.0-gpu
 ```
 
 
@@ -278,7 +278,7 @@ Again, use a random search:
 
 
 ```python
-%env IMAGE mesosphere/kubeflow-dev:d6b2c5c6-mnist-pytorch-1.11.0-gpu
+%env IMAGE mesosphere/kubeflow:2.0.0-mnist-pytorch-1.11.0-gpu
 ```
 
 

--- a/pages/dkp/kaptain/2.0.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/katib/index.md
@@ -87,7 +87,7 @@ Note that you typically use (YAML) resource definitions for Kubernetes from the 
 Of course, if you are more familiar or comfortable with `kubectl` and the command line, feel free to use a local CLI or the embedded terminals from the Jupyter Lab launch screen.
 
 
-```python
+```bash
 TF_EXPERIMENT_FILE = "katib-tfjob-experiment.yaml"
 PYTORCH_EXPERIMENT_FILE = "katib-pytorchjob-experiment.yaml"
 ```
@@ -95,7 +95,7 @@ PYTORCH_EXPERIMENT_FILE = "katib-pytorchjob-experiment.yaml"
 Set the following constants depending on whether you want to use GPUs or a custom image.
 
 
-```python
+```bash
 GPUS = 1  # set to 0 if the experiment should not use GPUs
 PARALLEL_TRIAL_COUNT = 3
 TOTAL_TRIAL_COUNT = 9
@@ -104,7 +104,7 @@ TOTAL_TRIAL_COUNT = 9
 Make the defined constants available as shell environment variables. They parameterize the `Experiment` manifests below.
 
 
-```python
+```bash
 %env GPUS $GPUS
 %env TF_EXPERIMENT_FILE $TF_EXPERIMENT_FILE
 %env PYTORCH_EXPERIMENT_FILE $PYTORCH_EXPERIMENT_FILE
@@ -122,7 +122,7 @@ Make the defined constants available as shell environment variables. They parame
 Define a helper function to capture output from a cell that usually looks like `some-resource created`, using [`%%capture`](https://ipython.readthedocs.io/en/stable/interactive/magics.html#cellmagic-capture):
 
 
-```python
+```bash
 import re
 
 from IPython.utils.capture import CapturedIO
@@ -165,7 +165,7 @@ Please note that [discrete values (e.g. epochs) and categorical values (e.g. opt
 The following YAML file describes an `Experiment` object:
 
 
-```python
+```bash
 %env IMAGE mesosphere/kubeflow:2.0.0-mnist-tensorflow-2.8.0-gpu
 ```
 
@@ -277,7 +277,7 @@ Run up to 9 trials with three such trials in parallel.
 Again, use a random search:
 
 
-```python
+```bash
 %env IMAGE mesosphere/kubeflow:2.0.0-mnist-pytorch-1.11.0-gpu
 ```
 
@@ -376,7 +376,7 @@ You can either execute these commands on your local machine with `kubectl` or yo
 If you do run these locally, you cannot rely on cell magic, so you have to manually copy-paste the experiment name wherever you see `$EXPERIMENT`.
 If you intend to run the following command locally, you have to set the user namespace for all subsequent commands:
 
-```
+```bash
 kubectl config set-context --current --namespace=<insert-namespace>
 ```
 
@@ -385,19 +385,19 @@ Please change the namespace to whatever has been set up by your administrator.
 Pick one of the following depending on which framework you want to use.
 
 
-```python
+```bash
 %env EXPERIMENT_FILE $PYTORCH_EXPERIMENT_FILE
 ```
 
 
-```python
+```bash
 %env EXPERIMENT_FILE $TF_EXPERIMENT_FILE
 ```
 
 To submit the experiment, execute:
 
 
-```python
+```bash
 %%capture kubectl_output --no-stderr
 %%sh
 kubectl apply -f "${EXPERIMENT_FILE}"
@@ -406,14 +406,14 @@ kubectl apply -f "${EXPERIMENT_FILE}"
 The cell magic grabs the output of the `kubectl` command and stores it in an object named `kubectl_output`:
 
 
-```python
+```bash
 %env EXPERIMENT {get_resource(kubectl_output)}
 ```
 
 To see the status, run:
 
 
-```sh
+```bash
 %%sh
 kubectl describe experiment.kubeflow.org $EXPERIMENT
 ```
@@ -421,7 +421,7 @@ kubectl describe experiment.kubeflow.org $EXPERIMENT
 To see experiment suggestions:
 
 
-```sh
+```bash
 %%sh
 kubectl describe suggestions.kubeflow.org $EXPERIMENT
 ```
@@ -429,7 +429,7 @@ kubectl describe suggestions.kubeflow.org $EXPERIMENT
 To get the list of created trials, use the following command:
 
 
-```sh
+```bash
 %%sh
 kubectl get trials.kubeflow.org -l katib.kubeflow.org/experiment=$EXPERIMENT
 ```
@@ -443,7 +443,7 @@ kubectl get trials.kubeflow.org -l katib.kubeflow.org/experiment=$EXPERIMENT
 To fetch the logs of a particular trial, use the following command:
 
 
-```sh
+```bash
 %%sh
 kubectl logs -l job-name=<trial-name> --all-containers --prefix=true
 ```
@@ -451,7 +451,7 @@ kubectl logs -l job-name=<trial-name> --all-containers --prefix=true
 After the experiment is completed, use `describe` to get the best trial results:
 
 
-```sh
+```bash
 %%sh
 kubectl describe experiment.kubeflow.org $EXPERIMENT
 ```
@@ -481,7 +481,7 @@ Status:
 If an Experiment needs to be deleted, including deleting it from the "Experiments (AutoML)" page:
 
 
-```sh
+```bash
 %%sh
 kubectl delete experiments.kubeflow.org $EXPERIMENT 
 ```

--- a/pages/dkp/kaptain/2.0.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/katib/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/pipelines/index.md
@@ -71,7 +71,7 @@ This notebook.
 Ensure Kubeflow Pipelines is available:
 
 
-```sh
+```bash
 %%sh
 pip show kfp
 ```
@@ -97,7 +97,7 @@ In order for KFServing to access MinIO, the credentials must be added to the def
 </p>
 
 
-```python
+```bash
 %%writefile minio_secret.yaml
 apiVersion: v1
 kind: Secret
@@ -123,7 +123,7 @@ secrets:
 
 
 
-```sh
+```bash
 %%sh
 kubectl apply -f minio_secret.yaml
 ```
@@ -137,7 +137,7 @@ kubectl apply -f minio_secret.yaml
 First, configure credentials for `mc`, the MinIO command line client.
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 
@@ -157,18 +157,18 @@ Use it to create a bucket, upload the dataset to it, and set access policy so th
 You may want to change the default bucket names used by this tutorial, since MinIO buckets are global resources shared between all cluster users.
 
 
-```python
+```bash
 INPUT_BUCKET = "pipelines-tutorial-data"
 EXPORT_BUCKET = "pipelines-tutorial-model"
 ```
 
 
-```python
+```bash
 %env INPUT_BUCKET $INPUT_BUCKET
 ```
 
 
-```sh
+```bash
 %%sh
 mc --no-color mb "minio/${INPUT_BUCKET}"
 ```
@@ -177,7 +177,7 @@ mc --no-color mb "minio/${INPUT_BUCKET}"
 
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 tar --dereference -czf datasets.tar.gz ./datasets
@@ -687,7 +687,7 @@ with open("input.json", "w") as json_file:
 ```
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 model="mnist"
@@ -702,7 +702,7 @@ curl --fail -L "${url}" -d@input.json -o output.json
 
 
 
-```sh
+```bash
 %%sh
 jq -M . output.json
 ```
@@ -729,7 +729,7 @@ The probabilities for each class (0-9) are shown in the `predictions` response.
 The model believes the image shows a "9", which indeed it does!
 
 
-```sh
+```bash
 %%sh
 jq -M --exit-status '.predictions[0] | indices(max)[0] == 9' output.json
 ```

--- a/pages/dkp/kaptain/2.0.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/pipelines/index.md
@@ -478,7 +478,7 @@ For GPU support, please add the "-gpu" suffix to the base image.
 
 
 ```python
-BASE_IMAGE = "mesosphere/kubeflow:1.3.0-tensorflow-2.5.0"
+BASE_IMAGE = "mesosphere/kubeflow:2.0.0-tensorflow-2.8.0"
 ```
 
 

--- a/pages/dkp/kaptain/2.0.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/pipelines/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/image-builder/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/image-builder/index.md
@@ -51,11 +51,11 @@ Please note that this notebook is interactive!
 Kaptain SDK 1.0.0 or later:
 
 
-```sh
+```bash
 %%sh
 pip show d2iq-kaptain
 ```
-
+```sh
     Name: d2iq-kaptain
     Version: 1.0.0
     Summary: A pack-and-ship SDK for Kaptain
@@ -66,7 +66,7 @@ pip show d2iq-kaptain
     Location: /opt/conda/lib/python3.7/site-packages
     Requires: python-dxf, retrying, botocore, kubernetes, types-requests, object-mapper, boto3, torch-model-archiver, kfserving, kubeflow-katib, kubeflow-training, tqdm, humanize, tenacity, typing
     Required-by: 
-
+```
 
 ### Prepare the training code and datasets
 The examples in this tutorial require a trainer code file `mnist.py` and a dataset to be present in the current folder.
@@ -340,7 +340,7 @@ Finally, the following cell will run the image build using the Dockerfile with a
 ```python
 builder.build_image()
 ```
-
+```sh
     2021-11-02 14:11:59,714 kaptain-log[INFO]: Building Docker image.
     2021-11-02 14:11:59,714 kaptain-log[INFO]: Creating secret docker-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:11:59,728 kaptain-log[INFO]: Creating secret context-ffccde4355a4a541 in namespace user1.
@@ -386,7 +386,7 @@ builder.build_image()
     2021-11-02 14:15:06,234 kaptain-log[INFO]: Deleting job kaniko-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:15:06,243 kaptain-log[INFO]: Deleting secret docker-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:15:06,253 kaptain-log[INFO]: Deleting secret context-ffccde4355a4a541 in namespace user1.
-
+```
 
 That's it! Image build has been completed and the image with required packages and files has been pushed to the Docker registry. 
 
@@ -422,7 +422,7 @@ model.train(
     hyperparameters={"--learning-rate": 0.1, "--momentum": 0.02, "--epochs": 5,},
 )
 ```
-
+```sh
     2021-11-02 18:37:40,752 kaptain-log[INFO]: Skipping image build for the model - the image 'mesosphere/kubeflow:kaptain-sdk-mnist-tf-1635862297' with the same contents has already been published to the registry.
     2021-11-02 18:37:40,755 kaptain-log[INFO]: Creating secret train-d5fd784b5409a57f in namespace user1.
     2021-11-02 18:37:40,768 kaptain-log[INFO]: Creating secret train-registry-c33ad3a574d5dee2 in namespace user1.
@@ -450,6 +450,6 @@ model.train(
     2021-11-02 18:38:30,371 kaptain-log[INFO]: Deleting secret train-d5fd784b5409a57f in namespace user1.
     2021-11-02 18:38:30,378 kaptain-log[INFO]: Deleting secret train-registry-c33ad3a574d5dee2 in namespace user1.
     2021-11-02 18:38:30,384 kaptain-log[INFO]: Model training is completed.
-
+```
 
 To learn more about creating and deploying machine learninig models with Kaptain SDK, refer to [Kaptain SDK with Tensorflow](../tensorflow) or [Kaptain SDK with Pytorch](../pytorch) tutorials.

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/image-builder/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/image-builder/index.md
@@ -274,10 +274,10 @@ requirements = "requirements.txt"
 extra_files = [requirements, "mnist.py", "datasets"]
 
 # Image used in the FROM instruction of the Dockerfile
-base_image = "mesosphere/kubeflow:1.3.0-tensorflow-2.5.0"
+base_image = "mesosphere/kubeflow:2.0.0-tensorflow-2.8.0"
 
 # Name of the final image
-image_name = f"mesosphere/kubeflow:kaptain-sdk-mnist-tensorflow-{timestamp}"
+image_name = f"mesosphere/kubeflow:kaptain-sdk-mnist-tf-{timestamp}"
 ```
 
 Create a requirements file with Python packages that need to be included in the resulting image. For the purpose of this example, we will specify packages already installed into the base image:
@@ -348,16 +348,16 @@ builder.build_image()
     2021-11-02 14:11:59,918 kaptain-log[INFO]: Waiting for Image Build to start...
     2021-11-02 14:12:03,869 kaptain-log[INFO]: Image Build started in pod: kaniko-ffccde4355a4a541-hz9pl.
     2021-11-02 14:12:05,996 kaptain-log[INFO]: [kaniko-ffccde4355a4a541-hz9pl/kaniko] logs:
-    [0001] Retrieving image manifest mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
-    [0001] Retrieving image mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
-    [0001] Retrieving image manifest mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
-    [0001] Retrieving image mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
+    [0001] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
+    [0001] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
+    [0001] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
+    [0001] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
     [0002] Built cross stage deps: map[]                
     2021-11-02 14:12:57,247 kaptain-log[INFO]: [kaniko-ffccde4355a4a541-hz9pl/kaniko] logs:
-    [0002] Retrieving image manifest mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
-    [0002] Retrieving image mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
-    [0003] Retrieving image manifest mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
-    [0003] Retrieving image mesosphere/kubeflow:1.3.0-tensorflow-2.5.0 
+    [0002] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
+    [0002] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
+    [0003] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
+    [0003] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0 
     [0004] Executing 0 build triggers                   
     [0004] Unpacking rootfs as cmd COPY . /workdir requires it. 
     [0054] Taking snapshot of full filesystem...        
@@ -382,7 +382,7 @@ builder.build_image()
     [0113] LABEL checksum=dd270080d096520306e0cb72857bd859 
     [0113] Applying label checksum=dd270080d096520306e0cb72857bd859 
     [0113] Taking snapshot of full filesystem...        
-    2021-11-02 14:15:06,233 kaptain-log[INFO]: Image build completed successfully. Image pushed: mesosphere/kubeflow:kaptain-sdk-mnist-tensorflow-1635862297
+    2021-11-02 14:15:06,233 kaptain-log[INFO]: Image build completed successfully. Image pushed: mesosphere/kubeflow:kaptain-sdk-mnist-tf-1635862297
     2021-11-02 14:15:06,234 kaptain-log[INFO]: Deleting job kaniko-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:15:06,243 kaptain-log[INFO]: Deleting secret docker-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:15:06,253 kaptain-log[INFO]: Deleting secret context-ffccde4355a4a541 in namespace user1.
@@ -423,7 +423,7 @@ model.train(
 )
 ```
 
-    2021-11-02 18:37:40,752 kaptain-log[INFO]: Skipping image build for the model - the image 'mesosphere/kubeflow:kaptain-sdk-mnist-tensorflow-1635862297' with the same contents has already been published to the registry.
+    2021-11-02 18:37:40,752 kaptain-log[INFO]: Skipping image build for the model - the image 'mesosphere/kubeflow:kaptain-sdk-mnist-tf-1635862297' with the same contents has already been published to the registry.
     2021-11-02 18:37:40,755 kaptain-log[INFO]: Creating secret train-d5fd784b5409a57f in namespace user1.
     2021-11-02 18:37:40,768 kaptain-log[INFO]: Creating secret train-registry-c33ad3a574d5dee2 in namespace user1.
     2021-11-02 18:37:40,775 kaptain-log[INFO]: Submitting a new training job "mnist-tfjob-30f13374".

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/image-builder/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/image-builder/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/pytorch/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/pytorch/index.md
@@ -444,9 +444,9 @@ Finally, a `Model` instance requires providing a base Docker image (`base_image`
 ```python
 # as the trainer file depends on the model file, the model file should be provided as a dependency via 'extra_files'
 extra_files = ["datasets/MNIST", "model.py"]
-base_image = "mesosphere/kubeflow:1.3.0-pytorch-1.7.1"
+base_image = "mesosphere/kubeflow:2.0.0-pytorch-1.11.0"
 # replace with your docker repository with a tag (optional), e.g. "repository/image"  or "repository/image:tag"
-image_name = "mesosphere/kubeflow:mnist-sdk-pytorch-example"
+image_name = "mesosphere/kubeflow:mnist-sdk-example-pytorch"
 # name of the file with additional python packages to install into the model image (e.g. "requirements.txt")
 requirements = "requirements.txt"
 ```
@@ -462,7 +462,7 @@ model = Model(
     description="MNIST Model",
     version="0.0.1",
     framework=ModelFramework.PYTORCH,
-    framework_version="1.7.1",
+    framework_version="1.11.0",
     main_file="trainer.py",
     extra_files=extra_files,
     image_name=image_name,
@@ -516,7 +516,7 @@ model.train(
 ```
 
     ...
-    INFO:root:Image build completed successfully. Image pushed: mesosphere/kubeflow:mnist-sdk-pytorch-example
+    INFO:root:Image build completed successfully. Image pushed: mesosphere/kubeflow:mnist-sdk-example-pytorch
     INFO:root:Submitting a new training job "mnist-pytorchjob-de194a8f".
     ...
     INFO:root:INFO:root:Epoch: 1 (  0.0%) - Loss: 2.3082287311553955

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/pytorch/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/pytorch/index.md
@@ -54,15 +54,15 @@ All you need is this notebook.
 Before proceeding, check you are using the correct notebook image, that is, [Pytorch](https://pytorch.org/docs/stable/index.html) is available:
 
 
-```sh
+```bash
 %%sh
 pip list | grep torch
 ```
-
+```sh
     kubeflow-pytorchjob           0.1.3
     torch                         1.7.1
     torchvision                   0.8.2
-
+```
 
 ## Prepare the Training Code and Data Sets
 The examples in this tutorial require a trainer code file `mnist.py` and a dataset to be present in the current folder.
@@ -406,9 +406,9 @@ def main():
 if __name__ == "__main__":
     main()
 ```
-
+```sh
     Writing trainer.py
-
+```
 
 ## Define the Model
 The central abstraction of the Kaptain SDK is a `Model` class that encapsulates all the configuration and high-level APIs required for the model training, tuning, and serving. Prior to creating an instance of the `Model` class, let's consider an example where we need to specify additional dependencies required for model training, tuning and serving, and also provide minimal required configuration for the model server.
@@ -423,9 +423,9 @@ Model dependencies can be provided via pip `requirements.txt`. For example:
 # fastai
 # torch
 ```
-
+```sh
     Writing requirements.txt
-
+```
 
 Below is an example of the minimally required serving configuration for a PyTorch model. To learn more about advanced configuration options, consult the Kaptain SDK documentation.
 
@@ -514,7 +514,7 @@ model.train(
     hyperparameters={"--epochs": epochs, "--batch-size": batch_size, "--seed": seed},
 )
 ```
-
+```sh
     ...
     INFO:root:Image build completed successfully. Image pushed: mesosphere/kubeflow:mnist-sdk-example-pytorch
     INFO:root:Submitting a new training job "mnist-pytorchjob-de194a8f".
@@ -538,7 +538,7 @@ model.train(
     ...
     INFO:root:Training result: Succeeded
 
-
+```
 The default `gpus` argument is 0, but it is shown here as an explicit option.
 Use `?Model.train` to see all supported arguments.
 
@@ -553,7 +553,7 @@ The low accuracy of the model is to make the demonstration of distributed traini
 ### Verify the Model is Exported to MinIO
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 
@@ -563,10 +563,10 @@ minio_secretkey=$(kubectl get secret minio-creds-secret -o jsonpath="{.data.secr
 mc --no-color alias set minio http://minio.kubeflow ${minio_accesskey} ${minio_secretkey}
 mc --no-color ls -r minio/kaptain/models
 ```
-
+```sh
     Added `minio` successfully.
     [2021-05-18 22:08:09 UTC] 4.6MiB dev/mnist/trained/e268b7a148af4aa7a26f0639f1695edc/model.pt
-
+```
 
 ## Deploy the Model
 A trained model can be deployed as an auto-scalable inference service with a single call. When providing additional serving dependencies,
@@ -616,7 +616,7 @@ model.tune(
     objective_goal=0.99
 )
 ```
-
+```sh
     ...
     [I 201214 11:27:11 experiment_runner:66] Creating experiment mnist-tune-14c4431d in namespace demo
     [I 201214 11:27:11 experiment_runner:68] Experiment mnist-tune-14c4431d has been created.
@@ -627,7 +627,7 @@ model.tune(
         parameters: {'--learning-rate': '0.6885679458378395', '--momentum': '0.3915904809621852', '--epochs': '10', '--steps': '100'}, best_trial_name: mnist-tune-14c4431d-wttgxggg
     [I 201214 11:34:27 models:432] Copying saved model with the best metrics from the trial to the target location.
     [I 201214 11:34:27 models:444] Removing intermediate trial models from the storage.
-
+```
 
 For more details on the arguments supported by the SDK, execute `?Model.tune` in a notebook.
 Available options are:
@@ -708,7 +708,7 @@ plt.show()
 ![Image](img/7.png)
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 model_name="dev-mnist"

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/pytorch/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/pytorch/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/quick-start/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/quick-start/index.md
@@ -59,7 +59,7 @@ All you need is this notebook.
 Before proceeding, check you are using the correct notebook image, that is, [scikit-learn](https://scikit-learn.org/stable/) is available:
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 pip list | grep scikit-learn
@@ -302,7 +302,7 @@ cpu = "0.5"
 ```python
 model.train(cpu=cpu, memory=memory, hyperparameters={})
 ```
-
+```sh
     2021-12-10 19:29:31,544 kaptain-log[INFO]: Skipping image build for the model - the image 'mesosphere/kubeflow:mnist-sklearn-sdk' with the same contents has already been published to the registry.
     2021-12-10 19:29:31,546 kaptain-log[INFO]: Creating secret train-d3adabf95994484a in namespace demo.
     2021-12-10 19:29:31,562 kaptain-log[INFO]: Creating secret train-registry-068ad4ec6b93f037 in namespace demo.
@@ -344,7 +344,7 @@ model.train(cpu=cpu, memory=memory, hyperparameters={})
     2021-12-10 19:29:38,400 kaptain-log[INFO]: Deleting secret train-d3adabf95994484a in namespace demo.
     2021-12-10 19:29:38,415 kaptain-log[INFO]: Deleting secret train-registry-068ad4ec6b93f037 in namespace demo.
     2021-12-10 19:29:38,426 kaptain-log[INFO]: Model training is completed.
-
+```
 
 The default `gpus` argument is 0, but it is shown here as an explicit option.
 Use `?Model.train` to see all supported arguments.
@@ -381,7 +381,7 @@ model.tune(
     objective_goal=0.99,
 )
 ```
-
+```sh
     2021-12-10 19:29:39,806 kaptain-log[INFO]: Skipping image build for the model - the image 'mesosphere/kubeflow:mnist-sklearn-sdk' with the same contents has already been published to the registry.
     2021-12-10 19:29:39,813 kaptain-log[INFO]: Creating secret tune-b07d30db2ea16212 in namespace demo.
     2021-12-10 19:29:39,827 kaptain-log[INFO]: Creating secret tune-registry-a3a9649180ddb293 in namespace demo.
@@ -395,12 +395,12 @@ model.tune(
     parameters: {'--gamma': '0.0009033059385183185', '--c': '0.8628663122572235'}, best_trial_name: mnist-tune-0174088b-sh2xfkbt
     2021-12-10 19:30:45,048 kaptain-log[INFO]: Copying saved model with the best metrics from the trial to the target location.
     2021-12-10 19:30:45,190 kaptain-log[INFO]: Removing intermediate trial models from the storage.
-
+```
 
 ## Verify the Model is Exported to MinIO
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 
@@ -410,12 +410,12 @@ minio_secretkey=$(kubectl get secret minio-creds-secret -o jsonpath="{.data.secr
 mc --no-color alias set minio http://minio.kubeflow ${minio_accesskey} ${minio_secretkey}
 mc --no-color ls -r minio/kaptain/models
 ```
-
+```sh
     Added `minio` successfully.
     [2021-12-09 23:26:38 UTC] 321KiB dev/mnist/deploy/25f6e33b86b54499820124695435e6f8/model.joblib
     [2021-12-09 23:25:24 UTC] 337KiB dev/mnist/trained/b3ca1937766b4698b909bbd5f0f8073c/model.joblib
     [2021-12-09 23:26:38 UTC] 321KiB dev/mnist/tuned/d039aa7b4bb64f2bb71490bb046cfd00/model.joblib
-
+```
 
 ## Deploy the Model
 
@@ -430,7 +430,7 @@ serving_config = {"protocol_version": "v2"}
 model.serving_config = serving_config
 model.deploy(cpu="0.5", memory="500M", replace=True)
 ```
-
+```sh
     2021-12-10 19:30:45,529 kaptain-log[INFO]: Building deployment artifacts and uploading to s3://kaptain/models/dev/mnist/deploy/b7d7f70cee7b4918ba5a71d9784deff4
     2021-12-10 19:30:45,641 kaptain-log[INFO]: Deploying model from s3://kaptain/models/dev/mnist/deploy/b7d7f70cee7b4918ba5a71d9784deff4
     2021-12-10 19:30:45,644 kaptain-log[INFO]: Reading secrets dev-mnist-secret in namespace demo.
@@ -453,7 +453,7 @@ model.deploy(cpu="0.5", memory="500M", replace=True)
 
 
     2021-12-10 19:31:35,472 kaptain-log[INFO]: Model dev/mnist deployed successfully. Cluster URL: http://dev-mnist.demo.svc.cluster.local/v2/models/dev-mnist/infer
-
+```
 
 ## Test the Model Endpoint
 

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/quick-start/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/quick-start/index.md
@@ -238,7 +238,7 @@ Finally, a `Model` instance requires providing a base Docker image (`base_image`
 
 
 ```python
-base_image = "mesosphere/kubeflow:1.3.0-base"
+base_image = "mesosphere/kubeflow:2.0.0-base"
 image_name = "mesosphere/kubeflow:mnist-sklearn-sdk"
 
 # name of the file with additional python packages to install into the model image (e.g. "requirements.txt")

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/quick-start/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/quick-start/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/tensorflow/index.md
@@ -55,7 +55,7 @@ All you need is this notebook.
 Before proceeding, check you are using the correct notebook image, that is, [TensorFlow](https://www.tensorflow.org/api_docs/) is available:
 
 
-```sh
+```bash
 %%sh
 pip list | grep tensorflow
 ```
@@ -329,7 +329,7 @@ model.train(
     args={}, # additional command line arguments for the training job. 
 )
 ```
-
+```sh
     ...
     10/10 [==============================] - 0s 48ms/step - accuracy: 0.2516 - loss: 2.2895
     [I 201214 11:18:01 kubernetes:190] Epoch 2/5
@@ -344,7 +344,7 @@ model.train(
     [I 201214 11:18:06 kubernetes:190] INFO:root:Metrics saved.
     [I 201214 11:18:07 job_runner:58] Waiting for the training job to complete...
     [I 201214 11:18:07 models:332] Training result: Succeeded
-
+```
 
 The default `gpus` argument is 0, but it is shown here as an explicit option.
 Use `?Model.train` to see all supported arguments.
@@ -360,7 +360,7 @@ The low accuracy of the model is to make the demonstration of distributed traini
 ### Verify the Model is Exported to MinIO
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 
@@ -503,7 +503,7 @@ with open("input.json", "w") as json_file:
 ```
 
 
-```sh
+```bash
 %%sh
 set -o errexit
 model_name="dev-mnist"

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/tensorflow/index.md
@@ -263,7 +263,7 @@ The central abstraction of the Kaptain SDK is a model:
 
 ```python
 extra_files = ["datasets/mnist"]
-base_image = "mesosphere/kubeflow:1.3.0-tensorflow-2.5.0"
+base_image = "mesosphere/kubeflow:2.0.0-tensorflow-2.8.0"
 # replace with your docker repository with a tag (optional), e.g. "repository/image"  or "repository/image:tag"
 image_name = "mesosphere/kubeflow:mnist-sdk-example"
 # name of the file with additional python packages to install into model image (e.g. "requirements.txt")
@@ -281,7 +281,7 @@ model = Model(
     description="MNIST Model",
     version="0.0.1",
     framework=ModelFramework.TENSORFLOW,
-    framework_version="2.5.0",
+    framework_version="2.8.0",
     main_file="trainer.py",
     extra_files=extra_files,
     image_name=image_name,

--- a/pages/dkp/kaptain/2.0.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/sdk/tensorflow/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/mxnet/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/mxnet/index.md
@@ -44,15 +44,14 @@ All you need is this notebook.
 Before proceeding, check you are using the correct notebook image, that is, [MXNet](https://mxnet.apache.org/api/python/docs/api/) is available:
 
 
-```sh
+```bash
 %%sh
 pip list | grep mxnet
 ```
-
+```sh
     mxnet-cu102mkl           1.6.0
 
-Yes!
-
+```
 Import the necessary Python modules and load the data:
 
 
@@ -155,9 +154,9 @@ mnist["train_label"][42]
 
 
 
-
+```sh
     7
-
+```
 
 
 Just to be on the safe side, check the pixel values have already been scaled into the [0, 1] range:
@@ -170,10 +169,9 @@ min(flattened), max(flattened)
 
 
 
-
+```sh
     (0.0, 1.0)
-
-
+```
 
 ## How to Train the Model
 
@@ -375,7 +373,7 @@ Invoke it with the defaults (and the pre-defined parameters):
 ```python
 model, acc = train(mnist, context, epochs, batch_size)
 ```
-
+```sh
     INFO:root:Epoch[0] Batch [0-100]	Speed: 1353.96 samples/sec	accuracy=0.114356
     INFO:root:Epoch[0] Batch [100-200]	Speed: 1438.84 samples/sec	accuracy=0.113700
     INFO:root:Epoch[0] Batch [200-300]	Speed: 1464.64 samples/sec	accuracy=0.112600
@@ -456,7 +454,7 @@ model, acc = train(mnist, context, epochs, batch_size)
     INFO:root:Epoch[9] Train-accuracy=0.990800
     INFO:root:Epoch[9] Time cost=48.257
     INFO:root:Epoch[9] Validation-accuracy=0.987700
-
+```
 
 <div style="color: #31708f; background-color: #d9edf7; border-color: #bce8f1; padding: 15px; margin-top: 10px; margin-bottom: 10px; border: 1px solid transparent; border-radius: 4px;">
     <b>A Note on Accuracy</b><br>
@@ -471,7 +469,7 @@ Because you wrapped the training process in a function, you can easily see the i
 ```python
 model_relu, acc_relu = train(mnist, context, epochs, batch_size, activation="relu")
 ```
-
+```sh
     INFO:root:Epoch[0] Batch [0-100]	Speed: 1693.27 samples/sec	accuracy=0.111089
     INFO:root:Epoch[0] Batch [100-200]	Speed: 1739.83 samples/sec	accuracy=0.118500
     INFO:root:Epoch[0] Batch [200-300]	Speed: 1768.59 samples/sec	accuracy=0.105400
@@ -552,7 +550,7 @@ model_relu, acc_relu = train(mnist, context, epochs, batch_size, activation="rel
     INFO:root:Epoch[9] Train-accuracy=0.992583
     INFO:root:Epoch[9] Time cost=34.517
     INFO:root:Epoch[9] Validation-accuracy=0.987800
-
+```
 
 
 ```python
@@ -587,7 +585,7 @@ prob[24], prob_relu[24]
 
 
 
-
+```sh
     (
      [3.88936355e-10 5.50869439e-09 1.38218335e-08 1.33717464e-11
       9.99999046e-01 1.08974885e-09 3.25030669e-07 8.28973228e-08
@@ -597,7 +595,7 @@ prob[24], prob_relu[24]
      [6.4347176e-08 7.3004806e-08 3.4015596e-08 5.8196594e-09 9.9998724e-01
       1.2476704e-07 1.9580840e-07 3.0599865e-06 1.2806310e-08 9.1640350e-06]
      <NDArray 10 @cpu(0)>)
-
+```
 
 
 The highest probability is observed for the fourth index (i.e. the digit '4'):
@@ -609,7 +607,7 @@ np.argmax(prob[24]), np.argmax(prob_relu[24])
 
 
 
-
+```sh
     (
      [4.]
      <NDArray 1 @cpu(0)>,
@@ -617,7 +615,7 @@ np.argmax(prob[24]), np.argmax(prob_relu[24])
      [4.]
      <NDArray 1 @cpu(0)>)
 
-
+```
 
 Since you did not shuffle data for the iterator `test_iter` that was used to generate probabilities, you can use the same index to obtain the label to verify that the model predicts the digit correctly:
 
@@ -628,7 +626,7 @@ mnist["test_label"][24]
 
 
 
-
+```sh
     4
-
+```
 

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/mxnet/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/mxnet/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/pytorch/index.md
@@ -659,7 +659,7 @@ It uses [containerd](https://containerd.io/) to run workloads (only) instead.
 The Dockerfile looks as follows:
 
 ```
-FROM mesosphere/kubeflow-dev:e2a898ff-pytorch-1.11.0-gpu
+FROM mesosphere/kubeflow:2.0.0-pytorch-1.11.0-gpu
 ADD mnist.py /
 ADD datasets /datasets
 
@@ -676,11 +676,11 @@ docker build -t <docker_image_name_with_tag> .
 docker push <docker_image_name_with_tag>
 ```
 
-The image is available as `mesosphere/kubeflow-dev:d6b2c5c6-mnist-pytorch-1.11.0-gpu` in case you want to skip it for now.
+The image is available as `mesosphere/kubeflow:2.0.0-mnist-pytorch-1.11.0-gpu` in case you want to skip it for now.
 
 
 ```python
-%env IMAGE mesosphere/kubeflow-dev:d6b2c5c6-mnist-pytorch-1.11.0-gpu
+%env IMAGE mesosphere/kubeflow:2.0.0-mnist-pytorch-1.11.0-gpu
 ```
 
 ## How to Create a Distributed `PyTorchJob`

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/pytorch/index.md
@@ -59,7 +59,7 @@ If you prefer to create your Docker image locally, you must also have a Docker c
 Before proceeding, check you are using the correct notebook image, that is, [PyTorch](https://pytorch.org/docs/stable/torch.html) is available:
 
 
-```sh
+```bash
 %%sh
 pip list | grep torch
 ```
@@ -119,7 +119,7 @@ mnist
 ```
 
 
-
+```sh
 
     Dataset MNIST
         Number of datapoints: 60000
@@ -127,7 +127,7 @@ mnist
         Split: Train
         StandardTransform
     Transform: ToTensor()
-
+```
 
 
 
@@ -137,9 +137,9 @@ list(mnist.data.size())
 
 
 
-
+```sh
     [60000, 28, 28]
-
+```
 
 
 That shows there are 60,000 28&times;28 pixel grayscale images.
@@ -152,9 +152,9 @@ mnist.data.float().min(), mnist.data.float().max()
 
 
 
-
+```sh
     (tensor(0.), tensor(255.))
-
+```
 
 
 
@@ -188,9 +188,9 @@ example_label
 
 
 
-
+```sh
     7
-
+```
 
 
 Normalize the data set to improve the training speed, which means you need to know the mean and standard deviation:
@@ -202,9 +202,9 @@ mnist.data.float().mean() / 255, mnist.data.float().std() / 255
 
 
 
-
+```sh
     (tensor(0.1307), tensor(0.3081))
-
+```
 
 
 These are the values hard-coded in the transformations within the model.
@@ -257,10 +257,10 @@ Make the defined constants available as shell environment variables. They parame
 %env EPOCHS $EPOCHS
 %env GPUS $GPUS
 ```
-
+```sh
     env: EPOCHS=5
     env: GPUS=1
-
+```
 
 ## How to Train the Model in the Notebook
 
@@ -519,9 +519,9 @@ def main():
 if __name__ == "__main__":
     main()
 ```
-
+```sh
     Writing mnist.py
-
+```
 
 That saves the file as defined by `TRAINER_FILE` but it does not run it.
 
@@ -580,7 +580,7 @@ Run the code from within the notebook to check that it is correct:
 ```python
 %run $TRAINER_FILE --epochs $EPOCHS --log-interval 128
 ```
-
+``sh
     INFO:root:Epoch: 1 (  0.0%) - Loss: 2.293032646179199
     INFO:root:Epoch: 1 ( 13.6%) - Loss: 0.5257666110992432
     INFO:root:Epoch: 1 ( 27.3%) - Loss: 0.08510863780975342
@@ -636,7 +636,7 @@ Run the code from within the notebook to check that it is correct:
     INFO:root:Test accuracy: 9909/10000 ( 99.1%)
     INFO:root:loss=0.0306
     INFO:root:accuracy=0.9909
-
+```
 
 
     <Figure size 432x288 with 0 Axes>
@@ -797,7 +797,7 @@ kubectl create -f "${KUBERNETES_FILE}"
 Check the status like so:
 
 
-```sh
+```bash
 %%sh
 kubectl describe $PYTORCH_JOB
 ```
@@ -821,16 +821,16 @@ Events:
 You should now be able to see the pods created, matching the specified number of replicas.
 
 
-```sh
+```bash
 %%sh
 kubectl get pods -l job-name=pytorchjob-mnist
 ```
-
+```sh
     NAME                         READY   STATUS    RESTARTS   AGE
-    pytorchjob-mnist-master-0   1/1     Running   0          34s
-    pytorchjob-mnist-worker-0   1/1     Running   0          34s
-    pytorchjob-mnist-worker-1   1/1     Running   0          34s
-
+    pytorchjob-mnist-master-0    1/1     Running   0          34s
+    pytorchjob-mnist-worker-0    1/1     Running   0          34s
+    pytorchjob-mnist-worker-1    1/1     Running   0          34s
+```
 
 The job name matches `metadata.name` from the YAML.
 
@@ -838,11 +838,11 @@ As per the specification, the training runs for 15 epochs.
 During that time, stream the logs from the `Master` pod to follow the progress:
 
 
-```sh
+```bash
 %%sh
 kubectl logs -f pytorchjob-mnist-master-0
 ```
-
+```sh
     Using distributed PyTorch with gloo backend
     Epoch: 1 (  0.0%) - Loss: 2.3082287311553955
     Epoch: 1 ( 81.8%) - Loss: 0.04400685429573059
@@ -919,7 +919,7 @@ kubectl logs -f pytorchjob-mnist-master-0
     Test accuracy: 9911/10000 ( 99.1%)
     loss=0.0267
     accuracy=0.9911
-
+```
 
 Note that it may take a while when the image has to be pulled from the registry.
 It usually takes a few minutes, depending on the arguments and resources of the cluster, for the status for all pods to be 'Running'.
@@ -927,11 +927,11 @@ It usually takes a few minutes, depending on the arguments and resources of the 
 The setting `spec.ttlSecondsAfterFinished` will result in the cleanup of the created job:
 
 
-```sh
+```bash
 %%sh
 kubectl get pytorchjobs -w
 ```
-
+```sh
     NAME               STATE     AGE
     pytorchjob-mnist   Created   0s
     pytorchjob-mnist   Running   2s
@@ -939,10 +939,10 @@ kubectl get pytorchjobs -w
     pytorchjob-mnist   Succeeded   70s
     pytorchjob-mnist   Succeeded   70s
     pytorchjob-mnist   Succeeded   11m
+```
 
 
-
-```sh
+```bash
 %%sh
 kubectl get pytorchjob pytorchjob-mnist
 ```
@@ -950,7 +950,7 @@ kubectl get pytorchjob pytorchjob-mnist
 To delete the job manually, execute:
 
 
-```sh
+```bash
 %%sh
 kubectl delete $PYTORCH_JOB
 ```

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/pytorch/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/spark/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/spark/index.md
@@ -243,9 +243,9 @@ if __name__ == "__main__":
     predict_number(model, x_test, image_index)
     spark.stop()
 ```
-
+```sh        
     Writing mnist.py
-
+```
 
 [Several things](https://github.com/horovod/horovod#concepts) are worth highlighting:
 
@@ -267,9 +267,9 @@ Horovod relies on [MPI](https://github.com/horovod/horovod/blob/master/docs/conc
 ```python
 %env HOROVOD_JOB=$TRAINER_FILE
 ```
-
+```sh
     env: HOROVOD_JOB=mnist.py
-
+```
 
 To verify the training job, first run it on Spark in local mode:
 
@@ -277,16 +277,16 @@ To verify the training job, first run it on Spark in local mode:
 ```python
 %env PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
 ```
-
-    env: PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
-
-
-
 ```sh
+    env: PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
+```
+
+
+```bash
 %%sh
 "${SPARK_HOME}/bin/spark-submit" --master "local[1]" "${HOROVOD_JOB}" --epochs=1
 ```
-
+```sh
     Expected prediction for index 100: 6
     Running 1 processes (inferred from spark.default.parallelism)...
     20/06/18 16:09:21 INFO Executor: Running task 0.0 in stage 0.0 (TID 0)
@@ -296,7 +296,7 @@ To verify the training job, first run it on Spark in local mode:
     Model prediction for index 100: 6
     ...
     20/06/18 16:09:30 INFO SparkContext: Successfully stopped SparkContext
-
+```
 
 This trains the model in the notebook, but does not distribute the procedure.
 To that end, build-and-push a container image that contains the code and input dataset.
@@ -425,9 +425,9 @@ spec:
       port: 8090
 END
 ```
-
+```sh
     Writing sparkapp-mnist.yaml
-
+```
 
 The operator's user guide explains [how to configure the application](https://github.com/mesosphere/spark-on-k8s-operator/blob/master/docs/user-guide.md).
 
@@ -441,7 +441,7 @@ If you do run these locally, you cannot rely on cell magic, so you have to manua
 If you execute the following commands on your own machine (and not inside the notebook), you obviously do not need the cell magic `%%` either.
 In that case, you have to set the user namespace for all subsequent commands:
 
-```
+```bash
 kubectl config set-context --current --namespace=<insert-namespace>
 ```
 
@@ -464,14 +464,14 @@ kubectl create -f "${KUBERNETES_FILE}"
 Check the pods are being created according to the specification:
 
 
-```sh
+```bash
 %%sh
 kubectl get pods -l sparkoperator.k8s.io/app-name=horovod-mnist
 ```
-
+```sh
     NAME                   READY   STATUS      RESTARTS   AGE
     horovod-mnist-driver   0/1     Completed   0          64s
-
+```
 
 Wait for the `SparkApplication` to complete:
 
@@ -490,11 +490,11 @@ for attempt in range(1, 60):
 See the status of the `horovod-mnist` `SparkApplication`:
 
 
-```sh
+```bash
 %%sh
 kubectl describe ${HVD_JOB}
 ```
-
+```sh
     Name:         horovod-mnist
     ...
     API Version:  sparkoperator.k8s.io/v1beta2
@@ -518,24 +518,24 @@ kubectl describe ${HVD_JOB}
       Normal  SparkExecutorRunning       61s   spark-operator  Executor horovod-mnist-1592496574728-exec-5 is running
       Normal  SparkDriverCompleted       23s   spark-operator  Driver horovod-mnist-driver completed
       Normal  SparkApplicationCompleted  23s   spark-operator  SparkApplication horovod-mnist completed
-
+```
 
 Check the model prediction (as before) by looking at the logs of the driver:
 
 
-```sh
+```bash
 %%sh
 kubectl logs horovod-mnist-driver | grep 'Model prediction'
 ```
-
-    Model prediction for index 100: 6
-
-
-
 ```sh
+    Model prediction for index 100: 6
+```
+
+
+```bash
 %%sh
 kubectl delete ${HVD_JOB}
 ```
-
+```sh
     sparkapplication.sparkoperator.k8s.io "horovod-mnist" deleted
-
+```

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/spark/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/spark/index.md
@@ -319,7 +319,7 @@ It uses [containerd](https://containerd.io/) to run workloads (only) instead.
 The Dockerfile looks as follows:
 
 ```
-FROM mesosphere/kubeflow-dev:1b046795-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu
+FROM mesosphere/kubeflow:2.0.0-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu
 ADD mnist.py /
 ADD datasets /datasets
 
@@ -336,7 +336,7 @@ docker build -t <docker_image_name_with_tag> .
 docker push <docker_image_name_with_tag>
 ```
 
-The image is available as `mesosphere/kubeflow-dev:c36ad777-mnist-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu` in case you want to skip it for now.
+The image is available as `mesosphere/kubeflow:2.0.0-mnist-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu` in case you want to skip it for now.
 
 ## How to Create a Distributed `SparkApplication`
 The [KUDO Spark Operator](https://github.com/kudobuilder/operators/tree/master/repository/spark/docs) manages Spark applications in a similar way as the [PyTorch](../pytorch) or [TensorFlow](../tensorflow) operators manage `PyTorchJob`s and `TFJob`s, respectively. 
@@ -354,7 +354,7 @@ It exposes a resource called `SparkApplication` that you will use to train the m
 ```python
 # set this to 0 when running on CPU.
 GPUS = 1
-IMAGE = "mesosphere/kubeflow-dev:c36ad777-mnist-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu"
+IMAGE = "mesosphere/kubeflow:2.0.0-mnist-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu"
 ```
 
 

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/spark/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/spark/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/tensorflow/index.md
@@ -449,7 +449,7 @@ It uses [containerd](https://containerd.io/) to run workloads (only) instead.
 The Dockerfile looks as follows:
 
 ```
-FROM mesosphere/kubeflow-dev:7b771523-tensorflow-2.8.0-gpu
+FROM mesosphere/kubeflow:2.0.0-tensorflow-2.8.0-gpu
 ADD mnist.py /
 ADD datasets /datasets
 
@@ -466,11 +466,11 @@ docker build -t <docker_image_name_with_tag> .
 docker push <docker_image_name_with_tag>
 ```
 
-The image is available as `mesosphere/kubeflow-dev:51d57053-mnist-tensorflow-2.8.0-gpu` in case you want to skip it for now.
+The image is available as `mesosphere/kubeflow:2.0.0-mnist-tensorflow-2.8.0-gpu` in case you want to skip it for now.
 
 
 ```python
-%env IMAGE mesosphere/kubeflow-dev:51d57053-mnist-tensorflow-2.8.0-gpu
+%env IMAGE mesosphere/kubeflow:2.0.0-mnist-tensorflow-2.8.0-gpu
 ```
 
 ## How to Create a Distributed `TFJob`

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/tensorflow/index.md
@@ -71,7 +71,7 @@ For Kubernetes commands to run outside of the cluster, you need [`kubectl`](http
 Before proceeding, check you are using the correct notebook image, that is, [TensorFlow](https://www.tensorflow.org/api_docs/) is available:
 
 
-```sh
+```bash
 %%sh
 pip list | grep tensorflow
 ```
@@ -413,7 +413,7 @@ Ensure the code is correct by running it from within the notebook:
 ```python
 %run $TRAINER_FILE --epochs $EPOCHS
 ```
-
+```sh
     Train for 10 steps
     Epoch 1/5
     10/10 [==============================] - 5s 450ms/step - loss: 2.1215 - accuracy: 0.2875
@@ -429,7 +429,7 @@ Ensure the code is correct by running it from within the notebook:
 
     INFO:root:loss=0.4222
     INFO:root:accuracy=0.8769
-
+```
 
 This trains the model in the notebook, but does not distribute it across nodes (a.k.a. pods) in the cluster.
 To that end, first create a Docker image with the code, push it to a registry (e.g. [Docker Hub](https://hub.docker.com/), [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/), [ECR](https://aws.amazon.com/ecr/), [GCR](https://cloud.google.com/container-registry/)), and then define the Kubernetes resource that uses the image.
@@ -448,7 +448,7 @@ It uses [containerd](https://containerd.io/) to run workloads (only) instead.
 
 The Dockerfile looks as follows:
 
-```
+```sh
 FROM mesosphere/kubeflow:2.0.0-tensorflow-2.8.0-gpu
 ADD mnist.py /
 ADD datasets /datasets
@@ -563,7 +563,7 @@ If you do run these locally, you cannot rely on cell magic, so you have to manua
 If you execute the following commands on your own machine (and not inside the notebook), you obviously do not need the cell magic `%%` lines either.
 In that case, you have to set the user namespace for all subsequent commands:
 
-```
+```bash
 kubectl config set-context --current --namespace=<insert-namespace>
 ```
 
@@ -588,7 +588,7 @@ spec:
 ```
 
 
-```sh
+```bash
 %%sh
 kubectl apply -f pvc.yaml
 ```
@@ -610,7 +610,7 @@ kubectl create -f "${KUBERNETES_FILE}"
 To see the job status, use the following command:
 
 
-```sh
+```bash
 %%sh
 kubectl describe ${TF_JOB}
 ```
@@ -618,20 +618,20 @@ kubectl describe ${TF_JOB}
 You should now be able to see the created pods matching the specified number of workers.
 
 
-```sh
+```bash
 %%sh
 kubectl get pods -l job-name=tfjob-mnist
 ```
-
+```sh
     NAME                   READY   STATUS    RESTARTS   AGE
     tfjob-mnist-worker-0   1/2     Running   0          8s
     tfjob-mnist-worker-1   1/2     Running   0          8s
-
+```
 
 In case of issues, it may be helpful to see the last ten events within the cluster:
 
 
-```sh
+```bash
 %%sh
 kubectl get events --sort-by='{.metadata.creationTimestamp}'
 ```
@@ -639,7 +639,7 @@ kubectl get events --sort-by='{.metadata.creationTimestamp}'
 Wait until the chief pod is ready:
 
 
-```sh
+```bash
 %%sh
 for i in $(seq 1 5); do kubectl wait pod/tfjob-mnist-chief-0 --for=condition=Ready --timeout=10m && break || sleep 5; done
 ```
@@ -647,11 +647,11 @@ for i in $(seq 1 5); do kubectl wait pod/tfjob-mnist-chief-0 --for=condition=Rea
 To stream logs from the chief pod to check the training progress, run the following command:
 
 
-```sh
+```bash
 %%sh
 kubectl logs -f tfjob-mnist-chief-0 -c tensorflow
 ```
-
+```sh
     Train for 250 steps
     Epoch 1/15
     250/250 [==============================] - 12s 47ms/step - loss: 0.5652 - accuracy: 0.8220
@@ -685,16 +685,16 @@ kubectl logs -f tfjob-mnist-chief-0 -c tensorflow
     250/250 [==============================] - 3s 13ms/step - loss: 0.0185 - accuracy: 0.9945
     INFO:root:loss=0.0521
     INFO:root:accuracy=0.9838
-
+```
 
 The setting `spec.runPolicy.ttlSecondsAfterFinished` will result in the cleanup of the created job:
 
 
-```sh
+```bash
 %%sh
 kubectl get tfjobs -w
 ```
-
+```sh
     NAME          STATE     AGE
     tfjob-mnist   Created   0s
     tfjob-mnist   Running   2s
@@ -702,10 +702,10 @@ kubectl get tfjobs -w
     tfjob-mnist   Succeeded   70s
     tfjob-mnist   Succeeded   70s
     tfjob-mnist   Succeeded   11m
+```
 
 
-
-```sh
+```bash
 %%sh
 kubectl get tfjob tfjob-mnist
 ```
@@ -713,7 +713,7 @@ kubectl get tfjob tfjob-mnist
 To delete the job manually, run the following command:
 
 
-```sh
+```bash
 %%sh
 kubectl delete ${TF_JOB}
 ```
@@ -736,7 +736,7 @@ spec:
 ```
 
 
-```sh
+```bash
 %%sh
 kubectl apply -f tensorboard.yaml
 ```

--- a/pages/dkp/kaptain/2.0.0/tutorials/training/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.0.0/tutorials/training/tensorflow/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-1.3.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.0.0.tar.gz | tar xz
 ```
 
 </p>


### PR DESCRIPTION
Signed-off-by: Alex Lembiyeuski <alembiyeuski@d2iq.com>

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/D2IQ-87250

## Description of changes being made
Re-generate tutorials and Kaptain chart configuration based on the changes from https://github.com/mesosphere/kaptain/pull/717.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4382.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
