### PR TITLE
Correct namespace for command to check calico-node rollout

### DIFF
--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
@@ -317,7 +317,7 @@ INFO[2021-11-12T18:22:55-08:00] Created/Updated NVIDIA GPU Feature Discovery Cus
 1.  Wait for the new pods to finish rolling out:
 
     ```bash
-    kubectl --kubeconfig=admin.conf -n kube-system rollout status daemonset/calico-node
+    kubectl --kubeconfig=admin.conf -n calico-system rollout status daemonset/calico-node
     ```
 
     The output appears similar to this:

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/preprovisioned/index.md
@@ -189,7 +189,7 @@ INFO[2021-11-12T18:22:55-08:00] Created/Updated NVIDIA GPU Feature Discovery Cus
 1.  Wait for the new pods to be rolled out:
 
     ```bash
-    kubectl --kubeconfig=admin.conf -n kube-system rollout status daemonset/calico-node
+    kubectl --kubeconfig=admin.conf -n calico-system rollout status daemonset/calico-node
     ```
 
     The output appears similar to this:


### PR DESCRIPTION
## Jira Ticket

Jira: [D2IQ-88426](https://jira.d2iq.com/browse/D2IQ-88426)

## Description of changes being made

Update namespace in one of the commands to check calico-node rollout for the Konvoy upgrade.

### Preview

http://docs-d2iq-com-pr-4447.s3-website-us-west-2.amazonaws.com/
