### PR TITLE
konvoy: changing default value to --with-aws-bootstrap-credentials=false

### DIFF
--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/bootstrap/index.md
@@ -23,7 +23,7 @@ Before you begin, you must:
 1.  Create a bootstrap cluster:
 
     ```bash
-    dkp create bootstrap --kubeconfig $HOME/.kube/config
+    dkp create bootstrap --with-aws-bootstrap-credentials=true --kubeconfig $HOME/.kube/config
     ```
 
     ```sh

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/delete/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/delete/index.md
@@ -20,7 +20,7 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
     <p class="message--note"><strong>NOTE: </strong>To avoid using the wrong kubeconfig, the following steps use explicit kubeconfig paths and contexts.</p>
 
     ```bash
-    dkp create bootstrap --kubeconfig $HOME/.kube/config
+    dkp create bootstrap --with-aws-bootstrap-credentials=true --kubeconfig $HOME/.kube/config
     ```
 
     ```sh

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/self-managed/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/self-managed/index.md
@@ -15,17 +15,15 @@ Before starting, ensure you create a workload cluster as described in [Create a 
 
 1.  Deploy cluster lifecycle services on the workload cluster:
 
-    By default, `create bootstrap controllers` configures the Cluster API controllers to use the AWS credentials from your environment. We recommend you use the `--with-aws-bootstrap-credentials=false` flag to configure the Cluster API controllers of your self-managed AWS cluster to use AWS IAM Instance Profiles, instead of the AWS credentials from your environment.
-
     ```bash
-    dkp create capi-components --with-aws-bootstrap-credentials=false --kubeconfig ${CLUSTER_NAME}.conf
+    dkp create capi-components --kubeconfig ${CLUSTER_NAME}.conf
     ```
 
     ```sh
 	✓ Initializing new CAPI components
     ```
 
-1.  Move the Cluster API objects from the bootstrap to the workload cluster:
+2.  Move the Cluster API objects from the bootstrap to the workload cluster:
 
     The cluster lifecycle services on the workload cluster are ready, but the workload cluster configuration is on the bootstrap cluster. The `move` command moves the configuration, which takes the form of Cluster API Custom Resource objects, from the bootstrap to the workload cluster. This process is also called a [Pivot][pivot].
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/bootstrap/index.md
@@ -26,7 +26,7 @@ Konvoy deploys all cluster lifecycle services to a bootstrap cluster, which depl
 1.  Create a bootstrap cluster:
 
     ```bash
-    dkp create bootstrap --kubeconfig $HOME/.kube/config
+    dkp create bootstrap --with-aws-bootstrap-credentials=true --kubeconfig $HOME/.kube/config
     ```
 
 1.  (Optional) Refresh the credentials used by the AWS provider at any time, using the command:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -61,6 +61,7 @@ We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builde
     dkp create cluster aws \
     --cluster-name=${CLUSTER_NAME} \
     --additional-tags=owner=$(whoami) \
+    --with-aws-bootstrap-credentials=true \    
     --self-managed
     ```
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/eks/advanced/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/eks/advanced/bootstrap/index.md
@@ -23,7 +23,7 @@ Before you begin, you must:
 1.  Create a bootstrap cluster:
 
     ```bash
-    dkp create bootstrap --kubeconfig $HOME/.kube/config
+    dkp create bootstrap --with-aws-bootstrap-credentials=true --kubeconfig $HOME/.kube/config
     ```
 
     ```sh

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/eks/quick-start/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/eks/quick-start/index.md
@@ -45,7 +45,7 @@ Before starting the Konvoy installation, verify that you have:
 1.  Create a bootstrap cluster:
 
     ```bash
-    dkp create bootstrap --kubeconfig $HOME/.kube/config
+    dkp create bootstrap --with-aws-bootstrap-credentials=true --kubeconfig $HOME/.kube/config
     ```
 	```sh
 	✓ Creating a bootstrap cluster

--- a/pages/dkp/konvoy/2.3/release-notes/2.3.0/index.md
+++ b/pages/dkp/konvoy/2.3/release-notes/2.3.0/index.md
@@ -37,6 +37,11 @@ The following features and capabilities are new for Version 2.2.
 
 ### Feature 1
 
+## Deprecations
+
+### Flag default changes
+
+The default value for flag `--with-aws-bootstrap-credentials` changed from `true` to `false`. Set the value to `true` to use AWS credentials from your environment, otherwise the AWS instance profile of the instance where the CAPA controller is running will be used. 
 
 ## Component updates
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

https://jira.d2iq.com/browse/D2IQ-89303

## Description of changes being made

Documenting the change of the default value of `--with-aws-bootstrap-credentials` to `false`. Code changes in https://github.com/mesosphere/konvoy2/pull/1279 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4438.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
