### PR TITLE
docs: updating eks to specific kernel

### DIFF
--- a/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
@@ -57,9 +57,9 @@ Konvoy supports the following base Operating Systems.
 ## EKS
 
 <!-- vale Vale.Spelling = NO -->
-| Operating System      | Kernel                           | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
+| Operating System         | Kernel                           | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
 |-----------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
-| [Amazon Linux 2][amzn_2] |                               | Yes            |      |            |                      |             |
+| [Amazon Linux 2][amzn_2] |  5.4.190-107.353.amzn2.x86_64    | Yes            |      |            |                      |             |
 
 ## AKS
 


### PR DESCRIPTION
## Jira Ticket

n/a

<!-- Link to JIRA ticket -->

## Description of changes being made
This is just to define the specific kernel that was used to build an EKS cluster

```
~/Development/d2iq/konvoy-app/dkp2.2/gaRelease :k get nodes
NAME                                         STATUS   ROLES    AGE   VERSION
ip-10-0-102-49.us-west-2.compute.internal    Ready    <none>   10m   v1.21.12-eks-5308cf7
ip-10-0-123-220.us-west-2.compute.internal   Ready    <none>   10m   v1.21.12-eks-5308cf7
ip-10-0-67-222.us-west-2.compute.internal    Ready    <none>   10m   v1.21.12-eks-5308cf7
ip-10-0-82-192.us-west-2.compute.internal    Ready    <none>   10m   v1.21.12-eks-5308cf7
~/Development/d2iq/konvoy-app/dkp2.2/gaRelease :k node-shell ip-10-0-102-49.us-west-2.compute.internal
spawning "nsenter-ehmv6k" on "ip-10-0-102-49.us-west-2.compute.internal"
If you don't see a command prompt, try pressing enter.
[root@ip-10-0-102-49 /]# uname -r
5.4.190-107.353.amzn2.x86_64
```


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
