### PR TITLE
Adding Ubuntu instead of CentOS

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,11 +48,10 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.  Essentially, a default AWS image is created which is not recommended for production use.
 
 <p class="message--note"><strong>NOTE: </strong>
-Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
-We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.
+We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default AWS image is created which is not recommended for production use.
 
 <p class="message--note"><strong>NOTE: </strong>
-We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
 <p class="message--note"><strong>NOTE: </strong>
-The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,7 +48,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
 The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
@@ -56,7 +56,7 @@ The default AWS image is not recommended for use in production. We suggest using
 
 1.  Create a Kubernetes cluster:
 
-    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
+    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub's rate limit</a> use your Docker Hub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
 
     ```bash
     dkp create cluster aws \

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,7 +48,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default AWS image is created which is not recommended for production use.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
 <p class="message--note"><strong>NOTE: </strong>
 The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
-The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and above now use Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
-The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and now uses Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,7 +48,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.  Essentially, a default AWS image is created which is not recommended for production use.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default AWS image is created which is not recommended for production use.
 
 <p class="message--note"><strong>NOTE: </strong>
 We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
-The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and above now use Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -86,7 +86,9 @@ Before starting the Konvoy installation, verify that you have:
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
+<p class="message--note"><strong>NOTE: </strong>
 The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+</p>
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -87,7 +87,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
 <p class="message--note"><strong>NOTE: </strong>
-The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 </p>
 
 1.  Give your cluster a name suitable for your environment:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -84,7 +84,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default Azure image is created which is not recommended for production use.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -86,6 +86,8 @@ Before starting the Konvoy installation, verify that you have:
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
+The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+
 1.  Give your cluster a name suitable for your environment:
 
     ```bash

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -84,7 +84,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
 The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
@@ -98,7 +98,7 @@ The default Azure image is not recommended for use in production. We suggest usi
 
 1.  Create a Kubernetes cluster:
 
-    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
+    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub's rate limit</a> use your Docker Hub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
 
     ```bash
     dkp create cluster azure \

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -86,7 +86,7 @@ Before starting the Konvoy installation, verify that you have:
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
-The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/quick-start-azure/index.md
@@ -84,7 +84,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default Azure image is created which is not recommended for production use.
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,11 +48,10 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default AWS image is created which is not recommended for production use.
 
 <p class="message--note"><strong>NOTE: </strong>
-Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
-We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.
+We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 forward now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
-The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 forward now uses Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and above forward now use Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,7 +48,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
 The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 forward now uses Ubuntu 20.04.
@@ -56,7 +56,7 @@ The default AWS image is not recommended for use in production. We suggest using
 
 1.  Create a Kubernetes cluster:
 
-    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
+    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub's rate limit</a> use your Docker Hub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
 
     ```bash
     dkp create cluster aws \

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -48,10 +48,10 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new AWS Kubernetes cluster
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default AWS image is created which is not recommended for production use.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
 <p class="message--note"><strong>NOTE: </strong>
-We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 forward now uses Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 forward now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
-The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and above forward now use Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and above now use Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -51,7 +51,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
 <p class="message--note"><strong>NOTE: </strong>
-The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 forward now uses Ubuntu 20.04.
+The default AWS image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-ami">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced AWS installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 forward now uses Ubuntu 20.04.
 </p>
 
 1.  Create a Kubernetes cluster:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
@@ -87,7 +87,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
-The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and above now use Ubuntu 20.04.
 </p>
 
 1.  Give your cluster a name suitable for your environment:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
@@ -86,7 +86,9 @@ Before starting the Konvoy installation, verify that you have:
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
+<p class="message--note"><strong>NOTE: </strong>
 The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+</p>
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
@@ -87,7 +87,7 @@ Before starting the Konvoy installation, verify that you have:
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
 
 <p class="message--note"><strong>NOTE: </strong>
-The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
+The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 </p>
 
 1.  Give your cluster a name suitable for your environment:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
@@ -84,7 +84,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default Azure image is created which is not recommended for production use.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. A default Azure image is created which is not recommended for production use.
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
@@ -84,7 +84,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
 <p class="message--note"><strong>NOTE: </strong>
 The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
@@ -98,7 +98,7 @@ The default Azure image is not recommended for use in production. We suggest usi
 
 1.  Create a Kubernetes cluster:
 
-    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
+    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub's rate limit</a> use your Docker Hub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
 
     ```bash
     dkp create cluster azure \

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
@@ -84,7 +84,9 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. A default Azure image is created which is not recommended for production use.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. 
+
+The default Azure image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-azure-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced Azure installation</a> topics for more options.  Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 now uses Ubuntu 20.04.
 
 1.  Give your cluster a name suitable for your environment:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/quick-start-azure/index.md
@@ -84,7 +84,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Create a new Azure Kubernetes cluster
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. Essentially, a default Azure image is created which is not recommended for production use.
 
 1.  Give your cluster a name suitable for your environment:
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
This issue affects community-maintained machine images (which users should not use in production). We've worked around this in 2.2 by using the Ubuntu 21.04 image instead of the CentOS7 one (https://github.com/mesosphere/konvoy2/pull/1213/)
### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4440.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
