### PR TITLE
fix: kommander upgrade not supported in migration

### DIFF
--- a/pages/dkp/konvoy/2.1/major-version-upgrade/understand-standard-config/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/understand-standard-config/index.md
@@ -189,7 +189,7 @@ spec:
       configVersion: stable-1.20-1.4.2
       addonsList:
         - name: kommander
-          enabled: true
+          enabled: false
   version: v1.8.3
 ```
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/understand-standard-config/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/understand-standard-config/index.md
@@ -192,6 +192,7 @@ spec:
           enabled: false
   version: v1.8.3
 ```
+Note that the Kommander Addon must be disabled to support the migration of Konvoy.
 
 Every environment is a "custom" environment to some degree. The most common customizations to the standard configuration include:
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Without this change, customers may be led to believe that the described Konvoy migration was covering Kommander as well. If done as documented, customers will hit the following error message:
```
$ kommander migrate -y
 ✓ Checking if migration from DKP 1.x is necessary 
Error: Kommander is installed on the cluster. Migration of this cluster is not supported.
```

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
