### PR TITLE
COPS7213 Cluster naming

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/new/index.md
@@ -23,6 +23,12 @@ enterprise: false
     export CLUSTER_NAME=aws-example
     ```
 
+<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters. 
+
+See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
+</p>
+
 ## Tips and Tricks
 
 1.  To get a list of names used in your AWS account, use the `aws` [CLI][download_aws_cli]. After downloading, use the following command:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/new/index.md
@@ -23,10 +23,8 @@ enterprise: false
     export CLUSTER_NAME=aws-example
     ```
 
-<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters. 
-
-See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
-
+<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
 </p>
 
 ## Tips and Tricks

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/new/index.md
@@ -29,11 +29,9 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
 
     See [Get Started with AWS][createnewcluster] for information on naming your cluster.
 
-    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
-    
-    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
-
-</p>
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 1.  Export variables for the existing infrastructure details:
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/new/index.md
@@ -29,6 +29,12 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
 
     See [Get Started with AWS][createnewcluster] for information on naming your cluster.
 
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
+    
+    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
+</p>
+
 1.  Export variables for the existing infrastructure details:
 
     ```bash

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
@@ -40,6 +40,10 @@ Before starting the Konvoy installation, verify that you have:
     export CLUSTER_NAME=my-aws-cluster
     ```
 
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
+    
+    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
 ## Create a new AWS Kubernetes cluster
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on a [CentOS 7 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/index.md
@@ -40,9 +40,9 @@ Before starting the Konvoy installation, verify that you have:
     export CLUSTER_NAME=my-aws-cluster
     ```
 
-    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
-    
-    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 ## Create a new AWS Kubernetes cluster
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -23,11 +23,9 @@ enterprise: false
     export CLUSTER_NAME=aws-example
     ```
 
-<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters. 
-
-See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
-
-</p>
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 ## Tips and Tricks
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -23,6 +23,12 @@ enterprise: false
     export CLUSTER_NAME=aws-example
     ```
 
+<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters. 
+
+See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
+</p>
+
 ## Tips and Tricks
 
 1.  To get a list of names used in your AWS account, use the `aws` [CLI][download_aws_cli]. After downloading, use the following command:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
@@ -29,6 +29,10 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
 
     See [Get Started with AWS][createnewcluster] for information on naming your cluster.
 
+     <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
+    
+    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
 1.  Export variables for the existing infrastructure details:
 
     ```bash

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
@@ -29,9 +29,9 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
 
     See [Get Started with AWS][createnewcluster] for information on naming your cluster.
 
-     <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
-    
-    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 1.  Export variables for the existing infrastructure details:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -45,6 +45,9 @@ Before starting the Konvoy installation, verify that you have:
     ```bash
     export CLUSTER_NAME=aws-example
     ```
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
+    
+    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
 
 ## Create a new AWS Kubernetes cluster
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/quick-start-aws/index.md
@@ -45,9 +45,9 @@ Before starting the Konvoy installation, verify that you have:
     ```bash
     export CLUSTER_NAME=aws-example
     ```
-    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
-    
-    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 ## Create a new AWS Kubernetes cluster
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/new/index.md
@@ -23,12 +23,9 @@ enterprise: false
     export CLUSTER_NAME=aws-example
     ```
 
-<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters. 
-
-See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
-
-</p>
-
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 ## Tips and Tricks
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/new/index.md
@@ -23,6 +23,13 @@ enterprise: false
     export CLUSTER_NAME=aws-example
     ```
 
+<p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters. 
+
+See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
+</p>
+
+
 ## Tips and Tricks
 
 1.  To get a list of names used in your AWS account, use the `aws` [CLI][download_aws_cli]. After downloading, use the following command:

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
@@ -29,9 +29,9 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
 
     See [Get Started with AWS][createnewcluster] for information on naming your cluster.
 
-    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
-    
-    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 1.  Export variables for the existing infrastructure details:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
@@ -29,6 +29,10 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
 
     See [Get Started with AWS][createnewcluster] for information on naming your cluster.
 
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
+    
+    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
 1.  Export variables for the existing infrastructure details:
 
     ```bash

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -46,6 +46,10 @@ Before starting the Konvoy installation, verify that you have:
     export CLUSTER_NAME=aws-example
     ```
 
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
+    
+    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+
 ## Create a new AWS Kubernetes cluster
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/quick-start-aws/index.md
@@ -46,9 +46,9 @@ Before starting the Konvoy installation, verify that you have:
     export CLUSTER_NAME=aws-example
     ```
 
-    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z, 0-9, . - and _</code>. Cluster creation will fail if the name has capital letters.           
-    
-    See [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) for more naming information.
+    <p class="message--note"><strong>NOTE: </strong>The cluster name may only contain the following characters: <code>a-z</code>, <code>0-9</code>, <code>.</code>, and <code>-</code>. Cluster creation will fail if the name has capital letters.
+    See <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/">Kubernetes</a> for more naming information.
+    </p>
 
 ## Create a new AWS Kubernetes cluster
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7213

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made

The Konvoy documentation around the CLUSTER_NAME variable could be a little unclear.

Konvoy 1.x documentation doesn't have the example one-liner to set a cluster, but dont see that as a problem now. 

For Konvoy 2.x, I would suggest that the following (taken from 1.x) is added, and also some extra text:

 

NOTE: The cluster name may only contain the following characters: a-z, 0-9, . - and _.

NOTE: Cluster creation will fail if the name has capital letters.  See kubernetes documentation https://kubernetes.io/docs/concepts/overview/working-with-objects/names/ for more details.

 

This should be in the same section as the first reference of CLUSTER-NAME:

https://docs.d2iq.com/dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws/
https://docs.d2iq.com/dkp/konvoy/2.1/choose-infrastructure/aws/advanced/new/
https://docs.d2iq.com/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/new/


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4448.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
