### PR TITLE
[Kaptain] Fixing broken links from 1.2 documentation (cops)

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -86,6 +86,7 @@ Fluentd
 (Frontmatter|frontmatter)
 gapped 
 (gcr|GCR)
+(Generalizability|generalizability)
 (Gensim|gensim)
 (Gitea|gitea)
 (gitops|GitOps)

--- a/pages/dkp/kaptain/1.2.0/custom-configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/1.2.0/custom-configuration/external-dex/index.md
@@ -105,4 +105,4 @@ Discover the Kaptain endpoint:
 When accessing Kaptain via `https://<Kaptain endpoint>`, you will be redirected to the login page of the management cluster's Dex instance.
 
 [attached-cluster]: /dkp/kommander/latest/clusters/attach-cluster/
-[create-managed-cluster]: /dkp/kommander/latest/clusters/create-connect-clusters/
+[create-managed-cluster]: ../../../../dkp/kommander/1.4/clusters/create-connect-clusters/

--- a/pages/dkp/kaptain/1.2.0/custom-configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/1.2.0/custom-configuration/external-dex/index.md
@@ -105,4 +105,4 @@ Discover the Kaptain endpoint:
 When accessing Kaptain via `https://<Kaptain endpoint>`, you will be redirected to the login page of the management cluster's Dex instance.
 
 [attached-cluster]: /dkp/kommander/latest/clusters/attach-cluster/
-[create-managed-cluster]: ../../../../dkp/kommander/1.4/clusters/create-connect-clusters/
+[create-managed-cluster]: ../../../../kommander/1.4/clusters/create-connect-clusters/

--- a/pages/dkp/kaptain/1.2.0/download/index.md
+++ b/pages/dkp/kaptain/1.2.0/download/index.md
@@ -9,8 +9,8 @@ enterprise: false
 
 <!-- markdownlint-disable MD034 -->
 
-Kaptain downloads are only available to licensed customers.  To obtain an evaluation license for Kaptain, please contact <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+Kaptain downloads are only available to licensed customers. To obtain an evaluation license for Kaptain, please contact <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
 
 If you already have a license, downloads are available in the [Support Portal][support-portal].
 
-[support-portal]: https://support.d2iq.com/s/
+[support-portal]: https://support.d2iq.com/hc/en-us/

--- a/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
+++ b/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
@@ -127,4 +127,4 @@ Once all components have been deployed, you can log in to Kaptain:
 
 [download]: ../../download/
 [kudo_cli]: https://kudo.dev/#get-kudo
-[konvoy_deploy_addons]: ../../../konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
+[konvoy_deploy_addons]: ../../../../konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade

--- a/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
+++ b/pages/dkp/kaptain/1.2.0/install/konvoy/index.md
@@ -127,4 +127,4 @@ Once all components have been deployed, you can log in to Kaptain:
 
 [download]: ../../download/
 [kudo_cli]: https://kudo.dev/#get-kudo
-[konvoy_deploy_addons]: /dkp/konvoy/latest/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade
+[konvoy_deploy_addons]: ../../../konvoy/1.8/upgrade/upgrade-kubernetes-addons/#prepare-for-addons-upgrade

--- a/pages/dkp/kaptain/1.2.0/install/on-premise/index.md
+++ b/pages/dkp/kaptain/1.2.0/install/on-premise/index.md
@@ -47,5 +47,5 @@ The steps to install Kaptain on an on-premises cluster are as follows:
     ```
 * When the Konvoy cluster is ready, [install Kaptain](../konvoy/).
 
-[konvoy-on-prem]: /dkp/konvoy/latest/install/install-onprem/
+[konvoy-on-prem]: ../../../../konvoy/1.8/install/install-onprem/
 [metallb-load-balancer]: /dkp/konvoy/1.8/install/install-onprem/#configure-metallb-load-balancing

--- a/pages/dkp/kaptain/1.2.0/monitoring/index.md
+++ b/pages/dkp/kaptain/1.2.0/monitoring/index.md
@@ -66,4 +66,4 @@ Kaptain provides the following dashboards:
 
 ![Kaptain Profiles Dashboard](img/kaptain-profiles-dashboard-2.png)
 
-[access_konvoy]: https://docs.d2iq.com/dkp/konvoy/latest/access-authentication/access-konvoy/
+[access_konvoy]: ../../../konvoy/1.8/access-authentication/access-konvoy/

--- a/pages/dkp/kaptain/1.2.0/sdk/0.3.x/private-registries/index.md
+++ b/pages/dkp/kaptain/1.2.0/sdk/0.3.x/private-registries/index.md
@@ -213,4 +213,4 @@ model = Model(
 )
 ```
 [credentials]: ../credentials/
