### PR TITLE
vSphere Upgrade Docs Essential and Enterprise

### DIFF
--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -21,6 +21,8 @@ menuWeight: 30
 
 * For AWS, set the required [environment variables][envariables2].
 
+* For vSphere, set the required [environment variables][envariables3].
+
 The following infrastructure environments are supported:
 
 * Amazon Web Services (AWS)
@@ -28,6 +30,8 @@ The following infrastructure environments are supported:
 * Microsoft Azure
 
 * Pre-provisioned environments
+
+* vSphere
 
 ## Overview
 
@@ -95,7 +99,7 @@ Your cluster comes preconfigured with a few different core addons that provide f
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, preprovisioned]) and the name of the cluster.
+Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, vsphere, preprovisioned]) and the name of the cluster.
 
 Examples:
 
@@ -193,3 +197,4 @@ For the overall process for upgrading to the latest version of DKP, refer back t
 [envariables]: ../../../choose-infrastructure/azure/quick-start-azure#configure-azure-prerequisites
 [backup]: ../../../../../kommander/2.2/backup-and-restore#back-up-on-demand
 [envariables2]: ../../../choose-infrastructure/aws/quick-start-aws#configure-aws-prerequisites
+[envariables3]: ../../../choose-infrastructure/vsphere/create-capi-vm-image/

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -22,6 +22,8 @@ menuWeight: 30
 
 -   For AWS, set the required [environment variables][envariables2].
 
+* For vSphere, set the required [environment variables][envariables3].
+
 The following infrastructure environments are supported:
 
 -   Amazon Web Services (AWS)
@@ -29,6 +31,8 @@ The following infrastructure environments are supported:
 -   Microsoft Azure
 
 -   Pre-provisioned environments
+
+-   vSphere
 
 ## Overview
 
@@ -90,7 +94,7 @@ Your cluster comes preconfigured with a few different core addons that provide f
 
 <p class="message--warning"><strong>IMPORTANT:</strong>If you have more than one essential cluster, ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, preprovisioned]) and the name of the cluster.
+Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, vsphere, preprovisioned]) and the name of the cluster.
 
 Examples:
 
@@ -190,3 +194,4 @@ For the overall process for upgrading to the latest version of DKP, refer back t
 [backup]: ../../../../../kommander/2.2/backup-and-restore#back-up-on-demand
 [envariables]: ../../../choose-infrastructure/azure/quick-start-azure#configure-azure-prerequisites
 [envariables2]: ../../../choose-infrastructure/aws/quick-start-aws#configure-aws-prerequisites
+[envariables3]: ../../../choose-infrastructure/vsphere/create-capi-vm-image/

--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -21,6 +21,8 @@ menuWeight: 30
 
 * For AWS, set the required [environment variables][envariables2].
 
+* For vSphere, set the required [environment variables][envariables3].
+
 The following infrastructure environments are supported:
 
 * Amazon Web Services (AWS)
@@ -28,6 +30,10 @@ The following infrastructure environments are supported:
 * Microsoft Azure
 
 * Pre-provisioned environments
+
+-   vSphere
+
+-   Google Cloud Platform
 
 ## Overview
 
@@ -95,7 +101,7 @@ Your cluster comes preconfigured with a few different core addons that provide f
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, preprovisioned]) and the name of the cluster.
+Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, vsphere, gcp, preprovisioned]) and the name of the cluster.
 
 Examples:
 
@@ -193,3 +199,4 @@ For the overall process for upgrading to the latest version of DKP, refer back t
 [envariables]: ../../../choose-infrastructure/azure/quick-start-azure#configure-azure-prerequisites
 [backup]: ../../../../../kommander/2.3/backup-and-restore#back-up-on-demand
 [envariables2]: ../../../choose-infrastructure/aws/quick-start-aws#configure-aws-prerequisites
+[envariables3]: ../../../choose-infrastructure/vsphere/create-capi-vm-image/

--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -22,6 +22,8 @@ menuWeight: 30
 
 -   For AWS, set the required [environment variables][envariables2].
 
+-   For vSphere, set the required [environment variables][envariables3].
+
 The following infrastructure environments are supported:
 
 -   Amazon Web Services (AWS)
@@ -29,6 +31,10 @@ The following infrastructure environments are supported:
 -   Microsoft Azure
 
 -   Pre-provisioned environments
+
+-   vSphere
+
+-   Google Cloud Platform
 
 ## Overview
 
@@ -90,7 +96,7 @@ Your cluster comes preconfigured with a few different core addons that provide f
 
 <p class="message--warning"><strong>IMPORTANT:</strong>If you have more than one essential cluster, ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, preprovisioned]) and the name of the cluster.
+Upgrade the core addons in a cluster using the 'dkp upgrade addons' command specifying the cluster infrastructure (choose [aws, azure, vsphere, gcp, preprovisioned]) and the name of the cluster.
 
 Examples:
 
@@ -190,3 +196,4 @@ For the overall process for upgrading to the latest version of DKP, refer back t
 [backup]: ../../../../../kommander/2.3/backup-and-restore#back-up-on-demand
 [envariables]: ../../../choose-infrastructure/azure/quick-start-azure#configure-azure-prerequisites
 [envariables2]: ../../../choose-infrastructure/aws/quick-start-aws#configure-aws-prerequisites
+[envariables3]: ../../../choose-infrastructure/vsphere/create-capi-vm-image/


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-88470

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Added vSphere to Upgrade Essential and Enterprise documents.  Added under upgrade Core Addons in that section as well in both 2.2 and 2.3.  Also added GCP in same sections but for 2.3 only.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
