### PR TITLE
Change Docker CLI for Registry mirror

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
@@ -82,7 +82,7 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
     --subnet-ids=${AWS_SUBNET_IDS} \
     --internal-load-balancer=true \
     --additional-security-group-ids=${AWS_ADDITIONAL_SECURITY_GROUPS} \
-    --registry-mirror-url=${DOCKER_REGISTRY_ADDRESS} \
+    --registry-mirror-url=${DOCKER_REGISTRY_URL} \
     --registry-mirror-cacert=${DOCKER_REGISTRY_CA} \
     --registry-mirror-username=${DOCKER_REGISTRY_USERNAME} \
     --registry-mirror-password=${DOCKER_REGISTRY_PASSWORD}

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/new/index.md
@@ -62,13 +62,13 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
     <p class="message--important"><strong>IMPORTANT: </strong>The AMI must be created by the <a href="https://github.com/mesosphere/konvoy-image-builder">konvoy-image-builder</a> project in order to use the registry mirror feature.</p>
 
     ```bash
-    export DOCKER_REGISTRY_ADDRESS=<https/http>://<registry-address>:<registry-port>
+    export DOCKER_REGISTRY_URL=<https/http>://<registry-address>:<registry-port>
     export DOCKER_REGISTRY_CA=<path to the CA on the bastion>
     export DOCKER_REGISTRY_USERNAME=<username>
     export DOCKER_REGISTRY_PASSWORD=<password>
     ```
 
-    - `DOCKER_REGISTRY_ADDRESS`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
+    - `DOCKER_REGISTRY_URL`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
     - `DOCKER_REGISTRY_CA`: (optional) the path on the bastion machine to the Docker registry CA. Konvoy will configure the cluster nodes to trust this CA. This value is only needed if the registry is using a self-signed certificate and the AMIs are not already configured to trust this CA.
     - `DOCKER_REGISTRY_USERNAME`: optional, set to a user that has pull access to this registry.
     - `DOCKER_REGISTRY_PASSWORD`: optional if username is not set.
@@ -118,7 +118,7 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
     --subnet-ids=${AWS_SUBNET_IDS} \
     --internal-load-balancer=true \
     --additional-security-group-ids=${AWS_ADDITIONAL_SECURITY_GROUPS} \
-    --registry-mirror-url=${DOCKER_REGISTRY_ADDRESS} \
+    --registry-mirror-url=${DOCKER_REGISTRY_URL} \
     --registry-mirror-cacert=${DOCKER_REGISTRY_CA} \
     --registry-mirror-username=${DOCKER_REGISTRY_USERNAME} \
     --registry-mirror-password=${DOCKER_REGISTRY_PASSWORD}

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -77,7 +77,7 @@ enterprise: false
     dkp create cluster preprovisioned --cluster-name ${CLUSTER_NAME} \
     --control-plane-endpoint-host <control plane endpoint host> \
     --control-plane-endpoint-port <control plane endpoint port, if different than 6443> \
-    --registry-mirror-url=${DOCKER_REGISTRY_ADDRESS} \
+    --registry-mirror-url=${DOCKER_REGISTRY_URL} \
     --registry-mirror-cacert=${DOCKER_REGISTRY_CA} \
     --registry-mirror-username=${DOCKER_REGISTRY_USERNAME} \
     --registry-mirror-password=${DOCKER_REGISTRY_PASSWORD}

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -62,13 +62,13 @@ enterprise: false
     <p class="message--note"><strong>NOTE: </strong>If your cluster is air-gapped or you have a local docker registry you must provide additional arguments when creating the cluster.</p>
 
     ```bash
-    export DOCKER_REGISTRY_ADDRESS="<https/http>://<registry-address>:<registry-port>"
+    export DOCKER_REGISTRY_URL="<https/http>://<registry-address>:<registry-port>"
     export DOCKER_REGISTRY_CA="<path to the CA on the bastion>"
     export DOCKER_REGISTRY_USERNAME="<username>"
     export DOCKER_REGISTRY_USERNAME="<password>"
     ```
 
-    - `DOCKER_REGISTRY_ADDRESS`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
+    - `DOCKER_REGISTRY_URL`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
     - `DOCKER_REGISTRY_CA`: (optional) the path on the bastion machine to the Docker registry CA. Konvoy will configure the cluster nodes to trust this CA. This value is only needed if the registry is using a self-signed certificate and the AMIs are not already configured to trust this CA.
     - `DOCKER_REGISTRY_USERNAME`: optional, set to a user that has pull access to this registry.
     - `DOCKER_REGISTRY_PASSWORD`: optional if username is not set.

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
@@ -82,7 +82,7 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
     --subnet-ids=${AWS_SUBNET_IDS} \
     --internal-load-balancer=true \
     --additional-security-group-ids=${AWS_ADDITIONAL_SECURITY_GROUPS} \
