### PR TITLE
[Kaptain] Updating compatibility index for SDK

### DIFF
--- a/pages/dkp/kaptain/2.0.0/sdk/compatibility/index.md
+++ b/pages/dkp/kaptain/2.0.0/sdk/compatibility/index.md
@@ -9,9 +9,8 @@ excerpt: Compares versions of the Kaptain SDK with Kaptain and shows compatibili
 The following chart shows SDK compatibility for the past 3 major releases of Kaptain. Where partial support is noted,
 the SDK will function for most tasks, but newer features introduced in the SDK or in Kaptain may not function properly.
 
-|               | Kaptain 1.3.0     | Kaptain 1.2.0     | Kaptain 1.1.0     |
+|               | Kaptain 2.0.0     | Kaptain 1.3.0     | Kaptain 1.2.0     |
 | ------------- | ----------------- | ----------------- | ----------------- |
-| SDK 1.0.0     | Full              | Partial           | Partial           |
-| SDK 0.4.0     | Full              | Partial           | Partial           |
-| SDK 0.3.0     | Partial           | Full              | Partial           |
-| SDK 0.2.0     | Partial           | Partial           | Full              |
+| SDK 1.0.1     | Full              | Partial           | Partial           |
+| SDK 1.0.0     | Full              | Full              | Partial           |
+| SDK 0.4.0     | Full              | Full              | Partial           |


### PR DESCRIPTION
## Jira Ticket

https://mesosphere.slack.com/archives/G0157326RFD/p1650624080459719

## Description of changes being made

The new release of Kaptain SDK will not be compatible with Kaptain 1.3 and older.
Deleted Kaptain 1.1.0 column and moved everything to the right to include a Kaptain 2.0.0 column. 
Added a SDK 1.0.1 row.

### Preview

http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

