### PR TITLE
docs: Fix migration table and link

### DIFF
--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
@@ -25,19 +25,20 @@ To successfully adapt your applications, you must have:
 
 - Sufficient disk and resource capacity to support the following applications that come installed by default with Kommander:
 
-    | Name                      | Minimum Resources Suggested    | Minimum Persistent Storage Required |
-    | ------------------------- | ------------------------------ | ----------------------------------- |
-    | centralized-grafana       | cpu: 200m<br />memory: 100Mi   |                                     |
-    | centralized-kubecost      | cpu: 1200m<br />memory: 4151Mi | # of PVs: 1<br />PV sizes: 32Gi     |
-    | dex                       | cpu: 100m<br />memory: 50Mi    |                                     |
-    | dex-k8s-authenticator     | cpu: 100m<br />memory: 128Mi   |                                     |
-    | gitea                     | cpu: 500m<br />memory: 512Mi   | # of PVs: 2<br />PV sizes: 10Gi     |
-    | karma                     |                                |                                     |
-    | kubefed                   | cpu: 300m<br />memory: 192Mi   |                                     |
-    | thanos                    |                                |                                     |
-    | traefik-forward-auth-mgmt | cpu: 100m<br />memory: 128Mi   |                                     |
+  | Name                      | Minimum Resources Suggested    | Minimum Persistent Storage Required |
+  | ------------------------- | ------------------------------ | ----------------------------------- |
+  | centralized-grafana       | cpu: 200m<br />memory: 100Mi   |                                     |
+  | centralized-kubecost      | cpu: 1200m<br />memory: 4151Mi | # of PVs: 1<br />PV sizes: 32Gi     |
+  | dex                       | cpu: 100m<br />memory: 50Mi    |                                     |
+  | dex-k8s-authenticator     | cpu: 100m<br />memory: 128Mi   |                                     |
+  | gitea                     | cpu: 500m<br />memory: 512Mi   | # of PVs: 2<br />PV sizes: 10Gi     |
+  | karma                     |                                |                                     |
+  | kommander-flux            | cpu: 4000m<br />memory: 4Gi    |                                     |
+  | kubefed                   | cpu: 300m<br />memory: 192Mi   |                                     |
+  | thanos                    |                                |                                     |
+  | traefik-forward-auth-mgmt | cpu: 100m<br />memory: 128Mi   |                                     |
 
-    Please see [workspace platform application requirements][../workspaces/applications/platform-applications/platform-application-requirements] to plan for additional requirements your custom workloads may demand.
+  Please see [workspace platform application requirements](../../../workspaces/applications/platform-applications/platform-application-requirements) to plan for additional requirements your custom workloads may demand.
 
 ## Prepare your cluster
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
![image](https://user-images.githubusercontent.com/5897740/164833275-22a519e3-1773-4a21-bd37-2fa4557ee0b6.png)

Noticed this table looked off and link was also bad

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4392.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
