### PR TITLE
2.2.1 Release Notes fixes

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -98,13 +98,13 @@ The following items are known issues with this release.
 
 ### Upgrade considerations
 
-Before attempting to upgrade an existing cluster to this release, please check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
+Before attempting to upgrade an existing cluster to this release, check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
 
 - kommanderAppManagementImageTag
 - kommanderAppManagementImageRepository
 - kommanderChartsVersion
 
-If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, please file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
+If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: DKP 2.2.1 Release Notes
 title: DKP 2.2.1 Release Notes
 menuWeight: 20
-excerpt: View release-specific information for DKP 2.1.1
+excerpt: View release-specific information for DKP 2.2.1
 enterprise: false
 beta: false
 ---
@@ -55,42 +55,42 @@ New preprovisioned clusters that use flatcar as a base operating system now use 
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:
 
-| Common Application Name | APP ID                                         | Version | Component Versions                                                                                                                                    |
-| ----------------------- | ---------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cert Manager            | cert-manager                                   | 1.7.1   | - chart: 1.7.1 `<br>`- cert-manager: 1.7.1                                                                                                          |
-| Chartmuseum             | chartmuseum                                    | 3.6.2   | - chart: 3.6.2 `<br>`- chartmuseum: 3.6.2                                                                                                           |
-| Containerd              | containerd                                     | 1.4.11  |                                                                                                                                                       |
-| Dex                     | dex                                            | 2.9.14  | - chart: 2.9.14 `<br>`- dex: 2.22.0                                                                                                                 |
-| External DNS            | external-dns                                   | 6.1.8   | - chart: 6.1.8 `<br>`- external-dns: 0.10.2                                                                                                         |
-| Fluent Bit              | fluent-bit                                     | 0.19.20 | - chart: 0.19.20 `<br>`- fluent-bit: 1.8.13                                                                                                         |
-| Flux                    | kommander-flux                                 | 0.27.4  |                                                                                                                                                       |
-| Gatekeeper              | gatekeeper                                     | 3.7.0   | - chart: 3.7.0 `<br>`- gatekeeper: 3.7.0                                                                                                            |
-| Grafana                 | grafana-logging                                | 6.22.0  | - chart: 6.22.0 `<br>`- grafana: 8.3.6                                                                                                              |
-| Loki                    | grafana-loki                                   | 0.33.2  | - chart: 0.33.1 `<br>`- loki: 2.2.1                                                                                                                 |
-| Istio                   | istio                                          | 1.11.6  | - chart: 1.11.6 `<br>`- istio: 1.11.5                                                                                                               |
-| Jaeger                  | jaeger                                         | 2.29.0  | - chart: 2.29.0 `<br>`- jaeger: 1.31.0                                                                                                              |
-| Karma                   | karma                                          | 2.0.1   | - chart: 2.0.1 `<br>`- karma: 0.88                                                                                                                  |
-| Kiali                   | kiali                                          | 1.47.0  | - chart: 1.47.0 `<br>`- kiali: 1.47.0                                                                                                               |
-| Knative                 | knative                                        | 0.3.9   | - chart: 0.3.9 `<br>`- knative: 0.22.3                                                                                                              |
-| Kube OIDC Proxy         | kube-oidc-proxy                                | 0.3.1   | - chart: 0.3.1 `<br>`- kube-oidc-proxy: 0.3.0                                                                                                       |
-| Kube Prometheus Stack   | [kube-prometheus-stack][kube-prometheus-stack] | 33.1.5  | - chart: 33.1.5 `<br>`- prometheus-operator: 0.54.1 `<br>`- prometheus: 2.33.4 `<br>`- prometheus alertmanager: 0.23.0 `<br>`- grafana: 8.3.6 |
-| Kubecost                | kubecost                                       | 0.23.3  | - chart: 0.23.3 `<br>`- cost-analyzer: 1.91.2                                                                                                       |
-| Kubefed                 | kubefed                                        | 0.9.1   | - chart: 0.9.1 `<br>`- kubefed: 0.9.1                                                                                                               |
-| Kubernetes Dashboard    | kubernetes-dashboard                           | 5.1.1   | - chart: 5.1.1 `<br>`- kubernetes-dashboard: 2.4.0                                                                                                  |
-| Kubetunnel              | kubetunnel                                     | 0.0.11  | - chart: 0.0.11 `<br>`- kubetunnel: 0.0.11                                                                                                          |
-| Logging Operator        | logging-operator                               | 3.17.2  | - chart: 3.17.2 `<br>`- logging-operator: 3.17.2                                                                                                    |
-| Minio                   | minio-operator                                 | 4.4.10  | - chart: 4.4.10 `<br>`- minio: 4.4.10                                                                                                               |
-| NFS Server Provisioner  | nfs-server-provisioner                         | 0.6.0   | - chart: 0.6.0 `<br>`- nfs-provisioner: 2.3.0                                                                                                       |
-| Nvidia                  | nvidia                                         | 0.4.4   | - chart: 0.4.4 `<br>`- nvidia-device-plugin: 0.9.0                                                                                                  |
-| Grafana (project)       | project-grafana-logging                        | 6.20.6  | - chart: 6.20.6 `<br>`- grafana: 8.3.6                                                                                                              |
-| Loki (project)          | project-grafana-loki                           | 0.33.2  | - chart: 0.33.1 `<br>`- loki: 2.2.1                                                                                                                 |
-|                         | project-logging                                | 1.0.0   |                                                                                                                                                       |
-| Prometheus Adapter      | prometheus-adapter                             | 2.17.1  | - chart: 2.17.1 `<br>`- prometheus-adapter: 0.9.1                                                                                                   |
-| Reloader                | reloader                                       | 0.0.104 | - chart: 0.0.104 `<br>`- reloader: 0.0.104                                                                                                          |
-| Thanos                  | thanos                                         | 0.4.6   | - chart: 0.4.6 `<br>`- thanos: 0.9.0                                                                                                                |
-| Traefik                 | traefik                                        | 10.9.1  | - chart: 10.9.1 `<br>`- traefik: 2.5.6                                                                                                              |
-| Traefik ForwardAuth     | traefik-forward-auth                           | 0.3.6   | - chart: 0.3.6 `<br>`- traefik-forward-auth: 3.1.0                                                                                                  |
-| Velero                  | velero                                         | 3.2.0   | - chart: 3.2.0 `<br>`- velero: 1.5.2                                                                                                                |
+| Common Application Name | APP ID                                         | Version | Component Versions                                                                                                                        |
+| ----------------------- | ---------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Cert Manager            | cert-manager                                   | 1.7.1   | - chart: 1.7.1<br>- cert-manager: 1.7.1                                                                                                 |
+| Chartmuseum             | chartmuseum                                    | 3.6.2   | - chart: 3.6.2<br>- chartmuseum: 3.6.2                                                                                                  |
+| Containerd              | containerd                                     | 1.4.11  |                                                                                                                                           |
+| Dex                     | dex                                            | 2.9.14  | - chart: 2.9.14<br>- dex: 2.22.0                                                                                                        |
+| External DNS            | external-dns                                   | 6.1.8   | - chart: 6.1.8<br>- external-dns: 0.10.2                                                                                                |
+| Fluent Bit              | fluent-bit                                     | 0.19.20 | - chart: 0.19.20<br>- fluent-bit: 1.8.13                                                                                                |
+| Flux                    | kommander-flux                                 | 0.27.4  |                                                                                                                                           |
+| Gatekeeper              | gatekeeper                                     | 3.7.0   | - chart: 3.7.0<br>- gatekeeper: 3.7.0                                                                                                   |
+| Grafana                 | grafana-logging                                | 6.22.0  | - chart: 6.22.0<br>- grafana: 8.3.6                                                                                                     |
+| Loki                    | grafana-loki                                   | 0.33.2  | - chart: 0.33.1<br>- loki: 2.2.1                                                                                                        |
+| Istio                   | istio                                          | 1.11.6  | - chart: 1.11.6<br>- istio: 1.11.5                                                                                                      |
+| Jaeger                  | jaeger                                         | 2.29.0  | - chart: 2.29.0<br>- jaeger: 1.31.0                                                                                                     |
+| Karma                   | karma                                          | 2.0.1   | - chart: 2.0.1<br>- karma: 0.88                                                                                                         |
+| Kiali                   | kiali                                          | 1.47.0  | - chart: 1.47.0<br>- kiali: 1.47.0                                                                                                      |
+| Knative                 | knative                                        | 0.3.9   | - chart: 0.3.9<br>- knative: 0.22.3                                                                                                     |
+| Kube OIDC Proxy         | kube-oidc-proxy                                | 0.3.1   | - chart: 0.3.1<br>- kube-oidc-proxy: 0.3.0                                                                                              |
+| Kube Prometheus Stack   | [kube-prometheus-stack][kube-prometheus-stack] | 33.1.5  | - chart: 33.1.5<br>- prometheus-operator: 0.54.1<br>- prometheus: 2.33.4<br>- prometheus alertmanager: 0.23.0<br>- grafana: 8.3.6 |
+| Kubecost                | kubecost                                       | 0.23.3  | - chart: 0.23.3<br>- cost-analyzer: 1.91.2                                                                                              |
+| Kubefed                 | kubefed                                        | 0.9.1   | - chart: 0.9.1<br>- kubefed: 0.9.1                                                                                                      |
+| Kubernetes Dashboard    | kubernetes-dashboard                           | 5.1.1   | - chart: 5.1.1<br>- kubernetes-dashboard: 2.4.0                                                                                         |
+| Kubetunnel              | kubetunnel                                     | 0.0.11  | - chart: 0.0.11<br>- kubetunnel: 0.0.11                                                                                                 |
+| Logging Operator        | logging-operator                               | 3.17.2  | - chart: 3.17.2<br>- logging-operator: 3.17.2                                                                                           |
+| Minio                   | minio-operator                                 | 4.4.10  | - chart: 4.4.10<br>- minio: 4.4.10                                                                                                      |
+| NFS Server Provisioner  | nfs-server-provisioner                         | 0.6.0   | - chart: 0.6.0<br>- nfs-provisioner: 2.3.0                                                                                              |
+| Nvidia                  | nvidia                                         | 0.4.4   | - chart: 0.4.4<br>- nvidia-device-plugin: 0.9.0                                                                                         |
+| Grafana (project)       | project-grafana-logging                        | 6.20.6  | - chart: 6.20.6<br>- grafana: 8.3.6                                                                                                     |
+| Loki (project)          | project-grafana-loki                           | 0.33.2  | - chart: 0.33.1<br>- loki: 2.2.1                                                                                                        |
+|                         | project-logging                                | 1.0.0   |                                                                                                                                           |
+| Prometheus Adapter      | prometheus-adapter                             | 2.17.1  | - chart: 2.17.1<br>- prometheus-adapter: 0.9.1                                                                                          |
+| Reloader                | reloader                                       | 0.0.104 | - chart: 0.0.104<br>- reloader: 0.0.104                                                                                                 |
+| Thanos                  | thanos                                         | 0.4.6   | - chart: 0.4.6<br>- thanos: 0.9.0                                                                                                       |
+| Traefik                 | traefik                                        | 10.9.1  | - chart: 10.9.1<br>- traefik: 2.5.6                                                                                                     |
+| Traefik ForwardAuth     | traefik-forward-auth                           | 0.3.6   | - chart: 0.3.6<br>- traefik-forward-auth: 3.1.0                                                                                         |
+| Velero                  | velero                                         | 3.2.0   | - chart: 3.2.0<br>- velero: 1.5.2                                                                                                       |
 
 ## Known Issues
 
