### PR TITLE
Upgrade CAPI commands if from 1.8 to 2.1 first

### DIFF
--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -55,7 +55,7 @@ If you are running on more than one management cluster (Kommander cluster), you 
 
 1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
 
-```bash
+    ```bash
     helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
     kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
     ```
@@ -71,6 +71,7 @@ If you are running on more than one management cluster (Kommander cluster), you 
     ```bash
     helm -n cert-manager delete cert-manager-kubeaddons
     ```
+    
 The output resembles the following:
 
 ```text
@@ -78,23 +79,7 @@ The output resembles the following:
 ✓ Waiting for CAPI components to be upgraded
 ✓ Initializing new CAPI components
 ✓ Deleting Outdated Global ClusterResourceSets
-```
-
- <p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.</p>
- 
-  ```bash
-  helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
-kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
-```
-
-```bash
-dkp upgrade capi-components
-```
-
-```bash
-  helm -n cert-manager delete cert-manager-kubeaddons
-  ```
-  
+``` 
  
 If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -54,7 +54,7 @@ If you are running on more than one management cluster (Kommander cluster), you 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
     
 
-1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
+1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for upgrade:
 
     ```bash
     helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -67,7 +67,7 @@ If you are running on more than one management cluster (Kommander cluster), you 
     dkp upgrade capi-components
     ```
 
-1.  If your cluster was upgraded to 2.1 from 1.8, remove the old cert-manager you marked in step 1:
+1.  If your cluster was upgraded to 2.1 from 1.8, remove the remaining old cert-manager resources from 1.8:
 
     ```bash
     helm -n cert-manager delete cert-manager-kubeaddons

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -53,7 +53,7 @@ If you are running on more than one management cluster (Kommander cluster), you 
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-Run the following upgrade command for the CAPI components.
+1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
 
 ```bash
     helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -56,9 +56,21 @@ If you are running on more than one management cluster (Kommander cluster), you 
 Run the following upgrade command for the CAPI components.
 
 ```bash
-dkp upgrade capi-components
-```
+    helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
+    kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
+    ```
 
+1.  For <strong>all</strong> clusters, upgrade capi-components:
+
+    ```bash
+    dkp upgrade capi-components
+    ```
+
+1.  If your cluster was upgraded to 2.1 from 1.8, remove the old cert-manager you marked in step 1:
+
+    ```bash
+    helm -n cert-manager delete cert-manager-kubeaddons
+    ```
 The output resembles the following:
 
 ```text

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -52,6 +52,7 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
 If you are running on more than one management cluster (Kommander cluster), you must upgrade the CAPI components on each of these clusters.
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
+    
 
 1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
 
@@ -71,18 +72,19 @@ If you are running on more than one management cluster (Kommander cluster), you 
     ```bash
     helm -n cert-manager delete cert-manager-kubeaddons
     ```
-    
-The output resembles the following:
 
-```text
+The command should output something similar to the following:
+
+```sh
 ✓ Upgrading CAPI components
 ✓ Waiting for CAPI components to be upgraded
 ✓ Initializing new CAPI components
 ✓ Deleting Outdated Global ClusterResourceSets
-``` 
- 
-If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
+```
 
+If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
+    
+    
 ## Upgrade the core addons
 
 To install the core addons, DKP relies on the `ClusterResourceSet` [Cluster API feature][CAPI]. In the CAPI component upgrade, we deleted the previous set of outdated global `ClusterResourceSets` because prior to DKP 2.2 some addons were installed using a global configuration. In order to support individual cluster upgrades, DKP 2.2 now installs all addons with a unique set of `ClusterResourceSet` and corresponding referenced resources, all named using the cluster’s name as a suffix. For example: `calico-cni-installation-my-aws-cluster`.

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -68,6 +68,22 @@ The output resembles the following:
 ✓ Deleting Outdated Global ClusterResourceSets
 ```
 
+ <p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.</p>
+ 
+  ```bash
+  helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
+kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
+```
+
+```bash
+dkp upgrade capi-components
+```
+
+```bash
+  helm -n cert-manager delete cert-manager-kubeaddons
+  ```
+  
+ 
 If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
 
 ## Upgrade the core addons


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-88839

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

###Description
If a user has previously upgraded from 1.8 to 2.1, an upgrade to 2.2 without the following instructions will break cert-manager.


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4424.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