-[konvoy_airgapped_guide]: /dkp/konvoy/latest/choose_infrastructure/aws/air-gapped/
+[konvoy_airgapped_guide]: ../../../../../konvoy/2.0/choose_infrastructure/aws/air-gapped/

--- a/pages/dkp/kaptain/1.2.0/sdk/0.4.x/private-registries/index.md
+++ b/pages/dkp/kaptain/1.2.0/sdk/0.4.x/private-registries/index.md
@@ -214,4 +214,4 @@ model = Model(
 )
 ```
 [credentials]: ../credentials/
-[konvoy_airgapped_guide]: /dkp/konvoy/latest/choose_infrastructure/aws/air-gapped/
+[konvoy_airgapped_guide]: ../../../../../konvoy/2.0/choose_infrastructure/aws/air-gapped/

--- a/pages/dkp/kaptain/1.2.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/katib/index.md
@@ -39,8 +39,8 @@ At the end of the experiment, Katib outputs the optimized values, which are also
     The training data set is, as always, to learn parameters (weights and biases) from data.
     The test data set is also known as the hold-out set and its sole purpose is to check the model's hypothesis of parameter values in terms of how well it generalizes to data it has never come across.
     The point of the validation data set is to cross-validate the model and tweak the hyperparameters.
-    Since information from this data set is used to adjust the model, it is not an objective test of the model's <a href=\"https://www.sciencedirect.com/topics/mathematics/generalizability/">generalizability</a>.
-    It is not unlike a <a href=\"https://www.linkedin.com/posts/activity-6424581736302284800-Kdas/">teacher checking up on students</a>:
+    Since information from this data set is used to adjust the model, it is not an objective test of the model's <a href="https://www.sciencedirect.com/topics/mathematics/generalizability/">generalizability</a>.
+    It is not unlike a <a href="https://www.linkedin.com/posts/activity-6424581736302284800-Kdas/">teacher checking up on students</a>:
     <ul>
       <li>The training data set is the text book to learn the theory from</li>
       <li>The validation data set comprises the exercises to practice the theory</li>

--- a/pages/dkp/kaptain/1.2.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/pipelines/index.md
@@ -27,7 +27,7 @@ These steps can be triggered automatically by a CI/CD workflow or on demand from
 
 Kubeflow Pipelines (`kfp`) comes with a user interface for managing and tracking experiments, jobs, and runs.
 A pipeline is a description of a machine learning workflow, replete with all inputs and outputs.
-In Kubeflow Pipelines, an **experiment** is a [workspace](../metadata) where you can _experiment with_ different configurations of your pipelines.
+In Kubeflow Pipelines, an **experiment** is a workspace where you can _experiment with_ different configurations of your pipelines.
 Experiments are a way to organize runs of jobs into logical groups.
 A **run** is simply a single execution (instance) of a pipeline.
 Kubeflow Pipelines also supports recurring runs, which is a repeatable run of a pipeline.
@@ -707,4 +707,4 @@ jq -M --exit-status '.predictions[0] | indices(max)[0] == 9' output.json
     true
 
 
-For more details on the URL, please check out this [example](https://github.com/kubeflow/kfserving/tree/master/docs/samples/tensorflow#run-a-prediction).
+For more details on the URL, please check out this [example](https://github.com/kserve/kserve/tree/master/docs/samples/v1beta1/tensorflow#run-a-prediction).

--- a/pages/dkp/kaptain/1.2.0/tutorials/sdk/pytorch/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/sdk/pytorch/index.md
@@ -25,7 +25,7 @@ will likely not work.</p>
 # Kaptain SDK: Training, Tuning, and Deploying
 
 ## Introduction
-To perform [distributed training](../training/) on a cluster's resources, conduct [experiments with multiple parallel trials](../katib/) to obtain the best hyperparameters, and [deploying a trained or tuned model](../pipelines/) typically requires additional steps, such as [building a Docker image](../fairing/) and providing framework-specific specifications for Kubernetes.
+To perform [distributed training](../../training/) on a cluster's resources, conduct [experiments with multiple parallel trials](../../katib/) to obtain the best hyperparameters, and [deploying a trained or tuned model](../../pipelines/) typically requires additional steps, such as [building a Docker image](../../fairing/) and providing framework-specific specifications for Kubernetes.
 This places the burden on each data scientist to learn all the details of all the components.
 
 Instead of doing all the work, using the Kaptain SDK, you can `train`, `tune`, and `deploy` from within a notebook without having to worry about framework specifics, Kubeflow-native SDKs, or even thinking about Kubernetes
@@ -35,7 +35,7 @@ The Kaptain SDK provides a data science-friendly user experience from within a n
 A model can be trained, tuned, deployed, and tracked.
 
 The example is based on Pytorch, but it works equally for Tensorflow.
-The original model code can be found in the tutorials [MNIST with PyTorch](../training/pytorch) and [MNIST with TensorFlow](../training/tensorflow).
+The original model code can be found in the tutorials [MNIST with PyTorch](../../training/pytorch/) and [MNIST with TensorFlow](../../training/tensorflow).
 
 The SDK relies on [MinIO](https://min.io/), an open-source S3-compliant object storage tool, that is already included with your Kaptain installation.
 

--- a/pages/dkp/kaptain/1.2.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/1.2.0/tutorials/sdk/tensorflow/index.md
@@ -25,7 +25,7 @@ will likely not work.</p>
 # Kaptain SDK: Training, Tuning, and Deploying
 
 ## Introduction
-To perform [distributed training](../training/) on a cluster's resources, conduct [experiments with multiple parallel trials](../katib/) to obtain the best hyperparameters, and [deploying a trained or tuned model](../pipelines/) typically requires additional steps, such as [building a Docker image](../fairing/) and providing framework-specific specifications for Kubernetes.
+To perform [distributed training](../../training/) on a cluster's resources, conduct [experiments with multiple parallel trials](../../katib/) to obtain the best hyperparameters, and [deploying a trained or tuned model](../../pipelines/) typically requires additional steps, such as [building a Docker image](../../fairing/) and providing framework-specific specifications for Kubernetes.
 This places the burden on each data scientist to learn all the details of all the components.
 
 Instead of doing all the work, using the Kaptain SDK, you can `train`, `tune`, and `deploy` from within a notebook without having to worry about framework specifics, Kubeflow-native SDKs, or even thinking about Kubernetes
@@ -35,8 +35,8 @@ The Kaptain SDK provides a data science-friendly user experience from within a n
 A model can be trained, tuned, deployed, and tracked.
 
 The example is based on TensorFlow, but it works equally for PyTorch.
-The original model code can be found in the tutorials [MNIST with TensorFlow](../training/tensorflow)
-and [MNIST with PyTorch](../training/pytorch).
+The original model code can be found in the tutorials [MNIST with TensorFlow](../../training/tensorflow/)
+and [MNIST with PyTorch](../../training/pytorch/).
 
 The SDK relies on [MinIO](https://min.io/), an open-source S3-compliant object storage tool, that is already included with your Kaptain installation.
 
@@ -60,7 +60,7 @@ pip list | grep tensorflow
 
 ## Prepare the Training Code and Data Sets
 The examples in this tutorial require a trainer code file `mnist.py` and a dataset to be present in the current folder.
-The code and datasets are already available in the [other tutorials](../training/) and can be reused here.
+The code and datasets are already available in the [other tutorials](../../training/) and can be reused here.
 
 ## How to Create a Docker Credentials File and Kubernetes Secret
 

--- a/pages/dkp/kaptain/1.2.0/user-management/index.md
+++ b/pages/dkp/kaptain/1.2.0/user-management/index.md
@@ -245,4 +245,4 @@ clusterrolebinding.rbac.authorization.k8s.io/<name of user> created
 
 [go-resourcequotaspec]: https://godoc.org/k8s.io/api/core/v1#ResourceQuotaSpec
 [k8s-limit-range]: https://kubernetes.io/docs/concepts/policy/limit-range/
-[konvoy-oidc]: /dkp/konvoy/latest/access-authentication/oidc/
+[konvoy-oidc]: ../../../konvoy/1.8/access-authentication/oidc/

--- a/pages/dkp/konvoy/2.2/Install/index.md
+++ b/pages/dkp/konvoy/2.2/Install/index.md
@@ -48,7 +48,7 @@ Before installing DKP, ensure you have the [following](../supported-operating-sy
 
 1.  Verify you have valid **CLOUD PROVIDER security credentials** to deploy the cluster on that platform. This step is not required if you are installing DKP on an on-premises environment. For information about installing in an on-premises environment, see [Install on-premises](../choose-infrastructure/on-prem).
 
-1.  Deploy with all of the default settings depending on which infrastructure you have.  Go to the Choose Infrastructure section of the documentation for further steps on creating a cluster on your Cloud platform. [Choose Infrastructure](../choose-infrastructure/) 
+1.  Deploy with all of the default settings depending on which infrastructure you have. Go to the Choose Infrastructure section of the documentation for further steps on creating a cluster on your Cloud platform. [Choose Infrastructure](../choose-infrastructure/) 
   
 1.  Lastly, you will want to [Install Kommander](/../../dkp/kommander/2.2/install/)   
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7192?filter=57924

### Preview

There are several broken links in 1.2 documentation that were showing an error. I tried to fix all of these, however, there are a couple of them where I am not 100% sure if they should lead somewhere else. 

For example, the "latest" (instead of version number) in relative links does not always work, specially when pages move around and newer documentation versions change completely (in terms of structure and content). 

### Preview

http://docs-d2iq-com-pr-4417.s3-website-us-west-2.amazonaws.com/


