### PR TITLE
Qa/vsphere edits builds

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -55,7 +55,7 @@ crt
 Crunchbase
 cthelper
 cttimeout
-datacenter
+(datacenter|Datacenter)
 datasource
 D2iQ
 daemonsets

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/bootstrap/index.md
@@ -29,7 +29,7 @@ Before you begin, you must:
 
     The output resembles this example:
 
-    ```
+    ```sh
     ✓ Creating a bootstrap cluster
     ✓ Initializing new CAPI components
     ```
@@ -44,7 +44,7 @@ Before you begin, you must:
 1.  Ensure that the CAPV controllers are present with the command:
 
     ```bash
-     kubectl get pods -n capv-system
+    kubectl get pods -n capv-system
     ```
 
     The output resembles the following:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-base-os-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-base-os-image/index.md
@@ -7,13 +7,13 @@ excerpt: Create a Base OS VM Image in the VMware vSphere Client
 enterprise: false
 ---
 
-### Create a base OS image in the vSphere client
+## Create a base OS image in the vSphere client
 
 Creating a base OS image from DVD ISO files is a one-time process. Building a base OS image creates a base vSphere template in your vSphere environment. You can use the base OS image template to create a Kubernetes node vSphere template for your cluster.
 
 Refer to the vCenter and vSphere Client documentation for details.
 
-The next step is to [create a vSphere VM template][create-vsphere-template] that contains the CAPI and Kubernetes objects.]
+The next step is to [create a vSphere VM template][create-vsphere-template] that contains the CAPI and Kubernetes objects.
 
 [vsphere-doc-base-image]: https://docs.vmware.com/en/VMware-vSphere/index.html
 [create-vsphere-template]: ../create-capi-vm-image/

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/delete/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/delete/index.md
@@ -9,15 +9,16 @@ enterprise: false
 
 ## Prepare to delete a self-managed workload cluster
 
-<p class="message--note"><strong>NOTE: </strong>A self-managed workload cluster cannot delete itself. If your workload cluster is self-managed, you must create a bootstrap cluster and move the cluster lifecycle services to the bootstrap cluster before deleting the workload cluster.</p>
+<p class="message--note"><strong>NOTE: </strong>A self-managing workload cluster cannot delete itself. If your workload cluster is self-managing, you must create a bootstrap cluster and move the cluster lifecycle services to the bootstrap cluster before deleting the workload cluster.</p>
 
-If you did not make your workload cluster self-managed, as described in [Make New Cluster Self-Managed][makeselfmanaged], see [Delete the workload cluster](#delete-the-workload-cluster).
+If you did not make your workload cluster self-managing, as described in [Make New Cluster Self-Managed][makeselfmanaged], see [Delete the workload cluster](#delete-the-workload-cluster).
 
 1.  Create a bootstrap cluster:
 
     The bootstrap cluster will host the Cluster API controllers that reconcile the cluster objects marked for deletion:
 
-    <p class="message--note"><strong>NOTE: </strong>To avoid using the wrong kubeconfig, the following steps use explicit kubeconfig paths and contexts.</p>
+    <p class="message--note"><strong>NOTE: </strong>To avoid using the wrong kubeconfig, the following steps use explicit kubeconfig paths and contexts.
+    If you have set your <code>KUBECONFIG</code> to your environment, run the command <code>unset KUBECONFIG</code> before continuing below.</p>
 
     ```bash
     dkp create bootstrap --kubeconfig $HOME/.kube/config
