### PR TITLE
Adding default storage driver for Azure in storage

### DIFF
--- a/pages/dkp/konvoy/2.1/storage/automated-storage/index.md
+++ b/pages/dkp/konvoy/2.1/storage/automated-storage/index.md
@@ -10,11 +10,12 @@ menuWeight: 20
 
 <!-- markdownlint-disable MD018 -->
 
-When deploying Konvoy using a supported cloud provisioner (AWS), Konvoy automatically configures native storage drivers for the target platform. In addition, Konvoy deploys a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for [dynamic persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) creation. The table below lists the driver and default StorageClass for each supported cloud provisioner.
+When deploying Konvoy using a supported cloud provisioner, Konvoy automatically configures native storage drivers for the target platform. In addition, Konvoy deploys a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for [dynamic persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) creation. The table below lists the driver and default StorageClass for each supported cloud provisioner.
 
 | Cloud Provisioner |  Driver              | Default Storage Class        |
 --------------------|----------------------|----------------------|
 | AWS               | aws-ebs-csi-driver   | [awscsiprovisioner](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)    |
+| Azure               | azuredisk-csi-driver   | [azurecsiprovisioner](https://github.com/kubernetes-sigs/azuredisk-csi-driver)    |
 
 When a default StorageClass is specified, persistent volume claims (PVCs) can be created without needing to specify the storage class. For instance, to request a volume using the default provisioner, create a PVC with the following:
 
@@ -83,6 +84,13 @@ Konvoy deploys with gp3 (general purpose SSDs) EBS volumes.
 
 - Driver documentation: [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
 - Volume types and pricing: [volume types](https://aws.amazon.com/ebs/features/)
+
+### Azure CSI Driver
+
+Konvoy deploys with StandardSSD_LRS for Azure Virtual Disks.
+
+- Driver documentation: [azure-csi-driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver)
+- Volume types and pricing: [volume types](https://azure.microsoft.com/en-us/pricing/details/storage/page-blobs/)
 
 ## On Premises and other storage options
 

--- a/pages/dkp/konvoy/2.2/storage/automated-storage/index.md
+++ b/pages/dkp/konvoy/2.2/storage/automated-storage/index.md
@@ -8,11 +8,12 @@ enterprise: false
 menuWeight: 20
 ---
 
-When deploying Konvoy using a supported cloud provisioner (AWS), Konvoy automatically configures native storage drivers for the target platform. In addition, Konvoy deploys a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for [dynamic persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) creation. The table below lists the driver and default StorageClass for each supported cloud provisioner.
+When deploying Konvoy using a supported cloud provisioner, Konvoy automatically configures native storage drivers for the target platform. In addition, Konvoy deploys a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for [dynamic persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) creation. The table below lists the driver and default StorageClass for each supported cloud provisioner.
 
 | Cloud Provisioner |  Driver              | Default Storage Class        |
 --------------------|----------------------|----------------------|
 | AWS               | aws-ebs-csi-driver   | [awscsiprovisioner](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)    |
+| Azure               | azuredisk-csi-driver   | [azurecsiprovisioner](https://github.com/kubernetes-sigs/azuredisk-csi-driver)    |
 
 When a default StorageClass is specified, persistent volume claims (PVCs) can be created without needing to specify the storage class. For instance, to request a volume using the default provisioner, create a PVC with the following:
 
@@ -79,8 +80,15 @@ parameters:
 
 Konvoy deploys with gp3 (general purpose SSDs) EBS volumes.
 
-- Driver documentation: [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
+- Driver documentation: [aws-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
 - Volume types and pricing: [volume types](https://aws.amazon.com/ebs/features/)
+
+### Azure CSI Driver
+
+Konvoy deploys with StandardSSD_LRS for Azure Virtual Disks.
+
+- Driver documentation: [azure-csi-driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver)
+- Volume types and pricing: [volume types](https://azure.microsoft.com/en-us/pricing/details/storage/page-blobs/)
 
 ## On Premises and other storage options
 

--- a/pages/dkp/konvoy/2.3/storage/automated-storage/index.md
+++ b/pages/dkp/konvoy/2.3/storage/automated-storage/index.md
@@ -8,11 +8,12 @@ enterprise: false
 menuWeight: 20
 ---
 
-When deploying Konvoy using a supported cloud provisioner (AWS), Konvoy automatically configures native storage drivers for the target platform. In addition, Konvoy deploys a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for [dynamic persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) creation. The table below lists the driver and default StorageClass for each supported cloud provisioner.
+When deploying Konvoy using a supported cloud provisioner, Konvoy automatically configures native storage drivers for the target platform. In addition, Konvoy deploys a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for [dynamic persistent volume (PV)](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) creation. The table below lists the driver and default StorageClass for each supported cloud provisioner.
 
 | Cloud Provisioner |  Driver              | Default Storage Class        |
 --------------------|----------------------|----------------------|
 | AWS               | aws-ebs-csi-driver   | [awscsiprovisioner](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)    |
+| Azure               | azuredisk-csi-driver   | [azurecsiprovisioner](https://github.com/kubernetes-sigs/azuredisk-csi-driver)    |
 
 When a default StorageClass is specified, persistent volume claims (PVCs) can be created without needing to specify the storage class. For instance, to request a volume using the default provisioner, create a PVC with the following:
 
@@ -81,6 +82,13 @@ Konvoy deploys with gp3 (general purpose SSDs) EBS volumes.
 
 - Driver documentation: [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
 - Volume types and pricing: [volume types](https://aws.amazon.com/ebs/features/)
+
+### Azure CSI Driver
+
+Konvoy deploys with StandardSSD_LRS for Azure Virtual Disks.
+
+- Driver documentation: [azure-csi-driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver)
+- Volume types and pricing: [volume types](https://azure.microsoft.com/en-us/pricing/details/storage/page-blobs/)
 
 ## On Premises and other storage options
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/D2IQ-84567
## Description of changes being made
We list default storage driver for AWS. Since we are supporting provisioning DKP on Azure as well, a default storage option for Azure should be added to this page.


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4540.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
