### PR TITLE
[Kaptain] Moving login section

### DIFF
--- a/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
@@ -123,21 +123,7 @@ kubectl patch client <Dex Client ID> -n kommander --type merge  -p '{"spec": {"r
 
 ## Log in to Kaptain using the management cluster's Dex instance
 
-Discover the Kaptain endpoint:
-
-- If you are running Kaptain _on-premises_:
-
-```bash
-kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
-```
-
-- Or if you are running Kaptain on _AWS_:
-
-```bash
-kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
-```
-
-When accessing Kaptain via `https://<Kaptain endpoint>`, you will be redirected to the login page of the management cluster's Dex instance.
+Refer to the [Kaptain login](../../install/deploy-kaptain#log-in-to-kaptain-using-the-management-clusters-dex-instance) section to access Kaptains's Kubeflow dashboard.
 
 [attached-cluster]: /dkp/kommander/latest/clusters/attach-cluster/
 [create-managed-cluster]: /dkp/kommander/latest/clusters/creating-konvoy-cluster-aws/

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -152,13 +152,7 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 ## Log in to Kaptain using the management cluster's Dex instance
 
-1.  Get your Kaptain login credentials: 
-
-    - For Konvoy 1.x: 
-
-    ```bash
-    konvoy get ops-portal
-    ```
+1.  Get your Kaptain login credentials:
 
     - For DKP 2.x:
 

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -154,6 +154,7 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 1.  Get your Kaptain login credentials: 
 
+
     - For Konvoy 1.x: 
 
     ```bash
@@ -170,6 +171,7 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 1.  Discover the Kaptain endpoint:
 
+
     - If you are running Kaptain _on-premises_:
 
     ```bash
@@ -177,6 +179,7 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
     ```
 
     The output displays a URL to your Kaptain instance.
+    
 
     - Or if you are running Kaptain on _AWS_:
 
@@ -188,7 +191,7 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 When calling up `https://<Kaptain endpoint>`, you will see the login page of the management cluster's Dex instance. After entering your credentials, you will be redirected to Kaptain's Kubeflow dashboard.
 
-<p class="message--note"><strong>NOTE: </strong>It is possible that you receive a browser warning due your instance's self-signed certificate. This instance is safe. You can bypass the warning in the advanced settings of the browser or by typing `thisisunsafe` once the warning appears (there is no specific field for this).</p>
+<p class="message--note"><strong>NOTE: </strong>It is possible that you receive a browser warning due your instance's self-signed certificate. This instance is safe. You can bypass the warning in the advanced settings of the browser or by typing <code>thisisunsafe</code> once the warning appears (there is no specific field for this).</p>
 
 [add_kaptain]: ../dkp/
 [existcluster]: ../../../../kommander/2.2/clusters/attach-cluster/

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -152,23 +152,43 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 ## Log in to Kaptain using the management cluster's Dex instance
 
-Discover the Kaptain endpoint:
+1.  Get your Kaptain login credentials: 
 
-- If you are running Kaptain _on-premises_:
+    - For Konvoy 1.x: 
 
-```bash
-kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
-```
-<!-- TODO: can we get example output? -->
+    ```bash
+    konvoy get ops-portal
+    ```
 
-- Or if you are running Kaptain on _AWS_:
+    - For DKP 2.x:
 
-```bash
-kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
-```
-<!-- TODO: can we get example output? -->
+    ```bash
+    kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}')
+    ```
+
+    The output displays your username and password.
+
+1.  Discover the Kaptain endpoint:
+
+    - If you are running Kaptain _on-premises_:
+
+    ```bash
+    kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
+    ```
+
+    The output displays a URL to your Kaptain instance.
+
+    - Or if you are running Kaptain on _AWS_:
+
+    ```bash
+    kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
+    ```
+
+    The output displays a URL to your Kaptain instance.
 
 When calling up `https://<Kaptain endpoint>`, you will see the login page of the management cluster's Dex instance. After entering your credentials, you will be redirected to Kaptain's Kubeflow dashboard.
+
+<p class="message--note"><strong>NOTE: </strong>It is possible that you receive a browser warning due your instance's self-signed certificate. This instance is safe. You can bypass the warning in the advanced settings of the browser or by typing `thisisunsafe` once the warning appears (there is no specific field for this).</p>
 
 [add_kaptain]: ../dkp/
 [existcluster]: ../../../../kommander/2.2/clusters/attach-cluster/

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -154,7 +154,6 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 1.  Get your Kaptain login credentials: 
 
-
     - For Konvoy 1.x: 
 
     ```bash
@@ -170,7 +169,6 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
     The output displays your username and password.
 
 1.  Discover the Kaptain endpoint:
-
 
     - If you are running Kaptain _on-premises_:
 

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -154,8 +154,6 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 1.  Get your Kaptain login credentials:
 
-    - For DKP 2.x:
-
     ```bash
     kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}')
     ```

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -12,7 +12,7 @@ enterprise: false
 You can deploy Kaptain to a cluster in a selected workspace. If you do not intend to deploy Kaptain to a certain cluster, you must switch the workspace you are deploying to or move that cluster to another workspace.
 </p>
 
-## Prerequisite
+## Prerequisites
 
 Ensure you add Kaptain to your DKP Catalog applications before you deploy it to your clusters. Refer to the corresponding documentation for your environment:
 
@@ -30,7 +30,7 @@ Follow these steps to enable Kaptain in air-gapped and networked environments fr
 
 1.  Select **Applications** from the sidebar menu.
 
-1.  Type Kaptain in the **Applications** search bar. If Kaptain is not available in the UI, add Kaptain to your DKP catalog as stated in the [prerequisite section](#prerequisite).
+1.  Type Kaptain in the **Applications** search bar. If Kaptain is not available in the UI, add Kaptain to your DKP catalog as stated in the [prerequisites section](#prerequisites).
 
 1.  Select the three dot menu > **Enable**, in the Kaptain tile.
     The `Enable Workspace Catalog Application` page is displayed.

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -176,9 +176,6 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
     kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
     ```
 
