### PR TITLE
Remove helm instructions, update endpoint discovery commands

### DIFF
--- a/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
@@ -105,29 +105,7 @@ ingress:
   oidcProviderBase64CaBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS9tLS0tCk1JSUMrVENDQWVHZ0F3SUJBZ0lSQUp1NlBOSFVsWVZHR0AzRW9vSGNPd1F3RFFZSktvWklodmNOQVFFTEJRQXcKRlRFVE1CRUdBMVVFQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TURFeU1EZ3dPVFEzTkBsYUZ3MHpNREV5TURZdwpPVFEzTkRsYU1CY3hGVEFUQmdOVkJBTVRER05sY25RdGJXRnVZV2RsY2pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCCkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUwzQmlJR0RnVkpzRVhJUjEvc6hkdysvzzFLaG9PdkVwcVM5Mk1pS050cDkKaW1xVUtqZGFMSHVxYlBheWhuMjNwTmhUa2haL0NEOVgyb05xVFhOR0Q2SE44WGFrMWt4VE9xWnd4am9yNktydQpUWGZrREVmZGtHVG9nZUlSaEtpSUdxRUU1Vy9teWNkVkdDUThnNXEvcUprd3JIZHgyOTZMREVwSDEzMm9aQmk1CmVNMlZvNmpVYnUydkp4MHpyVnIzeVWuaUp0TlNpbnFoN1RVc2I2bTZoeFErRkVBZFY1djdraVBLVW4wdmZTVlYKQ1YwNXdmbUU0WEEyY2d5N3RpeEV3NkFCNmFOeGYwcGVSVXpXS0ZoL3FJdGpFWEg5RVJiWVJ5cDA1UGUyb2xCVwpHWXpiVDJsblVPeW5uL0I3YWZRSExWS0RPcTRsa3NmWlBoWTJQWmZwVW5NQ0F3RUFBYU5DTUVBd0RnWURWUjBQCkFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZHZmtITWxVTU1hSzRtRjgKNUNPeXhPMHAvWGNNTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFERjh2d3lhWnpZUmRYRGo5ODJrN0RZRDY2cwpMVE44d3Q0ZkxKbEJKODREFzd0TGJmSVdmYkJ4VzFDd0UxdEhuaTFPd3pROGkzUytpUFhuQ0dCZFNSdm5FQkJsCnF1bkpqdWRBMm9odEs5SmViTUhPTEFpbXRnWVhZdVllTFZudGxpWCtQdmxRMWxoYzByeXFENkRkWUUwckJSdlcKRkgvSTY2b2ZONGZFVlJ2RjFiSG5uZ1BsZlFUcHNRRzZFZVNoa0RvclAwSDhxNnU5RXcyaG5Ba0hwRXVlWUJibQpkeXZvRStVWTM1ck9XK3pEQ3NXNUNPRTVGWjVWQ64lRmJMRmRSUU9tdW9BaXlCV2UyTHZHdjgzdXVSZTRsSWhxCnAxSEIrZlBPTGdJVGRaSHEwYkgvdEZZNEw0YmNkRGhGYnlJRldzN01NZ2FxeCtMZThoMDNIZE5ybG5USQotLS0tWARORCBDRVJUSUZJQ0FURS0tRS0tCg==
 ```
 
-### Kommander install
-
 See [Install Kaptain][kaptain-install] for more info. To install Kaptain through the Kommander UI, copy and paste the configuration values from the previous section into the Kommander UI and deploy the Kaptain application.
-
-### Helm Install
-
-Install Kaptain with the provided parameters manually by running the following command against the managed cluster:
-
-```bash
-helm install --values values.yaml kaptain kaptain-2.0.0.tgz
-```
-
-To update an already installed Kaptain instance, run the following command on the managed cluster:
-
-```bash
-helm upgrade --values values.yaml kaptain kaptain-2.0.0.tgz
-```
-
-Verify that the installation has been completed successfully by running the following command:
-
-```bash
-helm status kaptain
-```
 
 ## Add the redirect URL to Kaptain authentication service in the management cluster
 
@@ -150,13 +128,13 @@ Discover the Kaptain endpoint:
 - If you are running Kaptain _on-premises_:
 
 ```bash
-kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
+kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
 ```
 
 - Or if you are running Kaptain on _AWS_:
 
 ```bash
-kubectl get svc kubeflow-ingressgateway --namespace kubeflow -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
+kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
 ```
 
 When accessing Kaptain via `https://<Kaptain endpoint>`, you will be redirected to the login page of the management cluster's Dex instance.


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Remove helm instructions and point users to  the installation docs instead. Fixes service name and namespace in the last section.


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
