### PR TITLE
Updating k8s version to be v1.22.8 in FIPS docs

### DIFF
--- a/pages/dkp/konvoy/2.2/fips/index.md
+++ b/pages/dkp/konvoy/2.2/fips/index.md
@@ -36,7 +36,7 @@ In order to create a cluster in FIPS mode, we must inform the bootstrap controll
 
 | Component  | Repository           | Version        |
 |------------|----------------------|----------------|
-| Kubernetes | docker.io/mesosphere | v1.21.6+fips.0 |
+| Kubernetes | docker.io/mesosphere | v1.22.8+fips.0 |
 | etcd       | docker.io/mesosphere | v3.4.13+fips.0 |
 
 When creating a cluster, use the following command line options:
@@ -52,7 +52,7 @@ For example:
 ```bash
 dkp create cluster aws --cluster-name myFipsCluster \
 --ami=ami-03dcaa75d45aca36f \
---kubernetes-version=1.21.6+fips.0 \
+--kubernetes-version=1.22.8+fips.0 \
 --kubernetes-image-repository=docker.io/mesosphere \
 --etcd-image-repository=docker.io/mesosphere \
 --etcd-version=3.4.13+fips.0


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made
Version of Kubernetes that we use for DKP 2.2 is 1.22.8 - this just needed to be updated here

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4416.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
