### PR TITLE
Added MinIO attribution to docker registry page

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
@@ -16,6 +16,7 @@ Before creating a Kubernetes cluster you must have the required images in a loca
     ```bash
     curl -o konvoy-image-bundle.tar.gz -O https://downloads.d2iq.com/dkp/v2.2.0/konvoy_image_bundle_v2.2.0_linux_amd64.tar.gz
     ```
+<p class="message--note"><strong>NOTE: </strong>This docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio">here</a>.</p>
 
 1.  Place the bundle in a location where you can load and push the images to your private docker registry.
 


### PR DESCRIPTION
## Jira Ticket

Urgent work from legal and Tobi.

## Description of changes being made

Added attributions for MinIO code.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
