### PR TITLE
fix: redirect for broken UI links

### DIFF
--- a/s3config.json
+++ b/s3config.json
@@ -42,6 +42,7 @@
     { "Condition": { "KeyPrefixEquals": "mesosphere/dcos/services/beta-jenkins/latest/" },                     "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/services/beta-jenkins/4.0.0-2.204.2-beta/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "mesosphere/dcos/services/beta-kafka/latest/" },                       "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/services/beta-kafka/2.10.0-2.4.0-beta/", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/operations/cloud-providers" },                   "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/latest/operations/infrastructure-providers", "HttpRedirectCode": "307" } },
+    { "Condition": { "KeyPrefixEquals": "dkp/kommander/latest/workspaces/workspace-platform-services/platform-service-dependencies" },                   "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/latest/workspaces/applications/platform-applications/platform-application-dependencies", "HttpRedirectCode": "307" } },
     { "Condition": { "KeyPrefixEquals": "ksphere/" },                                                          "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "service-docs/" },                                                     "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "services/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "docs/" },                                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "", "HttpRedirectCode": "301" } },
@@ -52,7 +53,6 @@
     { "Condition": { "KeyPrefixEquals": "([0-9]+\\.[0-9]+/.*)$" },                                             "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "services/" },                                                         "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/services/", "HttpRedirectCode": "301" } },
     { "Condition": { "KeyPrefixEquals": "version-policy/" },                                                   "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "mesosphere/dcos/version-policy/", "HttpRedirectCode": "301" } },
-    { "Condition": { "KeyPrefixEquals": "support" },                                                           "Redirect": { "HostName": "support.d2iq.com", "Protocol": "https", "HttpRedirectCode": "301" } },
-    { "Condition": { "KeyPrefixEquals": "dkp/kommander/1.4/Architecture/" },                                "Redirect": { "HostName": "$REDIR_HOSTNAME", "ReplaceKeyPrefixWith": "dkp/kommander/1.4/architecture/", "HttpRedirectCode": "301" } }
+    { "Condition": { "KeyPrefixEquals": "support" },                                                           "Redirect": { "HostName": "support.d2iq.com", "Protocol": "https", "HttpRedirectCode": "301" } }
   ]
 }


### PR DESCRIPTION
Evidently the path for this changed in 2.2 docs and as such there are a
number of broken UI links for 2.2. Removed a redirect related to
Kommander 1.4 because we don't support that version anymore, and added
this one to fix the immediate issue.

Closes D2IQ-89309

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
