### PR TITLE
Adding upgrade image info for both AWS and Azure

### DIFF
--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -162,7 +162,7 @@ When upgrading the Kubernetes version of a cluster, first upgrade the control pl
 
 
 
-1. Upgrade the Kubernetes version of the control plane.
+2. Upgrade the Kubernetes version of the control plane.
 
 ```bash
 dkp update controlplane aws --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8

--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -156,7 +156,11 @@ Once complete, begin upgrading the Kubernetes version.
 
 When upgrading the Kubernetes version of a cluster, first upgrade the control plane and then the node pools. If you have any additional managed or attached clusters, you will need to upgrade the core addons and Kubernetes version for each one.
 
-<p class="message--note"><strong>NOTE:</strong> If an AMI was specified when initially creating a cluster, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/">Konvoy Image Builder</a> and pass it with <code>--ami</code>.
+1. Build a new image if applicable.  
+    - If an AMI was specified when initially creating a cluster for AWS, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-ami/">Konvoy Image Builder</a>.
+    - If an Azure Machine Image was specified for Azure, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-azure-image/">Konvoy Image Builder</a>.
+
+
 
 1. Upgrade the Kubernetes version of the control plane.
 
@@ -172,7 +176,7 @@ Waiting for control plane update to finish.
  ✓ Updating the control plane
 ```
 
-2. Upgrade the Kubernetes version of each of your node pools. Replace `my-nodepool` with the name of the node pool.
+3. Upgrade the Kubernetes version of each of your node pools. Replace `my-nodepool` with the name of the node pool.
 
 ```bash
 export NODEPOOL_NAME=my-nodepool

--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -160,8 +160,6 @@ When upgrading the Kubernetes version of a cluster, first upgrade the control pl
     - If an AMI was specified when initially creating a cluster for AWS, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-ami/">Konvoy Image Builder</a>.
     - If an Azure Machine Image was specified for Azure, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-azure-image/">Konvoy Image Builder</a>.
 
-
-
 2. Upgrade the Kubernetes version of the control plane.
 
 ```bash
@@ -175,7 +173,7 @@ Updating control plane resource controlplane.cluster.x-k8s.io/v1beta1, Kind=Kube
 Waiting for control plane update to finish.
  ✓ Updating the control plane
 ```
-
+    
 3. Upgrade the Kubernetes version of each of your node pools. Replace `my-nodepool` with the name of the node pool.
 
 ```bash

--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -151,7 +151,11 @@ Once complete, begin upgrading the Kubernetes version.
 
 When upgrading the Kubernetes version of a cluster, first upgrade the control plane and then the node pools.
 
-<p class="message--note"><strong>NOTE:</strong> If an AMI was specified when initially creating a cluster, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/">Konvoy Image Builder</a> and pass it with <code>--ami</code>.
+
+1. Build a new image if applicable.  
+    - If an AMI was specified when initially creating a cluster for AWS, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-ami/">Konvoy Image Builder</a>.
+    - If an Azure Machine Image was specified for Azure, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-azure-image/">Konvoy Image Builder</a>.
+
 
 1.  Upgrade the Kubernetes version of the control plane.
 

--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -156,7 +156,6 @@ When upgrading the Kubernetes version of a cluster, first upgrade the control pl
     - If an AMI was specified when initially creating a cluster for AWS, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-ami/">Konvoy Image Builder</a>.
     - If an Azure Machine Image was specified for Azure, you must build a new one with <a href="/dkp/konvoy/2.3/image-builder/create-azure-image/">Konvoy Image Builder</a>.
 
-
 1.  Upgrade the Kubernetes version of the control plane.
 
     ```bash


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[<!-- Link to JIRA ticket -->](https://jira.d2iq.com/browse/D2IQ-87530?filter=-1)

## Description of changes being made
Adding upgrade image using KIB as a step rather than note.  Also including the Azure step and link as well as the AMI.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4487.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
