### PR TITLE
docs: some formatting with code block issues

### DIFF
--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -16,7 +16,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
 -   **REQUIRED** Before upgrading, create an [on-demand backup][backup] of your current configuration with Velero.
 -   [Download][download_binary] and install the latest DKP CLI binary on your computer.
 -   Ensure you are on DKP version 2.1 or 2.1.1 and Kubernetes version 1.21.
--   If you have attached clusters, ensure they are on Kubernetes versions 1.19, 1.20 or 1.21. To upgrade your Kubernetes version, refer to the appropriate documentation for your environment: [AKS][AKS], [AWS][AWS], [Azure][Azure], [EKS][EKS], [pre-provisioned][pre_provisioned].
+-   If you have attached clusters, ensure they are on Kubernetes versions 1.19, 1.20 or 1.21.
 -   Review the [Platform Application version updates][release_notes] that are part of this upgrade.  
 -   For air-gapped environments **with** DKP Catalog Applications in a multi-cluster environment: [Load the Docker images into your Docker registry][load_images_catalog]
 -   For air-gapped environments **without** DKP Catalog Applications: [Load the Docker images into your Docker registry][load_images]
@@ -40,28 +40,28 @@ This section describes how to upgrade your Kommander Management cluster and all 
   wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz"
   ```
 
-  -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
+-   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
 
-    Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.1`:
+  Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.1`:
 
-    ```yaml
-      disableMutation: false # <-- this value is new in 2.2.1 
-      mutations:
-        enablePodProxy: true
-        podProxySettings:
-          noProxy: ...
-          httpProxy: ...
-          httpsProxy: ...
-        excludeNamespacesFromProxy: []
-        namespaceSelectorForProxy:
-          "gatekeeper.d2iq.com/mutate": "pod-proxy"
-    ```
+  ```yaml
+    disableMutation: false # <-- this value is new in 2.2.1 
+    mutations:
+      enablePodProxy: true
+      podProxySettings:
+        noProxy: ...
+        httpProxy: ...
+        httpsProxy: ...
+      excludeNamespacesFromProxy: []
+      namespaceSelectorForProxy:
+        "gatekeeper.d2iq.com/mutate": "pod-proxy"
+  ```
 
-    Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
+  Configure the `kommander-flux` namespace and adjust the label so the Gatekeeper mutation is active on the namespace:
 
-    ```bash
-    kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
-    ```
+  ```bash
+  kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
+  ```
 
 ## Detach MetalLB from Kommander
 
@@ -97,21 +97,21 @@ This section describes how to upgrade your Kommander Management cluster and all 
       appdeployment.apps.kommander.d2iq.io "metallb" deleted
       ```
 
-    This deletes the MetalLB App from Kommander while leaving the MetalLB resources running in the cluster.
-    Use the following command to view the pods:
+      This deletes the MetalLB App from Kommander while leaving the MetalLB resources running in the cluster.
+      Use the following command to view the pods:
 
-    ```bash
-    kubectl -n kommander get pod -l app=metallb
-    ```
+      ```bash
+      kubectl -n kommander get pod -l app=metallb
+      ```
 
-    ```sh
-    NAME                                 READY   STATUS    RESTARTS   AGE
-    metallb-controller-d657c8dbb-zlgrk   1/1     Running   0          20m
-    metallb-speaker-2gz6p                1/1     Running   0          20m
-    metallb-speaker-48d44                1/1     Running   0          20m
-    metallb-speaker-6gp76                1/1     Running   0          20m
-    metallb-speaker-dh9dm                1/1     Running   0          20m
-    ```
+      ```sh
+      NAME                                 READY   STATUS    RESTARTS   AGE
+      metallb-controller-d657c8dbb-zlgrk   1/1     Running   0          20m
+      metallb-speaker-2gz6p                1/1     Running   0          20m
+      metallb-speaker-48d44                1/1     Running   0          20m
+      metallb-speaker-6gp76                1/1     Running   0          20m
+      metallb-speaker-dh9dm                1/1     Running   0          20m
+      ```
 
 ## Upgrade Kommander
 
