### PR TITLE
Fixing Instructions for GCP Quick Start

### DIFF
--- a/pages/dkp/konvoy/2.3/choose-infrastructure/gcp/quick-start-gcp/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/gcp/quick-start-gcp/index.md
@@ -22,7 +22,7 @@ Before starting the Konvoy installation, verify that you have:
 
 ## Configure GCP prerequisites
 
-1.  Log in to Azure:
+1.  Log in to GCP:
 <!NEED CONFIRMATION OF STEPS PRE-RELEASE>
     ```bash
     gcp login

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/gcp/quick-start-gcp/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/gcp/quick-start-gcp/index.md
@@ -8,7 +8,7 @@ enterprise: false
 menuWeight: 6
 ---
 
-This Quick Start guide provides simplified instructions for using Konvoy to get your Kubernetes cluster up and running with minimal configuration requirements on a Google Cloud Platform (GCP).
+This Quick Start guide provides simplified instructions for using Konvoy to get your Kubernetes cluster up and running with minimal configuration requirements on GCP.
 
 ## Prerequisites
 
@@ -18,286 +18,175 @@ Before starting the Konvoy installation, verify that you have:
 - The `dkp` binary on this machine.
 - [Docker][install_docker] version 18.09.2 or later.
 - [kubectl][install_kubectl] for interacting with the running cluster.
-- A valid GCP account with [credentials configured](https://github.com/kubernetes-sigs/cluster-api-provider-gcp).
+- A valid GCP account with [credentials configured][gcp_credentials].
 
-# Create a Cluster in Google Cloud Platform 
+## Configure GCP prerequisites
+
+1.  Log in to Azure:
 <!NEED CONFIRMATION OF STEPS PRE-RELEASE>
-## Setup your gcloud CLI
-
-The following steps will be performed using clusterctl.
-1.  Install the CLI by following [GCP Install](https://cloud.google.com/sdk/docs/install). Select location for cluster using dkp create cluster gcp --location where the --location will default to us-west-1. ????????
-
-1.  Create a Service account
-   
-    ```
-    export GCP_PROJECT=eng-ksphere-platform
-    export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.gcloud/credentials.json"
-
-    gcloud iam service-accounts create "$USER"
-    gcloud projects add-iam-policy-binding $GCP_PROJECT --member="serviceAccount:$USER@$GCP_PROJECT.iam.gserviceaccount.com" --role=roles/editor
-    gcloud iam service-accounts keys create $GOOGLE_APPLICATION_CREDENTIALS --iam-account="$USER@$GCP_PROJECT.iam.gserviceaccount.com"
+    ```bash
+    gcp login
     ```
 
-##  Create a VPC network
-
-1.  Export required environment variables:
-
-    ```
-    export GCP_PROJECT=eng-ksphere-platform
-    export CLUSTER_NAME=$USER-gcp-quickstart
-    export GCP_NETWORK_NAME=$CLUSTER_NAME
-    export GCP_REGION=us-west1
-    ```
-
-1.  Create the VPC network:
-
-    ```
-    gcloud compute networks create "${CLUSTER_NAME}" --project="$GCP_PROJECT" --subnet-mode=auto --mtu=1460 --bgp-routing-mode=regional
-
-    gcloud compute firewall-rules create "${CLUSTER_NAME}-allow-ssh" --project="$GCP_PROJECT" --network="projects/$GCP_PROJECT/global/networks/${CLUSTER_NAME}" --description=Allows\ TCP\ connections\ from\ any\ source\ to\ any\ instance\ on\ the\ network\ using\ port\ 22. --direction=INGRESS --priority=65534 --source-ranges=0.0.0.0/0 --action=ALLOW --rules=tcp:22
-    ```
-
-### Setup Cloud NAT
-
-Kubernetes nodes, to communicate with the control plane, pull container images from registried (e.g. gcr.io or dockerhub) need to have NAT access or a public ip. By default, the provider creates Machines without a public IP.
-
-1.  Create the router:
-
-    ```
-    gcloud compute routers create "${CLUSTER_NAME}-router" --project="${GCP_PROJECT}" --region="${GCP_REGION}" --network="${GCP_NETWORK_NAME}"
-
-    gcloud compute routers nats create "${CLUSTER_NAME}-nat" --project="${GCP_PROJECT}" --router-region="${GCP_REGION}" --router="${CLUSTER_NAME}-router" --nat-all-subnet-ip-ranges --auto-allocate-nat-external-ips
+    ```sh
+    [
+      {
+        "cloudName": "GCPCloud",
+        "homeTenantId": "a1234567-b132-1234-1a11-1234a5678b90",
+        "id": "b1234567-abcd-11a1-a0a0-1234a5678b90",
+        "isDefault": true,
+        "managedByTenants": [],
+        "name": "Mesosphere Developer Subscription",
+        "state": "Enabled",
+        "tenantId": "a1234567-b132-1234-1a11-1234a5678b90",
+        "user": {
+          "name": "user@gcpmesosphere.onmicrosoft.com",
+          "type": "user"
+        }
+      }
+    ]
     ```
 
-## Build an image
+1.  Create an GCP Service Principal (SP) by running the following command:
 
-Google Cloud Platform does not publish images. You must first build the image.
+<!NEED CONFIRMATION OF STEPS PRE-RELEASE>
 
-<p class="message--note"><strong>Note:</strong> You may also skip this step and reuse one that already exists by exporting it.</p> ????
+    <p class="message--note"><strong>NOTE: </strong>If an SP with the name exists, this command will rotate the password.</p>
 
-```
-export IMAGE_NAME=cluster-api-ubuntu-2004-v1-21-10-1651240802
-```
-
-1.  Export required environment variables:
-
-    ```
-    export GCP_PROJECT_ID=$GCP_PROJECT
+    ```bash
+    az ad sp create-for-rbac --role contributor --name "$(whoami)-konvoy" --scopes=/subscriptions/$(az account show --query id -o tsv)
     ```
 
