### PR TITLE
fix: add note about email_verified OIDC token field for KOP

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -189,6 +189,7 @@ namespac(e|es|ed|ing)
 (nginx|NGINX)
 Nouveau
 (nvidia|Nvidia|NVIDIA)
+(OIDC|oidc)
 (onboarding|Onboarding)
 openssl
 (OpsPortal|opsportal)

--- a/pages/dkp/kommander/2.0/security/distributed-authnz/index.md
+++ b/pages/dkp/kommander/2.0/security/distributed-authnz/index.md
@@ -17,6 +17,8 @@ The Kommander dashboard admin credentials are stored as a secret. They never lea
 
 The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other platform services use the ID token as an authentication proof. User identity to the Kubernetes API server is provided by the [`kube-oidc-proxy`][kube_oidc_proxy] platform service that reads the identity from an ID token. Web requests to Kommander dashboard access are authenticated by the [traefik forward auth][traefik_forward_auth] platform service.
 
+<p class="message--note"><strong>NOTE: </strong>The <a href="https://github.com/jetstack/kube-oidc-proxy">kube-oidc-proxy</a> service authenticates kubectl CLI requests using the Kubernetes API Server Go library. This library requires that if an <strong>email_verified</strong> claim is present, it must be set to <strong>true</strong>, even if the <code>insecureSkipEmailVerified: true</code> flag is configured in the Dex connector. Thus, ensure that the OIDC provider is configured to set the email_verified field to 'true' </p>
+
 A user identity is shared across a Kommander cluster and all other attached clusters.
 
 ### Kommander attached clusters

--- a/pages/dkp/kommander/2.1/security/distributed-authnz/index.md
+++ b/pages/dkp/kommander/2.1/security/distributed-authnz/index.md
@@ -17,6 +17,8 @@ The Kommander dashboard admin credentials are stored as a secret. They never lea
 
 The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other platform services use the ID token as an authentication proof. User identity to the Kubernetes API server is provided by the [`kube-oidc-proxy`][kube_oidc_proxy] platform service that reads the identity from an ID token. Web requests to Kommander dashboard access are authenticated by the [traefik forward auth][traefik_forward_auth] platform service.
 
+<p class="message--note"><strong>NOTE: </strong>The <a href="https://github.com/jetstack/kube-oidc-proxy">kube-oidc-proxy</a> service authenticates kubectl CLI requests using the Kubernetes API Server Go library. This library requires that if an <strong>email_verified</strong> claim is present, it must be set to <strong>true</strong>, even if the <code>insecureSkipEmailVerified: true</code> flag is configured in the Dex connector. Thus, ensure that the OIDC provider is configured to set the email_verified field to 'true' </p>
+
 A user identity is shared across a Kommander cluster and all other attached clusters.
 
 ### Kommander attached clusters

--- a/pages/dkp/kommander/2.2/security/distributed-authnz/index.md
+++ b/pages/dkp/kommander/2.2/security/distributed-authnz/index.md
@@ -17,6 +17,8 @@ The DKP UI admin credentials are stored as a secret. They never leave the bounda
 
 The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other platform services use the ID token as an authentication proof. User identity to the Kubernetes API server is provided by the [`kube-oidc-proxy`][kube_oidc_proxy] platform service that reads the identity from an ID token. Web requests to DKP UI access are authenticated by the [traefik forward auth][traefik_forward_auth] platform service.
 
+<p class="message--note"><strong>NOTE: </strong>The <a href="https://github.com/jetstack/kube-oidc-proxy">kube-oidc-proxy</a> service authenticates kubectl CLI requests using the Kubernetes API Server Go library. This library requires that if an <strong>email_verified</strong> claim is present, it must be set to <strong>true</strong>, even if the <code>insecureSkipEmailVerified: true</code> flag is configured in the Dex connector. Thus, ensure that the OIDC provider is configured to set the email_verified field to 'true' </p>
+
 A user identity is shared across a Kommander cluster and all other attached clusters.
 
 ### Kommander attached clusters

--- a/pages/dkp/kommander/2.3/security/distributed-authnz/index.md
+++ b/pages/dkp/kommander/2.3/security/distributed-authnz/index.md
@@ -17,6 +17,8 @@ The DKP UI admin credentials are stored as a secret. They never leave the bounda
 
 The Dex service issues an [OIDC ID token][oidc_id_token] on successful user authentication. Other platform services use the ID token as an authentication proof. User identity to the Kubernetes API server is provided by the [`kube-oidc-proxy`][kube_oidc_proxy] platform service that reads the identity from an ID token. Web requests to DKP UI access are authenticated by the [traefik forward auth][traefik_forward_auth] platform service.
 
+<p class="message--note"><strong>NOTE: </strong>The <a href="https://github.com/jetstack/kube-oidc-proxy">kube-oidc-proxy</a> service authenticates kubectl CLI requests using the Kubernetes API Server Go library. This library requires that if an <strong>email_verified</strong> claim is present, it must be set to <strong>true</strong>, even if the <code>insecureSkipEmailVerified: true</code> flag is configured in the Dex connector. Thus, ensure that the OIDC provider is configured to set the email_verified field to 'true' </p>
+
 A user identity is shared across a Kommander cluster and all other attached clusters.
 
 ### Kommander attached clusters


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

JIRA: https://jira.d2iq.com/browse/D2IQ-88868

## Description of changes being made
In the https://jira.d2iq.com/browse/COPS-7262 we've discovered that OIDC ID token must have `email_verified` set to value `true` in order to be verified by `kube-oidc-proxy`. This change documents this finding.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4445.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
