### PR TITLE
[Konvoy] KIB Override page updates

### DIFF
--- a/pages/dkp/konvoy/2.0/image-builder/override-files/index.md
+++ b/pages/dkp/konvoy/2.0/image-builder/override-files/index.md
@@ -9,4 +9,36 @@ menuWeight: 75
 ---
 ## Override files
 
-The konvoy-image-builder is used to install the basic components required to run Konvoy. You can specify customization of the images through the use of override files, which are used to specify alternate package libraries, docker image repos, and other customizations. Konvoy comes with a default override file for use with [FIPS](../../fips/), and another for use with Nvidia.
+The konvoy-image-builder is used to install the basic components required to run Konvoy. You can specify customization of the images through the use of override files, which are used to specify alternate package libraries, docker image repos, and other customizations.
+
+Konvoy comes with default override files:
+
+- FIPS override:
+  ```yaml
+  ---
+  k8s_image_registry: docker.io/mesosphere
+
+  fips:
+  enabled: true
+
+  build_name_extra: -fips
+  kubernetes_build_metadata: fips.0
+  default_image_repo: hub.docker.io/mesosphere
+  kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v{{ kubernetes_version }}-fips/x86_64"
+  docker_rpm_repository_url: "\
+    https://containerd-fips.s3.us-east-2.amazonaws.com\
+    /{{ ansible_distribution_major_version|int }}\
+    /x86_64"
+  ```
+
+- Nvidia override:
+
+  ```yaml
+  ---
+  gpu:
+    types:
+      - nvidia
+
+  build_name_extra: "-nvidia"
+  nvidia_cuda_version: "470"
+  ```

--- a/pages/dkp/konvoy/2.0/image-builder/override-files/index.md
+++ b/pages/dkp/konvoy/2.0/image-builder/override-files/index.md
@@ -14,21 +14,24 @@ The konvoy-image-builder is used to install the basic components required to run
 Konvoy comes with default override files:
 
 - FIPS override:
+
   ```yaml
   ---
-  k8s_image_registry: docker.io/mesosphere
-
   fips:
-  enabled: true
-
+    enabled: true
+    etcdImageTag: v3.4.13_fips
   build_name_extra: -fips
   kubernetes_build_metadata: fips.0
   default_image_repo: hub.docker.io/mesosphere
-  kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v{{ kubernetes_version }}-fips/x86_64"
-  docker_rpm_repository_url: "\
-    https://containerd-fips.s3.us-east-2.amazonaws.com\
-    /{{ ansible_distribution_major_version|int }}\
-    /x86_64"
+  kubernetes_rpm_repository_url: "https://kubernetes-fips.s3.us-east-2.amazonaws.com\
+                              /{{ ansible_distribution_major_version|int }}\
+                              /x86_64"
+  kubernetes_rpm_gpg_key_url: "https://kubernetes-fips.s3.us-east-2.amazonaws.com\
+                               /{{ ansible_distribution_major_version|int }}\
+                               /rpm-gpg-pub-key"
+  docker_rpm_repository_url: "https://containerd-fips.s3.us-east-2.amazonaws.com\
+                              /{{ ansible_distribution_major_version|int }}\
+                              /x86_64"
   ```
 
 - Nvidia override:
@@ -38,7 +41,6 @@ Konvoy comes with default override files:
   gpu:
     types:
       - nvidia
-
+  
   build_name_extra: "-nvidia"
-  nvidia_cuda_version: "470"
   ```

--- a/pages/dkp/konvoy/2.1/image-builder/override-files/default-or-files/index.md
+++ b/pages/dkp/konvoy/2.1/image-builder/override-files/default-or-files/index.md
@@ -10,7 +10,32 @@ menuWeight: 0
 
 Konvoy comes with default override files:
 
-- [FIPS](../../../fips/) override file.
-- [Nvidia](../../../choose-infrastructure/aws/gpu/) override file.
+- FIPS override:
+  ```yaml
+  ---
+  k8s_image_registry: docker.io/mesosphere
 
