### PR TITLE
docs: fix tar command in 2.1 AG kommander install docs

### DIFF
--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -216,7 +216,7 @@ Based on the network latency between the environment of script execution and the
 1.  Download and extract the `kommander-applications` bundle.
 
     ```bash
-    mkdir kommander-applications && wget https://downloads.d2iq.com/dkp/kommander-applications_${VERSION}.tar.gz -O - | tar xvzf - -C kommander-applications --strip-components 1
+    mkdir kommander-applications && wget https://downloads.d2iq.com/dkp/kommander-applications_${VERSION}.tar.gz -O - | tar xvzf - -C kommander-applications
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7205

## Description of changes being made

Remove erroneous `--strip components

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4399.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
