### PR TITLE
docs: Align chart and component versions to match shipped config

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -61,7 +61,7 @@ The unified DKP user interface provides a smooth experience independent of where
 ### Kaptain AI/ML, D2iQ’s AI/ML offering
 
 For better integration with DKP 2.2, you can launch Kaptain as a catalog application. It also supports other platforms such as Amazon AWS EKS and Microsoft Azure AKS. Kaptain extends D2iQ’s ability to support Kubernetes platforms beyond DKP. It further enables an organization to develop, deploy and run entire ML workloads in production, at scale, with consistency and reliability.
- 
+
 ### DKP Insights
 
 This new predictive analytics tool provides greater support productivity, speed, and reduced costs. The [DKP Insights](/dkp/kommander/2.2/insights/) Engine collects events and metrics on the Attached cluster, and uses rule-based heuristics on potential problems of varying criticality, so they can be quickly identified and resolved. These Insights are then forwarded and displayed in the DKP Insights Dashboard, where it assists you with routine tasks such as:
@@ -123,7 +123,7 @@ When upgrading to this release, the following services and service components ar
 | Thanos | thanos | 0.4.6 | - chart: 0.4.6<br>- thanos: 0.9.0 |
 | Traefik | traefik | 10.9.1 | - chart: 10.9.1<br>- traefik: 2.5.6 |
 | Traefik ForwardAuth | traefik-forward-auth | 0.3.6 | - chart: 0.3.6<br>- traefik-forward-auth: 3.1.0 |
-| Velero | velero | 3.2.0 | - chart: 3.2.0<br>- velero: 1.5.2 |
+| Velero | velero | 3.1.5 | - chart: 3.1.5<br>- velero: 1.5.2 |
 
 
 ## Known issues
@@ -347,7 +347,7 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
 
     ```bash
     # spark-operator is the default value
-    # if you override the HelmRelease name in your override configmap, use that value in the following command 
+    # if you override the HelmRelease name in your override configmap, use that value in the following command
     export SPARK_OPERATOR_RELEASE_NAME=spark-operator
     # only one instance of spark operator should be deployed per cluster
     kubectl delete pod -n $WORKSPACE_NAMESPACE $(kubectl get pod -l app.kubernetes.io/name=$SPARK_OPERATOR_RELEASE_NAME -n $WORKSPACE_NAMESPACE -o jsonpath='{range .items[0]}{.metadata.name}')

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -62,8 +62,8 @@ When upgrading to this release, the following services and service components ar
 | Cert Manager            | cert-manager                                   | 1.7.1   | - chart: 1.7.1<br>- cert-manager: 1.7.1                                                                                                 |
 | Chartmuseum             | chartmuseum                                    | 3.6.2   | - chart: 3.6.2<br>- chartmuseum: 3.6.2                                                                                                  |
 | Containerd              | containerd                                     | 1.4.11  |                                                                                                                                           |
-| Dex                     | dex                                            | 2.9.14  | - chart: 2.9.14<br>- dex: 2.22.0                                                                                                        |
-| External DNS            | external-dns                                   | 6.1.8   | - chart: 6.1.8<br>- external-dns: 0.10.2                                                                                                |
+| Dex                     | dex                                            | 2.9.15  | - chart: 2.9.15<br>- dex: 2.22.0                                                                                                        |
+| External DNS            | external-dns                                   | 6.2.7   | - chart: 6.2.7<br>- external-dns: 0.11.0                                                                                                |
 | Fluent Bit              | fluent-bit                                     | 0.19.20 | - chart: 0.19.20<br>- fluent-bit: 1.8.13                                                                                                |
 | Flux                    | kommander-flux                                 | 0.27.4  |                                                                                                                                           |
 | Gatekeeper              | gatekeeper                                     | 3.7.0   | - chart: 3.7.0<br>- gatekeeper: 3.7.0                                                                                                   |
@@ -75,9 +75,9 @@ When upgrading to this release, the following services and service components ar
 | Kiali                   | kiali                                          | 1.47.0  | - chart: 1.47.0<br>- kiali: 1.47.0                                                                                                      |
 | Knative                 | knative                                        | 0.3.9   | - chart: 0.3.9<br>- knative: 0.22.3                                                                                                     |
 | Kube OIDC Proxy         | kube-oidc-proxy                                | 0.3.1   | - chart: 0.3.1<br>- kube-oidc-proxy: 0.3.0                                                                                              |
-| Kube Prometheus Stack   | [kube-prometheus-stack][kube-prometheus-stack] | 33.1.6  | - chart: 33.1.5<br>- prometheus-operator: 0.54.1<br>- prometheus: 2.33.4<br>- prometheus alertmanager: 0.23.0<br>- grafana: 8.3.6 |
+| Kube Prometheus Stack   | [kube-prometheus-stack][kube-prometheus-stack] | 33.1.6  | - chart: 33.1.6<br>- prometheus-operator: 0.54.1<br>- prometheus: 2.33.4<br>- prometheus alertmanager: 0.23.0<br>- grafana: 8.3.6 |
 | Kubecost                | kubecost                                       | 0.23.3  | - chart: 0.23.3<br>- cost-analyzer: 1.91.2                                                                                              |
-| Kubefed                 | kubefed                                        | 0.9.1   | - chart: 0.9.1<br>- kubefed: 0.9.1                                                                                                      |
+| Kubefed                 | kubefed                                        | 0.9.2   | - chart: 0.9.2<br>- kubefed: 0.9.1                                                                                                      |
 | Kubernetes Dashboard    | kubernetes-dashboard                           | 5.1.1   | - chart: 5.1.1<br>- kubernetes-dashboard: 2.4.0                                                                                         |
 | Kubetunnel              | kubetunnel                                     | 0.0.11  | - chart: 0.0.11<br>- kubetunnel: 0.0.11                                                                                                 |
 | Logging Operator        | logging-operator                               | 3.17.2  | - chart: 3.17.2<br>- logging-operator: 3.17.2                                                                                           |
@@ -92,7 +92,7 @@ When upgrading to this release, the following services and service components ar
 | Thanos                  | thanos                                         | 0.4.6   | - chart: 0.4.6<br>- thanos: 0.9.0                                                                                                       |
 | Traefik                 | traefik                                        | 10.9.1  | - chart: 10.9.1<br>- traefik: 2.5.6                                                                                                     |
 | Traefik ForwardAuth     | traefik-forward-auth                           | 0.3.6   | - chart: 0.3.6<br>- traefik-forward-auth: 3.1.0                                                                                         |
-| Velero                  | velero                                         | 3.2.0   | - chart: 3.2.0<br>- velero: 1.5.2                                                                                                       |
+| Velero                  | velero                                         | 3.1.5   | - chart: 3.1.5<br>- velero: 1.5.2                                                                                                       |
 
 ## Known Issues
 


### PR DESCRIPTION
## Jira Ticket

No Ticket. 

## Description of changes being made

I reviewed a 'stock' 2.2.1 install (as well as the kommander-applications/release-2.2  branch) and found some discrepancies between the documented chart/component versions with the release notes.  This PR brings the RN in alignment with reality.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
