### PR TITLE
docs: adds section on encapsulation

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -91,7 +91,7 @@ enterprise: false
 
 ### Modify the Calico installation
 
-### Setting interface
+### Set the interface
 
 Before exploring the new cluster, confirm your `calico` installation is correct.
 By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This is not always appropriate for your particular nodes. In that case, you must modify Calico's configuration to use a different method.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -194,7 +194,7 @@ VXLAN is a tunneling protocol that encapsulates layer 2 Ethernet frames in UDP p
 
 #### IPIP
 
-IP-in-IP is an IP tunneling protocol that encapsulates one IP packet in another IP packet. An outer packet header is added with the tunnel entrypoint and the tunnel exit point. The calico implementation of this protocol uses BGP to determine the exit point making this protocol unusable on networks that don’t pass BGP (eg Azure).
+IP-in-IP is an IP tunneling protocol that encapsulates one IP packet in another IP packet. An outer packet header is added with the tunnel entrypoint and the tunnel exit point. The calico implementation of this protocol uses BGP to determine the exit point making this protocol unusable on networks that don’t pass BGP.
 
 **Be aware that switching encapsulation modes can cause disruption to in-progress connections. Plan accordingly.**
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -169,7 +169,7 @@ Calico can leverage different network encapsulation methods to route traffic for
     - AWS across VPC subnet boundaries
     - environments where you cannot peer Calico over BGP to the underlay or easily configure static routes.
 
-IPIP is the default encapsualtion method.
+IPIP is the default encapsulation method.
 
 To change the encapsulation run the command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -162,7 +162,7 @@ Save this file. You may need to delete the node feature discovery worker pod in 
 
 ### Change the encapsulation type
 
-Calico can leverage different network encapsulation methods to route traffic for your workloads. Encapsulation can be useful when running on top of an underlying network that cannot easily be made aware of workload IPs. Common examples of this include:
+Calico can leverage different network encapsulation methods to route traffic for your workloads. Encapsulation is useful when running on top of an underlying network that is not aware of workload IPs. Common examples of this include:
 
 
     - public cloud environments where you don’t own the hardware

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -171,7 +171,7 @@ Calico can leverage different network encapsulation methods to route traffic for
 
 IPIP is the default encapsulation method.
 
-To change the encapsulation run the command:
+To change the encapsulation, run the following command:
 
    ```bash
    kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -190,11 +190,13 @@ The supported values are "IPIPCrossSubnet", "IPIP", "VXLAN", "VXLANCrossSubnet",
 
 #### VXLAN
 
-VXLAN is a tunneling protocol that encapsulates layer 2 Ethernet frames in UDP packets, enabling you to create virtualized layer 2 subnets that span Layer 3 networks. It has a slightly larger header than IP-in-IP which creates a very slight reduction in performance over IP-in-IP.
+VXLAN is a tunneling protocol that encapsulates layer 2 Ethernet frames in UDP packets, enabling you to create virtualized layer 2 subnets that span Layer 3 networks. It has a slightly larger header than IP-in-IP which creates a slight reduction in performance over IP-in-IP.
 
 #### IPIP
 
 IP-in-IP is an IP tunneling protocol that encapsulates one IP packet in another IP packet. An outer packet header is added with the tunnel entrypoint and the tunnel exit point. The calico implementation of this protocol uses BGP to determine the exit point making this protocol unusable on networks that don’t pass BGP (eg Azure).
+
+**Be aware that switching encapsulation modes can cause disruption to in-progress connections. Plan accordingly.**
 
 For more information, see:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -89,7 +89,7 @@ enterprise: false
     dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
     ```
 
-### Modifying your Calico installation
+### Modify the Calico installation
 
 ### Setting interface
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -160,7 +160,7 @@ Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interfa
 
 Save this file. You may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace if that pod has failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
 
-### Changing encapsulation type
+### Change the encapsulation type
 
 Calico can leverage different network encapsulation methods to route traffic for your workloads. Encapsulation can be useful when running on top of an underlying network that cannot easily be made aware of workload IPs. Common examples of this include:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -89,7 +89,9 @@ enterprise: false
     dkp get kubeconfig -c ${CLUSTER_NAME} > ${CLUSTER_NAME}.conf
     ```
 
-### Verify your Calico installation
+### Modify the Calico installation
+
+### Set the interface
 
 Before exploring the new cluster, confirm your `calico` installation is correct.
 By default, Calico automatically detects the IP to use for each node using the `first-found` [method][calico-method]. This is not always appropriate for your particular nodes. In that case, you must modify Calico's configuration to use a different method.
@@ -157,6 +159,51 @@ Change the value for `spec.calicoNetwork.nodeAddressAutodetectionV4` to `interfa
    ```
 
 Save this file. You may need to delete the node feature discovery worker pod in the `node-feature-discovery` namespace if that pod has failed. After you delete it, Kubernetes replaces the pod as part of its normal reconciliation.
+
+### Change the encapsulation type
+
+Calico can leverage different network encapsulation methods to route traffic for your workloads. Encapsulation is useful when running on top of an underlying network that is not aware of workload IPs. Common examples of this include:
+
+
+    - public cloud environments where you don’t own the hardware
+    - AWS across VPC subnet boundaries
+    - environments where you cannot peer Calico over BGP to the underlay or easily configure static routes.
+
+IPIP is the default encapsulation method.
+
+To change the encapsulation, run the following command:
+
+   ```bash
+   kubectl edit installation default --kubeconfig ${CLUSTER_NAME}.conf
+   ```
+
+Change the value for `spec.calicoNetwork.ipPools[0].encapsulation`
+
+  ```yaml
+    spec:
+    calicoNetwork:
+      ipPools:
+        - encapsulation: VXLAN
+  ```
+
+The supported values are "IPIPCrossSubnet", "IPIP", "VXLAN", "VXLANCrossSubnet", and "None".
+
+#### VXLAN
+
+VXLAN is a tunneling protocol that encapsulates layer 2 Ethernet frames in UDP packets, enabling you to create virtualized layer 2 subnets that span Layer 3 networks. It has a slightly larger header than IP-in-IP which creates a slight reduction in performance over IP-in-IP.
+
+#### IPIP
+
+IP-in-IP is an IP tunneling protocol that encapsulates one IP packet in another IP packet. An outer packet header is added with the tunnel entrypoint and the tunnel exit point. The calico implementation of this protocol uses BGP to determine the exit point making this protocol unusable on networks that don’t pass BGP.
+
+**Be aware that switching encapsulation modes can cause disruption to in-progress connections. Plan accordingly.**
+
+For more information, see:
+
+  - [Calico Overlay Networking][calico-overlay]
+  - [IP-in-IP RFC 2003][ipip]
+  - [VXLAN RFC 7348][vxlan]
+
 
 ## Use the built-in Virtual IP
 
@@ -311,6 +358,9 @@ Confirm that your [Calico installation is correct][calico-install].
 
 [calico-install]: #verify-your-calico-installation
 [calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods
+[calico-overlay]: https://docs.projectcalico.org/networking/vxlan-ipip
+[ipip]: https://datatracker.ietf.org/doc/html/rfc2003
+[vxlan]: https://datatracker.ietf.org/doc/html/rfc7348
 [create-secrets-and-overrides]: ../create-secrets-and-overrides
 [define-control-plane-endpoint]: ../define-control-plane-endpoint
 [kube-vip]: https://kube-vip.chipzoller.dev


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

https://jira.d2iq.com/browse/D2IQ-85911

## Description of changes being made

This adds a section explaining how to change the encapsulation method for preprovisioned clusters.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4455.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
