### PR TITLE
REDO: solving Vale error so check passes in other PRs + markdownlint

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -9,7 +9,7 @@ enterprise: false
 
 ## Create an AMI to be used in an air-gapped cluster
 
-<p class="message--note"><strong>NOTE: </strong>These Docker images include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">here</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>These Docker images include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">2020 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">2021 release</a>.</p>
 
 Using the [Konvoy Image Builder](../../../../image-builder), you can build an AMI without requiring access to the internet by providing an additional `--override` flag.
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
@@ -17,11 +17,11 @@ Before creating a Kubernetes cluster you must have the required images in a loca
     curl -o konvoy-image-bundle.tar.gz -O http://downloads.d2iq.com/konvoy/airgapped/v2.1.1/konvoy_image_bundle_v2.1.1_linux_amd64.tar.gz
     ```
 
-    <p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">here</a>.</p>
+    <p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">2020 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">2021 release</a>.</p>
 
-1. Place the bundle in a location where you can load and push the images to your private docker registry.
+1.  Place the bundle in a location where you can load and push the images to your private docker registry.
 
-1. Ensure you set the REGISTRY_URL and AIRGAPPED_TAR_FILE variable appropriately, then use the following script to load the air-gapped image bundle:
+1.  Ensure you set the REGISTRY_URL and AIRGAPPED_TAR_FILE variable appropriately, then use the following script to load the air-gapped image bundle:
 
     ``` sh
     #!/usr/bin/env bash

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -8,7 +8,7 @@ enterprise: false
 beta: false
 ---
 
-<p class="message--note"><strong>NOTE: </strong>These Docker images include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">here</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>These Docker images include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">2020 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">2021 release</a>.</p>
 
 ## Download the bootstrap image
 
@@ -118,9 +118,9 @@ Before creating a Kubernetes cluster you must have the required images in a loca
     curl -o konvoy-image-bundle.tar.gz -O http://downloads.d2iq.com/konvoy/airgapped/v2.1.1/konvoy_image_bundle_v2.1.1_linux_amd64.tar.gz
     ```
 
-1. Place the bundle in a location where you can load and push the images to your private docker registry.
+1.  Place the bundle in a location where you can load and push the images to your private docker registry.
 
-1. Ensure you set the REGISTRY_URL and AIRGAPPED_TAR_FILE variable appropriately, then use the following script to load the air-gapped image bundle:
+1.  Ensure you set the REGISTRY_URL and AIRGAPPED_TAR_FILE variable appropriately, then use the following script to load the air-gapped image bundle:
 
     ``` sh
     #!/usr/bin/env bash

--- a/pages/dkp/konvoy/2.1/download/index.md
+++ b/pages/dkp/konvoy/2.1/download/index.md
@@ -16,6 +16,6 @@ When you are ready to download a new version of Konvoy, select the button below:
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product.
 
-<p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">here</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">2020 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">2021 release</a>.</p>
 
 If you have problems downloading Konvoy, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -7,7 +7,7 @@ excerpt: Create an AMI using the DKP image builder
 enterprise: false
 ---
 
-<p class="message--note"><strong>NOTE: </strong>Docker image downloads on this page include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>Docker image downloads on this page include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">2021 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">2022 release</a>.</p>
 
 ## Create an AMI to be used in an air-gapped cluster
 
@@ -30,12 +30,12 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     The OS packages bundles will contain the RPMs for Containerd, Kubernetes and all of their dependencies required to install these packages without access to any external RPM repositories.
     The available options are:
 
-    * `centos_7_x86_64`
-    * `centos_7_x86_64_fips`
-    * `redhat_7_x86_64`
-    * `redhat_7_x86_64_fips`
-    * `redhat_8_x86_64`
-    * `redhat_8_x86_64_fips`
+    - `centos_7_x86_64`
+    - `centos_7_x86_64_fips`
+    - `redhat_7_x86_64`
+    - `redhat_7_x86_64_fips`
+    - `redhat_8_x86_64`
+    - `redhat_8_x86_64_fips`
 
     ```bash
     export BUNDLE_OS=centos_7_x86_64
@@ -51,8 +51,8 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
 
     The available options for each Kubernetes version are:
 
-    * `<version>_images.tar.gz`
-    * `<version>_images_fips.tar.gz`
+    - `<version>_images.tar.gz`
+    - `<version>_images_fips.tar.gz`
 
     ```bash
     curl --output artifacts/images/"$VERSION"_images.tar.gz -O https://downloads.d2iq.com/dkp/airgapped/kubernetes-images/"$VERSION"_images.tar.gz

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
@@ -17,7 +17,7 @@ Before creating a Kubernetes cluster you must have the required images in a loca
     curl -o konvoy-image-bundle.tar.gz -O https://downloads.d2iq.com/dkp/v2.2.0/konvoy_image_bundle_v2.2.0_linux_amd64.tar.gz
     ```
 
-    <p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>.</p>
+    <p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">2021 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">2022 release</a>.</p>
 
 1.  Place the bundle in a location where you can load and push the images to your private docker registry.
 
@@ -29,14 +29,13 @@ Before creating a Kubernetes cluster you must have the required images in a loca
     export DOCKER_REGISTRY_PASSWORD=<password>
     ```
 