-    The output displays a URL to your Kaptain instance.
-    
-
     - Or if you are running Kaptain on _AWS_:
 
     ```bash

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -150,6 +150,26 @@ NAME                      AGE     READY   STATUS
 kaptain-1                 3m40s   True    Release reconciliation succeeded
 ```
 
+## Log in to Kaptain using the management cluster's Dex instance
+
+Discover the Kaptain endpoint:
+
+- If you are running Kaptain _on-premises_:
+
+```bash
+kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
+```
+<!-- TODO: can we get example output? -->
+
+- Or if you are running Kaptain on _AWS_:
+
+```bash
+kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
+```
+<!-- TODO: can we get example output? -->
+
+When calling up `https://<Kaptain endpoint>`, you will see the login page of the management cluster's Dex instance. After entering your credentials, you will be redirected to Kaptain's Kubeflow dashboard.
+
 [add_kaptain]: ../dkp/
 [existcluster]: ../../../../kommander/2.2/clusters/attach-cluster/
 [add_dkp]: ../dkp/

--- a/pages/dkp/kaptain/2.1.0/configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/2.1.0/configuration/external-dex/index.md
@@ -123,21 +123,7 @@ kubectl patch client <Dex Client ID> -n kommander --type merge  -p '{"spec": {"r
 
 ## Log in to Kaptain using the management cluster's Dex instance
 
