### PR TITLE
fix: HTTP proxy configuration in 2.2.0+ version

### DIFF
--- a/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
@@ -86,6 +86,12 @@ Kommander installs with a dedicated CLI.
     ./kommander install --installer-config ./install.yaml
     ```
 
+1. Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+
+    ```bash
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
+    ```
+
 # Configure Workspace (or Project) in which you want to use proxy
 
 To have Gatekeeper mutate the manifests, create the `Workspace` (or `Project`) with the following label:

--- a/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
@@ -73,7 +73,7 @@ Kommander installs with a dedicated CLI.
               "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them such that the Gatekeeper mutation is active on the namespaces.
+1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them so the Gatekeeper mutation is active on the namespaces.
 
     ```bash
     kubectl create namespace kommander

--- a/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
@@ -73,23 +73,20 @@ Kommander installs with a dedicated CLI.
               "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-1. You can create a `kommander` namespace, or the namespace where Kommander will be installed, and then label it such that the Gatekeeper mutation is active on the namespace.
+1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them such that the Gatekeeper mutation is active on the namespaces.
 
     ```bash
     kubectl create namespace kommander
     kubectl label namespace kommander gatekeeper.d2iq.com/mutate=pod-proxy
+
+    kubectl create namespace kommander-flux
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 1. Install Kommander using the above configuration file:
 
     ```bash
     ./kommander install --installer-config ./install.yaml
-    ```
-
-1. Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
-
-    ```bash
-    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 # Configure Workspace (or Project) in which you want to use proxy

--- a/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
@@ -86,7 +86,7 @@ Kommander installs with a dedicated CLI.
     ./kommander install --installer-config ./install.yaml
     ```
 
-1. Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+1. Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
 
     ```bash
     kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -42,10 +42,10 @@ This section describes how to upgrade your Kommander Management cluster and all 
 
 -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
 
-    Edit the `gatekeeper-overrides`, and add a new configuration property `disableMutation` with the value `false`. The Gatekeeper configuration has changed between versions `v2.1.1` and `v2.2.0`:
+    Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.0`:
 
     ```yaml
-      disableMutation: false # <-- this value is new in 2.2.0 and is missing in documentation
+      disableMutation: false # <-- this value is new in 2.2.0
       mutations:
         enablePodProxy: true
         podProxySettings:

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -39,6 +39,30 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```bash
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
+
+-   For clusters that are installed with HTTP Proxy:
+
+    Edit the `gatekeeper-overrides` and add a new configuration property `disableMutation` with value `false`. The Gatekeeper configuration has changed between versions `v2.1.1` and `v2.2.0`:
+
+    ```yaml
+      disableMutation: false # <-- this value is new in 2.2.0 and is missing in documentation
+      mutations:
+        enablePodProxy: true
+        podProxySettings:
+          noProxy: ...
+          httpProxy: ...
+          httpsProxy: ...
+        excludeNamespacesFromProxy: []
+        namespaceSelectorForProxy:
+          "gatekeeper.d2iq.com/mutate": "pod-proxy"
+    ```
+
+    Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+
+    ```bash
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
+    ```
+
 ## Detach MetalLB from Kommander
 
   <p class="message--important"><strong>IMPORTANT:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -40,9 +40,9 @@ This section describes how to upgrade your Kommander Management cluster and all 
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
 
--   For clusters that are installed with HTTP Proxy:
+-   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
 
-    Edit the `gatekeeper-overrides` and add a new configuration property `disableMutation` with value `false`. The Gatekeeper configuration has changed between versions `v2.1.1` and `v2.2.0`:
+    Edit the `gatekeeper-overrides`, and add a new configuration property `disableMutation` with the value `false`. The Gatekeeper configuration has changed between versions `v2.1.1` and `v2.2.0`:
 
     ```yaml
       disableMutation: false # <-- this value is new in 2.2.0 and is missing in documentation
@@ -57,7 +57,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
           "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-    Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+    Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
 
     ```bash
     kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy

--- a/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
@@ -73,7 +73,7 @@ Kommander installs with the DKP CLI.
               "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them such that the Gatekeeper mutation is active on the namespaces.
+1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them so the Gatekeeper mutation is active on the namespaces.
 
     ```bash
     kubectl create namespace kommander

--- a/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
@@ -73,11 +73,14 @@ Kommander installs with the DKP CLI.
               "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-1.  You can create a `kommander` namespace, or the namespace where Kommander will be installed, and then label it such that the Gatekeeper mutation is active on the namespace.
+1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them such that the Gatekeeper mutation is active on the namespaces.
 
     ```bash
     kubectl create namespace kommander
     kubectl label namespace kommander gatekeeper.d2iq.com/mutate=pod-proxy
+
+    kubectl create namespace kommander-flux
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 1.  Install Kommander using the above configuration file:
@@ -86,12 +89,6 @@ Kommander installs with the DKP CLI.
 
     ```bash
     ./dkp install kommander --installer-config ./install.yaml
-    ```
-
-1. Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
-
-    ```bash
-    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 ## Configure Workspace (or Project) in which you want to use proxy

--- a/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
@@ -61,8 +61,8 @@ Kommander installs with the DKP CLI.
     apps:
       gatekeeper:
         values: |