-2.  Clone the `image-builder` project:
-
-    ```
-    git clone https://github.com/kubernetes-sigs/image-builder.git image-builder
-    cd image-builder/images/capi
-    ```
-
-3.  Update `packer.json` with network configuration by inserting these new values into `builders[0]`:
-
-    ```
-    "network": "{{ user `network` }}",
-    "subnetwork": "{{ user `subnetwork`  }}",
-    ```
-
-4.  Update packer template to support a non-default network:
-
-    ```
-    cat <<EOF >packer/gce/ubuntu-2004.json
+    ```sh
     {
-      "build_name": "ubuntu-2004",
-      "distribution_release": "focal",
-      "distribution_version": "2004",
-      "zone": "${GCP_REGION}-b",
-      "network": "${CLUSTER_NAME}",
-      "subnetwork": "${CLUSTER_NAME}"
+      "appId": "7654321a-1a23-567b-b789-0987b6543a21",
+      "displayName": "gcp-cli-2021-03-09-23-17-06",
+      "password": "Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C",
+      "tenant": "a1234567-b132-1234-1a11-1234a5678b90"
     }
-    EOF
     ```
 
-5.  Use `image-builder` to build an image:
+1.  Set the required environment variables:
+<!NEED CONFIRMATION OF STEPS PRE-RELEASE>
 
-    ```
-    make build-gce-ubuntu-2004
-    ```
-
-6.  Save the created image name:
-
-    ```
-    export IMAGE_NAME=<>
+    ```bash
+    export GCP_SUBSCRIPTION_ID="<id>"         # b1234567-abcd-11a1-a0a0-1234a5678b90
+    export GCP_TENANT_ID="<tenant>"           # a1234567-b132-1234-1a11-1234a5678b90
+    export GCP_CLIENT_ID="<appId>"            # 7654321a-1a23-567b-b789-0987b6543a21
+    export GCP_CLIENT_SECRET="<password>"     # Z79yVstq_E.R0R7RUUck718vEHSuyhAB0C
     ```
 
