### PR TITLE
fix: improve groups explanations

### DIFF
--- a/pages/dkp/kommander/2.2/operations/access-control/index.md
+++ b/pages/dkp/kommander/2.2/operations/access-control/index.md
@@ -10,14 +10,14 @@ excerpt: Centrally manage access across clusters
 You can centrally define role-based authorization within Kommander to control resource access on the management cluster and a set, or all, of the target clusters.
 These resources are similar to Kubernetes RBAC but with crucial differences, and they make it possible to define the roles and role bindings once, and have them federated to clusters within a given scope.
 
-Kommander has two conceptual groups of resources that are used to manage access control:
+DKP has two concepts used to manage access control:
 
-- Kommander Roles: control access to resources on the management cluster.
+- DKP Roles: control access to resources on the management cluster.
 - Cluster Roles: control access to resources on all target clusters in scope.
 
-Use these two groups of resources to manage access control within 3 levels of scope:
+Use these two sets of resources to manage access control within 3 levels of scope:
 
-| Context   | Kommander Roles                                                               | Cluster Roles                                                                              |
+| Context   | DKP Roles                                                                     | Cluster Roles                                                                              |
 | --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | Global    | Create ClusterRoles on the management cluster.                                | Federates ClusterRoles on all target clusters across all workspaces.                       |
 | Workspace | Create namespaced Roles on the management cluster in the workspace namespace. | Federates ClusterRoles on all target clusters in the workspace.                            |
@@ -27,9 +27,9 @@ The [role bindings][role-bindings] for each level and type create `RoleBindings`
 
 This approach gives you maximum flexibility over who has access to what resources, conveniently mapped to your existing identity providers' claims.
 
-### Special Limitation for Kommander Roles
+### Special Limitation for DKP Roles
 
-In addition to granting a Kommander Role, you must also grant the appropriate DKP role to allow external users and groups into the UI.
+In addition to granting a DKP Role, you must also grant the appropriate DKP role to allow external users and groups into the UI.
 See [RBAC - DKP UI Authorization][kommander-rbac] for details about the built-in DKP roles.
 Here are examples of `ClusterRoleBindings` that grant an IDP group admin access to the Kommander routes:
 
@@ -65,24 +65,6 @@ subjects:
     kind: Group
     name: oidc:engineering
 ```
-
-## Types of Access Control Objects
-
-Kubernetes role-based access control can be controlled with three different object categories: Groups, Roles and Policies, as explained in more detail below.
-
-### Groups
-
-You can map group and user claims made by your configured identity providers to Kommander groups by selecting Administration / Identity providers in the left sidebar in the global workspace level, and then selecting the **Groups** tab.
-
-### Roles
-
-`ClusterRoles` are named collections of rules defining which verbs can be applied to which resources.
-
--   Kommander Roles apply specifically to resources on the management cluster.
--   Cluster Roles apply to target clusters within their scope at these levels:
-    - Global level - this is all target clusters in all workspaces,
-    - Workspace level - this is all target clusters in the workspace,
-    - Project level - this is all target clusters that have been added to the project.
 
 ### Propagating Workspace Roles to Projects
 
@@ -139,18 +121,31 @@ subjects:
     name: oidc:engineering
 ```
 
-### Role Bindings
+## Role Bindings
 
-Kommander role bindings, cluster role bindings, and project role bindings bind a Kommander group to any number of roles.
-All groups defined in the **Groups** tab will be present at the global, workspace, or project level, and are ready for you to assign roles to them.
+DKP role bindings, cluster role bindings, and project role bindings bind a group of users to any number of roles. All groups defined by [Identity Providers][groups] are present in the **Cluster Role Bindings** tab at the global and workspace level, or within the **Role Bindings** tab at the project level.
+
+Before you can create a Role Binding, ensure an administrator has created a [Group][groups]. A Kommander Group can contain one or several Identity Provider users, groups, or both.
+
+You can assign a role to this Kommander Group:
+
+1.  From the top menu bar, select your target workspace.
+
+1.  Select **Access Control** in the **Administration** section of the sidebar menu.
+
+1.  Select the **Cluster Role Bindings** tab, and then select the **Add Roles** button next to the group you want.
+
+1.  Select the Role, or Roles, you want from the drop-down menu and select **Save**.
 
 ## Related Information
 
 - [Kommander RBAC Tutorial][kommander-rbac-tutorial]
 - [RBAC - DKP UI Authorization][kommander-rbac]
 - [Kubernetes RBAC Authorization][k8s-rbac-auth]