+          disableMutation: false
           mutations:
-            enable: true
             enablePodProxy: true
             podProxySettings:
               noProxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
@@ -86,6 +86,12 @@ Kommander installs with the DKP CLI.
 
     ```bash
     ./dkp install kommander --installer-config ./install.yaml
+    ```
+
+1. Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+
+    ```bash
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 ## Configure Workspace (or Project) in which you want to use proxy
@@ -134,8 +140,8 @@ data:
   values.yaml: |
     ---
     # enable mutations
+    disableMutation: false
     mutations:
-      enable: true
       enablePodProxy: true
       podProxySettings:
         noProxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"

--- a/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/http-proxy/index.md
@@ -88,7 +88,7 @@ Kommander installs with the DKP CLI.
     ./dkp install kommander --installer-config ./install.yaml
     ```
 
-1. Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+1. Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
 
     ```bash
     kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy

--- a/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
@@ -73,7 +73,7 @@ Kommander installs with the DKP CLI.
               "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them such that the Gatekeeper mutation is active on the namespaces.
+1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them so the Gatekeeper mutation is active on the namespaces.
 
     ```bash
     kubectl create namespace kommander

--- a/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
@@ -73,11 +73,14 @@ Kommander installs with the DKP CLI.
               "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-1.  You can create a `kommander` namespace, or the namespace where Kommander will be installed, and then label it such that the Gatekeeper mutation is active on the namespace.
+1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them such that the Gatekeeper mutation is active on the namespaces.
 
     ```bash
     kubectl create namespace kommander
     kubectl label namespace kommander gatekeeper.d2iq.com/mutate=pod-proxy
+
+    kubectl create namespace kommander-flux
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 1.  Install Kommander using the above configuration file:
@@ -86,12 +89,6 @@ Kommander installs with the DKP CLI.
 
     ```bash
     ./dkp install kommander --installer-config ./install.yaml
-    ```
-
-1. Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
-
-    ```bash
-    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 ## Configure Workspace (or Project) in which you want to use proxy

--- a/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
@@ -61,8 +61,8 @@ Kommander installs with the DKP CLI.
     apps:
       gatekeeper:
         values: |
+          disableMutation: false
           mutations:
-            enable: true
             enablePodProxy: true
             podProxySettings:
               noProxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
@@ -86,6 +86,12 @@ Kommander installs with the DKP CLI.
 
     ```bash
     ./dkp install kommander --installer-config ./install.yaml
+    ```
+
+1. Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+
+    ```bash
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
 ## Configure Workspace (or Project) in which you want to use proxy
@@ -134,8 +140,8 @@ data:
   values.yaml: |
     ---
     # enable mutations
+    disableMutation: false
     mutations:
-      enable: true
       enablePodProxy: true
       podProxySettings:
         noProxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"

--- a/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/http-proxy/index.md
@@ -88,7 +88,7 @@ Kommander installs with the DKP CLI.
     ./dkp install kommander --installer-config ./install.yaml
     ```
 
-1. Configure the `kommander-flux` namespace and label it such that the Gatekeeper mutation is active on the namespace.
+1. Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
 
     ```bash
     kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -42,10 +42,10 @@ This section describes how to upgrade your Kommander Management cluster and all 
 
   -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
 
-    Edit the `gatekeeper-overrides`, and add a new configuration property `disableMutation` with the value `false`. The Gatekeeper configuration has changed between versions `v2.1.1` and `v2.2.0`:
+    Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.0`:
 
     ```yaml
-      disableMutation: false # <-- this value is new in 2.2.0 and is missing in documentation
+      disableMutation: false # <-- this value is new in 2.2.0 
       mutations:
         enablePodProxy: true
         podProxySettings:

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -39,6 +39,30 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```bash
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
+
+  -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
+
+    Edit the `gatekeeper-overrides`, and add a new configuration property `disableMutation` with the value `false`. The Gatekeeper configuration has changed between versions `v2.1.1` and `v2.2.0`:
+
+    ```yaml
+      disableMutation: false # <-- this value is new in 2.2.0 and is missing in documentation
+      mutations:
+        enablePodProxy: true
+        podProxySettings:
+          noProxy: ...
+          httpProxy: ...
+          httpsProxy: ...
+        excludeNamespacesFromProxy: []
+        namespaceSelectorForProxy:
+          "gatekeeper.d2iq.com/mutate": "pod-proxy"
+    ```
+
+    Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
+
+    ```bash
+    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
+    ```
+
 ## Detach MetalLB from Kommander
 
   <p class="message--important"><strong>IMPORTANT:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed  MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/COPS-7236
https://jira.d2iq.com/browse/D2IQ-89710
https://jira.d2iq.com/browse/D2IQ-89674

## Description of changes being made

* In the COPS-7236 we've discovered a change in the Gatekeeper configuration file that requires to be reflected in the docs in order to get HTTP proxy clusters working with `v2.2.0`. 
* Add a step to the `v2.1.1` -> `v2.2.0` Kommander upgrade steps for clusters installed with HTTP proxy configuration that is necessary in order to successfully upgrade a cluster.
* Adds an installation step to include `kommander-flux` namespace in Gatekeeper mutated namespaces.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4457.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
