### PR TITLE
fix: use fixed layout for table and break words in tables

### DIFF
--- a/scss/base/_table.scss
+++ b/scss/base/_table.scss
@@ -2,6 +2,7 @@ table {
     width: 100%;
     border-collapse: collapse;
     text-align: left;
+    table-layout:fixed;
 }
 
 table,
@@ -10,6 +11,7 @@ td {
     padding: 0.5rem;
     border: 1px $color-grey-light solid;
     color: $color-dark;
+    word-wrap: break-word;
 }
 
 th {


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

https://mesosphere.slack.com/archives/C06FHSK3J/p1652763397844409

## Description of changes being made

USe a fixed layout for tables and break words in tables to let them not overflow, see slack thread.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4464.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
