### PR TITLE
[Kaptain] cert-manager workaround

### DIFF
--- a/pages/dkp/kaptain/1.3.0/release-notes/1.3.0/index.md
+++ b/pages/dkp/kaptain/1.3.0/release-notes/1.3.0/index.md
@@ -19,13 +19,13 @@ This release provides new features and capabilities that improve user experience
 ### Garbage Collection
 
 Kaptain 1.3 supports automatic cleanup of completed and idling workloads. This prevents new workflows or versioned deployments from encountering a lack of resources and unnecessary pressure on controllers. Users will not reach namespace quotas, often set by administrators, as quickly. 
-Garbage collection allows users to configure cleanup of Kubeflow Pipeline runs and culling for Jupyter notebooks. Resources are automatically cleaned up when a cell execution is interrupted. Also, using the SDK, users can see how certain resources were created (e.g., by a user or by the SDK).
+Garbage collection allows users to configure cleanup of Kubeflow Pipeline runs and culling for Jupyter notebooks. Resources are automatically cleaned up when a cell execution is interrupted. Also, using the SDK, users can see how certain resources were created (for example, by a user or by the SDK).
 For information on what resources are created during each phase of the model development lifecycle and how to use garbage collection, see [SDK](../../sdk/1.0.x/) and [SDK Troubleshooting](../../sdk/1.0.x/troubleshooting/).
 For examples of garbage collection for Katib experiments, see the [Hyperparameter Tutorial](../../tutorials/katib/).
 
 ### Support for model building/deploying using non-deep learning frameworks
 
-With Kaptain SDK version 1.0.0, users can build and deploy models using frameworks even if they aren't supported in Kaptain. The SDK API is made more generic by using Kubernetes Jobs.
+With Kaptain SDK version 1.0.0, users can build and deploy models using frameworks even if they are not supported in Kaptain. The SDK API is made more generic by using Kubernetes Jobs.
 For an example using scikit-learn, see [Quickstart Tutorial](../../tutorials/sdk/quick-start/)
 
 ### Models page
@@ -41,7 +41,7 @@ In DKP 2.1, Kaptain's dependencies are managed through Kommander, the centralize
 
 * Fixed Kaptain redirectUrl is missing the hostname (COPS-7138)
 
-* Fixed the issue with a notebook doesn't mount notebook volume on the correct mountpoint (COPS-7064)
+* Fixed the issue with a notebook that does not mount notebook volume on the correct mountpoint (COPS-7064)
 
 * Document how to use `requirements.txt` to add additional python dependencies to notebooks
 
@@ -70,3 +70,41 @@ In DKP 2.1, Kaptain's dependencies are managed through Kommander, the centralize
 * CUDA 11.2
 * MXNet 1.9
 