-## Create a cluster
-
-If you use these instructions to create a cluster on GCP using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an Ubuntu 20.04 operating system image with 3 control plane nodes, and 4 worker nodes.
-
-The following instructions come from [Kubernetes CAPI Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html).
-
-For a quick start, you will do the following in order.
- - create a bootstrap cluster
-- move the CAPI controllers from the workload cluster back to the bootstrap cluster
-- delete the workload cluster
-- delete the bootstrap cluster
-
-1.  Create a bootstrap cluster:
-
-    ```
-    kind create cluster
+1.  Base64 encode the same environment variables:
+<!NEED CONFIRMATION OF STEPS PRE-RELEASE>
+    ```bash
+    export GCP_SUBSCRIPTION_ID_B64="$(echo -n "${GCP_SUBSCRIPTION_ID}" | base64 | tr -d '\n')"
+    export GCP_TENANT_ID_B64="$(echo -n "${GCP_TENANT_ID}" | base64 | tr -d '\n')"
+    export GCP_CLIENT_ID_B64="$(echo -n "${GCP_CLIENT_ID}" | base64 | tr -d '\n')"
+    export GCP_CLIENT_SECRET_B64="$(echo -n "${GCP_CLIENT_SECRET}" | base64 | tr -d '\n')"
     ```
 
-1.  Initialize the CAPG controller:
+## Create a new GCP Kubernetes cluster
 
-    ```
-    GCP_B64ENCODED_CREDENTIALS=$( cat $GOOGLE_APPLICATION_CREDENTIALS | base64 | tr -d '\n' ) clusterctl init --infrastructure gcp
-    ```
+If you use these instructions to create a cluster on GCP using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
 
-2.  Export infrastructure variables:
+<p class="message--note"><strong>NOTE: </strong>
+The default GCP image is not recommended for use in production. We suggest using <a href="../../../image-builder/create-GCP-image">Konvoy Image Builder to create a custom image</a> to take advantage of enhanced cluster operations, and to explore the <a href="../advanced">advanced GCP installation</a> topics for more options. Previously, DKP 2.1 used a CentOS 7 image, but DKP 2.2 and above now use Ubuntu 20.04.
+</p>
 
-    ```
-    export KUBERNETES_VERSION=1.21.10
-    export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2
-    export GCP_NODE_MACHINE_TYPE=n1-standard-2
-    export IMAGE_ID=projects/${GCP_PROJECT}/global/images/${IMAGE_NAME}
-    export SERVICE_ACCOUNT_EMAIL=$(cat $GOOGLE_APPLICATION_CREDENTIALS | jq -r .client_email)
+1.  Give your cluster a name suitable for your environment:
+<!NEED CONFIRMATION OF STEPS PRE-RELEASE>
+    ```bash
+    export CLUSTER_NAME=gcp-example
     ```
 
-3.  Create kuztomize override file to set `ServiceAccount`:
+1.  Create a Kubernetes cluster:
 
-    ```
-    mkdir -p $CLUSTER_NAME
-
-    cat <<EOF >$CLUSTER_NAME/kustomization.yaml
-    apiVersion: kustomize.config.k8s.io/v1beta1
-    kind: Kustomization
-    metadata:
-      name: cluster-kustomize
-    bases:
-    - cluster.yaml
-    patchesStrategicMerge:
-    - sa.yaml
-    EOF
-
-    cat <<EOF >$CLUSTER_NAME/sa.yaml
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: GCPMachineTemplate
-    metadata:
-      name: $CLUSTER_NAME-control-plane
-      namespace: default
-    spec:
-      template:
-        spec:
-          serviceAccounts:
-            email: ${SERVICE_ACCOUNT_EMAIL}
-            scopes:
-              - https://www.googleapis.com/auth/cloud-platform            
-    ---
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: GCPMachineTemplate
-    metadata:
-      name: $CLUSTER_NAME-md-0
-      namespace: default
-    spec:
-      template:
-        spec:
-          serviceAccounts:
-            email: ${SERVICE_ACCOUNT_EMAIL}
-            scopes:
-              - https://www.googleapis.com/auth/cloud-platform
-    EOF
+    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub's rate limit</a> use your Docker Hub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
+<!NEED CONFIRMATION OF STEPS PRE-RELEASE>
+    ```bash
+    dkp create cluster gcp \
+    --cluster-name=${CLUSTER_NAME} \
+    --additional-tags=owner=$(whoami) \
+    --self-managed
     ```
 
-4.  Create the cluster file:
+    You will see output similar to the following:
 
-    ```
-    clusterctl generate cluster $CLUSTER_NAME \
-    --kubernetes-version $KUBERNETES_VERSION \
-    --control-plane-machine-count=3 \
-    --worker-machine-count=4 \
-    > $CLUSTER_NAME/cluster.yaml
-    ```
-
-5.  Add the `ServiceAccount` customization:
-
-    ```
-    kustomize build --reorder=none $CLUSTER_NAME -o $CLUSTER_NAME/cluster.yaml
-    ```
-
-6.  Create the cluster:
-
-    ```
-    kubectl apply -f $CLUSTER_NAME/cluster.yaml
-    ```
-
-
-7.  Tail the CAPG controller logs:
-
-    ```
-    kubectl logs -n capg-system -l cluster.x-k8s.io/provider=infrastructure-gcp -f
+    ```sh
+    Generating cluster resources
+    cluster.cluster.x-k8s.io/gcp-example created
+    gcpcluster.infrastructure.cluster.x-k8s.io/gcp-example created
+    kubeadmcontrolplane.controlplane.cluster.x-k8s.io/gcp-example-control-plane created
+    gcpmachinetemplate.infrastructure.cluster.x-k8s.io/gcp-example-control-plane created
+    secret/gcp-example-etcd-encryption-config created
+    machinedeployment.cluster.x-k8s.io/gcp-example-md-0 created
+    gcpmachinetemplate.infrastructure.cluster.x-k8s.io/gcp-example-md-0 created
+    kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/gcp-example-md-0 created
+    clusterresourceset.addons.cluster.x-k8s.io/calico-cni-installation-gcp-example created
+    configmap/calico-cni-installation-gcp-example created
+    configmap/tigera-operator-gcp-example created
+    clusterresourceset.addons.cluster.x-k8s.io/gcp-disk-csi-gcp-example created
+    configmap/gcp-disk-csi-gcp-example created
+    clusterresourceset.addons.cluster.x-k8s.io/cluster-autoscaler-gcp-example created
+    configmap/cluster-autoscaler-gcp-example created
+    clusterresourceset.addons.cluster.x-k8s.io/node-feature-discovery-gcp-example created
+    configmap/node-feature-discovery-gcp-example created
+    clusterresourceset.addons.cluster.x-k8s.io/nvidia-feature-discovery-gcp-example created
+    configmap/nvidia-feature-discovery-gcp-example created
     ```
 
