### PR TITLE
[Kommander 2.2] Integrate Microservices using istio

### DIFF
--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -69,10 +69,13 @@ Review the [list of available applications](../../workspaces/applications/platfo
     export PATH=$PWD/bin:$PATH
     ```
 
-4. You should now be able to run the following commands and see output like this:
+4. You should now be able to run the following `istioctl` command and view the subsequent output:
 
     ```bash
-    $ istioctl version
+    istioctl version
+    ```
+    
+    ```sh
     client version: <your istio version here>
     control plane version: <your istio version here>
     data plane version: <your istio version here> (1 proxies)

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -22,8 +22,6 @@ Before you begin, verify the following:
 
 - You must have a properly deployed and running cluster.
 
-- You must have `cert-manager` enabled and deployed through your `cluster.yaml` configuration.
-
 ## Deploy Istio using DKP
 
 Review the [list of available applications](../../workspaces/applications/platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -1,6 +1,6 @@
 ---
 layout: layout.pug
-navigationTitle: Integrate microservices using Istio
+navigationTitle: Use Istio
 title: Integrate microservices using Istio
 menuWeight: 24
 excerpt: Learn how to integrate microservices managed by Istio into a DKP cluster

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -26,7 +26,7 @@ Before you begin, verify the following:
 
 Review the [list of available applications](../../workspaces/applications/platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.
 
-1.  Enable a supported application to deploy to [your existing attached cluster](../../clusters/attach-cluster/) with an `AppDeployment` resource.
+1.  Enable the deployment of Istio to [your existing attached cluster](../../clusters/attach-cluster/) by creating an `AppDeployment` resource.
 
 1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be enabled:
 

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.pug
 navigationTitle: Use Istio
-title: Integrate microservices using Istio
+title: Use Istio
 menuWeight: 24
 excerpt: Learn how to integrate microservices managed by Istio into a DKP cluster
 beta: false

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -20,9 +20,9 @@ Before you begin, verify the following:
 
 - You must have access to a Linux, macOS, or Windows computer with a supported operating system version.
 
-- You must have a properly deployed and running cluster. For information about deploying Kubernetes with default settings, see the [Quick start][quickstart].
+- You must have a properly deployed and running cluster.
 
-- You must have `cert-manager` enabled and deployed through your `cluster.yaml` addon configuration.
+- You must have `cert-manager` enabled and deployed through your `cluster.yaml` configuration.
 
 ## Deploy Istio using DKP
 

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -28,7 +28,7 @@ Before starting this tutorial, you should verify the following:
 
 ## Deploy Istio using DKP
 
-Review the [list of available applications](../../platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.
+Review the [list of available applications](../../workspaces/applications/platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.
 
 1.  Enable a supported application to deploy to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
 

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -24,7 +24,7 @@ Before you begin, verify the following:
 
 ## Deploy Istio using DKP
 
-Review the [list of available applications](../../workspaces/applications/platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.
+Review the [list of available applications](../../workspaces/applications/platform-applications#workspace-platform-applications) to obtain the current 'APP NAME' for the Istio application, as you will need this name later in this procedure.
 
 1.  Enable the deployment of Istio to [your existing attached cluster](../../clusters/attach-cluster/) by creating an `AppDeployment` resource.
 

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -87,6 +87,8 @@ The Istio BookInfo sample application is composed of four separate microservices
 
 1. Deploy the sample `bookinfo` application on the Kubernetes cluster by running the following commands:
 
+    <p class="message--warning"><strong>IMPORTANT:</strong> Ensure your <code>dkp</code> configuration references the cluster where you deployed Istio by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
+
     ```bash
     kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml)
     kubectl apply -f samples/bookinfo/networking/bookinfo-gateway.yaml

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -6,7 +6,6 @@ menuWeight: 24
 excerpt: Learn how to integrate microservices managed by Istio into a DKP cluster
 beta: false
 experimental: true
-enterprise: false
 ---
 
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -11,7 +11,7 @@ experimental: true
 
 Istio helps you manage cloud-based deployments by providing an open-source service mesh to connect, secure, control, and observe microservices.
 
-This tutorial demonstrates how to expose an application running on the DKP cluster using the LoadBalancer (layer-4) service type.
+This topic describes how to expose an application running on the DKP cluster using the LoadBalancer (layer-4) service type.
 
 <p class="message--note"><strong>NOTE: </strong>Usage and installation of Istio on DKP is currently a self-service feature.</p>
 

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -8,7 +8,6 @@ beta: false
 experimental: true
 ---
 
-<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 
 Istio helps you manage cloud-based deployments by providing an open-source service mesh to connect, secure, control, and observe microservices.
 

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -100,7 +100,7 @@ The Istio BookInfo sample application is composed of four separate microservices
 
     The command displays output similar to the following:
 
-    ```bash
+    ```sh
     NAME                   TYPE           CLUSTER-IP    EXTERNAL-IP                                                               PORT(S)                                                                                                                                      AGE
     istio-ingressgateway   LoadBalancer   10.0.29.241   a682d13086ccf11e982140acb7ee21b7-2083182676.us-west-2.elb.amazonaws.com   15020:30380/TCP,80:31380/TCP,443:31390/TCP,31400:31400/TCP,15029:30756/TCP,15030:31420/TCP,15031:31948/TCP,15032:32061/TCP,15443:31232/TCP   110s
     ```

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -16,7 +16,7 @@ This topic describes how to expose an application running on the DKP cluster usi
 <p class="message--note"><strong>NOTE: </strong>Usage and installation of Istio on DKP is currently a self-service feature.</p>
 
 ## Before you begin
-Before starting this tutorial, you should verify the following:
+Before you begin, verify the following:
 
 - You must have access to a Linux, macOS, or Windows computer with a supported operating system version.
 

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -111,4 +111,3 @@ The Istio BookInfo sample application is composed of four separate microservices
 1. Follow the steps in the Istio [BookInfo Application][istiobook] documentation to understand the different Istio features.
 
 [istiobook]:https://istio.io/docs/examples/bookinfo/
-[quickstart]:../../quick-start/

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -1,0 +1,116 @@
+---
+layout: layout.pug
+navigationTitle: Integrate microservices using Istio
+title: Integrate microservices using Istio
+menuWeight: 24
+excerpt: Learn how to integrate microservices managed by Istio into a DKP cluster
+beta: false
+experimental: true
+enterprise: false
+---
+
+<!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
+
+Istio helps you manage cloud-based deployments by providing an open-source service mesh to connect, secure, control, and observe microservices.
+
+This tutorial demonstrates how to expose an application running on the DKP cluster using the LoadBalancer (layer-4) service type.
+
+<p class="message--note"><strong>NOTE: </strong>Usage and installation of Istio on DKP is currently a self-service feature.</p>
+
+## Before you begin
+Before starting this tutorial, you should verify the following:
+
+- You must have access to a Linux, macOS, or Windows computer with a supported operating system version.
+
+- You must have a properly deployed and running cluster. For information about deploying Kubernetes with default settings, see the [Quick start][quickstart].
+
+- You must have `cert-manager` enabled and deployed through your `cluster.yaml` addon configuration.
+
+## Deploy Istio using DKP
+
+Review the [list of available applications](../../platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.
+
+1.  Enable a supported application to deploy to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
+
+1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be enabled:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: apps.kommander.d2iq.io/v1alpha2
+    kind: AppDeployment
+    metadata:
+      name: istio
+      namespace: ${WORKSPACE_NAMESPACE}
+    spec:
+      appRef:
+        name: istio-1.11.6
+        kind: ClusterApp
+    EOF
+    ```
+
+1.  Create the resource in the workspace you just created, which instructs Kommander to deploy the `AppDeployment` to the `KommanderCluster`s in the same workspace.
+
+<p class="message--note"><strong>NOTE: </strong>The <code>appRef.name</code> must match the app <code>name</code> from the list of available applications.</p>
+
+## Download the Istio command line utility
+
+1. Store a local environment variable containing the current Istio version running in your cluster:
+
+    ```bash
+    export KONVOY_ISTIO_VERSION="$(kubectl get clusteraddons istio -o go-template='{{ .spec.chartReference.version }}')"
+    ```
+
+2. Pull a copy of the corresponding Istio command line to your system:
+
+    ```bash
+    curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${KONVOY_ISTIO_VERSION} sh -
+    ```
+
+3. Change to the Istio directory and set your PATH environment variable by running the following commands:
+
+    ```bash
+    cd istio*
+    export PATH=$PWD/bin:$PATH
+    ```
+
+4. You should now be able to run the following commands and see output like this:
+
+    ```bash
+    $ istioctl version
+    client version: <your istio version here>
+    control plane version: <your istio version here>
+    data plane version: <your istio version here> (1 proxies)
+    ```
+
+## Deploy a sample application on Istio
+
+The Istio BookInfo sample application is composed of four separate microservices that demonstrate various Istio features.
+
+1. Deploy the sample `bookinfo` application on the Kubernetes cluster by running the following commands:
+
+    ```bash
+    kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml)
+    kubectl apply -f samples/bookinfo/networking/bookinfo-gateway.yaml
+    ```
+
+1. Get the URL of the load balancer created on AWS for this service by running the following command:
+
+    ```bash
+    kubectl get svc istio-ingressgateway -n istio-system
+    ```
+
+    The command displays output similar to the following:
+
+    ```bash
+    NAME                   TYPE           CLUSTER-IP    EXTERNAL-IP                                                               PORT(S)                                                                                                                                      AGE
+    istio-ingressgateway   LoadBalancer   10.0.29.241   a682d13086ccf11e982140acb7ee21b7-2083182676.us-west-2.elb.amazonaws.com   15020:30380/TCP,80:31380/TCP,443:31390/TCP,31400:31400/TCP,15029:30756/TCP,15030:31420/TCP,15031:31948/TCP,15032:32061/TCP,15443:31232/TCP   110s
+    ```
+
+1. Open a web browser and navigate to the external IP address for the load balancer to access the application.
+
+    For example, the external IP address in the sample output is `a682d13086ccf11e982140acb7ee21b7-2083182676.us-west-2.elb.amazonaws.com`, enabling you to access the application using the following URL: `http://a682d13086ccf11e982140acb7ee21b7-2083182676.us-west-2.elb.amazonaws.com/productpage`
+
+1. Follow the steps in the Istio [BookInfo Application][istiobook] documentation to understand the different Istio features.
+
+[istiobook]:https://istio.io/docs/examples/bookinfo/
+[quickstart]:../../quick-start/

--- a/pages/dkp/kommander/2.2/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.2/networking/use-istio/index.md
@@ -30,7 +30,7 @@ Before starting this tutorial, you should verify the following:
 
 Review the [list of available applications](../../workspaces/applications/platform-applications#workspace-platform-applications) that can be enabled to deploy to your attached cluster.
 
-1.  Enable a supported application to deploy to [your existing attached cluster](../../../../clusters/attach-cluster/) with an `AppDeployment` resource.
+1.  Enable a supported application to deploy to [your existing attached cluster](../../clusters/attach-cluster/) with an `AppDeployment` resource.
 
 1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be enabled:
 

--- a/pages/dkp/kommander/2.3/networking/use-istio/index.md
+++ b/pages/dkp/kommander/2.3/networking/use-istio/index.md
@@ -1,0 +1,116 @@
+---
+layout: layout.pug
+navigationTitle: Use Istio
+title: Use Istio
+menuWeight: 24
+excerpt: Learn how to integrate microservices managed by Istio into a DKP cluster
+beta: false
+experimental: true
+---
+
+
+Istio helps you manage cloud-based deployments by providing an open-source service mesh to connect, secure, control, and observe microservices.
+
+This topic describes how to expose an application running on the DKP cluster using the LoadBalancer (layer-4) service type.
+
+<p class="message--note"><strong>NOTE: </strong>Usage and installation of Istio on DKP is currently a self-service feature.</p>
+
+## Before you begin
+Before you begin, verify the following:
+
+- You must have access to a Linux, macOS, or Windows computer with a supported operating system version.
+
+- You must have a properly deployed and running cluster.
+
+## Deploy Istio using DKP
+
+Review the [list of available applications](../../workspaces/applications/platform-applications#workspace-platform-applications) to obtain the current 'APP NAME' for the Istio application, as you will need this name later in this procedure.
+
+1.  Enable the deployment of Istio to [your existing attached cluster](../../clusters/attach-cluster/) by creating an `AppDeployment` resource.
+
+1.  Within the `AppDeployment`, define the `appRef` to specify which `App` will be enabled:
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: apps.kommander.d2iq.io/v1alpha2
+    kind: AppDeployment
+    metadata:
+      name: istio
+      namespace: ${WORKSPACE_NAMESPACE}
+    spec:
+      appRef:
+        name: istio-1.11.6
+        kind: ClusterApp
+    EOF
+    ```
+
+1.  Create the resource in the workspace you just created, which instructs Kommander to deploy the `AppDeployment` to the `KommanderCluster`s in the same workspace.
+
+<p class="message--note"><strong>NOTE: </strong>The <code>appRef.name</code> must match the app <code>name</code> from the list of available applications.</p>
+
+## Download the Istio command line utility
+
+1. Store a local environment variable containing the current Istio version running in your cluster:
+
+    ```bash
+    export KONVOY_ISTIO_VERSION="$(kubectl get clusteraddons istio -o go-template='{{ .spec.chartReference.version }}')"
+    ```
+
+2. Pull a copy of the corresponding Istio command line to your system:
+
+    ```bash
+    curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${KONVOY_ISTIO_VERSION} sh -
+    ```
+
+3. Change to the Istio directory and set your PATH environment variable by running the following commands:
+
+    ```bash
+    cd istio*
+    export PATH=$PWD/bin:$PATH
+    ```
+
+4. You should now be able to run the following `istioctl` command and view the subsequent output:
+
+    ```bash
+    istioctl version
+    ```
+    
+    ```sh
+    client version: <your istio version here>
+    control plane version: <your istio version here>
+    data plane version: <your istio version here> (1 proxies)
+    ```
+
+## Deploy a sample application on Istio
+
+The Istio BookInfo sample application is composed of four separate microservices that demonstrate various Istio features.
+
+1. Deploy the sample `bookinfo` application on the Kubernetes cluster by running the following commands:
+
+    <p class="message--warning"><strong>IMPORTANT:</strong> Ensure your <code>dkp</code> configuration references the cluster where you deployed Istio by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
+
+    ```bash
+    kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml)
+    kubectl apply -f samples/bookinfo/networking/bookinfo-gateway.yaml
+    ```
+
+1. Get the URL of the load balancer created on AWS for this service by running the following command:
+
+    ```bash
+    kubectl get svc istio-ingressgateway -n istio-system
+    ```
+
+    The command displays output similar to the following:
+
+    ```sh
+    NAME                   TYPE           CLUSTER-IP    EXTERNAL-IP                                                               PORT(S)                                                                                                                                      AGE
+    istio-ingressgateway   LoadBalancer   10.0.29.241   a682d13086ccf11e982140acb7ee21b7-2083182676.us-west-2.elb.amazonaws.com   15020:30380/TCP,80:31380/TCP,443:31390/TCP,31400:31400/TCP,15029:30756/TCP,15030:31420/TCP,15031:31948/TCP,15032:32061/TCP,15443:31232/TCP   110s
+    ```
+
+1. Open a web browser and navigate to the external IP address for the load balancer to access the application.
+
+    For example, the external IP address in the sample output is `a682d13086ccf11e982140acb7ee21b7-2083182676.us-west-2.elb.amazonaws.com`, enabling you to access the application using the following URL: `http://a682d13086ccf11e982140acb7ee21b7-2083182676.us-west-2.elb.amazonaws.com/productpage`
+
+1. Follow the steps in the Istio [BookInfo Application][istiobook] documentation to understand the different Istio features.
+
+[istiobook]:https://istio.io/docs/examples/bookinfo/


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-78973

## Description of changes being made

Added relevant istio integration topic with updated application enablement process to the Kommander 2.2 Networking section.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4443.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
