### PR TITLE
Document work around for bug 88839

### DIFF
--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -50,11 +50,24 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-Run the following upgrade command for the CAPI components.
+1.  If you cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
 
-```bash
-dkp upgrade capi-components
-```
+    ```bash
+    helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
+    kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
+    ```
+
+1.  For <strong>all</strong> clusters, upgrade capi-components:
+
+    ```bash
+    dkp upgrade capi-components
+    ```
+
+1.  If your cluster was upgraded to 2.1 from 1.8, remove the old cert-manager you marked in step 1:
+
+    ```bash
+    helm -n cert-manager delete cert-manager-kubeaddons
+    ```
 
 The command should output something similar to the following:
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -64,7 +64,22 @@ The command should output something similar to the following:
 ✓ Initializing new CAPI components
 ✓ Deleting Outdated Global ClusterResourceSets
 ```
+<p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.</p>
+ 
+  ```bash
+  helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
+kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
+```
 
+```bash
+dkp upgrade capi-components
+```
+
+```bash
+  helm -n cert-manager delete cert-manager-kubeaddons
+  ```
+
+ 
 If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
 
 ## Upgrade the core addons

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -50,7 +50,7 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1.  If you cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
+1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
 
     ```bash
     helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -7,28 +7,28 @@ beta: false
 enterprise: false
 menuWeight: 30
 ---
+
 ## Prerequisites
 
-* Create an [on-demand backup][backup] of your current configuration with Velero.
+-   Create an [on-demand backup][backup] of your current configuration with Velero.
 
-* Follow the steps listed in the [DKP upgrade overview][dkpup].
+-   Follow the steps listed in the [DKP upgrade overview][dkpup].
 
-* Ensure that all platform applications in the management cluster have been upgraded to avoid compatibility issues with the [Kubernetes version][releasenotes] included in this release. This is done automatically when [upgrading Kommander][upgradekomm], so ensure that you upgrade Kommander prior to upgrading Konvoy.
+-   Ensure that all platform applications in the management cluster have been upgraded to avoid compatibility issues with the [Kubernetes version][releasenotes] included in this release. This is done automatically when [upgrading Kommander][upgradekomm], so ensure that you upgrade Kommander prior to upgrading Konvoy.
 
-* For air-gapped: Download the required bundles either at our [support site][supportsite] or by using the CLI.
+-   For air-gapped: Download the required bundles either at our [support site][supportsite] or by using the CLI.
 
-* For Azure, set the required [environment variables][envariables].
+-   For Azure, set the required [environment variables][envariables].
 
-* For AWS, set the required [environment variables][envariables2].
-
+-   For AWS, set the required [environment variables][envariables2].
 
 The following infrastructure environments are supported:
 
-* Amazon Web Services (AWS)
+-   Amazon Web Services (AWS)
 
-* Microsoft Azure
+-   Microsoft Azure
 
-* Pre-provisioned environments
+-   Pre-provisioned environments
 
 ## Overview
 
@@ -58,16 +58,17 @@ dkp upgrade capi-components
 
 The command should output something similar to the following:
 
-```text
+```sh
 ✓ Upgrading CAPI components
 ✓ Waiting for CAPI components to be upgraded
 ✓ Initializing new CAPI components
 ✓ Deleting Outdated Global ClusterResourceSets
 ```
+
 <p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.</p>
- 
-  ```bash
-  helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
+
+```bash
+helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
 kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
 ```
 
@@ -76,10 +77,9 @@ dkp upgrade capi-components
 ```
 
 ```bash
-  helm -n cert-manager delete cert-manager-kubeaddons
-  ```
+helm -n cert-manager delete cert-manager-kubeaddons
+```
 
- 
 If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
 
 ## Upgrade the core addons
@@ -101,7 +101,7 @@ dkp upgrade addons aws --cluster-name=${CLUSTER_NAME}
 
 The output should be similar to:
 