+- [Groups][groups]
 
 [k8s-rbac-auth]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-[kommander-rbac]: rbac#kommander-dashboard-authorization
+[kommander-rbac]: rbac#dkp-ui-authorization
 [kommander-rbac-tutorial]: rbac
 [role-bindings]: #role-bindings
+[groups]: ../identity-providers#groups

--- a/pages/dkp/kommander/2.2/operations/identity-providers/index.md
+++ b/pages/dkp/kommander/2.2/operations/identity-providers/index.md
@@ -63,12 +63,19 @@ You can configure as many Identity Providers as you like. Users can then select 
 
 Select the three dot button on the Identity Providers table and select **Disable** from the drop-down menu. The provider option no longer appears on the login screen.
 
-<img style="margin-top:0.85rem;" src="../../img/Identity-provider-table-action-menu.png" alt="Identity Provider Table Row Action Menu" width="500"/>
-<figcaption>Identity Provider Table Row Action Menu</figcaption>
-
 ## Groups
 
-Access control groups are configured in the Groups tab of the Identity Providers page. Refer to [Access Control](../../operations/access-control/) for an overview of groups in Kommander.
+With groups, you can define segments of users within your connected identity provider. These groups can then be used to configure access to various workspaces, projects and other resources via role bindings.
+
+1.  After clicking on the **Groups** tab Begin by selecting the **Create Group** button, which will direct you to the **Create Group** form.
+
+1.  Name your group.
+
+1.  Add one or more users or groups of users that exist within your identity provider already. At least one identity provider group or user is required to save your group.
+
+1.  Select **Save** to create your Group.
+
+Once a group is created, it can be used within [Access Control](../../operations/access-control/) to create role bindings with RBAC roles that define access to resources.
 
 <!--- ## Related Information
 

--- a/pages/dkp/kommander/2.2/projects/project-policies/index.md
+++ b/pages/dkp/kommander/2.2/projects/project-policies/index.md
@@ -10,15 +10,15 @@ Project Role Bindings grant access to a specified Project Role for a specified g
 
 ## Configure Project Role Bindings - UI Method
 
-Before you can create a Project Role Binding, ensure you have created a Group. A Kommander Group can contain one or several Identity Provider users or groups.
+Before you can create a Project Role Binding, ensure an administrator has created a [Group][groups]. A Kommander Group can contain one or several Identity Provider users or groups.
 
 You can assign a role to this Kommander Group:
 
 1.  From the Projects page, select your project.
 
-1.  Select the Role Bindings tab, then select Add Roles next to the group you want.
+1.  Select the Role Bindings tab, then select **Add Roles** next to the group you want.
 
-1.  Select the Role, or Roles, you want from the drop-down menu, and then select Save.
+1.  Select the Role, or Roles, you want from the drop-down menu, and then select **Save**.
 
 ## Configure Project Role Bindings - CLI Method
 
