### PR TITLE
Remove kudo references from user management page

### DIFF
--- a/pages/dkp/kaptain/2.0.0/user-management/index.md
+++ b/pages/dkp/kaptain/2.0.0/user-management/index.md
@@ -45,7 +45,7 @@ Automatic profile creation is disabled by default. To enable it, set the `regist
 registrationFlow: true
 ```
 
-See [Deploy Kaptain][deploy-kaptain] for information about configuring Kaptain.
+Refer to [Deploy Kaptain documentation][deploy-kaptain] for information on how to configure Kaptain.
 
 ### Manual profile creation
 For a finer-grain control and per-namespace resource quota management, profiles for the new users can be created

--- a/pages/dkp/kaptain/2.0.0/user-management/index.md
+++ b/pages/dkp/kaptain/2.0.0/user-management/index.md
@@ -39,11 +39,13 @@ Kubeflow grants users with namespace admin permissions for their namespaces.
 
 ### Automatic profile creation
 When an authenticated user logs into the system and visits the central dashboard for the first time, they trigger a profile creation automatically, this is referred to as a "Registration Flow".
-Automatic profile creation is disabled by default. To enable it, set the `registrationFlow` parameter to `true`:
+Automatic profile creation is disabled by default. To enable it, set the `registrationFlow` parameter to `true` by specifying it in the `ConfigMap` for Kaptain's configuration:
 
 ```
-kubectl kudo install --instance kaptain --namespace kubeflow --create-namespace ./kubeflow-1.4.0_1.3.0.tgz -p registrationFlow=true
+registrationFlow: true
 ```
+
+See [Deploy Kaptain][deploy-kaptain] for information about configuring Kaptain.
 
 ### Manual profile creation
 For a finer-grain control and per-namespace resource quota management, profiles for the new users can be created
@@ -246,3 +248,4 @@ clusterrolebinding.rbac.authorization.k8s.io/<name of user> created
 [go-resourcequotaspec]: https://godoc.org/k8s.io/api/core/v1#ResourceQuotaSpec
 [k8s-limit-range]: https://kubernetes.io/docs/concepts/policy/limit-range/
 [oidc]: ../../../kommander/2.2/security/oidc/
+[deploy-kaptain]: ../install/deploy-kaptain/


### PR DESCRIPTION
## Jira Ticket

[D2IQ-87576](https://jira.d2iq.com/browse/D2IQ-87576)

## Description of changes being made

We remove remaining kudo instructions from Kaptain 2.0.0 docs

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