-    --registry-mirror-url=${DOCKER_REGISTRY_ADDRESS} \
+    --registry-mirror-url=${DOCKER_REGISTRY_URL} \
     --registry-mirror-cacert=${DOCKER_REGISTRY_CA} \
     --registry-mirror-username=${DOCKER_REGISTRY_USERNAME} \
     --registry-mirror-password=${DOCKER_REGISTRY_PASSWORD}

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/new/index.md
@@ -62,13 +62,13 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
     <p class="message--important"><strong>IMPORTANT: </strong>The AMI must be created by the <a href="https://github.com/mesosphere/konvoy-image-builder">konvoy-image-builder</a> project in order to use the registry mirror feature.</p>
 
     ```bash
-    export DOCKER_REGISTRY_ADDRESS=<https/http>://<registry-address>:<registry-port>
+    export DOCKER_REGISTRY_URL=<https/http>://<registry-address>:<registry-port>
     export DOCKER_REGISTRY_CA=<path to the CA on the bastion>
     export DOCKER_REGISTRY_USERNAME=<username>
     export DOCKER_REGISTRY_PASSWORD=<password>
     ```
 
-    - `DOCKER_REGISTRY_ADDRESS`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
+    - `DOCKER_REGISTRY_URL`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
     - `DOCKER_REGISTRY_CA`: (optional) the path on the bastion machine to the Docker registry CA. Konvoy will configure the cluster nodes to trust this CA. This value is only needed if the registry is using a self-signed certificate and the AMIs are not already configured to trust this CA.
     - `DOCKER_REGISTRY_USERNAME`: optional, set to a user that has pull access to this registry.
     - `DOCKER_REGISTRY_PASSWORD`: optional if username is not set.
@@ -118,7 +118,7 @@ When you use existing infrastructure, DKP does _not_ create, modify, or delete t
     --subnet-ids=${AWS_SUBNET_IDS} \
     --internal-load-balancer=true \
     --additional-security-group-ids=${AWS_ADDITIONAL_SECURITY_GROUPS} \
-    --registry-mirror-url=${DOCKER_REGISTRY_ADDRESS} \
+    --registry-mirror-url=${DOCKER_REGISTRY_URL} \
     --registry-mirror-cacert=${DOCKER_REGISTRY_CA} \
     --registry-mirror-username=${DOCKER_REGISTRY_USERNAME} \
     --registry-mirror-password=${DOCKER_REGISTRY_PASSWORD}

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -77,7 +77,7 @@ enterprise: false
     dkp create cluster preprovisioned --cluster-name ${CLUSTER_NAME} \
     --control-plane-endpoint-host <control plane endpoint host> \
     --control-plane-endpoint-port <control plane endpoint port, if different than 6443> \
-    --registry-mirror-url=${DOCKER_REGISTRY_ADDRESS} \
+    --registry-mirror-url=${DOCKER_REGISTRY_URL} \
     --registry-mirror-cacert=${DOCKER_REGISTRY_CA} \
     --registry-mirror-username=${DOCKER_REGISTRY_USERNAME} \
     --registry-mirror-password=${DOCKER_REGISTRY_PASSWORD}

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -62,13 +62,13 @@ enterprise: false
     <p class="message--note"><strong>NOTE: </strong>If your cluster is air-gapped or you have a local docker registry you must provide additional arguments when creating the cluster.</p>
 
     ```bash
-    export DOCKER_REGISTRY_ADDRESS="<https/http>://<registry-address>:<registry-port>"
+    export DOCKER_REGISTRY_URL="<https/http>://<registry-address>:<registry-port>"
     export DOCKER_REGISTRY_CA="<path to the CA on the bastion>"
     export DOCKER_REGISTRY_USERNAME="<username>"
     export DOCKER_REGISTRY_USERNAME="<password>"
     ```
 
-    - `DOCKER_REGISTRY_ADDRESS`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
+    - `DOCKER_REGISTRY_URL`: the address of an existing Docker registry accessible in the VPC that the new cluster nodes will be configured to use a mirror registry when pulling images.
     - `DOCKER_REGISTRY_CA`: (optional) the path on the bastion machine to the Docker registry CA. Konvoy will configure the cluster nodes to trust this CA. This value is only needed if the registry is using a self-signed certificate and the AMIs are not already configured to trust this CA.
     - `DOCKER_REGISTRY_USERNAME`: optional, set to a user that has pull access to this registry.
     - `DOCKER_REGISTRY_PASSWORD`: optional if username is not set.


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->
https://jira.d2iq.com/browse/D2IQ-89796


## Description of changes being made
variable pointing to --registry-mirror-url. 

Change this variable from  DOCKER_REGISTRY_ADDRESS to DOCKER_REGISTRY_URL (this is variable pointing to --registry-mirror-url which requires an https URL)
### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4517.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
