### PR TITLE
Worker node req Essential vs Enterpr

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -29,6 +29,8 @@ Each control plane node should have at least:
 - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+DKP on AWS defaults to deploying an `m5.xlarge` instance with an 80GiB root volume for control plane nodes, which meets the above requirements.
+
 ## Worker nodes
 
 You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,7 +19,38 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</p>
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
+## Control plane nodes
+
+You should have at least three control plane nodes.
+Each control plane node should have at least:
+
+- 4 cores
+- 16 GiB memory
+- Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+## Worker nodes
+
+You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
+Each worker node should have at least:
+
+- 8 cores
+- 32 GiB memory
+- Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.  DKP creates the nodes size by default unless otherwise specified with a flag.
+
+    Control plane:
+    * instanceType: m5.xlarge
+    * rootVolume: 
+    * size: 80
+
+    Worker node:
+    * instanceType: m5.2xlarge
+    * rootVolume:
+    * size: 80
+
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -41,15 +41,15 @@ Each worker node should have at least:
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
-In particular, it will use the following Amazon Instance Types:
+In particular, it will use the Amazon Instance Types listed below:
 
    Control plane:
-    - instanceType: m5.xlarge
-    - Root volume size:  80GB
+    -  instanceType: m5.xlarge
+    -  Root volume size:  80GB
 
    Worker node:
-    - instanceType: m5.2xlarge
-    - Root volume size:  80GB
+    -  instanceType: m5.2xlarge
+    -  Root volume size:  80GB
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -48,8 +48,7 @@ If you use these instructions to create a cluster on AWS using the DKP default s
 
    Worker node:
     * instanceType: m5.2xlarge
-    * rootVolume:
-    * size: 80
+    * Root volume size:  80GB
 
 
 <p class="message--note"><strong>NOTE: </strong>

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -41,7 +41,7 @@ Each worker node should have at least:
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
-In particular, it will use the Amazon Instance Types listed below:
+In particular, DKP will use the Amazon Instance Types listed below:
 
 Control plane:
 -  instanceType: m5.xlarge

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -43,15 +43,13 @@ If you use these instructions to create a cluster on AWS using the DKP default s
 
 In particular, it will use the following Amazon Instance Types:
 
-
    Control plane:
-    * instanceType: m5.xlarge
-    * Root volume size:  80GB
+    - instanceType: m5.xlarge
+    - Root volume size:  80GB
 
    Worker node:
-    * instanceType: m5.2xlarge
-    * Root volume size:  80GB
-
+    - instanceType: m5.2xlarge
+    - Root volume size:  80GB
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -41,12 +41,13 @@ Each worker node should have at least:
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.  DKP creates the nodes size by default unless otherwise specified with a flag.
 
-    Control plane:
+
+   Control plane:
     * instanceType: m5.xlarge
     * rootVolume: 
     * size: 80
 
-    Worker node:
+   Worker node:
     * instanceType: m5.2xlarge
     * rootVolume:
     * size: 80

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -41,6 +41,8 @@ Each worker node should have at least:
 - Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+DKP on AWS defaults to deploying a`m5.2xlarge` instance with an 80GiB root volume for worker nodes, which meets the above requirements.
+
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
 In particular, DKP will use the Amazon Instance Types listed below:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -43,13 +43,13 @@ If you use these instructions to create a cluster on AWS using the DKP default s
 
 In particular, it will use the Amazon Instance Types listed below:
 
-   Control plane:
-    -  instanceType: m5.xlarge
-    -  Root volume size:  80GB
+Control plane:
+-  instanceType: m5.xlarge
+-  Root volume size:  80GB
 
-   Worker node:
-    -  instanceType: m5.2xlarge
-    -  Root volume size:  80GB
+Worker node:
+-  instanceType: m5.2xlarge
+-  Root volume size:  80GB
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -44,8 +44,7 @@ If you use these instructions to create a cluster on AWS using the DKP default s
 
    Control plane:
     * instanceType: m5.xlarge
-    * rootVolume: 
-    * size: 80
+    * Root volume size:  80GB
 
    Worker node:
     * instanceType: m5.2xlarge

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,7 +19,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</p>
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
@@ -43,6 +43,8 @@ Before you begin using Konvoy with AWS, you must:
     ```bash
     export AWS_PROFILE=<profile>
     ```