@@ -148,3 +148,5 @@ subjects:
   kind: User
   name: user1@d2iq.lab
 ```
+
+[groups]: ../../operations/identity-providers#groups

--- a/pages/dkp/kommander/2.2/workspaces/workspace-role-bindings/index.md
+++ b/pages/dkp/kommander/2.2/workspaces/workspace-role-bindings/index.md
@@ -10,7 +10,7 @@ Workspace Role Bindings grant access to a specified Project Role for a specified
 
 ## Configure Workspace Role Bindings
 
-Before you can create a Workspace Role Binding, ensure you have created a Group. A Kommander Group can contain one or several Identity Provider users, groups or both.
+Before you can create a Workspace Role Binding, ensure an administrator has created a [Group][groups]. A Kommander Group can contain one or several Identity Provider users, groups or both.
 
 You can assign a role to this Kommander Group:
 
@@ -21,3 +21,5 @@ You can assign a role to this Kommander Group:
 1.  Select the **Cluster Role Bindings** tab, and then select the **Add Roles** button next to the group you want.
 
 1.  Select the Role, or Roles, you want from the drop-down menu and select **Save**.
+
+[groups]: ../../operations/identity-providers#groups

--- a/pages/dkp/kommander/2.3/operations/access-control/index.md
+++ b/pages/dkp/kommander/2.3/operations/access-control/index.md
@@ -10,14 +10,14 @@ excerpt: Centrally manage access across clusters
 You can centrally define role-based authorization within Kommander to control resource access on the management cluster and a set, or all, of the target clusters.
 These resources are similar to Kubernetes RBAC but with crucial differences, and they make it possible to define the roles and role bindings once, and have them federated to clusters within a given scope.
 
-Kommander has two conceptual groups of resources that are used to manage access control:
+DKP has two concepts used to manage access control:
 
-- Kommander Roles: control access to resources on the management cluster.
+- DKP Roles: control access to resources on the management cluster.
 - Cluster Roles: control access to resources on all target clusters in scope.
 
-Use these two groups of resources to manage access control within 3 levels of scope:
+Use these two sets of resources to manage access control within 3 levels of scope:
 
-| Context   | Kommander Roles                                                               | Cluster Roles                                                                              |
+| Context   | DKP Roles                                                                     | Cluster Roles                                                                              |
 | --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | Global    | Create ClusterRoles on the management cluster.                                | Federates ClusterRoles on all target clusters across all workspaces.                       |
 | Workspace | Create namespaced Roles on the management cluster in the workspace namespace. | Federates ClusterRoles on all target clusters in the workspace.                            |
@@ -27,9 +27,9 @@ The [role bindings][role-bindings] for each level and type create `RoleBindings`
 
 This approach gives you maximum flexibility over who has access to what resources, conveniently mapped to your existing identity providers' claims.
 
-### Special Limitation for Kommander Roles
+### Special Limitation for DKP Roles
 
-In addition to granting a Kommander Role, you must also grant the appropriate DKP role to allow external users and groups into the UI.
+In addition to granting a DKP Role, you must also grant the appropriate DKP role to allow external users and groups into the UI.
 See [RBAC - DKP UI Authorization][kommander-rbac] for details about the built-in DKP roles.
 Here are examples of `ClusterRoleBindings` that grant an IDP group admin access to the Kommander routes:
 
@@ -65,24 +65,6 @@ subjects:
     kind: Group
     name: oidc:engineering
 ```
-
-## Types of Access Control Objects
-
-Kubernetes role-based access control can be controlled with three different object categories: Groups, Roles and Policies, as explained in more detail below.
-
-### Groups
-
-You can map group and user claims made by your configured identity providers to Kommander groups by selecting Administration / Identity providers in the left sidebar in the global workspace level, and then selecting the **Groups** tab.
-
-### Roles
-
-`ClusterRoles` are named collections of rules defining which verbs can be applied to which resources.
-
--   Kommander Roles apply specifically to resources on the management cluster.
--   Cluster Roles apply to target clusters within their scope at these levels:
-    - Global level - this is all target clusters in all workspaces,
-    - Workspace level - this is all target clusters in the workspace,
-    - Project level - this is all target clusters that have been added to the project.
 
 ### Propagating Workspace Roles to Projects
 
