### PR TITLE
[Kommander] MinIO attributions in download locations

### DIFF
--- a/pages/dkp/kommander/1.4/install-airgapped/index.md
+++ b/pages/dkp/kommander/1.4/install-airgapped/index.md
@@ -96,7 +96,10 @@ Your `cluster.yaml` file should look similar to the following for Kommander Addo
 
  If you wish to disable the Docker registry certificate verification, set `docker-registry-insecure-skip-tls-verify` to `true` in the `utilityApiserver`'s `extraArgs`. We encourage you to keep the certificate verification enabled to validate all TLS connections to the registry.
 
- This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of Kommander.
+ This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with Kommander 1.4.0 are available at these URLs:
+
+ * https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z
+ * https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z
 
 [air-gap-before-you-begin]: /dkp/konvoy/1.8/install/install-airgapped/#before-you-begin
 [air-gap-control-plane]: /dkp/konvoy/1.8/install/install-airgapped/#control-plane-nodes

--- a/pages/dkp/kommander/1.4/install-airgapped/index.md
+++ b/pages/dkp/kommander/1.4/install-airgapped/index.md
@@ -96,6 +96,8 @@ Your `cluster.yaml` file should look similar to the following for Kommander Addo
 
  If you wish to disable the Docker registry certificate verification, set `docker-registry-insecure-skip-tls-verify` to `true` in the `utilityApiserver`'s `extraArgs`. We encourage you to keep the certificate verification enabled to validate all TLS connections to the registry.
 
+ This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of Kommander.
+
 [air-gap-before-you-begin]: /dkp/konvoy/1.8/install/install-airgapped/#before-you-begin
 [air-gap-control-plane]: /dkp/konvoy/1.8/install/install-airgapped/#control-plane-nodes
 [air-gap-config-image-reg]: /dkp/konvoy/1.8/install/install-airgapped/#configure-the-image-registry

--- a/pages/dkp/kommander/1.4/install/index.md
+++ b/pages/dkp/kommander/1.4/install/index.md
@@ -29,7 +29,10 @@ You can also reach the Kommander UI via this url, given that Kommander is deploy
 ```
 https://<CLUSTER_URL>/ops/portal/kommander/ui
 ```
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with Kommander 1.4.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z
+* https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z
 
 [konvoy-base-addons]: /dkp/konvoy/1.8/addons/
 [konvoy-download]: /dkp/konvoy/1.8/download/

--- a/pages/dkp/kommander/1.4/install/index.md
+++ b/pages/dkp/kommander/1.4/install/index.md
@@ -29,6 +29,7 @@ You can also reach the Kommander UI via this url, given that Kommander is deploy
 ```
 https://<CLUSTER_URL>/ops/portal/kommander/ui
 ```
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of Kommander.
 
 [konvoy-base-addons]: /dkp/konvoy/1.8/addons/
 [konvoy-download]: /dkp/konvoy/1.8/download/

