### PR TITLE
Deleting Konvoy 1.x references

### DIFF
--- a/pages/dkp/kaptain/2.0.0/install/dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/dkp/index.md
@@ -143,8 +143,6 @@ You have now added Kaptain to your DKP Catalog applications. The next step is to
 [install-spark-dkp2]: /dkp/kommander/2.1/workspaces/applications/catalog-applications/dkp-applications/spark-operator/
 [kommander-install]: /dkp/kommander/latest/install/
 [kommander-gpu]: /dkp/kommander/latest/gpu/
-[konvoy-gpu]: /dkp/konvoy/1.8/gpu/
-[konvoy_deploy_addons]: /dkp/konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [dex]: ../../configuration/external-dex/
 [airgapped_install]: ../air-gapped-dkp/

--- a/pages/dkp/kaptain/2.0.0/install/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--important"><strong>IMPORTANT: </strong>Refer to the <a href="../migration">Kaptain migration instructions</a>, if you already have Kaptain and want to move from 1.x to 2.x.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Refer to the <a href="../fresh-install">Kaptain fresh install instructions</a>, if you already have Kaptain and want to move from 1.x to 2.x. Keep in mind. that it is not possible to migrate your data at this point.</p>
 
 How do you want to deploy Kaptain?
 

--- a/pages/dkp/kaptain/2.0.0/install/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--important"><strong>IMPORTANT: </strong>Refer to the <a href="../fresh-install">Kaptain fresh install instructions</a>, if you already have Kaptain and want to move from 1.x to 2.x. Keep in mind. that it is not possible to migrate your data at this point.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Refer to the <a href="../fresh-install">Kaptain fresh install instructions</a>, if you already have Kaptain and want to move from 1.x to 2.x. Note that it is not possible to migrate your data.</p>
 
 How do you want to deploy Kaptain?
 

--- a/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
@@ -18,6 +18,6 @@ Please note that the IP address of the Kaptain UI will come from the IP address 
 
 When your cluster is ready, [install Kaptain](../) by adding Kaptain to your DKP Catalog Applications and deploying it to your clusters.
 
-[konvoy-on-prem]: /dkp/konvoy/1.8/install/install-onprem/
+[konvoy-on-prem]: ../../../../konvoy/2.2/choose-infrastructure/on-prem/
 [dkp-install]: /dkp/kommander/latest/networking/load-balancing#on-premises
-[metallb-load-balancer]: /dkp/konvoy/1.8/install/install-onprem/#configure-metallb-load-balancing
+[metallb-load-balancer]: ../../../../konvoy/2.2/choose-infrastructure/pre-provisioned/metal-lb/

--- a/pages/dkp/kaptain/2.0.0/monitoring/index.md
+++ b/pages/dkp/kaptain/2.0.0/monitoring/index.md
@@ -49,7 +49,7 @@ types are enabled:
 ## Grafana Dashboards
 
 Kaptain installation also includes two Grafana dashboards, which are automatically imported to Grafana and ready-to-use.
-To access the dashboard, follow the [Access a Konvoy cluster][access_konvoy] or [Access Kommander Web UI][access_kommander]
+To access the dashboard, follow the [Access DKP UI instructions][access_dkp].
 documentation page to access the operations portal, and then click on the "Dashboard" button on the Grafana tile on
 the "Platform Services" tab.
 
@@ -66,5 +66,4 @@ Kaptain provides the following dashboards:
 
 ![Kaptain Profiles Dashboard](img/kaptain-profiles-dashboard-2.png)
 
-[access_konvoy]: /dkp/konvoy/1.8/access-authentication/access-konvoy/
-[access_kommander]: /dkp/kommander/latest/install/networked/#access-kommander-web-ui
+[access_dkp]: /dkp/kommander/latest/install/networked#access-dkp-ui

--- a/pages/dkp/kaptain/2.0.0/user-management/index.md
+++ b/pages/dkp/kaptain/2.0.0/user-management/index.md
@@ -18,7 +18,7 @@ D2iQ recommends appropriately configured `ClusterRole` objects. As with all matt
 we encourage you to thoroughly review permissions set by our predefined `ClusterRoles` in conjunction with your security team.
 
 _NB: The following tutorial assumes you have already connected an OIDC provider to your Konvoy/Kommander cluster via Konvoy's
-built-in Dex integration. If you have not yet done so, please review the relevant documentation for Konvoy [konvoy-oidc] or Kommander [kommander-oidc] before proceeding._
+built-in Dex integration. If you have not yet done so, please review the relevant documentation for [OpenID Connect][oidc] before proceeding._
 
 ## Kubeflow Predefined `ClusterRoles`
 Kaptain comes with a set of predefined Kubernetes `ClusterRoles` designed to simplify the workflow of administrators who manage permissions of users.
@@ -245,5 +245,4 @@ clusterrolebinding.rbac.authorization.k8s.io/<name of user> created
 
 [go-resourcequotaspec]: https://godoc.org/k8s.io/api/core/v1#ResourceQuotaSpec
 [k8s-limit-range]: https://kubernetes.io/docs/concepts/policy/limit-range/
-[konvoy-oidc]: /dkp/konvoy/1.8/access-authentication/oidc/
-[kommander-oidc]: /dkp/kommander/latest/security/oidc/
+[oidc]: ../../../kommander/2.2/security/oidc/


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-87585

## Description of changes being made
Konvoy 1.x textual references were already removed. However some links were not up-to-date and still referenced 1.8.
Also updated the reference to the "migration" topic which now is a "fresh install" topic.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4393.s3-website-us-west-2.amazonaws.com/
