### PR TITLE
[Konvoy 2.1] COPS-7222 Fixed Copy+Paste Quotation Error

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/define-infrastructure/index.md
@@ -42,7 +42,7 @@ Konvoy needs to know how to access your cluster hosts. This is done using invent
     spec:
       hosts:
         # Create as many of these as needed to match your infrastructure
-        # Note that the command line parameter `--control-plane-replicas` determines how many control plane nodes will actually be used.
+        # Note that the command line parameter "--control-plane-replicas" determines how many control plane nodes will actually be used.
         #
         - address: $CONTROL_PLANE_1_ADDRESS
         - address: $CONTROL_PLANE_2_ADDRESS


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7222?filter=-1

## Description of changes being made

Added correct quotation marks to commented out item so folks don't get error returned messages for copying code.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