-```text
+```sh
 Generating addon resources
 clusterresourceset.addons.cluster.x-k8s.io/calico-cni-installation-my-aws-cluster upgraded
 configmap/calico-cni-installation-my-aws-cluster upgraded
@@ -125,33 +125,34 @@ When upgrading the Kubernetes version of a cluster, first upgrade the control pl
 
 <p class="message--note"><strong>NOTE:</strong> If an AMI was specified when initially creating a cluster, you must build a new one with <a href="/dkp/konvoy/2.2/image-builder/">Konvoy Image Builder</a> and pass it with <code>--ami</code>.
 
-1. Upgrade the Kubernetes version of the control plane.
+1.  Upgrade the Kubernetes version of the control plane.
 
-```bash
-dkp update controlplane aws --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
-```
+    ```bash
+    dkp update controlplane aws --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
+    ```
 
-The output should be similar to:
+    The output should be similar to:
 
-```text
-Updating control plane resource controlplane.cluster.x-k8s.io/v1beta1, Kind=KubeadmControlPlane default/my-aws-cluster-control-plane
-Waiting for control plane update to finish.
- ✓ Updating the control plane
-```
+    ```sh
+    Updating control plane resource controlplane.cluster.x-k8s.io/v1beta1, Kind=KubeadmControlPlane default/my-aws-cluster-control-plane
+    Waiting for control plane update to finish.
+     ✓ Updating the control plane
+    ```
 
-2. Upgrade the Kubernetes version of each of your node pools. Replace `my-nodepool` with the name of the node pool.
+1.  Upgrade the Kubernetes version of each of your node pools. Replace `my-nodepool` with the name of the node pool.
 
-```bash
-export NODEPOOL_NAME=my-nodepool
-dkp update nodepool aws ${NODEPOOL_NAME} --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
-```
-The output should be similar to:
+    ```bash
+    export NODEPOOL_NAME=my-nodepool
+    dkp update nodepool aws ${NODEPOOL_NAME} --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
+    ```
 
-```text
-Updating node pool resource cluster.x-k8s.io/v1beta1, Kind=MachineDeployment default/my-aws-cluster-my-nodepool
-Waiting for node pool update to finish.
- ✓ Updating the my-aws-cluster-my-nodepool node pool
-```
+    The output should be similar to:
+
+    ```sh
+    Updating node pool resource cluster.x-k8s.io/v1beta1, Kind=MachineDeployment default/my-aws-cluster-my-nodepool
+    Waiting for node pool update to finish.
+     ✓ Updating the my-aws-cluster-my-nodepool node pool
+    ```
 
 Repeat this step for each additional node pool.
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -50,7 +50,7 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
+1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for upgrade:
 
     ```bash
     helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -63,7 +63,7 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
     dkp upgrade capi-components
     ```
 
-1.  If your cluster was upgraded to 2.1 from 1.8, remove the old cert-manager you marked in step 1:
+1.  If your cluster was upgraded to 2.1 from 1.8, remove the remaining old cert-manager resources from 1.8:
 
     ```bash
     helm -n cert-manager delete cert-manager-kubeaddons

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -65,21 +65,6 @@ The command should output something similar to the following:
 ✓ Deleting Outdated Global ClusterResourceSets
 ```
 
-<p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.</p>
-
-```bash
-helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
-kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
-```
-
-```bash
-dkp upgrade capi-components
-```
-
-```bash
-helm -n cert-manager delete cert-manager-kubeaddons
-```
-
 If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
 
 ## Upgrade the core addons

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -115,7 +115,7 @@ When upgrading to this release, the following services and service components ar
 
 ## Known issues
 
-### Cert-Manager issue from 1.8-2.1 then to 2.2
+### Work around to upgrade from 1.8.x > 2.1.x > 2.2.0 
 
 <p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.  This is relevant for both DKP Essential and Enterprise.</p>
 

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -115,9 +115,9 @@ When upgrading to this release, the following services and service components ar
 
 ## Known issues
 