-Discover the Kaptain endpoint:
-
-- If you are running Kaptain _on-premises_:
-
-```bash
-kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
-```
-
-- Or if you are running Kaptain on _AWS_:
-
-```bash
-kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
-```
-
-When accessing Kaptain via `https://<Kaptain endpoint>`, you will be redirected to the login page of the management cluster's Dex instance.
+Refer to the [Kaptain login](../../install/deploy-kaptain#log-in-to-kaptain-using-the-management-clusters-dex-instance) section to access Kaptains's Kubeflow dashboard.
 
 [attached-cluster]: /dkp/kommander/latest/clusters/attach-cluster/
 [create-managed-cluster]: /dkp/kommander/latest/clusters/creating-konvoy-cluster-aws/

--- a/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
@@ -12,7 +12,7 @@ enterprise: false
 You can deploy Kaptain to a cluster in a selected workspace. If you do not intend to deploy Kaptain to a certain cluster, you must switch the workspace you are deploying to or move that cluster to another workspace.
 </p>
 
-## Prerequisite
+## Prerequisites
 
 Ensure you add Kaptain to your DKP Catalog applications before you deploy it to your clusters. Refer to the corresponding documentation for your environment:
 
@@ -30,7 +30,7 @@ Follow these steps to enable Kaptain in air-gapped and networked environments fr
 
 1.  Select **Applications** from the sidebar menu.
 
-1.  Type Kaptain in the **Applications** search bar. If Kaptain is not available in the UI, add Kaptain to your DKP catalog as stated in the [prerequisite section](#prerequisite).
+1.  Type Kaptain in the **Applications** search bar. If Kaptain is not available in the UI, add Kaptain to your DKP catalog as stated in the [prerequisite section](#prerequisites).
 
 1.  Select the three dot menu > **Enable**, in the Kaptain tile.
     The `Enable Workspace Catalog Application` page is displayed.
@@ -149,6 +149,46 @@ kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}
 NAME                      AGE     READY   STATUS
 kaptain-1                 3m40s   True    Release reconciliation succeeded
 ```
+
+## Log in to Kaptain using the management cluster's Dex instance
+
+1.  Get your Kaptain login credentials: 
+
+    - For Konvoy 1.x: 
+
+    ```bash
+    konvoy get ops-portal
+    ```
+
+    - For DKP 2.x:
+
+    ```bash
+    kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}')
+    ```
+
+    The output displays your username and password.
+
+1.  Discover the Kaptain endpoint:
+
+    - If you are running Kaptain _on-premises_:
+
+    ```bash
+    kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
+    ```
+
+    The output displays a URL to your Kaptain instance.
+
+    - Or if you are running Kaptain on _AWS_:
+
+    ```bash
+    kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"
+    ```
+
+    The output displays a URL to your Kaptain instance.
+
+When calling up `https://<Kaptain endpoint>`, you will see the login page of the management cluster's Dex instance. After entering your credentials, you will be redirected to Kaptain's Kubeflow dashboard.
+
+<p class="message--note"><strong>NOTE: </strong>It is possible that you receive a browser warning due your instance's self-signed certificate. This instance is safe. You can bypass the warning in the advanced settings of the browser or by typing `thisisunsafe` once the warning appears (there is no specific field for this).</p>
 
 [add_kaptain]: ../dkp/
 [existcluster]: ../../../../kommander/2.2/clusters/attach-cluster/

--- a/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
@@ -152,15 +152,7 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 ## Log in to Kaptain using the management cluster's Dex instance
 
-1.  Get your Kaptain login credentials: 
-
-    - For Konvoy 1.x: 
-
-    ```bash
-    konvoy get ops-portal
-    ```
-
-    - For DKP 2.x:
+1.  Get your Kaptain login credentials:
 
     ```bash
     kubectl -n kommander get secret dkp-credentials -o go-template='Username: {{.data.username|base64decode}}{{ "\n"}}Password: {{.data.password|base64decode}}{{ "\n"}}')

--- a/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
@@ -176,8 +176,6 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
     kubectl get svc kaptain-ingress --namespace kaptain-ingress -o jsonpath="{.status.loadBalancer.ingress[*].ip}"
     ```
 
-    The output displays a URL to your Kaptain instance.
-
     - Or if you are running Kaptain on _AWS_:
 
     ```bash

--- a/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.1.0/install/deploy-kaptain/index.md
@@ -188,7 +188,7 @@ kaptain-1                 3m40s   True    Release reconciliation succeeded
 
 When calling up `https://<Kaptain endpoint>`, you will see the login page of the management cluster's Dex instance. After entering your credentials, you will be redirected to Kaptain's Kubeflow dashboard.
 
-<p class="message--note"><strong>NOTE: </strong>It is possible that you receive a browser warning due your instance's self-signed certificate. This instance is safe. You can bypass the warning in the advanced settings of the browser or by typing `thisisunsafe` once the warning appears (there is no specific field for this).</p>
+<p class="message--note"><strong>NOTE: </strong>It is possible that you receive a browser warning due your instance's self-signed certificate. This instance is safe. You can bypass the warning in the advanced settings of the browser or by typing <code>thisisunsafe</code> once the warning appears (there is no specific field for this).</p>
 
 [add_kaptain]: ../dkp/
 [existcluster]: ../../../../kommander/2.2/clusters/attach-cluster/


### PR DESCRIPTION
## Jira Ticket

No Jira, but a slack convo: 
https://mesosphere.slack.com/archives/G0157326RFD/p1654702181007889

## Description of changes being made

We decided to move the login section to a place where it is more visible and makes more sense for users. 
NOTE: I will add this to 2.2 docs once we are done contributing and have a final version.

### Preview

http://docs-d2iq-com-pr-4536.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
