### PR TITLE
Fixed Azure and AKS support in the 2.2 Docs

### DIFF
--- a/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
@@ -47,6 +47,13 @@ Konvoy supports the following base Operating Systems.
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64           | Yes            | Yes  | Yes        |                      | Yes         |
 | [RHEL 8.4][rhel_8_4]  | 4.18.0-193.6.3.el8_4.x86_64      | Yes            | Yes  | Yes        |                      | Yes         |
 
+## Azure
+
+<!-- vale Vale.Spelling = NO -->
+| Operating System      | Kernel                           | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
+|-----------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
+| [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |                | Yes            |      |            |                      |             |
+
 ## EKS
 
 <!-- vale Vale.Spelling = NO -->
@@ -59,7 +66,7 @@ Konvoy supports the following base Operating Systems.
 <!-- vale Vale.Spelling = NO -->
 | Operating System      | Kernel                           | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
 |-----------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
-| [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |                | Yes            |      |            |                      |             |
+| [Ubuntu 18.04 (Bionic Beaver)][ubuntu_18] |              | Yes            |      |            |                      |             |
 
 [centos7]: https://wiki.centos.org/action/show/Manuals/ReleaseNotes/CentOS7.2003
 [centos8]: https://wiki.centos.org/action/show/Manuals/ReleaseNotes/CentOS8.2004


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7271 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4431.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