-8.  Check the status of the cluster
-
-    ```
-    clusterctl describe cluster $CLUSTER_NAME
-    ```
+    As part of the underlying processing, the DKP CLI:
+    - creates a bootstrap cluster
+    - creates a workload cluster
+    - moves CAPI controllers from the bootstrap cluster to the workload cluster, making it self-managed
+    - deletes the bootstrap cluster
 
 ## Explore the new Kubernetes cluster
 
-1.  Get the kubeconfig:
+The kubeconfig file is written to your local directory and you can now explore the cluster.
 
-    ```
-    clusterctl get kubeconfig $CLUSTER_NAME > $CLUSTER_NAME/$CLUSTER_NAME.conf
-    export KUBECONFIG=$CLUSTER_NAME/$CLUSTER_NAME.conf
-    ```
+1.  List the Nodes with the command:
 
-1.  Verify the API server is up (the Nodes will not be ready until CSI is deployed):
-
-    ```
-    kubectl get nodes
+    ```bash
+    kubectl --kubeconfig=${CLUSTER_NAME}.conf get nodes
     ```
 
+    You will see output similar to:
 
-## Deploy Addons
-
-1.  Deploy Calico CNI:
-
-    ```
-    kubectl apply -f https://docs.projectcalico.org/v3.22/manifests/calico.yaml
-    ```
-
-1.  Deploy GCP CSI:
-
-    ```
-    export CSI_DRIVER_DIR=$(go env GOPATH)/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
-    mkdir -p $CSI_DRIVER_DIR
-    git clone github.com:kubernetes-sigs/gcp-compute-persistent-disk-csi-driver.git $CSI_DRIVER_DIR
-
-    GOPATH=$(go env GOPATH) GCE_PD_DRIVER_VERSION=noauth $CSI_DRIVER_DIR/deploy/kubernetes/deploy-driver.sh
-    ```
-    
-1.  Create a StorageClass:
-
-    ```
-    kubectl apply -f $CSI_DRIVER_DIR/examples/kubernetes/demo-zonal-sc.yaml
+    ```sh
+    NAME                                 STATUS   ROLES                  AGE     VERSION
+    gcp-example-control-plane-84htt    Ready    control-plane,master   8m11s   v1.22.7
+    gcp-example-control-plane-r8srg    Ready    control-plane,master   4m17s   v1.22.7
+    gcp-example-control-plane-wrdql    Ready    control-plane,master   6m15s   v1.22.7
+    gcp-example-md-0-9crp9             Ready    <none>                 6m47s   v1.22.7
+    gcp-example-md-0-dvx5d             Ready    <none>                 6m42s   v1.22.7
+    gcp-example-md-0-gc9mx             Ready    <none>                 5m27s   v1.22.7
+    gcp-example-md-0-tkqf7             Ready    <none>                 4m48s   v1.22.7
     ```
 