-You can find these override files in the [Konvoy Image Builder repo](https://github.com/mesosphere/konvoy-image-builder/tree/main/overrides).
+  fips:
+  enabled: true
+
+  build_name_extra: -fips
+  kubernetes_build_metadata: fips.0
+  default_image_repo: hub.docker.io/mesosphere
+  kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v{{ kubernetes_version }}-fips/x86_64"
+  docker_rpm_repository_url: "\
+    https://containerd-fips.s3.us-east-2.amazonaws.com\
+    /{{ ansible_distribution_major_version|int }}\
+    /x86_64"
+  ```
+
+- Nvidia override:
+
+  ```yaml
+  ---
+  gpu:
+    types:
+      - nvidia
+
+  build_name_extra: "-nvidia"
+  nvidia_cuda_version: "470"
+  ```

--- a/pages/dkp/konvoy/2.1/image-builder/override-files/default-or-files/index.md
+++ b/pages/dkp/konvoy/2.1/image-builder/override-files/default-or-files/index.md
@@ -11,21 +11,26 @@ menuWeight: 0
 Konvoy comes with default override files:
 
 - FIPS override:
+
   ```yaml
   ---
-  k8s_image_registry: docker.io/mesosphere
-
+  etcd_image_tag: v3.4.13_fips.0
   fips:
-  enabled: true
-
+    enabled: true
+    etcdImageTag: "{{ etcd_image_tag }}"
   build_name_extra: -fips
   kubernetes_build_metadata: fips.0
   default_image_repo: hub.docker.io/mesosphere
-  kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v{{ kubernetes_version }}-fips/x86_64"
-  docker_rpm_repository_url: "\
-    https://containerd-fips.s3.us-east-2.amazonaws.com\
-    /{{ ansible_distribution_major_version|int }}\
-    /x86_64"
+  k8s_image_registry: mesosphere
+  kubernetes_rpm_repository_url: "https://kubernetes-fips.s3.us-east-2.amazonaws.com\
+                              /{{ ansible_distribution_major_version|int }}\
+                              /x86_64"
+  kubernetes_rpm_gpg_key_url: "https://kubernetes-fips.s3.us-east-2.amazonaws.com\
+                               /{{ ansible_distribution_major_version|int }}\
+                               /rpm-gpg-pub-key"
+  docker_rpm_repository_url: "https://containerd-fips.s3.us-east-2.amazonaws.com\
+                              /{{ ansible_distribution_major_version|int }}\
+                              /x86_64"
   ```
 
 - Nvidia override:
@@ -35,7 +40,6 @@ Konvoy comes with default override files:
   gpu:
     types:
       - nvidia
-
+  
   build_name_extra: "-nvidia"
-  nvidia_cuda_version: "470"
   ```

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/default-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/default-or-files/index.md
@@ -10,9 +10,49 @@ menuWeight: 0
 
 Konvoy comes with default override files:
 
-- [FIPS](../../../fips/) override file.
-- [Nvidia](../../../choose-infrastructure/aws/gpu/) override file.
-- Offline override file.
-- Offline for FIPS override file.
+- FIPS override:
+  ```yaml
+  ---
+  k8s_image_registry: docker.io/mesosphere
 
-You can find these override files in the [Konvoy Image Builder repo](https://github.com/mesosphere/konvoy-image-builder/tree/main/overrides).
+  fips:
+  enabled: true
+
+  build_name_extra: -fips
+  kubernetes_build_metadata: fips.0
+  default_image_repo: hub.docker.io/mesosphere
+  kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v{{ kubernetes_version }}-fips/x86_64"
+  docker_rpm_repository_url: "\
+    https://containerd-fips.s3.us-east-2.amazonaws.com\
+    /{{ ansible_distribution_major_version|int }}\
+    /x86_64"
+  ```
+
+- Nvidia override:
+
+  ```yaml
+  ---
+  gpu:
+    types:
+      - nvidia
+
+  build_name_extra: "-nvidia"
+  nvidia_cuda_version: "470"
+  ```
+
+- Offline override:
+
+  ```yaml  
+  os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ kubernetes_version }}_{{ ansible_distribution|lower }}_{{ ansible_distribution_major_version }}_x86_64.tar.gz"
+  pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
+  images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"
+  ```
+
+- Offline for FIPS override:
+
+  ```yaml
+# fips os-packages
+os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ kubernetes_version }}_{{ ansible_distribution|lower }}_{{ ansible_distribution_major_version }}_x86_64_fips.tar.gz"
+pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
+images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"
+```

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/default-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/default-or-files/index.md
@@ -11,13 +11,14 @@ menuWeight: 0
 Konvoy comes with default override files:
 
 - FIPS override:
+
   ```yaml
   ---
   k8s_image_registry: docker.io/mesosphere
-
+  
   fips:
-  enabled: true
-
+    enabled: true
+  
   build_name_extra: -fips
   kubernetes_build_metadata: fips.0
   default_image_repo: hub.docker.io/mesosphere
@@ -35,9 +36,8 @@ Konvoy comes with default override files:
   gpu:
     types:
       - nvidia
-
+  
   build_name_extra: "-nvidia"
-  nvidia_cuda_version: "470"
   ```
 
 - Offline override:
@@ -51,8 +51,8 @@ Konvoy comes with default override files:
 - Offline for FIPS override:
 
   ```yaml
-# fips os-packages
-os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ kubernetes_version }}_{{ ansible_distribution|lower }}_{{ ansible_distribution_major_version }}_x86_64_fips.tar.gz"
-pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
-images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"
-```
+  # fips os-packages
+  os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ kubernetes_version }}_{{ ansible_distribution|lower }}_{{ ansible_distribution_major_version }}_x86_64_fips.tar.gz"
+  pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
+  images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"
+  ```

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/default-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/default-or-files/index.md
@@ -42,7 +42,7 @@ Konvoy comes with default override files:
 
 - Offline override:
 
-  ```yaml  
+  ```yaml
   os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ kubernetes_version }}_{{ ansible_distribution|lower }}_{{ ansible_distribution_major_version }}_x86_64.tar.gz"
   pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
   images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-87545

## Description of changes being made

Un-linked override files from main and pasted content from directory to the docs site as requested by support.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4495.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
