### PR TITLE
changing archive references

### DIFF
--- a/pages/dkp/kommander/1.4/archives/index.md
+++ b/pages/dkp/kommander/1.4/archives/index.md
@@ -9,23 +9,7 @@ render: mustache
 ---
 # Access archived versions of Kommander documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.1 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Kommander.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
 
 [policy](/dkp/kommander/latest/version-policy/)
 [repo](https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/kommander)

--- a/pages/dkp/kommander/2.0/archives/index.md
+++ b/pages/dkp/kommander/2.0/archives/index.md
@@ -10,23 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Kommander documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.1 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
 
 [policy](/dkp/kommander/2.0/version-policy/)
 [repo](https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/kommander)

--- a/pages/dkp/kommander/2.0/archives/index.md
+++ b/pages/dkp/kommander/2.0/archives/index.md
@@ -10,7 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Kommander documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. This includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
 
 [policy](/dkp/kommander/2.0/version-policy/)
 [repo](https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/kommander)

--- a/pages/dkp/kommander/2.1/archives/index.md
+++ b/pages/dkp/kommander/2.1/archives/index.md
@@ -10,25 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Kommander documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation.
-At this time, this includes documentation for Kommander 1.1 and below.
-You can still access older versions of Kommander documentation on our [public GitHub repository][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/kommander

--- a/pages/dkp/kommander/2.2/archives/index.md
+++ b/pages/dkp/kommander/2.2/archives/index.md
@@ -10,25 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Kommander documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation.
-At this time, this includes documentation for Kommander 1.1 and below.
-You can still access older versions of Kommander documentation on our [public GitHub repository][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/kommander

--- a/pages/dkp/kommander/2.2/archives/index.md
+++ b/pages/dkp/kommander/2.2/archives/index.md
@@ -10,7 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Kommander documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. This includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/kommander

--- a/pages/dkp/kommander/2.3/archives/index.md
+++ b/pages/dkp/kommander/2.3/archives/index.md
@@ -10,25 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Kommander documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation.
-At this time, this includes documentation for Kommander 1.1 and below.
-You can still access older versions of Kommander documentation on our [public GitHub repository][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Kommander documentation. At this time, this includes documentation for Kommander 1.3 and below. You can still access older versions of Kommander documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/kommander

--- a/pages/dkp/konvoy/1.6/archives/index.md
+++ b/pages/dkp/konvoy/1.6/archives/index.md
@@ -10,7 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.5 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo], or by locally running a Docker image (experimental):
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. This includes documentation for Konvoy 1.5 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo], or by locally running a Docker image (experimental):
 
 On your local machine, run:
 

--- a/pages/dkp/konvoy/1.8/archives/index.md
+++ b/pages/dkp/konvoy/1.8/archives/index.md
@@ -11,23 +11,8 @@ render: mustache
 
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.5 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo], or by locally running a Docker image (experimental):
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
 
 [policy]: ../version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/konvoy

--- a/pages/dkp/konvoy/1.8/archives/index.md
+++ b/pages/dkp/konvoy/1.8/archives/index.md
@@ -11,7 +11,7 @@ render: mustache
 
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. This includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
 
 [policy]: ../version-policy/

--- a/pages/dkp/konvoy/2.0/archives/index.md
+++ b/pages/dkp/konvoy/2.0/archives/index.md
@@ -10,23 +10,8 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.5 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo], or by locally running a Docker image (experimental):
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
 
 [policy]: ../version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/konvoy

--- a/pages/dkp/konvoy/2.1/archives/index.md
+++ b/pages/dkp/konvoy/2.1/archives/index.md
@@ -10,7 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. This includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/konvoy

--- a/pages/dkp/konvoy/2.1/archives/index.md
+++ b/pages/dkp/konvoy/2.1/archives/index.md
@@ -10,23 +10,7 @@ render: mustache
 <!-- markdownlint-disable MD004 MD007 MD025 MD030 -->
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.5 and below. You can still access older versions of Konvoy documentation on our [public GitHub repository][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/konvoy

--- a/pages/dkp/konvoy/2.2/archives/index.md
+++ b/pages/dkp/konvoy/2.2/archives/index.md
@@ -10,7 +10,7 @@ render: mustache
 
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. This includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/konvoy

--- a/pages/dkp/konvoy/2.2/archives/index.md
+++ b/pages/dkp/konvoy/2.2/archives/index.md
@@ -10,23 +10,7 @@ render: mustache
 
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.5 and below. You can still access older versions of Konvoy documentation on our [public GitHub repository][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/konvoy

--- a/pages/dkp/konvoy/2.3/archives/index.md
+++ b/pages/dkp/konvoy/2.3/archives/index.md
@@ -10,23 +10,7 @@ render: mustache
 
 ## Access archived versions of Konvoy documentation
 
-In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.5 and below. You can still access older versions of Konvoy documentation on our [public GitHub repository][repo], or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```docker
-docker run -p 5000:5000 -it mesosphere/archived_docs
-```
-
-After running this command, you will see:
-
-```sh
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of Konvoy.
+In accordance with our [version policy][policy], we regularly archive older, unsupported versions of our Konvoy documentation. At this time, this includes documentation for Konvoy 1.7 and below. You can still access older versions of Konvoy documentation on our [public GitHub repo][repo].
 
 [policy]: ../legal/version-policy/
 [repo]: https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/dkp/konvoy

--- a/pages/mesosphere/dcos/2.2/archives/index.md
+++ b/pages/mesosphere/dcos/2.2/archives/index.md
@@ -9,20 +9,6 @@ render: mustache
 model: /mesosphere/dcos/2.2/data.yml
 ---
 
-# Access archived versions of DC/OS documentation 
+# Access archived versions of DC/OS documentation
 
-In accordance with our [version policy](https://docs.d2iq.com/mesosphere/dcos/version-policy/), we regularly archive older, unsupported versions of our DC/OS documentation. At this time, this includes documentation for DC/OS 1.12 and below. You can still access older versions of DC/OS documentation on our [public github repo](https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/mesosphere/dcos), or by locally running a Docker image (experimental):
-
-On your local machine, run:
-
-```
-docker run -p 5000:5000 -it mesosphere/archived_docs  
-```
-After running this command, you will see:
-```
-   │   Serving!                                     │
-   │                                                │
-   │   - Local:            http://0.0.0.0:5000      │
-```
-
-where you can access the documentation for archived versions of DC/OS.
+In accordance with our [version policy](https://docs.d2iq.com/mesosphere/dcos/version-policy/), we regularly archive older, unsupported versions of our DC/OS documentation. This includes documentation for DC/OS 1.12 and below. You can still access older versions of DC/OS documentation on our [public github repo](https://github.com/mesosphere/dcos-docs-site/tree/archive/pages/mesosphere/dcos).


### PR DESCRIPTION
Signed-off-by: Casie Oxford <coxford@d2iq.com>

## Jira Ticket

goes with Mack's archive PR  - https://github.com/mesosphere/dcos-docs-site/pull/4408 

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4466.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