--- a/pages/dkp/kommander/2.0/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.0/install/air-gapped/index.md
@@ -136,5 +136,11 @@ Based on the network latency between the environment of script execution and the
 
 1.  [Verify your installation](../networked#verify-installation).
 
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.0.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z
+* https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z
+
+
 [air-gap-konvoy]: /dkp/konvoy/2.0/choose_infrastructure/aws/air-gapped/
 [air-gap-before-you-begin]: /dkp/konvoy/2.0/choose_infrastructure/aws/air-gapped/prerequisites/

--- a/pages/dkp/kommander/2.0/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.0/install/air-gapped/index.md
@@ -39,7 +39,7 @@ export VERSION=v2.0.0
     wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
     ```
 
-1.  Place the bundle into a location where you can load and push the images to your private Docker registry.
+1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.0.0.tar.gz` bundle within a location where you can load and push the images to your private Docker registry.
 
 1.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately and then use the following script to load the air-gapped image bundle:
 

--- a/pages/dkp/kommander/2.0/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.0/install/air-gapped/index.md
@@ -14,7 +14,7 @@ This topic shows how to run Kommander on top of an [air-gapped Konvoy cluster][a
 
 Before installing, ensure you have:
 
--   A Docker registry containing all the necessary Docker installation images, including the Kommander images. The `kommander-image-bundle.tar` tarball has the required artifacts.
+-   A Docker registry containing all the necessary Docker installation images, including the Kommander images. The `kommander_image_bundle_v2.0.0_linux_amd64.tar` tarball has the required artifacts.
 
 -   Connectivity with clusters attaching to the management cluster:
     - Both management and attached clusters must connect to the Docker registry.
@@ -33,22 +33,22 @@ export VERSION=v2.0.0
 
 ### Load the Docker images into your Docker registry
 
-1.  Download the `kommander-image-bundle.tar.gz` file.
+1.  Download the `kommander_image_bundle_v2.0.0_linux_amd64.tar` file.
 
     ```bash
-    wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
+    wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" | tar -xvf -
     ```
 
-1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.0.0.tar.gz` bundle within a location where you can load and push the images to your private Docker registry.
+2.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander_image_bundle_v2.0.0_linux_amd64.tar` bundle within a location where you can load and push the images to your private Docker registry.
 
-1.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately and then use the following script to load the air-gapped image bundle:
+3.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately and then use the following script to load the air-gapped image bundle:
 
     ```bash
     #!/usr/bin/env bash
     set -euo pipefail
     IFS=$'\n\t'
 
-    readonly AIRGAPPED_TAR_FILE=${AIRGAPPED_TAR_FILE:-"kommander-image-bundle.tar"}
+    readonly AIRGAPPED_TAR_FILE=${AIRGAPPED_TAR_FILE:-"kommander_image_bundle_v2.0.0_linux_amd64.tar"}
     readonly REGISTRY_URL=${REGISTRY_URL?"Need to set REGISTRY_URL. E.g: 10.23.45.67:5000"}
 
     docker load <"${AIRGAPPED_TAR_FILE}"

--- a/pages/dkp/kommander/2.1/download/index.md
+++ b/pages/dkp/kommander/2.1/download/index.md
@@ -38,4 +38,7 @@ dkp and kommander binaries placed in the local directory, to run:
 
 You will now see two binaries: `dkp` and `kommander` in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.1.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z
+* https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z

--- a/pages/dkp/kommander/2.1/download/index.md
+++ b/pages/dkp/kommander/2.1/download/index.md
@@ -18,8 +18,6 @@ To download a new version of Kommander, you have 2 options:
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product.</p>
 
-<p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">here</a>.</p>
-
 ## Download from the AWS Marketplace
 
 Follow the instructions on AWS console to download the container image.
@@ -39,3 +37,5 @@ dkp and kommander binaries placed in the local directory, to run:
 ```
 
 You will now see two binaries: `dkp` and `kommander` in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.

--- a/pages/dkp/kommander/2.1/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/catalog/index.md
@@ -109,4 +109,7 @@ To configure the Gitea server, follow these steps:
 
 1. After the newly created `GitRepository` on the management cluster reconciles, any corresponding `App`s are loaded by Kommander controller.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.1.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z
+* https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z

--- a/pages/dkp/kommander/2.1/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/catalog/index.md
@@ -29,7 +29,7 @@ To configure the Gitea server, follow these steps:
     ```
 
 1. Go to the Gitea UI below and register a new user account:
-    
+
     ```bash
     GITEA_HOSTNAME=$((kubectl -n kommander get cm konvoyconfig-kubeaddons -o go-template='{{if ne .data.clusterHostname ""}}{{.data.clusterHostname}}{{"\n"}}{{end}}' ; kubectl -n kommander get ingress gitea -o jsonpath="{.status.loadBalancer.ingress[0]['ip','hostname']}") | head -1) && echo https://${GITEA_HOSTNAME}/dkp/kommander/git/
     ```
@@ -55,8 +55,6 @@ To configure the Gitea server, follow these steps:
     ```bash
     curl -fsSL https://github.com/mesosphere/dkp-catalog-applications/archive/refs/tags/${VERSION}.tar.gz | tar zxf - --strip-components=1 -C ${GITEA_REPOSITORY_NAME}
     ```
-
-    <p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">here</a>.</p>
 
 1. Navigate into the `${GITEA_REPOSITORY_NAME}` directory and push the changes:
 
@@ -110,3 +108,5 @@ To configure the Gitea server, follow these steps:
     ```
 
 1. After the newly created `GitRepository` on the management cluster reconciles, any corresponding `App`s are loaded by Kommander controller.
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.

--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -14,7 +14,7 @@ This topic shows how to run Kommander on top of an [air-gapped Konvoy cluster][a
 
 Before installing, ensure you have:
 
--   A Docker registry containing all the necessary Docker installation images, including the Kommander images. The `kommander-image-bundle.tar` tarball has the required artifacts.
+-   A Docker registry containing all the necessary Docker installation images, including the Kommander images. The `kommander_image_bundle_v2.1.1_linux_amd64.tar` tarball has the required artifacts.
 
 -   Connectivity with clusters attaching to the management cluster:
     - Both management and attached clusters must connect to the Docker registry.
@@ -124,19 +124,19 @@ export VERSION=v2.1.1
 1.  Download the image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
+    wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" | tar -xvf -
     ```
 
-1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.1.0.tar.gz` bundle within a location where you can load and push the images to your private Docker registry.
+2.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander_image_bundle_v2.1.1_linux_amd64.tar` bundle within a location where you can load and push the images to your private Docker registry.
 
-1.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately, then use the following script to load the air-gapped image bundle:
+3.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately, then use the following script to load the air-gapped image bundle:
 
     ```bash
     #!/usr/bin/env bash
     set -euo pipefail
     IFS=$'\n\t'
 
-    readonly AIRGAPPED_TAR_FILE=${AIRGAPPED_TAR_FILE:-"kommander-image-bundle.tar"}
+    readonly AIRGAPPED_TAR_FILE=${AIRGAPPED_TAR_FILE:-"kommander_image_bundle_v2.1.1_linux_amd64.tar"}
     readonly REGISTRY_URL=${REGISTRY_URL?"Need to set REGISTRY_URL. E.g: 10.23.45.67:5000"}
 
     docker load <"${AIRGAPPED_TAR_FILE}"

--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -127,8 +127,6 @@ export VERSION=v2.1.1
     wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
     ```
 
-    <p class="message--note"><strong>NOTE: </strong>This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z">here</a>.</p>
-
 1.  Place the bundle in a location where you can load and push the images to your private Docker registry.
 
 1.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately, then use the following script to load the air-gapped image bundle:
@@ -228,6 +226,7 @@ Based on the network latency between the environment of script execution and the
     ```bash
     kommander install --installer-config ./install.yaml --kommander-applications-repository ./kommander-applications
     ```
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
 
 1.  [Verify your installation](../networked#verify-installation).
 

--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -127,7 +127,7 @@ export VERSION=v2.1.1
     wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
     ```
 
-1.  Unpack the bundle and the nested bundle within in a location where you can load and push the images to your private Docker registry.
+1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.1.0.tar.gz` bundle within a location where you can load and push the images to your private Docker registry.
 
 1.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately, then use the following script to load the air-gapped image bundle:
 

--- a/pages/dkp/kommander/2.1/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.1/install/air-gapped/index.md
@@ -127,7 +127,7 @@ export VERSION=v2.1.1
     wget "https://downloads.d2iq.com/kommander/airgapped/${VERSION}/kommander_image_bundle_${VERSION}_linux_amd64.tar" -O kommander-image-bundle.tar
     ```
 
-1.  Place the bundle in a location where you can load and push the images to your private Docker registry.
+1.  Unpack the bundle and the nested bundle within in a location where you can load and push the images to your private Docker registry.
 
 1.  Ensure you set the `REGISTRY_URL` and `AIRGAPPED_TAR_FILE` variable appropriately, then use the following script to load the air-gapped image bundle:
 
@@ -226,9 +226,13 @@ Based on the network latency between the environment of script execution and the
     ```bash
     kommander install --installer-config ./install.yaml --kommander-applications-repository ./kommander-applications
     ```
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
 
 1.  [Verify your installation](../networked#verify-installation).
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.1.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z
+* https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -40,9 +40,6 @@ This section describes how to upgrade your Kommander Management cluster and all 
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
 
-<p class="message--note"><strong>NOTE: </strong>These docker images include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>.</p>
-
-
 -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
 
     Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.0`:
@@ -153,7 +150,7 @@ Before running the following command, ensure that your `dkp` configuration **ref
     ```bash
     dkp upgrade kommander  --kommander-applications-repository ~/work/git_repos/kommander-applications
     ```
-    
+
     ```sh
     ✓ Ensuring upgrading conditions are met
     ✓ Ensuring application definitions are updated
@@ -178,6 +175,8 @@ Before running the following command, ensure that your `dkp` configuration **ref
     For Essential customers (single-cluster environment): Proceed with the [Konvoy Upgrade][konvoy_upgrade].
 
 You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the next steps depending on your environment and license type.
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
 
 [download_binary]: ../../download/
 [AKS]: https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -176,7 +176,10 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
 You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the next steps depending on your environment and license type.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 
 [download_binary]: ../../download/
 [AKS]: https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster

--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -31,13 +31,13 @@ This section describes how to upgrade your Kommander Management cluster and all 
   Download the Kommander charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz" | tar -xvf -
   ```
 
   If you have any DKP Catalog Applications, download the DKP Catalog Application charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz" | tar -xvf -
   ```
 
 -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:

--- a/pages/dkp/kommander/2.2/download/index.md
+++ b/pages/dkp/kommander/2.2/download/index.md
@@ -8,8 +8,6 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--note"><strong>NOTE: </strong>This docker image includes code from the MinIO Project (“MinIO”), which is ©2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>.</p>
-
 To download a new version of DKP, you have 2 options:
 
 ## Download from the support website
@@ -20,7 +18,7 @@ To download a new version of DKP, you have 2 options:
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
 
-## Download from the command line 
+## Download from the command line
 
 You can download image bundle files by running the following CLI command:
 
@@ -46,3 +44,5 @@ dkp binary is placed in the local directory, to run:
 ```
 
 You will now see the `dkp` binary in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.

--- a/pages/dkp/kommander/2.2/download/index.md
+++ b/pages/dkp/kommander/2.2/download/index.md
@@ -45,4 +45,7 @@ dkp binary is placed in the local directory, to run:
 
 You will now see the `dkp` binary in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z

--- a/pages/dkp/kommander/2.2/download/index.md
+++ b/pages/dkp/kommander/2.2/download/index.md
@@ -18,14 +18,6 @@ To download a new version of DKP, you have 2 options:
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
 
-## Download from the command line
-
-You can download image bundle files by running the following CLI command:
-
-    ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" | tar -xvf -
-    ```
-
 ## Download from the AWS Marketplace
 
 Follow the instructions on AWS console to download the container image.

--- a/pages/dkp/kommander/2.2/download/index.md
+++ b/pages/dkp/kommander/2.2/download/index.md
@@ -23,7 +23,7 @@ If you have problems downloading DKP, contact your sales representative or <a hr
 You can download image bundle files by running the following CLI command:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" | tar -xvf -
     ```
 
 ## Download from the AWS Marketplace

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -175,7 +175,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
     wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-image-bundle-v2.2.0.tar.gz" -O catalog-applications-image-bundle.tar.gz
     ```
 
-1.  Unpack the bundle and the nested bundle within in a location where you can load and push the images to your private Docker registry.
+1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.2.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.2.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -166,13 +166,13 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 1.  Download the Kommander image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" | tar -xvf -
     ```
 
 1.  Download the [DKP catalog applications][dkp_catalog_applications] image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-image-bundle-v2.2.0.tar.gz" -O catalog-applications-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-image-bundle-v2.2.0.tar.gz" | tar -xvf -
     ```
 
 1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.2.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.2.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -163,8 +163,6 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 
 ### Load the Docker images into your Docker registry
 
-<p class="message--note"><strong>NOTE: </strong>These docker images include code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a> and <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>.</p>
-
 1.  Download the Kommander image bundle file:
 
     ```bash
@@ -240,6 +238,8 @@ It may take a while to push all the images to your image registry, depending on 
     ```
 
 1.  [Verify your installation](../../networked#verify-installation).
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -180,7 +180,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
     ```bash
-    dkp push image-bundle --image-bundle kommander-image-bundle.tar.gz --to-registry <REGISTRY_URL>
+    dkp push image-bundle --image-bundle kommander-image-bundle-v2.2.0.tar.gz --to-registry <REGISTRY_URL>
     dkp push image-bundle --image-bundle catalog-applications-image-bundle.tar.gz --to-registry <REGISTRY_URL>
     ```
 
@@ -219,13 +219,13 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz" | tar -xvf -
     ```
 
 1.  Download the [DKP catalog applications][dkp_catalog_applications] chart bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz" | tar -xvf -
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -175,7 +175,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
     wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-image-bundle-v2.2.0.tar.gz" -O catalog-applications-image-bundle.tar.gz
     ```
 
-1.  Place the bundles in a location where you can load and push the images to your private Docker registry.
+1.  Unpack the bundle and the nested bundle within in a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
@@ -239,7 +239,10 @@ It may take a while to push all the images to your image registry, depending on 
 
 1.  [Verify your installation](../../networked#verify-installation).
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -220,7 +220,10 @@ It may take a while to push all the images to your image registry, depending on 
 
 1.  [Verify your installation](../networked#verify-installation).
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -169,7 +169,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
     ```bash
-    dkp push image-bundle --image-bundle kommander-image-bundle.tar.gz --to-registry <REGISTRY_URL>
+    dkp push image-bundle --image-bundle kommander-image-bundle-v2.2.0.tar.gz --to-registry <REGISTRY_URL>
     ```
 
 It may take a while to push all the images to your image registry, depending on the performance of the network between the machine you are running the script on and the Docker registry.
@@ -207,7 +207,7 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz" | tar -xvf -
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -164,7 +164,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 
 ### Load the Docker images into your Docker registry
 
-1.  Place the bundle you [downloaded](../../download/) in a location where you can load and push the images to your private Docker registry.
+1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.2.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.2.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -34,7 +34,7 @@ Before installing, ensure you have:
 -   [MetalLB enabled and configured][air-gap-install-metallb], which provides load-balancing services.
 
 -   Sufficient resources on your cluster to run Kommander. Review the [Management cluster application requirements](../mgmt-cluster-apps) and [Workspace platform application requirements](../../workspaces/applications/platform-applications/platform-application-requirements) for application requirements.
--   The image bundle files [downloaded](../../download/). 
+-   The image bundle files [downloaded](../../download/).
 
 ### Kommander charts bundle
 
@@ -219,6 +219,8 @@ It may take a while to push all the images to your image registry, depending on 
     ```
 
 1.  [Verify your installation](../networked#verify-installation).
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.3/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.3/dkp-upgrade/upgrade-kommander/index.md
@@ -25,19 +25,19 @@ This section describes how to upgrade your Kommander Management cluster and all 
   Download the Kommander application definitions:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.3.0/kommander-applications-v2.3.0.tar.gz"
   ```
 
   Download the Kommander charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.3.0/dkp-kommander-charts-bundle-v2.3.0.tar.gz" | tar -xvf -
   ```
 
   If you have any DKP Catalog Applications, download the DKP Catalog Application charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.3.0.tar.gz" | tar -xvf -
   ```
 
 ## Detach MetalLB from Kommander
@@ -103,13 +103,13 @@ Before running the following command, ensure that your `dkp` configuration **ref
     -   For air-gapped:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.3.0.tar.gz --kommander-applications-repository kommander-applications-v2.3.0.tar.gz
         ```
 
     -   For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz --kommander-applications-repository kommander-applications-v2.2.0.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.3.0.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.3.0.tar.gz --kommander-applications-repository kommander-applications-v2.3.0.tar.gz
         ```
 
         After the upgrade, follow the [DKP Catalog Applications configuration page](../../install/configuration/enterprise-catalog#air-gapped-catalog-configuration) to update the Git repository.

--- a/pages/dkp/kommander/2.3/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.3/dkp-upgrade/upgrade-kommander/index.md
@@ -39,6 +39,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
   ```bash
   wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
   ```
+
 ## Detach MetalLB from Kommander
 
   <p class="message--important"><strong>IMPORTANT:</strong> Beginning with DKP version 2.2, MetalLB is no longer managed as a platform application. If you installed MetalLB on the cluster that you're upgrading prior to DKP version 2.2, you will need to detach MetalLB from the cluster prior to upgrading.</p>
@@ -126,7 +127,7 @@ Before running the following command, ensure that your `dkp` configuration **ref
     ```bash
     dkp upgrade kommander  --kommander-applications-repository ~/work/git_repos/kommander-applications
     ```
-    
+
     ```sh
     ✓ Ensuring upgrading conditions are met
     ✓ Ensuring application definitions are updated
@@ -151,6 +152,8 @@ Before running the following command, ensure that your `dkp` configuration **ref
     For Essential customers (single-cluster environment): Proceed with the [Konvoy Upgrade][konvoy_upgrade].
 
 You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the next steps depending on your environment and license type.
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
 
 [download_binary]: ../../download/
 [AKS]: https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster

--- a/pages/dkp/kommander/2.3/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.3/dkp-upgrade/upgrade-kommander/index.md
@@ -153,7 +153,10 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
 You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the next steps depending on your environment and license type.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 
 [download_binary]: ../../download/
 [AKS]: https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster

--- a/pages/dkp/kommander/2.3/download/index.md
+++ b/pages/dkp/kommander/2.3/download/index.md
@@ -38,4 +38,7 @@ dkp binary is placed in the local directory, to run:
 
 You will now see the `dkp` binary in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.3.0 are available at these URLs: 
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z

--- a/pages/dkp/kommander/2.3/download/index.md
+++ b/pages/dkp/kommander/2.3/download/index.md
@@ -8,8 +8,6 @@ beta: false
 enterprise: false
 ---
 
-<!-- markdownlint-disable MD034 -->
-
 To download a new version of DKP, you have 2 options:
 
 ## Download from the support website
@@ -18,6 +16,8 @@ To download a new version of DKP, you have 2 options:
 
 You must be a registered user and logged on to the support portal to download DKP. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.
 If you have problems downloading DKP, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.</p>
+
+
 
 ## Download from the AWS Marketplace
 
@@ -37,3 +37,5 @@ dkp binary is placed in the local directory, to run:
 ```
 
 You will now see the `dkp` binary in your working directory. Follow the [Kommander installation instructions](../install/networked) using these binaries, and then [add your license](../licensing/add/) to Kommander. If you have problems downloading or installing Kommander, contact your sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a>.
+
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.

--- a/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
@@ -239,6 +239,8 @@ It may take a while to push all the images to your image registry, depending on 
 
 1.  [Verify your installation](../../networked#verify-installation).
 
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb
 [air-gap-konvoy]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/

--- a/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
@@ -239,7 +239,10 @@ It may take a while to push all the images to your image registry, depending on 
 
 1.  [Verify your installation](../../networked#verify-installation).
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
@@ -175,12 +175,12 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
     wget "https://downloads.d2iq.com/dkp/v2.3.0/dkp-catalog-applications-image-bundle-v2.3.0.tar.gz" | tar -xvf -
     ```
 
-1. See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.2.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.2.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
+1. See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.3.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.3.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
     ```bash
-    dkp push image-bundle --image-bundle kommander-image-bundle.tar.gz --to-registry <REGISTRY_URL>
+    dkp push image-bundle --image-bundle kommander-image-bundle-v2.3.0.tar.gz --to-registry <REGISTRY_URL>
     dkp push image-bundle --image-bundle catalog-applications-image-bundle.tar.gz --to-registry <REGISTRY_URL>
     ```
 
@@ -213,28 +213,28 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/kommander-applications-v2.3.0.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/dkp-kommander-charts-bundle-v2.3.0.tar.gz" | tar -xvf -
     ```
 
 1.  Download the [DKP catalog applications][dkp_catalog_applications] chart bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/dkp-catalog-applications-charts-bundle-v2.3.0.tar.gz" | tar -xvf -
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
     dkp install kommander --installer-config ./install.yaml \
-    --kommander-applications-repository kommander-applications-v2.2.0.tar.gz \
-    --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz \
-    --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.0.tar.gz
+    --kommander-applications-repository kommander-applications-v2.3.0.tar.gz \
+    --charts-bundle dkp-kommander-charts-bundle-v2.3.0.tar.gz \
+    --charts-bundle dkp-catalog-applications-charts-bundle-v2.3.0.tar.gz
     ```
 
 1.  [Verify your installation](../../networked#verify-installation).

--- a/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/catalog/index.md
@@ -166,16 +166,16 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 1.  Download the Kommander image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/kommander-image-bundle-v2.3.0.tar.gz" | tar -xvf -
     ```
 
 1.  Download the [DKP catalog applications][dkp_catalog_applications] image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-image-bundle-v2.2.0.tar.gz" -O catalog-applications-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/dkp-catalog-applications-image-bundle-v2.3.0.tar.gz" | tar -xvf -
     ```
 
-1.  Place the bundles in a location where you can load and push the images to your private Docker registry.
+1. See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.2.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.2.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 

--- a/pages/dkp/kommander/2.3/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/index.md
@@ -166,10 +166,10 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 1.  Download the image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/kommander-image-bundle-v2.3.0.tar.gz" -O kommander-image-bundle.tar.gz
     ```
 
-1.  Unpack the bundle and the nested bundle within in a location where you can load and push the images to your private Docker registry.
+1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.3.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.3.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 

--- a/pages/dkp/kommander/2.3/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/index.md
@@ -223,6 +223,8 @@ It may take a while to push all the images to your image registry, depending on 
 
 1.  [Verify your installation](../networked#verify-installation).
 
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb
 [air-gap-konvoy]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/

--- a/pages/dkp/kommander/2.3/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/index.md
@@ -169,7 +169,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
     wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-image-bundle-v2.2.0.tar.gz" -O kommander-image-bundle.tar.gz
     ```
 
-1.  Place the bundle in a location where you can load and push the images to your private Docker registry.
+1.  Unpack the bundle and the nested bundle within in a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
@@ -223,7 +223,10 @@ It may take a while to push all the images to your image registry, depending on 
 
 1.  [Verify your installation](../networked#verify-installation).
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+* https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+* https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 
 [air-gap-before-you-begin]: /dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/prerequisites/
 [air-gap-install-metallb]: #use-metallb

--- a/pages/dkp/kommander/2.3/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.3/install/air-gapped/index.md
@@ -166,7 +166,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 1.  Download the image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.3.0/kommander-image-bundle-v2.3.0.tar.gz" -O kommander-image-bundle.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/kommander-image-bundle-v2.3.0.tar.gz" | tar -xvf -
     ```
 
 1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.3.0.tar.gz` and `dkp-catalog-applications-image-bundle-v2.3.0.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
@@ -174,7 +174,7 @@ See [Kommander Load Balancing][kommander-load-balancing] for more information.
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
     ```bash
-    dkp push image-bundle --image-bundle kommander-image-bundle.tar.gz --to-registry <REGISTRY_URL>
+    dkp push image-bundle --image-bundle kommander-image-bundle-v2.3.0.tar.gz --to-registry <REGISTRY_URL>
     ```
 
 It may take a while to push all the images to your image registry, depending on the performance of the network between the machine you are running the script on and the Docker registry.
@@ -204,21 +204,21 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/kommander-applications-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/kommander-applications-v2.3.0.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-kommander-charts-bundle-v2.2.0.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/dkp-kommander-charts-bundle-v2.3.0.tar.gz" | tar -xvf -
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
     dkp install kommander --installer-config ./install.yaml \
-    --kommander-applications-repository kommander-applications-v2.2.0.tar.gz \
-    --charts-bundle dkp-kommander-charts-bundle-v2.2.0.tar.gz
+    --kommander-applications-repository kommander-applications-v2.3.0.tar.gz \
+    --charts-bundle dkp-kommander-charts-bundle-v2.3.0.tar.gz
     ```
 
 1.  [Verify your installation](../networked#verify-installation).

--- a/pages/dkp/kommander/2.3/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/enterprise-catalog/index.md
@@ -80,4 +80,7 @@ When running in air-gapped environments, update the configuration by replacing `
     ```bash
     dkp install kommander --installer-config <config_file.yaml>
     ```
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.
+    This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+
+    * https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
+    * https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z

--- a/pages/dkp/kommander/2.3/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/enterprise-catalog/index.md
@@ -55,7 +55,7 @@ When running in air-gapped environments, update the configuration by replacing `
 1.  Download the DKP catalog application Git repository archive:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.0/dkp-catalog-applications-v2.2.0.tar.gz" -O dkp-catalog-applications.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.3.0/dkp-catalog-applications-v2.3.0.tar.gz" -O dkp-catalog-applications.tar.gz
     ```
 
 1.  Update the Kommander configuration file with:

--- a/pages/dkp/kommander/2.3/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/enterprise-catalog/index.md
@@ -80,3 +80,4 @@ When running in air-gapped environments, update the configuration by replacing `
     ```bash
     dkp install kommander --installer-config <config_file.yaml>
     ```
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for MinIO is available for the [2021 release][[https://github.com/minio/minio/tree/RELEASE.2020-12-03T05-49-24Z] of DKP/Kommander and the [2022 release][https://github.com/minio/minio/tree/RELEASE.2021-07-30T00-02-00Z] of DKP/Kommander.


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-89883

## Description of changes being made

Added minIO attributions to Kommander versions 2.3, 2.2, 2.1, and 1.4 in locations where the product is downloaded.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4483.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
