### PR TITLE
COPS-7168 - backport 2 pages to Kommander 2.1

### DIFF
--- a/pages/dkp/kommander/2.1/install/mgmt-cluster-apps/index.md
+++ b/pages/dkp/kommander/2.1/install/mgmt-cluster-apps/index.md
@@ -1,0 +1,26 @@
+---
+layout: layout.pug
+navigationTitle: Management cluster application requirements
+title: Management cluster application requirements
+menuWeight: 40
+excerpt: Management cluster application minimum resources and storage requirements
+beta: false
+enterprise: true
+---
+This section only details requirements for management cluster-specific applications. For the list of all platform applications, see [Platform Application Configuration Requirements](../../workspaces/applications/platform-applications/platform-application-requirements/).
+
+This table describes the workspace platform applications specific to the management cluster, minimum resource requirements, and minimum persistent storage requirements.
+
+| Common Name       | Application Name          | Minimum Resources Suggested | Minimum Persistent Storage Required |
+|-------------------|---------------------------|-----------------------------|-------------------------------------|
+| Grafana           | centralized-grafana       | cpu: 200m<br>memory: 100Mi  |                                     |
+| Kubecost          | centralized-kubecost      | cpu: 1200m<br>memory: 4151Mi | # of PVs: 1<br>PV sizes: 32Gi      |
+| Chartmuseum       | chartmuseum               |                             | # of PVs: 1<br>PV sizes: 2Gi        |
+| Dex               | dex                       | cpu: 100m<br>memory: 50Mi   |                                     |
+| Dex Authenticator | dex-k8s-authenticator     | cpu: 100m<br>memory: 128Mi  |                                     |
+| Gitea             | gitea                     | cpu: 500m<br>memory: 512Mi  | # of PVs: 2<br>PV sizes: 10Gi       |
+| Karma             | karma                     |                             |                                     |
+| Flux              | kommander-flux            | cpu: 4000m<br>memory: 4Gi   |                                     |
+| Kubefed           | kubefed                   | cpu: 300m<br>memory: 192Mi  |                                     |
+| Thanos            | thanos                    |                             |                                     |
+| Traefik ForwardAuth | traefik-forward-auth-mgmt | cpu: 100m<br>memory: 128Mi |                                    |

--- a/pages/dkp/kommander/2.1/install/mgmt-cluster-apps/index.md
+++ b/pages/dkp/kommander/2.1/install/mgmt-cluster-apps/index.md
@@ -7,6 +7,7 @@ excerpt: Management cluster application minimum resources and storage requiremen
 beta: false
 enterprise: true
 ---
+
 This section only details requirements for management cluster-specific applications. For the list of all platform applications, see [Platform Application Configuration Requirements](../../workspaces/applications/platform-applications/platform-application-requirements/).
 
 This table describes the workspace platform applications specific to the management cluster, minimum resource requirements, and minimum persistent storage requirements.
@@ -15,7 +16,6 @@ This table describes the workspace platform applications specific to the managem
 |-------------------|---------------------------|-----------------------------|-------------------------------------|
 | Grafana           | centralized-grafana       | cpu: 200m<br>memory: 100Mi  |                                     |
 | Kubecost          | centralized-kubecost      | cpu: 1200m<br>memory: 4151Mi | # of PVs: 1<br>PV sizes: 32Gi      |
-| Chartmuseum       | chartmuseum               |                             | # of PVs: 1<br>PV sizes: 2Gi        |
 | Dex               | dex                       | cpu: 100m<br>memory: 50Mi   |                                     |
 | Dex Authenticator | dex-k8s-authenticator     | cpu: 100m<br>memory: 128Mi  |                                     |
 | Gitea             | gitea                     | cpu: 500m<br>memory: 512Mi  | # of PVs: 2<br>PV sizes: 10Gi       |

--- a/pages/dkp/kommander/2.1/workspaces/applications/platform-applications/platform-application-requirements/index.md
+++ b/pages/dkp/kommander/2.1/workspaces/applications/platform-applications/platform-application-requirements/index.md
@@ -8,6 +8,8 @@ enterprise: false
 draft: true
 ---
 
+<!-- markdownlint-disable MD037 -->
+
 ## Workspace platform application requirements
 
 Workspace platform applications require more resources than solely deploying or attaching clusters into a workspace. Your cluster must have sufficient resources when deploying or attaching to ensure that the platform services are installed successfully.
@@ -29,7 +31,7 @@ The following table describes all the workspace platform applications that are a
 | kube-oidc-proxy |  |  | Yes |
 | kubecost | cpu: 700m<br />memory: 1700Mi | # of PVs: 3<br />PV sizes: 2Gi, 32Gi, 32Gi (total: 66Gi) | Yes |
 | kubernetes-dashboard | cpu: 250m<br />memory: 300Mi |  | Yes |
-| logging-operator | cpu: cpu: 350m * # of nodes + 600m<br />memory: 228Mi + 350Mi * # of nodes | # of PVs: 1<br />PV sizes: 10Gi | No |
+| logging-operator | cpu: 350m * # of nodes + 600m<br />memory: 228Mi + 350Mi * # of nodes | # of PVs: 1<br />PV sizes: 10Gi | No |
 | minio-operator |  cpu: 200m<br />memory: 256Mi |  | No |
 | nfs-server-provisioner |  | # of PVs: 1<br />PV sizes: 100Gi | No |
 | nvidia | cpu: 100m<br />memory: 128Mi |  | No |


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7168

## Description of changes being made
Backporting these 2 pages from 2.2 into the 2.1 doc set; no other changes.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/