@@ -34,17 +35,16 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
     The cluster lifecycle services on the bootstrap cluster are ready, but the workload cluster configuration is on the workload cluster. The `move` command moves the configuration, which takes the form of Cluster API Custom Resource objects, from the workload to the bootstrap cluster. This process is also called a [Pivot][pivot].
 
     ```bash
-    dkp move \
-        --from-kubeconfig ${CLUSTER_NAME}.conf \
-        --from-context konvoy-${CLUSTER_NAME}-admin@konvoy-${CLUSTER_NAME} \
-        --to-kubeconfig $HOME/.kube/config \
-        --to-context kind-konvoy-capi-bootstrapper
+    dkp move capi-resources \
+    --from-kubeconfig ${CLUSTER_NAME}.conf \
+    --from-context ${CLUSTER_NAME}-admin@${CLUSTER_NAME} \
+    --to-kubeconfig $HOME/.kube/config \
+    --to-context kind-konvoy-capi-bootstrapper
     ```
 
     ```sh
-    INFO[2021-06-09T11:47:11-07:00] Running pivot command                         fromClusterKubeconfig=aws-example.conf fromClusterContext= src="move/move.go:83" toClusterKubeconfig=/home/clusteradmin/.kube/config toClusterContext=
-    INFO[2021-06-09T11:47:36-07:00] Pivot operation complete.                     src="move/move.go:108"
-    INFO[2021-06-09T11:47:36-07:00] You can now view resources in the moved cluster by using the --kubeconfig flag with kubectl. For example: kubectl --kubeconfig=/home/clusteradmin/.kube/config get nodes  src="move/move.go:155"
+     ✓ Moving cluster resources 
+    You can now view resources in the moved cluster by using the --kubeconfig flag with kubectl. For example: kubectl --kubeconfig=$HOME/.kube/config get nodes
     ```
 
 1.  Use the cluster lifecycle services on the workload cluster to check the workload cluster status:
@@ -69,7 +69,7 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
         └─Machine/d2iq--md-0-74c849dc8c-sqklv                           True                     13h
     ```
 
-     <p class="message--note"><strong>NOTE: </strong>After moving the cluster lifecycle services to the workload cluster, remember to use dkp with the workload cluster kubeconfig.</p>
+     <p class="message--note"><strong>NOTE: </strong>After moving the cluster lifecycle services to the workload cluster, remember to use DKP with the workload cluster kubeconfig.</p>
 
     Use DKP with the bootstrap cluster to delete the workload cluster.
 
@@ -104,9 +104,11 @@ If you did not make your workload cluster self-managed, as described in [Make Ne
     ```
 
     ```sh
-    INFO[2022-03-30T11:53:42-07:00] Running cluster delete command                clusterName=d2iq-e2e-cluster-1 managementClusterKubeconfig= namespace=default src="cluster/delete.go:95"
-    INFO[2022-03-30T11:53:42-07:00] Waiting for cluster to be fully deleted       src="cluster/delete.go:123"
-    INFO[2022-03-30T12:14:03-07:00] Deleted default/d2iq-e2e-cluster-1 cluster  src="cluster/delete.go:129"
+     ✓ Deleting Services with type LoadBalancer for Cluster default/d2iq-e2e-cluster-1 
+     ✓ Deleting ClusterResourceSets for Cluster default/d2iq-e2e-cluster-1
+     ✓ Deleting cluster resources
+     ✓ Waiting for cluster to be fully deleted 
+    Deleted default/d2iq-e2e-cluster-1 cluster
     ```
 
     After the workload cluster is deleted, delete the bootstrap cluster.
@@ -118,7 +120,7 @@ dkp delete bootstrap --kubeconfig $HOME/.kube/config
 ```
 
 ```sh
-INFO[2021-06-09T12:15:20-07:00] Deleting bootstrap cluster                    src="bootstrap/bootstrap.go:182"
+ ✓ Deleting bootstrap cluster 
 ```
 
 ## Known Limitations

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/explore/index.md
@@ -2,14 +2,17 @@
 layout: layout.pug
 navigationTitle: Explore New Cluster
 title: Explore New Cluster
-menuWeight: 75
+menuWeight: 70
 excerpt: Learn to interact with your Kubernetes cluster
 enterprise: false
 ---
 
 This guide explains how to use the command line interface to interact with your newly-deployed Kubernetes cluster.
 
-Before you start, make sure you have [created a workload cluster][create-new-cluster] and, if needed, that you have [made the cluster self-managing][make-self-managed].
+Before you start, make sure you have [created a workload cluster][create-new-cluster] and, if needed, that you have [made the cluster self-managing][make-self-manage].
+
+<p class="message--note"><strong>NOTE: </strong>If you need to make your cluster self-managing, you must first <a href="#get-the-kubeconfig-file-for-the-new-kubernetes-cluster">create a kubeconfig</a> for your cluster.
+</p>
 
 ## Get the kubeconfig file for the new Kubernetes cluster
 
@@ -32,7 +35,7 @@ Before you start, make sure you have [created a workload cluster][create-new-clu
 1.  Return to the DKP CLI, and delete the existing `StorageClass` with the command:
 
     ```bash
