### PR TITLE
Fixed RHEL 8.4 kernal version name

### DIFF
--- a/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
@@ -23,7 +23,7 @@ Konvoy supports the following base Operating Systems.
 | [RHEL 8.4][rhel_8_4]  | 4.18.0-305.el8.x86_64            | Yes            | Yes  | Yes        |                      | Yes         |
 | [Ubuntu 18.04 (Bionic Beaver)][ubuntu_18] |              | Yes            |      |            |                      |             |
 | [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |                | Yes            |      |            |                      | Yes         |
-| [SLES 15](https://documentation.suse.com/sles/15-SP3/)    |                                  | Yes            |      | Yes        |                      | Yes         |
+| [SLES 15 SP3](https://documentation.suse.com/sles/15-SP3/)    |                                  | Yes            |      | Yes        |                      | Yes         |
 | [Oracle Linux RHCK 7.9][RHCK] | kernel-3.10.0-1160.el7   | Yes            | Yes  |            |                      |             |
 
 ## Pre-Provisioned/On Premises
@@ -35,7 +35,7 @@ Konvoy supports the following base Operating Systems.
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64           | Yes            |      |            |                      | Yes         |
 | [RHEL 8.4][rhel_8_4]  | 4.18.0-305.el8.x86_64            | Yes            |      |            |                      | Yes         |
 | [Flatcar][flatcar]    | 3033.2.x                         | Yes            |      |            |                      |             |
-| [SLES 15](https://documentation.suse.com/sles/15-SP3/)    |                                  | Yes            |      |            |                      |             |
+| [SLES 15 SP3](https://documentation.suse.com/sles/15-SP3/)    |                                  | Yes            |      |            |                      |             |
 | [Oracle Linux RHCK 7.9][RHCK] | kernel-3.10.0-1160.el7   | Yes            |      |            |                      |             |
 
 ## vSphere

--- a/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
@@ -20,7 +20,7 @@ Konvoy supports the following base Operating Systems.
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64           | Yes            | Yes  | Yes        | Yes                  | Yes         |
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64           | Yes            | Yes  | Yes        |                      | Yes         |
 | [RHEL 8.2][rhel_8_2]  | 4.18.0-193.6.3.el8_2.x86_64      | Yes            | Yes  | Yes        |                      | Yes         |
-| [RHEL 8.4][rhel_8_4]  | 4.18.0-193.6.3.el8_4.x86_64      | Yes            | Yes  | Yes        |                      | Yes         |
+| [RHEL 8.4][rhel_8_4]  | 4.18.0-305.el8.x86_64            | Yes            | Yes  | Yes        |                      | Yes         |
 | [Ubuntu 18.04 (Bionic Beaver)][ubuntu_18] |              | Yes            |      |            |                      |             |
 | [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |                | Yes            |      |            |                      | Yes         |
 | [SLES 15](https://documentation.suse.com/sles/15-SP3/)    |                                  | Yes            |      | Yes        |                      | Yes         |
@@ -33,7 +33,7 @@ Konvoy supports the following base Operating Systems.
 |-----------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64           | Yes            | Yes  | Yes        |                      |             |
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64           | Yes            |      |            |                      | Yes         |
-| [RHEL 8.4][rhel_8_4]  | 4.18.0-193.6.3.el8_4.x86_64      | Yes            |      |            |                      | Yes         |
+| [RHEL 8.4][rhel_8_4]  | 4.18.0-305.el8.x86_64            | Yes            |      |            |                      | Yes         |
 | [Flatcar][flatcar]    | 3033.2.x                         | Yes            |      |            |                      |             |
 | [SLES 15](https://documentation.suse.com/sles/15-SP3/)    |                                  | Yes            |      |            |                      |             |
 | [Oracle Linux RHCK 7.9][RHCK] | kernel-3.10.0-1160.el7   | Yes            |      |            |                      |             |
@@ -45,7 +45,7 @@ Konvoy supports the following base Operating Systems.
 |-----------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64           | Yes            |      |            |                      |             |
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64           | Yes            | Yes  | Yes        |                      | Yes         |
-| [RHEL 8.4][rhel_8_4]  | 4.18.0-193.6.3.el8_4.x86_64      | Yes            | Yes  | Yes        |                      | Yes         |
+| [RHEL 8.4][rhel_8_4]  | 4.18.0-305.el8.x86_64            | Yes            | Yes  | Yes        |                      | Yes         |
 
 ## Azure
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-82728

## Description of changes being made

Fixed RHEL 8.4 kernal version for DKP 2.2

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
