### PR TITLE
Fixing menuweights

### DIFF
--- a/pages/dkp/kommander/2.3/index.md
+++ b/pages/dkp/kommander/2.3/index.md
@@ -1,9 +1,9 @@
 ---
 layout: layout.pug
-navigationTitle: Kommander 2.2
-title: Kommander 2.2
-version: 2.2
-menuWeight: 20
+navigationTitle: Kommander 2.3
+title: Kommander 2.3
+version: 2.3
+menuWeight: 18
 subtree:
   beta: false
   draft: false

--- a/pages/dkp/kommander/2.3/index.md
+++ b/pages/dkp/kommander/2.3/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Kommander 2.3
 title: Kommander 2.3
 version: 2.3
-menuWeight: 18
+menuWeight: 15
 subtree:
   beta: false
   draft: false

--- a/pages/dkp/konvoy/2.3/index.md
+++ b/pages/dkp/konvoy/2.3/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Konvoy 2.3
 title: Welcome to Konvoy 2.3
 version: 2.3
-menuWeight: 20
+menuWeight: 18
 subtree:
   beta: false
 ---

--- a/pages/dkp/konvoy/2.3/index.md
+++ b/pages/dkp/konvoy/2.3/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: Konvoy 2.3
 title: Welcome to Konvoy 2.3
 version: 2.3
-menuWeight: 18
+menuWeight: 15
 subtree:
   beta: false
 ---


### PR DESCRIPTION
## Jira Ticket

<img width="371" alt="Screenshot 2022-05-16 at 14 24 42" src="https://user-images.githubusercontent.com/98893586/168591939-6a05c6c8-ad56-4bd7-912c-bc8e0d042e79.png">

## Description of changes being made

2.3 docs are shown below 2.2 instead of on top, as it should be. Besides, 2.3 is labeled 2.2. 


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4459.s3-website-us-west-2.amazonaws.com/