-    kubectl delete storageclass vsphere-raw-block-sc
+    kubectl --kubeconfig ${CLUSTER_NAME}.conf delete storageclass vsphere-raw-block-sc
     ```
 
 1.  Run the following command to create a new StorageClass, supplying the correct values for your environment:
@@ -52,12 +55,22 @@ Before you start, make sure you have [created a workload cluster][create-new-clu
     EOF
     ```
 
+1.  Create thew new StorageClass:
+
+    ```bash
+    kubectl --kubeconfig ${CLUSTER_NAME}.conf apply -f vsphere-raw-block-sc.yaml
+    ```
+
+    ```sh
+    storageclass.storage.k8s.io/vsphere-raw-block-sc created
+    ```
+
 ## Explore Nodes and Pods in the New Cluster
 
 1.  List the Nodes using this command:
 
     ```bash
-    kubectl --kubeconfig=${CLUSTER_NAME}.conf get nodes
+    kubectl --kubeconfig ${CLUSTER_NAME}.conf get nodes
     ```
 
     <p class="message--note"><strong>NOTE: </strong>It may take a few minutes for the Status to move to <code>Ready</code> while the Pod network is deployed. The Node's Status should change to Ready soon after the <code>calico-node</code> DaemonSet Pods are Ready.</p>