-2.  Run the following command to load the air-gapped image bundle into your private Docker registry.
+1.  Run the following command to load the air-gapped image bundle into your private Docker registry.
 
     ```bash
     dkp push image-bundle --image-bundle konvoy-image-bundle.tar.gz --to-registry $DOCKER_REGISTRY_ADDRESS --to-registry-username $DOCKER_REGISTRY_USERNAME --to-registry-password $DOCKER_REGISTRY_PASSWORD
     ```
 
 It may take a while to push all the images to your image registry, depending on the performance of the network between the machine you are running the script on and the Docker registry.
-
 
 Then, [begin creating the bootstrap cluster][bootstrap].
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -8,7 +8,7 @@ enterprise: false
 beta: false
 ---
 
-<p class="message--note"><strong>NOTE: </strong>Docker image downloads on this page include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>Docker image downloads on this page include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">2021 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">2022 release</a>.</p>
 
 ## Download the bootstrap image
 
@@ -24,7 +24,7 @@ beta: false
     docker load -i konvoy-bootstrap_v2.2.0.tar
     ```
 
-## Copy air-gapped artifacts onto cluster hosts 
+## Copy air-gapped artifacts onto cluster hosts
 
 Using the [Konvoy Image Builder](../../../image-builder), you can copy the required artifacts onto your cluster hosts.
 
@@ -45,12 +45,12 @@ Using the [Konvoy Image Builder](../../../image-builder), you can copy the requi
     The OS packages bundles will contain the RPMs for Containerd, Kubernetes and all of their dependencies required to install these packages without access to any external RPM repositories.
     The available options are:
 
-    * `centos_7_x86_64`
-    * `centos_7_x86_64_fips`
-    * `redhat_7_x86_64`
-    * `redhat_7_x86_64_fips`
-    * `redhat_8_x86_64`
-    * `redhat_8_x86_64_fips`
+    - `centos_7_x86_64`
+    - `centos_7_x86_64_fips`
+    - `redhat_7_x86_64`
+    - `redhat_7_x86_64_fips`
+    - `redhat_8_x86_64`
+    - `redhat_8_x86_64_fips`
 
     ```bash
     export BUNDLE_OS=centos_7_x86_64
@@ -66,8 +66,8 @@ Using the [Konvoy Image Builder](../../../image-builder), you can copy the requi
 
     The available options for each Kubernetes version are:
 
-    * `<version>_images.tar.gz`
-    * `<version>_images_fips.tar.gz`
+    - `<version>_images.tar.gz`
+    - `<version>_images_fips.tar.gz`
 
     ```bash
     curl --output artifacts/images/"$VERSION"_images.tar.gz -O https://downloads.d2iq.com/dkp/airgapped/kubernetes-images/"$VERSION"_images.tar.gz
@@ -132,7 +132,6 @@ Using the [Konvoy Image Builder](../../../image-builder), you can copy the requi
 
 Before creating a Kubernetes cluster you must have the required images in a local docker registry. This registry must be accessible from both the bastion machine and the machines that will be created for the Kubernetes cluster.
 
-
 1.  Download the images bundle:
 
     ```bash
@@ -147,7 +146,7 @@ Before creating a Kubernetes cluster you must have the required images in a loca
     export DOCKER_REGISTRY_ADDRESS=<registry-address>:<registry-port>
     ```
 
-2.  Run the following command to load the air-gapped image bundle into your private Docker registry:
+1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
     ```bash
     dkp push image-bundle --image-bundle konvoy-image-bundle.tar.gz --to-registry $DOCKER_REGISTRY_ADDRESS

--- a/pages/dkp/konvoy/2.2/download/index.md
+++ b/pages/dkp/konvoy/2.2/download/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>.</p>
+<p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. The complete source code for MinIO is available for the <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">2021 release</a> and the <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">2022 release</a>.</p>
 
 To download a new version of DKP, you have 2 options:
 
@@ -20,7 +20,7 @@ To download a new version of DKP, you have 2 options:
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
 
-## Download from the command line 
+## Download from the command line
 
 You can download image bundle files by running the following CLI command:
 


### PR DESCRIPTION
## Jira Ticket

No Jira, but this Vale error was not letting Vale pass in another unrelated PR. 
<img width="893" alt="Screenshot 2022-05-19 at 10 41 08" src="https://user-images.githubusercontent.com/98893586/169251605-dedcd139-0e2e-4836-85e0-7795bea68300.png">


## Description of changes being made

Rewording so the link is not worded with `here` but with text, so the Vale linter passes in another PR.
As I was doing it, addressed other Markdown linter warnings. 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

