### PR TITLE
Download errant command line in 2x

### DIFF
--- a/pages/dkp/konvoy/2.2/download/index.md
+++ b/pages/dkp/konvoy/2.2/download/index.md
@@ -24,7 +24,7 @@ If you have problems downloading DKP, contact your sales representative or <a hr
 
 ## Download from the AWS Marketplace
 
-Follow the instructions on provider's console to download the container image.
+Follow the instructions on the AWS console to download the container image.
 
 After downloading the image, run the following command to copy the binaries onto your host.
 

--- a/pages/dkp/konvoy/2.2/download/index.md
+++ b/pages/dkp/konvoy/2.2/download/index.md
@@ -20,17 +20,11 @@ To download a new version of DKP, you have 2 options:
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
 
-## Download from the command line
 
-You can download image bundle files by running the following CLI command:
 
-    ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
-    ```
+## Download image from the Infrastructure Provider of choice marketplace
 
-## Download from the AWS Marketplace
-
-Follow the instructions on AWS console to download the container image.
+Follow the instructions on provider's console to download the container image.
 
 After downloading the image, run the following command to copy the binaries onto your host.
 

--- a/pages/dkp/konvoy/2.2/download/index.md
+++ b/pages/dkp/konvoy/2.2/download/index.md
@@ -22,7 +22,7 @@ If you have problems downloading DKP, contact your sales representative or <a hr
 
 
 
-## Download image from the Infrastructure Provider of choice marketplace
+## Download from the AWS Marketplace
 
 Follow the instructions on provider's console to download the container image.
 

--- a/pages/dkp/konvoy/2.3/download/index.md
+++ b/pages/dkp/konvoy/2.3/download/index.md
@@ -22,7 +22,7 @@ If you have problems downloading DKP, contact your sales representative or <a hr
 
 ## Download from the AWS Marketplace
 
-Follow the instructions on provider's console to download the container image.
+Follow the instructions on AWS console to download the container image.
 
 After downloading the image, run the following command to copy the binaries onto your host.
 

--- a/pages/dkp/konvoy/2.3/download/index.md
+++ b/pages/dkp/konvoy/2.3/download/index.md
@@ -20,7 +20,7 @@ To download a new version of DKP, you have 2 options:
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
 
-## Download image from the Infrastructure Provider of choice marketplace
+## Download from the AWS Marketplace
 
 Follow the instructions on provider's console to download the container image.
 

--- a/pages/dkp/konvoy/2.3/download/index.md
+++ b/pages/dkp/konvoy/2.3/download/index.md
@@ -20,9 +20,9 @@ To download a new version of DKP, you have 2 options:
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
 
-## Download from the AWS Marketplace
+## Download image from the Infrastructure Provider of choice marketplace
 
-Follow the instructions on AWS console to download the container image.
+Follow the instructions on provider's console to download the container image.
 
 After downloading the image, run the following command to copy the binaries onto your host.
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[<!-- Link to JIRA ticket -->](https://jira.d2iq.com/browse/D2IQ-89807)

## Description of changes being made
2.2 had an extra command line that did not pull the correct binary.  Also, Craig said they only download from the button.  ALso took out AWS specific language for 2.2 and 2.3

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4479.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