@@ -142,7 +155,10 @@ Before you start, make sure you have [created a workload cluster][create-new-clu
     vmware-system-csi        vsphere-csi-node-rp77r                                               3/3     Running    0             19h
     ```
 
+The optional next step is to [make the cluster self-managing][make-self-manage].
+The step is optional because, as an example, if you are using an existing, self-managed cluster to create a managed cluster, you would not want the managed cluster to be self-managed.
+
 [install_docker]: https://docs.docker.com/get-docker/
 [install_kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [create-new-cluster]: ../new
-[make-self-managed]: ../self-managed/
+[make-self-manage]: ../self-managed/

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/new/index.md
@@ -15,7 +15,7 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 
 1.  Give your cluster a unique name suitable for your environment.
 
-1.  Set the CLUSTER_NAME environment variable with the command:
+1.  Set the `CLUSTER_NAME` environment variable with the command:
 
     ```bash
     export CLUSTER_NAME=my-vsphere-cluster
@@ -39,7 +39,7 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 
 1.  Generate the Kubernetes cluster objects by copying and editing this command to include the correct values, including the VM template name you assigned in the previous procedure:
 
-    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
+    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub's rate limit</a> use your Docker Hub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
 
     ```bash
     dkp create cluster vsphere \
@@ -49,9 +49,10 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
       --data-center <DATACENTER_NAME> \
       --data-store <DATASTORE_NAME> \
       --folder <FOLDER_NAME> \
-      --server <VCENTER_API_SERVER_UTR \
+      --server <VCENTER_API_SERVER_UTR> \
       --ssh-public-key-file <SSH_PUBLIC_KEY_FILE> \
       --resource-pool <RESOURE_POOL_NAME> \
+      --virtual-ip-interface <NETWORK_INTERFACE> \
       --vm-template <TEMPLATE_NAME>
     ```
 
@@ -78,7 +79,7 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 
 1.  (Optional) Create a Kubernetes cluster with HTTP proxy configured. This step assumes you did not already create a cluster in the previous steps:
 
-    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Dockerhub's rate limit</a> use your Dockerhub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
+    <p class="message--note"><strong>NOTE: </strong>To increase <a href="https://docs.docker.com/docker-hub/download-rate-limit/">Docker Hub's rate limit</a> use your Docker Hub credentials when creating the cluster, by setting the following flag <code>--registry-mirror-url=https://registry-1.docker.io --registry-mirror-username= --registry-mirror-password=</code> on the <code>dkp create cluster command</code>.</p>
 
     ```bash
     dkp create cluster vsphere --cluster-name=${CLUSTER_NAME} \
@@ -116,7 +117,7 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 1.  Create the cluster from the objects.
 
     ```bash
-    kubectl apply -f ${CLUSTER_NAME}.yaml
+    kubectl create -f ${CLUSTER_NAME}.yaml
     ```
 
     ```sh
@@ -184,7 +185,7 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 
 1.  Verify that the kubeadm control plane is ready with the command
 
-     ```sh
+     ```bash
     kubectl get kubeadmcontrolplane
     ```
 
@@ -197,7 +198,7 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 
 1.  Describe the kubeadm control plane and check its status and events with the command:
 
-    ```sh
+    ```bash
     kubectl describe kubeadmcontrolplane
     ```
 
@@ -221,9 +222,10 @@ Before you begin, make sure you have created a [Bootstrap][bootstrap] cluster.
 
 -   DKP Konvoy does not validate edits to cluster objects.
 
-The optional next step is to [make the cluster self-managing][make-self-manage]. The step is optional because, as an example, if you are using an existing, self-managed cluster to create a managed cluster, you would not want the managed cluster to be self-managed.
+Next, [explore your cluster][explore-cluster] and create your kubeconfig.
 
 [bootstrap]: ../bootstrap
 [capi_concepts]: https://cluster-api.sigs.k8s.io/user/concepts.html
+[explore-cluster]: ../explore
 [k8s_custom_resources]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 [make-self-manage]: ../self-managed/

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/prerequisites/index.md
@@ -19,7 +19,7 @@ Before using DKP to create a vSphere cluster, verify that you have:
 
 - An x86_64-based Linux&reg; or macOS&reg; machine.
 
-- The `dkp` binaries and [Konvoy Image Builder (KIB)][kib-bundle] image bundle for Linux or macOS.
+- The [`dkp` binaries][dkp-download] and [Konvoy Image Builder (KIB)][kib-bundle] image bundle for Linux or macOS.
 
 - [Docker&reg;][install_docker] version 18.09.2 or later installed.
   You must have Docker installed on the host where the DKP Konvoy CLI runs. For example, if you are installing Konvoy on your laptop, ensure the laptop has a supported version of Docker.
@@ -36,7 +36,7 @@ Before installing, verify that your [VMware vSphere Client environment][vsphere-
 
 - Access to a bastion VM, or other network connected host, running vSphere Client version v6.7.x with Update 3 or later version
 
-  - You must be able to reach the vSphere API endpoint from where the Konvoy command line interface (CLI) runs.
+  - You must be able to reach the vSphere API endpoint from where the DKP command line interface (CLI) runs.
 
 - vSphere account with credentials configured - this account must have Administrator privileges.
 
@@ -76,10 +76,11 @@ The next step is:
 
 - for air-gapped environments, [create and prepare a bastion VM][create-bastion-vm]
 
-[install_docker]: https://docs.docker.com/get-docker/
-[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
-[vsphere-vm-administration]: https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-55238059-912E-411F-A0E9-A7A536972A91.html
-[vmware-esxi-hosts]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.esxi.install.doc/GUID-B2F01BF5-078A-4C7E-B505-5DFFED0B8C38.html
 [create-base-os-image]: ../create-base-os-image/
 [create-bastion-vm]: ../air-gapped/create-bastion-vm
-[kib-bundle]: ../../../download/
+[dkp-download]: ../../../download
+[install_docker]: https://docs.docker.com/get-docker/
+[install_kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[kib-bundle]: ../../../image-builder
+[vmware-esxi-hosts]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.esxi.install.doc/GUID-B2F01BF5-078A-4C7E-B505-5DFFED0B8C38.html
+[vsphere-vm-administration]: https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-55238059-912E-411F-A0E9-A7A536972A91.html

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/prerequisites/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/prerequisites/index.md
@@ -9,72 +9,72 @@ enterprise: false
 
 Fulfilling the prerequisites involves completing these areas:
 
-- DKP prerequisites
+-   DKP prerequisites
 
-- vSphere prerequisites
+-   vSphere prerequisites
 
 ## DKP Prerequisites
 
 Before using DKP to create a vSphere cluster, verify that you have:
 
-- An x86_64-based Linux&reg; or macOS&reg; machine.
+-   An x86_64-based Linux&reg; or macOS&reg; machine.
 
-- The [`dkp` binaries][dkp-download] and [Konvoy Image Builder (KIB)][kib-bundle] image bundle for Linux or macOS.
+-   The [`dkp` binaries][dkp-download] and [Konvoy Image Builder (KIB)][kib-bundle] image bundle for Linux or macOS.
 
-- [Docker&reg;][install_docker] version 18.09.2 or later installed.
+-   [Docker&reg;][install_docker] version 18.09.2 or later installed.
   You must have Docker installed on the host where the DKP Konvoy CLI runs. For example, if you are installing Konvoy on your laptop, ensure the laptop has a supported version of Docker.
 
 <p class="message--note"><strong>NOTE: </strong>On macOS, Docker runs in a virtual machine. Configure this virtual machine with at least 8GB of memory.</strong></p>
 
-- [kubectl][install_kubectl] 1.21.6 for interacting with the running cluster, installed on the host where the DKP Konvoy command line interface (CLI) runs.
+-   [kubectl][install_kubectl] 1.21.6 for interacting with the running cluster, installed on the host where the DKP Konvoy command line interface (CLI) runs.
 
-- A valid VMware vSphere account with credentials configured.
+-   A valid VMware vSphere account with credentials configured.
 
 ## VMware vSphere Prerequisites
 
 Before installing, verify that your [VMware vSphere Client environment][vsphere-vm-administration] meets the following basic requirements:
 
-- Access to a bastion VM, or other network connected host, running vSphere Client version v6.7.x with Update 3 or later version
+-   Access to a bastion VM, or other network connected host, running vSphere Client version v6.7.x with Update 3 or later version
 
-  - You must be able to reach the vSphere API endpoint from where the DKP command line interface (CLI) runs.
+    - You must be able to reach the vSphere API endpoint from where the DKP command line interface (CLI) runs.
 
-- vSphere account with credentials configured - this account must have Administrator privileges.
+-   vSphere account with credentials configured - this account must have Administrator privileges.
 
-- A RedHat&reg; subscription with user name and password for downloading DVD ISOs
+-   A RedHat&reg; subscription with user name and password for downloading DVD ISOs
 
-- For air-gapped environments, a [bastion VM host template][create-bastion-vm] with access to a configured Docker registry
+-   For air-gapped environments, a [bastion VM host template][create-bastion-vm] with access to a configured Docker registry
 
-- Valid vSphere values for the following:
+-   Valid vSphere values for the following:
 
-  - vCenter API server URL
+    -   vCenter API server URL
 
-  - Datacenter name
+    -   Datacenter name
 
-  - Zone name that contains [ESXi hosts][vmware-esxi-hosts] for your cluster's nodes
+    -   Zone name that contains [ESXi hosts][vmware-esxi-hosts] for your cluster's nodes
 
-  - Datastore name for the shared storage resource to be used for the VMs in the cluster.
+    -   Datastore name for the shared storage resource to be used for the VMs in the cluster.
 
-    - Use of PersistentVolumes in your cluster depends on Cloud Native Storage (CNS), available in vSphere v6.7.x with Update 3 and later versions. CNS depends on this shared Datastore's configuration.
+        - Use of PersistentVolumes in your cluster depends on Cloud Native Storage (CNS), available in vSphere v6.7.x with Update 3 and later versions. CNS depends on this shared Datastore's configuration.
 
-  - Datastore URL from the datastore record for the shared datastore you want your cluster to use.
+    -   Datastore URL from the datastore record for the shared datastore you want your cluster to use.
 
-    - You need this URL value to ensure that the correct Datastore is used when DKP creates VMs for your cluster in vSphere.
+        - You need this URL value to ensure that the correct Datastore is used when DKP creates VMs for your cluster in vSphere.
 
-  - Folder name
+    -   Folder name
 
-  - Base template name, such as base-rhel-8, or base-rhel-7
+    -   Base template name, such as base-rhel-8, or base-rhel-7
 
-  - Name of a Virtual Network that has DHCP enabled for both air-gapped and non air-gapped environments
+    -   Name of a Virtual Network that has DHCP enabled for both air-gapped and non air-gapped environments
 
-  - Resource Pools - at least one resource pool needed, with every host in the pool having access to shared storage, such as VSAN
+    -   Resource Pools - at least one resource pool needed, with every host in the pool having access to shared storage, such as VSAN
 
-    - Each host in the resource pool needs access to shared storage, such as NFS or VSAN, to make use of MachineDeployments and high-availability control planes.
+        - Each host in the resource pool needs access to shared storage, such as NFS or VSAN, to make use of MachineDeployments and high-availability control planes.
 
 The next step is:
 
-- for non air-gapped environments, [create a base OS image][create-base-os-image]
+-   for non air-gapped environments, [create a base OS image][create-base-os-image]
 
-- for air-gapped environments, [create and prepare a bastion VM][create-bastion-vm]
+-   for air-gapped environments, [create and prepare a bastion VM][create-bastion-vm]
 
 [create-base-os-image]: ../create-base-os-image/
 [create-bastion-vm]: ../air-gapped/create-bastion-vm

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/self-managed/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/self-managed/index.md
@@ -92,7 +92,6 @@ Before starting, ensure you create a workload cluster as described in [Create a 
 
 -   DKP Konvoy only supports moving all namespaces in the cluster; DKP does not support migration of individual namespaces.
 
-
 Next, you can [explore the new cluster][explore-cluster] or [explore the new air-gapped cluster][explore-air-gapped].
 
 [bootstrap]: ../bootstrap

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/self-managed/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/self-managed/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Make New Cluster Self-Managed
 title: Make the New Cluster Self-Managed
-menuWeight: 70
+menuWeight: 75
 excerpt: Make the new Kubernetes cluster manage itself
 enterprise: false
 ---
@@ -28,12 +28,12 @@ Before starting, ensure you create a workload cluster as described in [Create a 
     The cluster lifecycle services on the workload cluster are ready, but the workload cluster configuration is on the bootstrap cluster. The `move` command moves the configuration, which takes the form of Cluster API Custom Resource objects, from the bootstrap to the workload cluster. This process is also called a [Pivot][pivot].
 
     ```bash
-    dkp move --to-kubeconfig ${CLUSTER_NAME}.conf
+    dkp move capi-resources --to-kubeconfig ${CLUSTER_NAME}.conf
     ```
 
     ```sh
-    INFO[2021-08-11T12:09:36-07:00] Pivot operation complete.                     src="move/move.go:154"
-    INFO[2021-08-11T12:09:36-07:00] You can now view resources in the moved cluster by using the --kubeconfig flag with kubectl. For example: kubectl --kubeconfig=/home/clusteradmin/.kube/config get nodes  src="move/move.go:155"
+     ✓ Moving cluster resources 
+    You can now view resources in the moved cluster by using the --kubeconfig flag with kubectl. For example: kubectl --kubeconfig=${CLUSTER_NAME}.conf get nodes
     ```
 
     <p class="message--note"><strong>NOTE: </strong>To ensure only one set of cluster lifecycle services manages the workload cluster, Konvoy first pauses reconciliation of the objects on the bootstrap cluster, then creates the objects on the workload cluster. As Konvoy copies the objects, the cluster lifecycle services on the workload cluster reconcile the objects. The workload cluster becomes self-managed after Konvoy creates all the objects. If it fails, the <code>move</code> command can be safely retried.</p>
@@ -79,7 +79,7 @@ Before starting, ensure you create a workload cluster as described in [Create a 
     ```
 
     ```sh
-    INFO[2022-03-30T17:53:36-07:00] Deleting bootstrap cluster                    src="bootstrap/bootstrap.go:182"
+     ✓ Deleting bootstrap cluster
     ```
 
 ## Known Limitations


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

Did a run through of vSphere and this updated everything to what's up to date in 2.2 and fixed some minor things.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