-1.  Test CIS by creating a pod with a PVC:
+1.  List the Pods with the command:
 
+    ```bash
+    kubectl --kubeconfig=${CLUSTER_NAME}.conf get pods -A
     ```
-    kubectl apply -f $CSI_DRIVER_DIR/examples/kubernetes/demo-pod.yaml
+
+    You will see output similar to:
+
+    ```sh
+    NAMESPACE                           NAME                                                                 READY   STATUS    RESTARTS   AGE
+    calico-system                       calico-typha-665d976df-rf7jg                                         1/1     Running   0          60m
+    capa-system                         capa-controller-manager-697b7df888-vhcbj                             2/2     Running   0          57m
+    capi-kubeadm-bootstrap-system       capi-kubeadm-bootstrap-controller-manager-67d8fc9688-5p65s           1/1     Running   0          57m
+    capi-kubeadm-control-plane-system   capi-kubeadm-control-plane-controller-manager-846ff8b565-jqmhd       1/1     Running   0          57m
+    capi-system                         capi-controller-manager-865fddc84c-9g7bb                             1/1     Running   0          57m
+    cappp-system                        cappp-controller-manager-7859fbbb7f-xjh6k                            1/1     Running   0          56m
+    ...
     ```
 
 ## Delete the Kubernetes cluster and cleanup your environment
-????????????
-If you no longer need the cluster and want to delete it, you can do so using the DKP CLI.
 
-1.  Update the GCP bootstrap credentials:
-
-    ```bash
-    dkp update bootstrap credentials gcp --kubeconfig=${CLUSTER_NAME}.conf
-    ```
-
-1.  Delete the provisioned Kubernetes cluster:
-
+1.  Delete the provisioned Kubernetes cluster and wait a few minutes:
+<!NEED CONFIRMATION OF STEPS PRE-RELEASE>
     ```bash
     dkp delete cluster \
     --cluster-name=${CLUSTER_NAME} \
@@ -305,16 +194,17 @@ If you no longer need the cluster and want to delete it, you can do so using the
     --self-managed
     ```
 
-    You will see output similar to:
-
     ```sh
-	 ✓ Creating a bootstrap cluster
-	 ✓ Initializing new CAPI components
-	 ✓ Moving cluster resources
-	You can now view resources in the moved cluster by using the --kubeconfig flag with kubectl. For example: kubectl --kubeconfig=gcp-example-bootstrap.conf get nodes
+    ✓ Deleting Services with type LoadBalancer for Cluster default/gcp-example
+    ✓ Deleting ClusterResourceSets for Cluster default/gcp-example
+    ✓ Deleting cluster resources
+    ✓ Waiting for cluster to be fully deleted
+    Deleted default/gcp-example cluster
+    ```
 
-    Similar to `create cluster`, use the flag `--self-managed` with the `delete cluster`command:
-
-
-
-To understand how this process works step by step, you can follow the workflow in [Delete Cluster](../advanced/delete).
+[gcp_cli]: https://github.com/kubernetes-sigs/cluster-api-provider-gcp
+blob/master/docs/book/src/topics/getting-started.md#prerequisites
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[supported-systems]: ../../../supported-operating-systems
+[gcp_credentials]:https://github.com/kubernetes-sigs/cluster-api-provider-gcp

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/gcp/quick-start-gcp/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/gcp/quick-start-gcp/index.md
@@ -32,15 +32,7 @@ Before starting the Konvoy installation, verify that you have:
     [
       {
         "cloudName": "GCPCloud",
-        "homeTenantId": "a1234567-b132-1234-1a11-1234a5678b90",
-        "id": "b1234567-abcd-11a1-a0a0-1234a5678b90",
-        "isDefault": true,
-        "managedByTenants": [],
-        "name": "Mesosphere Developer Subscription",
-        "state": "Enabled",
-        "tenantId": "a1234567-b132-1234-1a11-1234a5678b90",
-        "user": {
-          "name": "user@gcpmesosphere.onmicrosoft.com",
+        
           "type": "user"
         }
       }


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-88471

## Description of changes being made
My mistake.. found out that Dimitri's notes from Jira https://jira.d2iq.com/browse/D2IQ-88531 were about backend setup for GCP and not customer facing.  He said to make it look like the rest of the Quick Start guides for other providers.  Confirmation of newly coded CLI will come in Sprint 12 so I can update where tags are in code !NEED CONFIRMATION OF STEPS PRE-RELEASE
### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4515.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