@@ -143,18 +143,18 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
         If you have DKP Catalog Applications deployed, follow the [DKP Catalog Applications configuration page](../../../../kommander/2.2/install/configuration/enterprise-catalog#configure-a-default-enterprise-catalog) to update the Git repository after the upgrade.
 
-    An output similar to this appears:
+        ```bash
+        dkp upgrade kommander  --kommander-applications-repository ~/work/git_repos/kommander-applications
+        ```
 
-    ```bash
-    dkp upgrade kommander  --kommander-applications-repository ~/work/git_repos/kommander-applications
-    ```
+        An output similar to this appears:
 
-    ```sh
-    ✓ Ensuring upgrading conditions are met
-    ✓ Ensuring application definitions are updated
-    ✓ Ensuring helm-mirror implementation is migrated to chartmuseum
-    ...
-    ```
+        ```sh
+        ✓ Ensuring upgrading conditions are met
+        ✓ Ensuring application definitions are updated
+        ✓ Ensuring helm-mirror implementation is migrated to chartmuseum
+        ...
+        ```
 
 1.  For air-gapped deployments, an additional step is required to upgrade the Grafana Loki MinIO Tenant:
 
@@ -180,7 +180,7 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
 You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the next steps depending on your environment and license type.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with DKP 2.2.x are available at these URLs:
 
 * https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
 * https://github.com/minio/minio/tree/RELEASE.2022-01-08T03-11-54Z
@@ -188,10 +188,10 @@ This Docker image includes code from the MinIO Project (“MinIO”), which is �
 
 [download_binary]: ../../download/
 [AKS]: https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster
-[AWS]: ../../choose-infrastructure/aws/advanced/update/
-[Azure]: ../../choose-infrastructure/azure/advanced/update/
+<!--- [AWS]: ../../choose-infrastructure/aws/advanced/update/
+[Azure]: ../../choose-infrastructure/azure/advanced/update/ -->
 [EKS]: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
-[pre_provisioned]: ../../choose-infrastructure/pre-provisioned/upgrade/control-plane/
+<!--- [pre_provisioned]: ../../choose-infrastructure/pre-provisioned/upgrade/control-plane/ -->
 [k8s_access_to_clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [upgrade_workspaces]: ../../../../kommander/2.2/projects/applications/platform-applications#upgrade-platform-applications-from-the-cli
 [release_notes]: ../../release-notes/

--- a/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/konvoy/2.3/dkp-upgrade/upgrade-kommander/index.md
@@ -14,7 +14,7 @@ This section describes how to upgrade your Kommander Management cluster and all 
 -   **REQUIRED** Before upgrading, create an [on-demand backup][backup] of your current configuration with Velero.
 -   [Download][download_binary] and install the latest DKP CLI binary on your computer.
 -   Ensure you are on DKP version 2.2 or 2.2.x and Kubernetes version 1.22.
--   If you have attached clusters, ensure they are on Kubernetes versions 1.21 or 1.22. To upgrade your Kubernetes version, refer to the appropriate documentation for your environment: [AKS][AKS], [AWS][AWS], [Azure][Azure], [EKS][EKS], [pre-provisioned][pre_provisioned].
+-   If you have attached clusters, ensure they are on Kubernetes versions 1.21 or 1.22.
 -   Review the [Platform Application version updates][release_notes] that are part of this upgrade.  
 -   For air-gapped environments **with** DKP Catalog Applications in a multi-cluster environment: [Load the Docker images into your Docker registry][load_images_catalog]
 -   For air-gapped environments **without** DKP Catalog Applications: [Load the Docker images into your Docker registry][load_images]
@@ -126,15 +126,18 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
         If you have DKP Catalog Applications deployed, follow the [DKP Catalog Applications configuration page](../../../../kommander/2.3/install/configuration/enterprise-catalog#configure-a-default-enterprise-catalog) to update the Git repository after the upgrade.
 
-    An output similar to this appears:
+        ```bash
+        dkp upgrade kommander  --kommander-applications-repository ~/work/git_repos/kommander-applications
+        ```
 
-    ```bash
-    $ dkp upgrade kommander  --kommander-applications-repository ~/work/git_repos/kommander-applications
-    ✓ Ensuring upgrading conditions are met
-    ✓ Ensuring application definitions are updated
-    ✓ Ensuring helm-mirror implementation is migrated to chartmuseum
-    ...
-    ```
+        An output similar to this appears:
+
+        ```sh
+        ✓ Ensuring upgrading conditions are met
+        ✓ Ensuring application definitions are updated
+        ✓ Ensuring helm-mirror implementation is migrated to chartmuseum
+        ...
+        ```
 
 1.  For air-gapped deployments, an additional step is required to upgrade the Grafana Loki MinIO Tenant:
 
@@ -153,17 +156,17 @@ Before running the following command, ensure that your `dkp` configuration **ref
 
 You can always go back to the [DKP Upgrade overview][dkp_upgrade], to review the next steps depending on your environment and license type.
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0][https://www.gnu.org/licenses/agpl-3.0.en.html]. The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with DKP 2.2.0 are available at these URLs:
 
 * https://github.com/minio/minio/tree/RELEASE.2022-04-01T03-41-39Z
 * https://github.com/minio/minio/tree/RELEASE.2022-01-08T03-11-54Z
 
 [download_binary]: ../../download/
 [AKS]: https://docs.microsoft.com/en-us/azure/aks/upgrade-cluster
-[AWS]: ../../choose-infrastructure/aws/advanced/update/
-[Azure]: ../../choose-infrastructure/azure/advanced/update/
+<!--- [AWS]: ../../choose-infrastructure/aws/advanced/update/
+[Azure]: ../../choose-infrastructure/azure/advanced/update/ -->
 [EKS]: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
-[pre_provisioned]: ../../choose-infrastructure/pre-provisioned/upgrade/control-plane/
+<!--- [pre_provisioned]: ../../choose-infrastructure/pre-provisioned/upgrade/control-plane/ -->
 [k8s_access_to_clusters]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [upgrade_workspaces]: ../../../../kommander/2.3/projects/applications/platform-applications#upgrade-platform-applications-from-the-cli
 [release_notes]: ../../release-notes/


### PR DESCRIPTION
also got rid of broken links for specific
provider upgrade pages

## Jira Ticket

n/a - this started off being pretty minor so just took care of some out of order stuff for 
when it said 'view the output' 
but it was the bash code block command snippet first

Then there was just some formatting that I took care of

Then there are some links to upgrade pages that do not exist, so just got rid of those.

FYI @kevinmiller-conley - there was also a markdown link in here that wasn't rendering correctly for Minio, and I just took care of that, as well.

## Description of changes being made
see above

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
