### PR TITLE
konvoy: document that creating an override is required for preprov clusters with an HTTP proxy

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -175,6 +175,8 @@ If you require HTTP proxy configurations, you can apply them during the `create`
 | HTTPS proxy for worker machines          | `--worker-https-proxy string`        |
 | No Proxy list for worker machines        | `--worker-no-proxy strings`          |
 
+<p class="message--note"><strong>NOTE: </strong>You must also add the same configuration as an <a href="../create-secrets-and-overrides#create_overrides">override</a>. For more information, refer to <a href="../../../image-builder/override-files/create-custom-or-files/proxy-or-files">this documentation</a>.</p>
+
 ### HTTP Proxy Example
 
 ```bash

--- a/pages/dkp/konvoy/2.1/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
+++ b/pages/dkp/konvoy/2.1/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
@@ -8,18 +8,14 @@ enterprise: false
 menuWeight: 105
 ---
 
-You can use an HTTP proxy configuration when creating your image. The Ansible playbooks create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`.
-
-To configure a proxy for use during image creation, create a new override file like the following example, and specify the correct values for your environment:
+An HTTP proxy configuration can be used when creating your image. The Ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file and specify the following:
 
 ```yaml
-cat <<EOF > overrides.yaml
+# Example override-proxy.yaml
 https_proxy: "http://10.0.64.5:3128"
 http_proxy: "http://10.0.64.5:3128"
 no_proxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
 EOF
 ```
 
-These values are only used for the image creation. After DKP creates the image, the Ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file.
-
-You can use the `dkp` command to configure the `KubeadmConfigTemplate` object to create this file on boot-up of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.
+These values are only used for the image creation. After the image is created, the Ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file. The `dkp` command can be used to configure the `KubeadmConfigTemplate` object to create this file on bootup of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -206,6 +206,8 @@ If you require HTTP proxy configurations, you can apply them during the `create`
 | HTTPS proxy for worker machines          | `--worker-https-proxy string`        |
 | No Proxy list for worker machines        | `--worker-no-proxy strings`          |
 
+<p class="message--note"><strong>NOTE: </strong>You must also add the same configuration as an <a href="../create-secrets-and-overrides#create_overrides">override</a>. For more information, refer to <a href="../../../image-builder/override-files/create-custom-or-files/proxy-or-files">this documentation</a>.</p>
+
 ### HTTP Proxy Example
 
 <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
@@ -8,15 +8,14 @@ enterprise: false
 menuWeight: 105
 ---
 
-An HTTP proxy configuration can be used when creating your AMI image. The Ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file and specify the following:
+An HTTP proxy configuration can be used when creating your image. The Ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file and specify the following:
 
 ```yaml
 # Example override-proxy.yaml
----
-export http_proxy: http://example.org:8080
-export https_proxy: http://example.org:8081
-export no_proxy: example.org,example.com,example.net
-
+https_proxy: "http://10.0.64.5:3128"
+http_proxy: "http://10.0.64.5:3128"
+no_proxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
+EOF
 ```
 
 These values are only used for the image creation. After the image is created, the Ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file. The `dkp` command can be used to configure the `KubeadmConfigTemplate` object to create this file on bootup of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -206,6 +206,8 @@ If you require HTTP proxy configurations, you can apply them during the `create`
 | HTTPS proxy for worker machines          | `--worker-https-proxy string`        |
 | No Proxy list for worker machines        | `--worker-no-proxy strings`          |
 
+<p class="message--note"><strong>NOTE: </strong>You must also add the same configuration as an <a href="../create-secrets-and-overrides#create_overrides">override</a>. For more information, refer to <a href="../../../image-builder/override-files/create-custom-or-files/proxy-or-files">this documentation</a>.</p>
+
 ### HTTP Proxy Example
 
 <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>

--- a/pages/dkp/konvoy/2.3/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
+++ b/pages/dkp/konvoy/2.3/image-builder/override-files/create-custom-or-files/proxy-or-files/index.md
@@ -8,15 +8,14 @@ enterprise: false
 menuWeight: 105
 ---
 
-An HTTP proxy configuration can be used when creating your AMI image. The Ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file and specify the following:
+An HTTP proxy configuration can be used when creating your image. The Ansible playbooks will create `systemd` drop-in files for `containerd` and `kubelet` to configure the `http_proxy`, `http_proxy`, and `no_proxy` environment variables for the service from the file `/etc/konvoy_http_proxy.conf`. To configure a proxy for use during image creation, create a new override file and specify the following:
 
 ```yaml
 # Example override-proxy.yaml
----
-export http_proxy: http://example.org:8080
-export https_proxy: http://example.org:8081
-export no_proxy: example.org,example.com,example.net
-
+https_proxy: "http://10.0.64.5:3128"
+http_proxy: "http://10.0.64.5:3128"
+no_proxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
+EOF
 ```
 
 These values are only used for the image creation. After the image is created, the Ansible playbooks remove the `/etc/konvoy_http_proxy.conf` file. The `dkp` command can be used to configure the `KubeadmConfigTemplate` object to create this file on bootup of the image with values supplied during the `dkp` invocation. This enables using different proxy settings for image creation and runtime.


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

Fixeshttps://jira.d2iq.com/browse/D2IQ-89698.
Documentation for https://jira.d2iq.com/browse/COPS-7214.
I created a separate task https://jira.d2iq.com/browse/D2IQ-89695 for code changes.

<!-- Link to JIRA ticket -->

## Description of changes being made

Added a Note about users needing to create an override to hold their HTTP proxy configuration. Also fixed the `proxy-or-files/index.md` and made them all consistent across releases.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4450.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