-### Work around to upgrade from 1.8.x > 2.1.x > 2.2.0 
+### NOTE: Ensure performing all steps if upgraded from 1.8.x > 2.1.x before 2.2.0 
 
-<p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.  This is relevant for both DKP Essential and Enterprise.</p>
+<p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands in regards to upgrading CAPI components.  This is relevant for both DKP Essential and Enterprise.</p>
 
 1.  If you cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
 

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -115,29 +115,6 @@ When upgrading to this release, the following services and service components ar
 
 ## Known issues
 
-### NOTE: Ensure performing all steps if upgraded from 1.8.x > 2.1.x before 2.2.0 
-
-<p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands in regards to upgrading CAPI components.  This is relevant for both DKP Essential and Enterprise.</p>
-
-1.  If you cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
-
-    ```bash
-    helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
-    kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
-    ```
-
-1.  For all clusters, upgrade capi-components:
-
-    ```bash
-    dkp upgrade capi-components
-    ```
-
-1.  If your cluster was upgraded to 2.1 from 1.8, remove the old cert-manager you marked in step 1:
-
-    ```bash
-    helm -n cert-manager delete cert-manager-kubeaddons
-    ```
-
 ### Overriding configuration for kube-oidc-proxy and traefik-forward-auth
 
 Configuration overrides for kube-oidc-proxy and traefik-forward-auth platform applications must be manually applied for each cluster that requires custom configuration on top of the default configuration. Passing in the configuration via the CLI installer *will not work*. Instead, you must edit the cluster's custom configuration in the appropriate `FederatedConfigMap`'s `spec.overrides` list. For kube-oidc-proxy, the `FederatedConfigMap` is called `kube-oidc-proxy-overrides`, and for traefik-forward-auth, it is called `traefik-forward-auth-kommander-overrides`. See below for an example to override the kube-oidc-proxy configuration to use a custom domain `mycluster.domain.dom`:

--- a/pages/dkp/konvoy/2.2/release-notes/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/index.md
@@ -115,6 +115,29 @@ When upgrading to this release, the following services and service components ar
 
 ## Known issues
 
+### Cert-Manager issue from 1.8-2.1 then to 2.2
+
+<p class="message--warning"><strong>WARNING:</strong> If you upgraded 1.8 to 2.1 before upgrading to 2.2, run the following upgrade commands instead.  This is relevant for both DKP Essential and Enterprise.</p>
+
+1.  If you cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for removal:
+
+    ```bash
+    helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
+    kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
+    ```
+
+1.  For all clusters, upgrade capi-components:
+
+    ```bash
+    dkp upgrade capi-components
+    ```
+
+1.  If your cluster was upgraded to 2.1 from 1.8, remove the old cert-manager you marked in step 1:
+
+    ```bash
+    helm -n cert-manager delete cert-manager-kubeaddons
+    ```
+
 ### Overriding configuration for kube-oidc-proxy and traefik-forward-auth
 
 Configuration overrides for kube-oidc-proxy and traefik-forward-auth platform applications must be manually applied for each cluster that requires custom configuration on top of the default configuration. Passing in the configuration via the CLI installer *will not work*. Instead, you must edit the cluster's custom configuration in the appropriate `FederatedConfigMap`'s `spec.overrides` list. For kube-oidc-proxy, the `FederatedConfigMap` is called `kube-oidc-proxy-overrides`, and for traefik-forward-auth, it is called `traefik-forward-auth-kommander-overrides`. See below for an example to override the kube-oidc-proxy configuration to use a custom domain `mycluster.domain.dom`:


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-88839
<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
If a user has previously upgraded from 1.8 to 2.1, an upgrade to 2.2 without the following instructions will break cert-manager. Please add these to the docs pages as indicated with the appropriate caveats:

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4425.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