@@ -139,18 +121,31 @@ subjects:
     name: oidc:engineering
 ```
 
-### Role Bindings
+## Role Bindings
 
-Kommander role bindings, cluster role bindings, and project role bindings bind a Kommander group to any number of roles.
-All groups defined in the **Groups** tab will be present at the global, workspace, or project level, and are ready for you to assign roles to them.
+DKP role bindings, cluster role bindings, and project role bindings bind a group of users to any number of roles. All groups defined by [Identity Providers][groups] are present in the **Cluster Role Bindings** tab at the global and workspace level, or within the **Role Bindings** tab at the project level.
+
+Before you can create a Role Binding, ensure an administrator has created a [Group][groups]. A Kommander Group can contain one or several Identity Provider users, groups, or both.
+
+You can assign a role to this Kommander Group:
+
+1.  From the top menu bar, select your target workspace.
+
+1.  Select **Access Control** in the **Administration** section of the sidebar menu.
+
+1.  Select the **Cluster Role Bindings** tab, and then select the **Add Roles** button next to the group you want.
+
+1.  Select the Role, or Roles, you want from the drop-down menu and select **Save**.
 
 ## Related Information
 
 - [Kommander RBAC Tutorial][kommander-rbac-tutorial]
 - [RBAC - DKP UI Authorization][kommander-rbac]
 - [Kubernetes RBAC Authorization][k8s-rbac-auth]
+- [Groups][groups]
 
 [k8s-rbac-auth]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-[kommander-rbac]: rbac#kommander-dashboard-authorization
+[kommander-rbac]: rbac#dkp-ui-authorization
 [kommander-rbac-tutorial]: rbac
 [role-bindings]: #role-bindings
+[groups]: ../identity-providers#groups

--- a/pages/dkp/kommander/2.3/operations/identity-providers/index.md
+++ b/pages/dkp/kommander/2.3/operations/identity-providers/index.md
@@ -63,12 +63,19 @@ You can configure as many Identity Providers as you like. Users can then select 
 
 Select the three dot button on the Identity Providers table and select **Disable** from the drop-down menu. The provider option no longer appears on the login screen.
 
-<img style="margin-top:0.85rem;" src="../../img/Identity-provider-table-action-menu.png" alt="Identity Provider Table Row Action Menu" width="500"/>
-<figcaption>Identity Provider Table Row Action Menu</figcaption>
-
 ## Groups
 
-Access control groups are configured in the Groups tab of the Identity Providers page. Refer to [Access Control](../../operations/access-control/) for an overview of groups in Kommander.
+With groups, you can define segments of users within your connected identity provider. These groups can then be used to configure access to various workspaces, projects and other resources via role bindings.
+
+1.  After clicking on the **Groups** tab Begin by selecting the **Create Group** button, which will direct you to the **Create Group** form.
+
+1.  Name your group.
+
+1.  Add one or more users or groups of users that exist within your identity provider already. At least one identity provider group or user is required to save your group.
+
+1.  Select **Save** to create your Group.
+
+Once a group is created, it can be used within [Access Control](../../operations/access-control/) to create role bindings with RBAC roles that define access to resources.
 
 <!--- ## Related Information
 

--- a/pages/dkp/kommander/2.3/projects/project-policies/index.md
+++ b/pages/dkp/kommander/2.3/projects/project-policies/index.md
@@ -10,15 +10,15 @@ Project Role Bindings grant access to a specified Project Role for a specified g
 
 ## Configure Project Role Bindings - UI Method
 
-Before you can create a Project Role Binding, ensure you have created a Group. A Kommander Group can contain one or several Identity Provider users or groups.
+Before you can create a Project Role Binding, ensure an administrator has created a [Group][groups]. A Kommander Group can contain one or several Identity Provider users or groups.
 
 You can assign a role to this Kommander Group:
 
 1.  From the Projects page, select your project.
 
-1.  Select the Role Bindings tab, then select Add Roles next to the group you want.
+1.  Select the Role Bindings tab, then select **Add Roles** next to the group you want.
 
-1.  Select the Role, or Roles, you want from the drop-down menu, and then select Save.
+1.  Select the Role, or Roles, you want from the drop-down menu, and then select **Save**.
 
 ## Configure Project Role Bindings - CLI Method
 
@@ -148,3 +148,5 @@ subjects:
   kind: User
   name: user1@d2iq.lab
 ```
+
+[groups]: ../../operations/identity-providers#groups

--- a/pages/dkp/kommander/2.3/workspaces/workspace-role-bindings/index.md
+++ b/pages/dkp/kommander/2.3/workspaces/workspace-role-bindings/index.md
@@ -10,7 +10,7 @@ Workspace Role Bindings grant access to a specified Project Role for a specified
 
 ## Configure Workspace Role Bindings
 
-Before you can create a Workspace Role Binding, ensure you have created a Group. A Kommander Group can contain one or several Identity Provider users, groups or both.
+Before you can create a Workspace Role Binding, ensure an administrator has created a [Group][groups]. A Kommander Group can contain one or several Identity Provider users, groups or both.
 
 You can assign a role to this Kommander Group:
 
@@ -21,3 +21,5 @@ You can assign a role to this Kommander Group:
 1.  Select the **Cluster Role Bindings** tab, and then select the **Add Roles** button next to the group you want.
 
 1.  Select the Role, or Roles, you want from the drop-down menu and select **Save**.
+
+[groups]: ../../operations/identity-providers#groups


### PR DESCRIPTION
The relationship between groups created in Identity Providers and then
leveraged by the Access Control sections was not well documented and
circular.

Removed the word "group" from some early explanation of Roles in Access
Control. Removed a redundant section of Access Control, and added
explanation on where to create groups for use with Role Bindings

Additionally, tried to improve the explanation of how to create groups
with identity providers in the first place in all the places I could
find that discussed Role Bindings.

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[<!-- Link to JIRA ticket -->](https://jira.d2iq.com/browse/COPS-7264)

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4527.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