@@ -100,18 +100,21 @@ The following items are known issues with this release.
 
 Before attempting to upgrade an existing cluster to this release, please check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
 
--   kommanderAppManagementImageTag
--   kommanderAppManagementImageRepository
--   kommanderChartsVersion
+- kommanderAppManagementImageTag
+- kommanderAppManagementImageRepository
+- kommanderChartsVersion
 
 If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, please file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
 
 ## Additional resources
 
-<!-- Add links to external documentation as needed -->
-
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
+
+[kube-prometheus-stack]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
+[kubernetes-doc]: https://kubernetes.io/docs/home/
+
 For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd).
+
 [kubernetes-doc]: https://kubernetes.io/docs/home/
 [attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
 [konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -15,7 +15,7 @@ beta: false
 
 ## Release summary
 
-Welcome to D2iQ Kubernetes Platform (DKP) 2.2.x! This release provides fixes to reported issues, integrates changes from previous releases, and maintain compatibility and support for other packages used in DKP. 
+Welcome to D2iQ Kubernetes Platform (DKP) 2.2.1! This release provides fixes to reported issues, integrates changes from previous releases, and maintains compatibility and support for other packages used in DKP.
 
 For this release, we are maintaining the documentation sets for individual platform components Konvoy and Kommander, while publishing some combined DKP documentation for processes, such as Upgrading DKP version.
 
@@ -96,7 +96,7 @@ The following items are known issues with this release.
 
 ### Upgrade considerations
 
-Before attempting to upgrade an existing cluster to this release, check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
+Before attempting to upgrade an existing cluster to this release, check the `kommander-vars` Configmap in the `kommander` namespace for the following fields:
 
 - kommanderAppManagementImageTag
 - kommanderAppManagementImageRepository

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -109,6 +109,7 @@ If any of the these fields are present, then there is a possibility the upgrade 
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
+
 For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd).
 
 [kube-prometheus-stack]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -9,15 +9,13 @@ beta: false
 ---
 **D2iQ&reg; Kommander&reg; version 2.2.1 was released on June 1, 2022.**
 
-[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Kommander[/button]
-
-To get started with Kommander, [download](../../download/) and [install](../../install/) the latest version of Kommander.
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download DKP[/button]
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 
 ## Release summary
 
-Welcome to D2iQ Kubernetes Platform (DKP) 2.2.x! This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy. In this release, we are beginning the process of combining our two flagship products, Konvoy and Kommander, into a single DKP product with two service level options: DKP Enterprise for multi-cluster environments, and DKP Essential for single-cluster environments.
+Welcome to D2iQ Kubernetes Platform (DKP) 2.2.x! This release provides fixes to reported issues, integrates changes from previous releases, and maintain compatibility and support for other packages used in DKP. 
 
 For this release, we are maintaining the documentation sets for individual platform components Konvoy and Kommander, while publishing some combined DKP documentation for processes, such as Upgrading DKP version.
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -7,7 +7,7 @@ excerpt: View release-specific information for DKP 2.2.1
 enterprise: false
 beta: false
 ---
-**D2iQ&reg; Konvoy&reg; version 2.2.1 was released on June 1, 2022.**
+**D2iQ&reg; Kommander&reg; version 2.2.1 was released on June 1, 2022.**
 
 [button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Kommander[/button]
 
@@ -109,12 +109,9 @@ If any of the these fields are present, then there is a possibility the upgrade 
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
-
-[kube-prometheus-stack]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
-[kubernetes-doc]: https://kubernetes.io/docs/home/
-
 For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd).
 
+[kube-prometheus-stack]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
 [kubernetes-doc]: https://kubernetes.io/docs/home/
 [attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
 [konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
@@ -3,7 +3,7 @@ layout: layout.pug
 navigationTitle: DKP 2.2.1 Release Notes
 title: DKP 2.2.1 Release Notes
 menuWeight: 20
-excerpt: View release-specific information for DKP 2.1.1
+excerpt: View release-specific information for DKP 2.2.1
 enterprise: false
 beta: false
 ---
@@ -29,7 +29,7 @@ DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster yo
 | ------------------ | ------- |
 | **Minimum**  | 1.21.0  |
 | **Maximum**  | 1.22.x  |
-| **Default**  | 1.22.8  |
+| **Default**  | 1.22.0  |
 
 ## Fixes and Improvements
 
@@ -55,42 +55,42 @@ New preprovisioned clusters that use flatcar as a base operating system now use 
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:
 
-| Common Application Name | APP ID                                         | Version | Component Versions                                                                                                                                    |
-| ----------------------- | ---------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cert Manager            | cert-manager                                   | 1.7.1   | - chart: 1.7.1 `<br>`- cert-manager: 1.7.1                                                                                                          |
-| Chartmuseum             | chartmuseum                                    | 3.6.2   | - chart: 3.6.2 `<br>`- chartmuseum: 3.6.2                                                                                                           |
-| Containerd              | containerd                                     | 1.4.11  |                                                                                                                                                       |
-| Dex                     | dex                                            | 2.9.14  | - chart: 2.9.14 `<br>`- dex: 2.22.0                                                                                                                 |
-| External DNS            | external-dns                                   | 6.1.8   | - chart: 6.1.8 `<br>`- external-dns: 0.10.2                                                                                                         |
-| Fluent Bit              | fluent-bit                                     | 0.19.20 | - chart: 0.19.20 `<br>`- fluent-bit: 1.8.13                                                                                                         |
-| Flux                    | kommander-flux                                 | 0.27.4  |                                                                                                                                                       |
-| Gatekeeper              | gatekeeper                                     | 3.7.0   | - chart: 3.7.0 `<br>`- gatekeeper: 3.7.0                                                                                                            |
-| Grafana                 | grafana-logging                                | 6.22.0  | - chart: 6.22.0 `<br>`- grafana: 8.3.6                                                                                                              |
-| Loki                    | grafana-loki                                   | 0.33.2  | - chart: 0.33.1 `<br>`- loki: 2.2.1                                                                                                                 |
-| Istio                   | istio                                          | 1.11.6  | - chart: 1.11.6 `<br>`- istio: 1.11.5                                                                                                               |
-| Jaeger                  | jaeger                                         | 2.29.0  | - chart: 2.29.0 `<br>`- jaeger: 1.31.0                                                                                                              |
-| Karma                   | karma                                          | 2.0.1   | - chart: 2.0.1 `<br>`- karma: 0.88                                                                                                                  |
-| Kiali                   | kiali                                          | 1.47.0  | - chart: 1.47.0 `<br>`- kiali: 1.47.0                                                                                                               |
-| Knative                 | knative                                        | 0.3.9   | - chart: 0.3.9 `<br>`- knative: 0.22.3                                                                                                              |
-| Kube OIDC Proxy         | kube-oidc-proxy                                | 0.3.1   | - chart: 0.3.1 `<br>`- kube-oidc-proxy: 0.3.0                                                                                                       |
-| Kube Prometheus Stack   | [kube-prometheus-stack][kube-prometheus-stack] | 33.1.5  | - chart: 33.1.5 `<br>`- prometheus-operator: 0.54.1 `<br>`- prometheus: 2.33.4 `<br>`- prometheus alertmanager: 0.23.0 `<br>`- grafana: 8.3.6 |
-| Kubecost                | kubecost                                       | 0.23.3  | - chart: 0.23.3 `<br>`- cost-analyzer: 1.91.2                                                                                                       |
-| Kubefed                 | kubefed                                        | 0.9.1   | - chart: 0.9.1 `<br>`- kubefed: 0.9.1                                                                                                               |
-| Kubernetes Dashboard    | kubernetes-dashboard                           | 5.1.1   | - chart: 5.1.1 `<br>`- kubernetes-dashboard: 2.4.0                                                                                                  |
-| Kubetunnel              | kubetunnel                                     | 0.0.11  | - chart: 0.0.11 `<br>`- kubetunnel: 0.0.11                                                                                                          |
-| Logging Operator        | logging-operator                               | 3.17.2  | - chart: 3.17.2 `<br>`- logging-operator: 3.17.2                                                                                                    |
-| Minio                   | minio-operator                                 | 4.4.10  | - chart: 4.4.10 `<br>`- minio: 4.4.10                                                                                                               |
-| NFS Server Provisioner  | nfs-server-provisioner                         | 0.6.0   | - chart: 0.6.0 `<br>`- nfs-provisioner: 2.3.0                                                                                                       |
-| Nvidia                  | nvidia                                         | 0.4.4   | - chart: 0.4.4 `<br>`- nvidia-device-plugin: 0.9.0                                                                                                  |
-| Grafana (project)       | project-grafana-logging                        | 6.20.6  | - chart: 6.20.6 `<br>`- grafana: 8.3.6                                                                                                              |
-| Loki (project)          | project-grafana-loki                           | 0.33.2  | - chart: 0.33.1 `<br>`- loki: 2.2.1                                                                                                                 |
-|                         | project-logging                                | 1.0.0   |                                                                                                                                                       |
-| Prometheus Adapter      | prometheus-adapter                             | 2.17.1  | - chart: 2.17.1 `<br>`- prometheus-adapter: 0.9.1                                                                                                   |
-| Reloader                | reloader                                       | 0.0.104 | - chart: 0.0.104 `<br>`- reloader: 0.0.104                                                                                                          |
-| Thanos                  | thanos                                         | 0.4.6   | - chart: 0.4.6 `<br>`- thanos: 0.9.0                                                                                                                |
-| Traefik                 | traefik                                        | 10.9.1  | - chart: 10.9.1 `<br>`- traefik: 2.5.6                                                                                                              |
-| Traefik ForwardAuth     | traefik-forward-auth                           | 0.3.6   | - chart: 0.3.6 `<br>`- traefik-forward-auth: 3.1.0                                                                                                  |
-| Velero                  | velero                                         | 3.2.0   | - chart: 3.2.0 `<br>`- velero: 1.5.2                                                                                                                |
+| Common Application Name | APP ID                                         | Version | Component Versions                                                                                                                        |
+| ----------------------- | ---------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Cert Manager            | cert-manager                                   | 1.7.1   | - chart: 1.7.1<br>- cert-manager: 1.7.1                                                                                                 |
+| Chartmuseum             | chartmuseum                                    | 3.6.2   | - chart: 3.6.2<br>- chartmuseum: 3.6.2                                                                                                  |
+| Containerd              | containerd                                     | 1.4.11  |                                                                                                                                           |
+| Dex                     | dex                                            | 2.9.14  | - chart: 2.9.14<br>- dex: 2.22.0                                                                                                        |
+| External DNS            | external-dns                                   | 6.1.8   | - chart: 6.1.8<br>- external-dns: 0.10.2                                                                                                |
+| Fluent Bit              | fluent-bit                                     | 0.19.20 | - chart: 0.19.20<br>- fluent-bit: 1.8.13                                                                                                |
+| Flux                    | kommander-flux                                 | 0.27.4  |                                                                                                                                           |
+| Gatekeeper              | gatekeeper                                     | 3.7.0   | - chart: 3.7.0<br>- gatekeeper: 3.7.0                                                                                                   |
+| Grafana                 | grafana-logging                                | 6.22.0  | - chart: 6.22.0<br>- grafana: 8.3.6                                                                                                     |
+| Loki                    | grafana-loki                                   | 0.33.2  | - chart: 0.33.1<br>- loki: 2.2.1                                                                                                        |
+| Istio                   | istio                                          | 1.11.6  | - chart: 1.11.6<br>- istio: 1.11.5                                                                                                      |
+| Jaeger                  | jaeger                                         | 2.29.0  | - chart: 2.29.0<br>- jaeger: 1.31.0                                                                                                     |
+| Karma                   | karma                                          | 2.0.1   | - chart: 2.0.1<br>- karma: 0.88                                                                                                         |
+| Kiali                   | kiali                                          | 1.47.0  | - chart: 1.47.0<br>- kiali: 1.47.0                                                                                                      |
+| Knative                 | knative                                        | 0.3.9   | - chart: 0.3.9<br>- knative: 0.22.3                                                                                                     |
+| Kube OIDC Proxy         | kube-oidc-proxy                                | 0.3.1   | - chart: 0.3.1<br>- kube-oidc-proxy: 0.3.0                                                                                              |
+| Kube Prometheus Stack   | [kube-prometheus-stack][kube-prometheus-stack] | 33.1.5  | - chart: 33.1.5<br>- prometheus-operator: 0.54.1<br>- prometheus: 2.33.4<br>- prometheus alertmanager: 0.23.0<br>- grafana: 8.3.6 |
+| Kubecost                | kubecost                                       | 0.23.3  | - chart: 0.23.3<br>- cost-analyzer: 1.91.2                                                                                              |
+| Kubefed                 | kubefed                                        | 0.9.1   | - chart: 0.9.1<br>- kubefed: 0.9.1                                                                                                      |
+| Kubernetes Dashboard    | kubernetes-dashboard                           | 5.1.1   | - chart: 5.1.1<br>- kubernetes-dashboard: 2.4.0                                                                                         |
+| Kubetunnel              | kubetunnel                                     | 0.0.11  | - chart: 0.0.11<br>- kubetunnel: 0.0.11                                                                                                 |
+| Logging Operator        | logging-operator                               | 3.17.2  | - chart: 3.17.2<br>- logging-operator: 3.17.2                                                                                           |
+| Minio                   | minio-operator                                 | 4.4.10  | - chart: 4.4.10<br>- minio: 4.4.10                                                                                                      |
+| NFS Server Provisioner  | nfs-server-provisioner                         | 0.6.0   | - chart: 0.6.0<br>- nfs-provisioner: 2.3.0                                                                                              |
+| Nvidia                  | nvidia                                         | 0.4.4   | - chart: 0.4.4<br>- nvidia-device-plugin: 0.9.0                                                                                         |
+| Grafana (project)       | project-grafana-logging                        | 6.20.6  | - chart: 6.20.6<br>- grafana: 8.3.6                                                                                                     |
+| Loki (project)          | project-grafana-loki                           | 0.33.2  | - chart: 0.33.1<br>- loki: 2.2.1                                                                                                        |
+|                         | project-logging                                | 1.0.0   |                                                                                                                                           |
+| Prometheus Adapter      | prometheus-adapter                             | 2.17.1  | - chart: 2.17.1<br>- prometheus-adapter: 0.9.1                                                                                          |
+| Reloader                | reloader                                       | 0.0.104 | - chart: 0.0.104<br>- reloader: 0.0.104                                                                                                 |
+| Thanos                  | thanos                                         | 0.4.6   | - chart: 0.4.6<br>- thanos: 0.9.0                                                                                                       |
+| Traefik                 | traefik                                        | 10.9.1  | - chart: 10.9.1<br>- traefik: 2.5.6                                                                                                     |
+| Traefik ForwardAuth     | traefik-forward-auth                           | 0.3.6   | - chart: 0.3.6<br>- traefik-forward-auth: 3.1.0                                                                                         |
+| Velero                  | velero                                         | 3.2.0   | - chart: 3.2.0<br>- velero: 1.5.2                                                                                                       |
 
 ## Known Issues
 
@@ -98,20 +98,20 @@ The following items are known issues with this release.
 
 ### Upgrade considerations
 
-Before attempting to upgrade an existing cluster to this release, check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
+Before attempting to upgrade an existing cluster to this release, please check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
 
--   kommanderAppManagementImageTag
--   kommanderAppManagementImageRepository
--   kommanderChartsVersion
+- kommanderAppManagementImageTag
+- kommanderAppManagementImageRepository
+- kommanderChartsVersion
 
-If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
+If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, please file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
 
 ## Additional resources
 
-<!-- Add links to external documentation as needed -->
-
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
-For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd)
+For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd).
+
+[kube-prometheus-stack]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
 [kubernetes-doc]: https://kubernetes.io/docs/home/
 [attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
 [konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/quick-start-aws#optional-move-controllers-to-the-newly-created-cluster

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
@@ -98,17 +98,18 @@ The following items are known issues with this release.
 
 ### Upgrade considerations
 
-Before attempting to upgrade an existing cluster to this release, please check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
+Before attempting to upgrade an existing cluster to this release, check the 'kommander-vars' Configmap in the 'kommander' namespace for the following fields:
 
 - kommanderAppManagementImageTag
 - kommanderAppManagementImageRepository
 - kommanderChartsVersion
 
-If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, please file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
+If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
 
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].
+
 For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd).
 
 [kube-prometheus-stack]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
@@ -15,7 +15,7 @@ beta: false
 
 ## Release summary
 
-Welcome to D2iQ Kubernetes Platform (DKP) 2.2.x! This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy. 
+Welcome to D2iQ Kubernetes Platform (DKP) 2.2.1! This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintains compatibility and support for other packages used in Konvoy.
 
 DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster you want to attach using DKP 2.2.x must be running a Kubernetes version in this range.
 
@@ -25,7 +25,7 @@ DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster yo
 | ------------------ | ------- |
 | **Minimum**  | 1.21.0  |
 | **Maximum**  | 1.22.x  |
-| **Default**  | 1.22.0  |
+| **Default**  | 1.22.8  |
 
 ## Fixes and Improvements
 

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
@@ -9,17 +9,13 @@ beta: false
 ---
 **D2iQ&reg; Konvoy&reg; version 2.2.1 was released on June 1, 2022.**
 
-[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Kommander[/button]
+[button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download DKP[/button]
 
-To get started with Kommander, [download](../../download/) and [install](../../install/) the latest version of Kommander.
-
-<p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
+<p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install DKP.</p>
 
 ## Release summary
 
-Welcome to D2iQ Kubernetes Platform (DKP) 2.2.x! This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy. In this release, we are beginning the process of combining our two flagship products, Konvoy and Kommander, into a single DKP product with two service level options: DKP Enterprise for multi-cluster environments, and DKP Essential for single-cluster environments.
-
-For this release, we are maintaining the documentation sets for individual platform components Konvoy and Kommander, while publishing some combined DKP documentation for processes, such as Upgrading DKP version.
+Welcome to D2iQ Kubernetes Platform (DKP) 2.2.x! This release provides new features and enhancements to improve the user experience, fix reported issues, integrate changes from previous releases, and maintain compatibility and support for other packages used in Konvoy. 
 
 DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster you want to attach using DKP 2.2.x must be running a Kubernetes version in this range.
 


### PR DESCRIPTION
### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4513.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