+## Known issues
+
+### cert-manager workaround for Kaptain
+
+Due to an oversight, some Kommander versions do not properly handle certificate renewal for the Cluster CA and certificates that are created for Kommander applications, which also affects Kaptain. While the effects can vary, the most common failure is the inability to launch Kaptain notebooks in Jupyter.
+
+#### Regenerate the secrets in DKP
+
+A permanent fix for the issue requires upgrading to Kommander 2.2.1 or higher. If you are running other versions of DKP, refer to the cert-manager expiration workaround documentation for DKP [2.1.0](../../../../kommander/2.1/release-notes/2.1.0#cert-manager-expiration-workaround), [2.1.1](../../../../kommander/2.1/release-notes/2.1.1#cert-manager-expiration-workaround) or [2.1.2](../../../../kommander/2.1/release-notes/2.1.2#cert-manager-expiration-workaround) to run a docker container that extends the validity of the Cluster CA to 10 years and fixes the certificate reload issue.
+
+Once this is done, you can fix the issue on Kaptain’s side.
+
+#### Regain access to Kaptain
+
+This gives you back the capability of launching notebooks in Jupyter:
+
+1.  Kaptain has one certificate that you have to delete to force a refresh, and one that you can update manually for Istio:
+
+    ```bash
+    kubectl delete secrets kubeflow-gateway-certs -n kubeflow --force
+    ```
+
+1.  Obtain the CA from one of the other recreated certs:
+
+    ```bash
+    kubectl get secret kommander-traefik-certificate -o jsonpath='{.data.ca\.crt}' > ca.crt
+    ```
+
+1.  Use this CA and apply it to the Istio CA:
+
+    ```bash
+    kubectl delete secret kubeflow-oidc-ca-bundle -n kubeflow --force
+    kubectl -n kubeflow create secret generic kubeflow-oidc-ca-bundle --from-file=oidcCABundle\.crt=ca.crt
+    ```
+
+Running this command reloads the pod automatically. Wait a few minutes until you attempt to log in to DKP and Kaptain again. 
+
+Test by logging into both and launch a new notebook in Jupyter.

--- a/pages/dkp/kaptain/1.3.0/release-notes/1.3.0/index.md
+++ b/pages/dkp/kaptain/1.3.0/release-notes/1.3.0/index.md
@@ -74,7 +74,7 @@ In DKP 2.1, Kaptain's dependencies are managed through Kommander, the centralize
 
 ### cert-manager workaround for Kaptain
 
-Due to an oversight, some Kommander versions do not properly handle certificate renewal for the Cluster CA and certificates that are created for Kommander applications, which also affects Kaptain. While the effects can vary, the most common failure is the inability to launch Kaptain notebooks in Jupyter.
+Some Kommander versions do not properly handle certificate renewal for the Cluster CA and certificates that are created for Kommander applications, which also affects Kaptain. While the effects can vary, the most common failure is the inability to launch Kaptain notebooks in Jupyter.
 
 #### Regenerate the secrets in DKP
 

--- a/pages/dkp/kaptain/1.3.0/release-notes/1.3.0/index.md
+++ b/pages/dkp/kaptain/1.3.0/release-notes/1.3.0/index.md
@@ -41,7 +41,7 @@ In DKP 2.1, Kaptain's dependencies are managed through Kommander, the centralize
 
 * Fixed Kaptain redirectUrl is missing the hostname (COPS-7138)
 
-* Fixed the issue with a notebook that does not mount notebook volume on the correct mountpoint (COPS-7064)
+* Fixed the issue with a notebook that does not mount notebook volume on the correct mount point (COPS-7064)
 
 * Document how to use `requirements.txt` to add additional python dependencies to notebooks
 
@@ -95,7 +95,7 @@ This gives you back the capability of launching notebooks in Jupyter:
 1.  Obtain the CA from one of the other recreated certs:
 
     ```bash
-    kubectl get secret kommander-traefik-certificate -o jsonpath='{.data.ca\.crt}' > ca.crt
+    kubectl get secret kommander-traefik-certificate -n kommander -o jsonpath='{.data.ca\.crt}' > ca.crt
     ```
 
 1.  Use this CA and apply it to the Istio CA:

--- a/pages/dkp/kaptain/2.0.0/release-notes/2.0.0/index.md
+++ b/pages/dkp/kaptain/2.0.0/release-notes/2.0.0/index.md
@@ -66,7 +66,7 @@ Kaptain 2.0 drastically reduces the bundle sizes improving download times, espec
 
 ### cert-manager workaround for Kaptain
 
-Due to an oversight, some Kommander versions do not properly handle certificate renewal for the Cluster CA and certificates that are created for Kommander applications, which also affects Kaptain. While the effects can vary, the most common failure is the inability to launch Kaptain notebooks in Jupyter.
+Some Kommander versions do not properly handle certificate renewal for the Cluster CA and certificates that are created for Kommander applications, which also affects Kaptain. While the effects can vary, the most common failure is the inability to launch Kaptain notebooks in Jupyter.
 
 #### Regenerate the secrets in DKP
 

--- a/pages/dkp/kaptain/2.0.0/release-notes/2.0.0/index.md
+++ b/pages/dkp/kaptain/2.0.0/release-notes/2.0.0/index.md
@@ -19,7 +19,7 @@ D2iQ is announcing Kaptain 2.0 which includes several user experience features, 
 
 ### Added Kaptain as DKP Catalog application
 
-Starting with Kaptain 2.0, it can be easily installed via the DKP workspace catalog in both single and multi-cluster experiences. Kaptain 2.0 is supported on DKP 2.1.2 onwards.
+Starting with Kaptain 2.0, it can be easily installed via the DKP workspace catalog in both single and multi-cluster experiences. Kaptain 2.0 is supported on DKP 2.1.2 and later.
 
 ### Support for Amazon EKS, Azure AKS and DKP multi-cluster
 
@@ -45,7 +45,7 @@ Kaptain 2.0 drastically reduces the bundle sizes improving download times, espec
 
 * Moved from KFServing to KServe
 * Fixed the cudatoolkit version regression (COPS-7219)
-* Bumped Pytorch to 1.11.0 and CUDA to 11.4 to support modern multi-instance GPUs, such as Nvidia A100 (COPS-7211)
+* Bumped PyTorch to 1.11.0 and CUDA to 11.4 to support modern multi-instance GPUs, such as Nvidia A100 (COPS-7211)
 
 ## Software updates
 
@@ -57,7 +57,46 @@ Kaptain 2.0 drastically reduces the bundle sizes improving download times, espec
 - Kubeflow Pipelines 1.8.1
 - Training Operator 1.4.0
 - Tensorflow 2.8.0
-- Pytorch 1.11.0
+- PyTorch 1.11.0
 - CUDA 11.4
 - MXNet 1.9
 - Horovod 0.24.2
+
+## Known issues
+
+### cert-manager workaround for Kaptain
+
+Due to an oversight, some Kommander versions do not properly handle certificate renewal for the Cluster CA and certificates that are created for Kommander applications, which also affects Kaptain. While the effects can vary, the most common failure is the inability to launch Kaptain notebooks in Jupyter.
+
+#### Regenerate the secrets in DKP
+
+A permanent fix for the issue requires upgrading to Kommander 2.2.1 or higher. If you are running other versions of DKP, refer to the cert-manager expiration workaround documentation for DKP [2.1.0](../../../../kommander/2.1/release-notes/2.1.0#cert-manager-expiration-workaround), [2.1.1](../../../../kommander/2.1/release-notes/2.1.1#cert-manager-expiration-workaround) or [2.1.2](../../../../kommander/2.1/release-notes/2.1.2#cert-manager-expiration-workaround) to run a docker container that extends the validity of the Cluster CA to 10 years and fixes the certificate reload issue.
+
+Once this is done, you can fix the issue on Kaptain’s side.
+
+#### Regain access to Kaptain
+
+This gives you back the capability of launching notebooks in Jupyter:
+
+1.  Kaptain has one certificate that you have to delete to force a refresh, and one that you can update manually for Istio:
+
+    ```bash
+    kubectl delete secrets kubeflow-gateway-certs -n kaptain-ingress --force
+    ```
+
+1.  Obtain the CA from one of the other recreated certs:
+
+    ```bash
+    kubectl get secret kommander-traefik-certificate -n kommander -o jsonpath='{.data.ca\.crt}' > ca.crt
+    ```
+
+1.  Use this CA and apply it to the Istio CA:
+
+    ```bash
+    kubectl delete secret kubeflow-oidc-ca-bundle -n kaptain-ingress --force
+    kubectl -n kubeflow create secret generic kubeflow-oidc-ca-bundle --from-file=oidcCABundle\.crt=ca.crt
+    ```
+
+Running this command reloads the pod automatically. Wait a few minutes until you attempt to log in to DKP and Kaptain again. 
+
+Test by logging into both and launch a new notebook in Jupyter.


### PR DESCRIPTION
## Jira Ticket

Offering a workaround for https://jira.d2iq.com/browse/COPS-7287. 
The Kaptain team has decided to have a fix for Kaptain 2.1, therefore adding the workaround to 1.3 and 2.0 only. 

## Description of changes being made

The cert-manager issue we faced with DKP is affecting Kaptain as well. This workaround is based on a [fix provided by support](https://hackmd.io/@d2iq-gs/ryc9LW_Ic). The commands still need to fixed and tested.

### Preview

http://docs-d2iq-com-pr-4545.s3-website-us-west-2.amazonaws.com/