+
+
 
 [aws_credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 [iampolicies]: ../../iam-policies

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -39,7 +39,9 @@ Each worker node should have at least:
 - Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.  DKP creates the nodes size by default unless otherwise specified with a flag.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
+
+In particular, it will use the following Amazon Instance Types:
 
 
    Control plane:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -45,16 +45,6 @@ DKP on AWS defaults to deploying a`m5.2xlarge` instance with an 80GiB root volum
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
-In particular, DKP will use the Amazon Instance Types listed below:
-
-Control plane:
--  instanceType: m5.xlarge
--  Root volume size:  80GB
-
-Worker node:
--  instanceType: m5.2xlarge
--  Root volume size:  80GB
-
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.
 We suggest using <a href="../../../../image-builder/create-ami/">Konvoy Image Builder to create a custom AMI</a> to take advantage of enhanced cluster operations.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -45,16 +45,16 @@ If you use these instructions to create a cluster on Azure using the DKP default
 In particular without flags specified, it will use the Azure defaults listed below:
 
 Control plane:
--  dataDisks:
+dataDisks:
 -    diskSizeGB: 80
 -    nameSuffix: etcddisk
--  osDisk:
+osDisk:
 -    diskSizeGB: 128
 -    managedDisk storageAccountType: Premium_LRS
 -    vmSize: Standard_D4s_v3
 
 Worker node:
--  osDisk:
+osDisk:
 -    diskSizeGB: 80
 -    managedDisk storageAccountType: Premium_LRS
 -    vmSize: Standard_D8s_v3

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -20,7 +20,45 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
+## Control plane nodes
+
+You should have at least three control plane nodes.
+Each control plane node should have at least:
+
+- 4 cores
+- 16 GiB memory
+- Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+## Worker nodes
+
+You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
+Each worker node should have at least:
+
+- 8 cores
+- 32 GiB memory
+- Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
+
+In particular without flags specified, it will use the Azure defaults listed below:
+
+Control plane:
+-  dataDisks:
+    diskSizeGB: 80
+    nameSuffix: etcddisk
+   osDisk:
+    diskSizeGB: 128
+    managedDisk storageAccountType: Premium_LRS
+   vmSize: Standard_D4s_v3
+
+Worker node:
+-  osDisk:
+    diskSizeGB: 80
+    managedDisk storageAccountType: Premium_LRS
+   vmSize: Standard_D8s_v3
+
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -46,18 +46,18 @@ In particular without flags specified, it will use the Azure defaults listed bel
 
 Control plane:
 -  dataDisks:
-*    diskSizeGB: 80
-*    nameSuffix: etcddisk
+-    diskSizeGB: 80
+-    nameSuffix: etcddisk
 -  osDisk:
-*    diskSizeGB: 128
-*    managedDisk storageAccountType: Premium_LRS
-*    vmSize: Standard_D4s_v3
+-    diskSizeGB: 128
+-    managedDisk storageAccountType: Premium_LRS
+-    vmSize: Standard_D4s_v3
 
 Worker node:
 -  osDisk:
-*    diskSizeGB: 80
-*    managedDisk storageAccountType: Premium_LRS
-*    vmSize: Standard_D8s_v3
+-    diskSizeGB: 80
+-    managedDisk storageAccountType: Premium_LRS
+-    vmSize: Standard_D8s_v3
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -48,7 +48,7 @@ Control plane:
 -  dataDisks:
     diskSizeGB: 80
     nameSuffix: etcddisk
-   osDisk:
+-  osDisk:
     diskSizeGB: 128
     managedDisk storageAccountType: Premium_LRS
    vmSize: Standard_D4s_v3

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -45,6 +45,7 @@ If you use these instructions to create a cluster on Azure using the DKP default
 In particular without flags specified, it will use the Azure defaults listed below:
 
 Control plane:
+
 dataDisks:
 -    diskSizeGB: 80
 -    nameSuffix: etcddisk
@@ -54,6 +55,7 @@ osDisk:
 -    vmSize: Standard_D4s_v3
 
 Worker node:
+
 osDisk:
 -    diskSizeGB: 80
 -    managedDisk storageAccountType: Premium_LRS

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -43,20 +43,21 @@ Each worker node should have at least:
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
 In particular without flags specified, it will use the Azure defaults listed below:
+
 Control plane:
 -  dataDisks:
--    diskSizeGB: 80
--    nameSuffix: etcddisk
+*    diskSizeGB: 80
+*    nameSuffix: etcddisk
 -  osDisk:
--    diskSizeGB: 128
--    managedDisk storageAccountType: Premium_LRS
--    vmSize: Standard_D4s_v3
+*    diskSizeGB: 128
+*    managedDisk storageAccountType: Premium_LRS
+*    vmSize: Standard_D4s_v3
 
 Worker node:
 -  osDisk:
--    diskSizeGB: 80
--    managedDisk storageAccountType: Premium_LRS
--    vmSize: Standard_D8s_v3
+*    diskSizeGB: 80
+*    managedDisk storageAccountType: Premium_LRS
+*    vmSize: Standard_D8s_v3
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -47,26 +47,6 @@ DKP on Azure defaults to deploying a `Standard_D8s_v3` virtual machine with an 8
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
-In particular without flags specified, DKP will use the Azure defaults listed below:
-
-- Control plane:
-
-  -    dataDisks:
-       -    diskSizeGB: 80
-       -    nameSuffix: etcddisk
-
-  -    osDisk:
-       -    diskSizeGB: 128
-       -    managedDisk storageAccountType: Premium_LRS
-       -    vmSize: Standard_D4s_v3
-
-- Worker node:
-
-  -    osDisk:
-       -    diskSizeGB: 80
-       -    managedDisk storageAccountType: Premium_LRS
-       -    vmSize: Standard_D8s_v3
-
 ## Azure prerequisites
 
 Before you begin using Konvoy with Azure, you must:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -43,6 +43,8 @@ Each worker node should have at least:
 - Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+DKP on Azure defaults to deploying a `Standard_D8s_v3` virtual machine with an 80 GiB volume for the OS, which meets the above requirements.
+
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
 In particular without flags specified, DKP will use the Azure defaults listed below:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -44,23 +44,23 @@ If you use these instructions to create a cluster on Azure using the DKP default
 
 In particular without flags specified, it will use the Azure defaults listed below:
 
-Control plane:
+- Control plane:
 
-dataDisks:
--    diskSizeGB: 80
--    nameSuffix: etcddisk
+  -    dataDisks:
+       -    diskSizeGB: 80
+       -    nameSuffix: etcddisk
 
-osDisk:
--    diskSizeGB: 128
--    managedDisk storageAccountType: Premium_LRS
--    vmSize: Standard_D4s_v3
+  -    osDisk:
+       -    diskSizeGB: 128
+       -    managedDisk storageAccountType: Premium_LRS
+       -    vmSize: Standard_D4s_v3
 
-Worker node:
+- Worker node:
 
-osDisk:
--    diskSizeGB: 80
--    managedDisk storageAccountType: Premium_LRS
--    vmSize: Standard_D8s_v3
+  -    osDisk:
+       -    diskSizeGB: 80
+       -    managedDisk storageAccountType: Premium_LRS
+       -    vmSize: Standard_D8s_v3
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -20,7 +20,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -42,7 +42,7 @@ Each worker node should have at least:
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
-In particular without flags specified, it will use the Azure defaults listed below:
+In particular without flags specified, DKP will use the Azure defaults listed below:
 
 - Control plane:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -43,22 +43,20 @@ Each worker node should have at least:
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
 In particular without flags specified, it will use the Azure defaults listed below:
-
 Control plane:
 -  dataDisks:
-    diskSizeGB: 80
-    nameSuffix: etcddisk
+-    diskSizeGB: 80
+-    nameSuffix: etcddisk
 -  osDisk:
-    diskSizeGB: 128
-    managedDisk storageAccountType: Premium_LRS
-   vmSize: Standard_D4s_v3
+-    diskSizeGB: 128
+-    managedDisk storageAccountType: Premium_LRS
+-    vmSize: Standard_D4s_v3
 
 Worker node:
 -  osDisk:
-    diskSizeGB: 80
-    managedDisk storageAccountType: Premium_LRS
-   vmSize: Standard_D8s_v3
-
+-    diskSizeGB: 80
+-    managedDisk storageAccountType: Premium_LRS
+-    vmSize: Standard_D8s_v3
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -49,6 +49,7 @@ Control plane:
 dataDisks:
 -    diskSizeGB: 80
 -    nameSuffix: etcddisk
+
 osDisk:
 -    diskSizeGB: 128
 -    managedDisk storageAccountType: Premium_LRS

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -30,6 +30,9 @@ Each control plane node should have at least:
 - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+
+DKP on Azure defaults to deploying a `Standard_D4s_v3` virtual machine with an 128 GiB volume for the OS and an 80GiB volume for etcd storage, which meets the above requirements.
+
 ## Worker nodes
 
 You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -30,7 +30,6 @@ Each control plane node should have at least:
 - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
-
 DKP on Azure defaults to deploying a `Standard_D4s_v3` virtual machine with an 128 GiB volume for the OS and an 80GiB volume for etcd storage, which meets the above requirements.
 
 ## Worker nodes

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/replace-node/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/replace-node/index.md
@@ -16,7 +16,7 @@ Before you begin, you must:
 
 ## Replace a worker node
 
-In certain situations, you may want to delete a worker node and have [Cluster API][capi_book] replace it with a newly provisioned machine. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
+In certain situations, you may want to delete a worker node and have [Cluster API][capi_book] replace it with a newly provisioned machine. 
 
 1.  Identify the name of the node to delete.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/replace-node/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/azure/advanced/replace-node/index.md
@@ -16,7 +16,7 @@ Before you begin, you must:
 
 ## Replace a worker node
 
-In certain situations, you may want to delete a worker node and have [Cluster API][capi_book] replace it with a newly provisioned machine.
+In certain situations, you may want to delete a worker node and have [Cluster API][capi_book] replace it with a newly provisioned machine. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
 
 1.  Identify the name of the node to delete.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -33,7 +33,7 @@ Each control plane node should have at least:
 
 ## Worker nodes
 
-You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
+For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.  (See below for minimal suggested requirements)
 
 Each worker node should have at least:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -33,7 +33,7 @@ Each control plane node should have at least:
 
 ## Worker nodes
 
-For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.  (See below for minimal suggested requirements)
+For Enterprise, the recommendation is at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.  (See below for minimal suggested requirements)
 
 Each worker node should have at least:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites/index.md
@@ -33,7 +33,7 @@ Each control plane node should have at least:
 
 ## Worker nodes
 
-For Enterprise, the recommendation is at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.  (See below for minimal suggested requirements)
+For DKP Enterprise or Essential, the recommendation is at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.  (See below for minimal suggested requirements)
 
 Each worker node should have at least:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,7 +19,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</p>
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -41,7 +41,7 @@ Each worker node should have at least:
 
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
-In particular, it will use the Amazon Instance Types listed below:
+In particular, DKP will use the Amazon Instance Types listed below:
 
 Control plane:
 -  instanceType: m5.xlarge

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -29,6 +29,8 @@ Each control plane node should have at least:
 - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+DKP on AWS defaults to deploying an `m5.xlarge` instance with an 80GiB root volume for control plane nodes, which meets the above requirements.
+
 ## Worker nodes
 
 You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
@@ -39,17 +41,9 @@ Each worker node should have at least:
 - Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+DKP on AWS defaults to deploying a`m5.2xlarge` instance with an 80GiB root volume for worker nodes, which meets the above requirements.
+
 If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
-
-In particular, DKP will use the Amazon Instance Types listed below:
-
-Control plane:
--  instanceType: m5.xlarge
--  Root volume size:  80GB
-
-Worker node:
--  instanceType: m5.2xlarge
--  Root volume size:  80GB
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/advanced/prerequisites/index.md
@@ -19,7 +19,37 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</p>
 
-If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
+## Control plane nodes
+
+You should have at least three control plane nodes.
+Each control plane node should have at least:
+
+- 4 cores
+- 16 GiB memory
+- Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+## Worker nodes
+
+You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
+Each worker node should have at least:
+
+- 8 cores
+- 32 GiB memory
+- Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+If you use these instructions to create a cluster on AWS using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
+
+In particular, it will use the Amazon Instance Types listed below:
+
+Control plane:
+-  instanceType: m5.xlarge
+-  Root volume size:  80GB
+
+Worker node:
+-  instanceType: m5.2xlarge
+-  Root volume size:  80GB
 
 <p class="message--note"><strong>NOTE: </strong>
 Using these default images work, but due to missing optimizations, the created cluster will have certain limits.

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -30,6 +30,8 @@ Each control plane node should have at least:
 - Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+DKP on Azure defaults to deploying a `Standard_D4s_v3` virtual machine with an 128 GiB volume for the OS and an 80GiB volume for etcd storage, which meets the above requirements.
+
 ## Worker nodes
 
 You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
@@ -41,26 +43,6 @@ Each worker node should have at least:
 - Disk usage must be below 85% on the root volume.
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
-
-In particular without flags specified, DKP will use the Azure defaults listed below:
-
-- Control plane:
-
-  -    dataDisks:
-       -    diskSizeGB: 80
-       -    nameSuffix: etcddisk
-
-  -    osDisk:
-       -    diskSizeGB: 128
-       -    managedDisk storageAccountType: Premium_LRS
-       -    vmSize: Standard_D4s_v3
-
-- Worker node:
-
-  -    osDisk:
-       -    diskSizeGB: 80
-       -    managedDisk storageAccountType: Premium_LRS
-       -    vmSize: Standard_D8s_v3
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -42,6 +42,8 @@ Each worker node should have at least:
 - Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
 - Disk usage must be below 85% on the root volume.
 
+DKP on Azure defaults to deploying a `Standard_D8s_v3` virtual machine with an 80 GiB volume for the OS, which meets the above requirements.
+
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
 ## Azure prerequisites

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -44,23 +44,23 @@ If you use these instructions to create a cluster on Azure using the DKP default
 
 In particular without flags specified, it will use the Azure defaults listed below:
 
-Control plane:
+- Control plane:
 
-dataDisks:
--    diskSizeGB: 80
--    nameSuffix: etcddisk
+  -    dataDisks:
+       -    diskSizeGB: 80
+       -    nameSuffix: etcddisk
 
-osDisk:
--    diskSizeGB: 128
--    managedDisk storageAccountType: Premium_LRS
--    vmSize: Standard_D4s_v3
+  -    osDisk:
+       -    diskSizeGB: 128
+       -    managedDisk storageAccountType: Premium_LRS
+       -    vmSize: Standard_D4s_v3
 
-Worker node:
+- Worker node:
 
-osDisk:
--    diskSizeGB: 80
--    managedDisk storageAccountType: Premium_LRS
--    vmSize: Standard_D8s_v3
+  -    osDisk:
+       -    diskSizeGB: 80
+       -    managedDisk storageAccountType: Premium_LRS
+       -    vmSize: Standard_D8s_v3
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -20,7 +20,46 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
+## Control plane nodes
+
+You should have at least three control plane nodes.
+Each control plane node should have at least:
+
+- 4 cores
+- 16 GiB memory
+- Approximately 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+## Worker nodes
+
+You should have at least four worker nodes. The specific number of worker nodes required for your environment can vary depending on the cluster workload and size of the nodes.
+Each worker node should have at least:
+
+- 8 cores
+- 32 GiB memory
+- Around 80 GiB of free space for the volume used for /var/lib/kubelet and /var/lib/containerd.
+- Disk usage must be below 85% on the root volume.
+
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
+
+In particular without flags specified, it will use the Azure defaults listed below:
+
+Control plane:
+
+dataDisks:
+-    diskSizeGB: 80
+-    nameSuffix: etcddisk
+osDisk:
+-    diskSizeGB: 128
+-    managedDisk storageAccountType: Premium_LRS
+-    vmSize: Standard_D4s_v3
+
+Worker node:
+
+osDisk:
+-    diskSizeGB: 80
+-    managedDisk storageAccountType: Premium_LRS
+-    vmSize: Standard_D8s_v3
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -20,7 +20,7 @@ Before you begin using Konvoy, you must have:
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes.
+If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster will be deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes. For Enterprise, the recommendation is at least four worker nodes. Essential, however, only requires one worker node.  DKP creates the worker nodes via CLI and will use acceptable numbers by default.
 
 ## Azure prerequisites
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -42,7 +42,7 @@ Each worker node should have at least:
 
 If you use these instructions to create a cluster on Azure using the DKP default settings without any edits to configuration files or additional flags, your cluster is deployed on an [Ubuntu 20.04 operating system image][supported-systems] with 3 control plane nodes, and 4 worker nodes which match the requirements above.  
 
-In particular without flags specified, it will use the Azure defaults listed below:
+In particular without flags specified, DKP will use the Azure defaults listed below:
 
 - Control plane:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/azure/advanced/prerequisites/index.md
@@ -49,6 +49,7 @@ Control plane:
 dataDisks:
 -    diskSizeGB: 80
 -    nameSuffix: etcddisk
+
 osDisk:
 -    diskSizeGB: 128
 -    managedDisk storageAccountType: Premium_LRS


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-90252

## Description of changes being made
Add worker node requirements for Essential/Enterprise into/below the pre-req section of each provider. Although for other providers, DKP creates the worker nodes, and so is in a position to  set the number by default via CLI.  We should document them for all providers, but we can also mention that for AWS/Azure/GCP, the CLI will use acceptable numbers by default.   Will add GCP after merge other PR.
### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4521.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
