### PR TITLE
vSphere yaml variable specifics for KIB

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,13 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
--    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
--    datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
--    datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
--    folder: Virtual machine folder to create the virtual machine in.
--    network: The vSphere network in which the virtual machine will be connected to.
--    resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
--    template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
+-    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere.
+-    datacenter: vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
+-    datastore: vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
+-    folder: Virtual machine folder in which to create the virtual machine.
+-    network: The vSphere network in which the virtual machine will be connected.
+-    resource_pool: vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    template: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it, which will produce a new vSphere template. The new vsphere template can be used to create virtual machines for the Kubernetes cluster.
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -46,13 +46,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
--    'cluster': vSphere cluster is a name of the collection of ESXi hosts in vSphere.
--    'datacenter': vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
--    'datastore': vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
--    'folder': Virtual machine folder in which to create the virtual machine.
--    'network': The vSphere network in which the virtual machine will be connected.
--    'resource_pool': vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
--    'template': Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template which can be used to create virtual machines for the Kubernetes cluster.
+-    `cluster`: vSphere cluster is a name of the collection of ESXi hosts in vSphere.
+-    `datacenter`: vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
+-    `datastore`: vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
+-    `folder`: Virtual machine folder in which to create the virtual machine.
+-    `network`: The vSphere network in which the virtual machine will be connected.
+-    `resource_pool`: vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    `template`: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template which can be used to create virtual machines for the Kubernetes cluster.
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -68,3 +68,4 @@ Next, create a Kubernetes [bootstrap cluster][bootstrap] to enable creating your
 
 [vsphere-base-os-image]: ../create-base-os-image/
 [bootstrap]: ../bootstrap
+

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -46,13 +46,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
--    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere.
--    datacenter: vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
--    datastore: vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
--    folder: Virtual machine folder in which to create the virtual machine.
--    network: The vSphere network in which the virtual machine will be connected.
--    resource_pool: vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
--    template: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template which can be used to create virtual machines for the Kubernetes cluster.
+-    'cluster': vSphere cluster is a name of the collection of ESXi hosts in vSphere.
+-    'datacenter': vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
+-    'datastore': vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
+-    'folder': Virtual machine folder in which to create the virtual machine.
+-    'network': The vSphere network in which the virtual machine will be connected.
+-    'resource_pool': vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    'template': Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template which can be used to create virtual machines for the Kubernetes cluster.
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,6 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
+cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
+datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
+datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
+folder: Virtual machine folder to create the virtual machine in.
+network: The vSphere network in which the virtual machine will be connected to.
+resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -46,7 +46,6 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
-<!Shalin - please enter the variables you believe would benefit the customer>
 -    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere.
 -    datacenter: vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
 -    datastore: vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -53,7 +53,7 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 -    folder: Virtual machine folder in which to create the virtual machine.
 -    network: The vSphere network in which the virtual machine will be connected.
 -    resource_pool: vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
--    template: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it, which will produce a new vSphere template. The new vsphere template can be used to create virtual machines for the Kubernetes cluster.
+-    template: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template which can be used to create virtual machines for the Kubernetes cluster.
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,13 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
-cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
-datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
-datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
-folder: Virtual machine folder to create the virtual machine in.
-network: The vSphere network in which the virtual machine will be connected to.
-resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
-template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
+-    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
+-    datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
+-    datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
+-    folder: Virtual machine folder to create the virtual machine in.
+-    network: The vSphere network in which the virtual machine will be connected to.
+-    resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -44,7 +44,7 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
       distribution_version: "example_7.9"
     ```
 
-    The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables.  However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
+    The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -44,7 +44,11 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
       distribution_version: "example_7.9"
     ```
 
-1. Create the vSphere VM template with the following command:
+    The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables.  However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
+
+<!Shalin - please enter the variables you believe would benefit the customer>
+
+4. Create the vSphere VM template with the following command:
 
    ```bash
    konvoy-image build path/to/image.yaml

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,13 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
--    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere.
--    datacenter: vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
--    datastore: vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
--    folder: Virtual machine folder in which to create the virtual machine.
--    network: The vSphere network in which the virtual machine will be connected.
--    resource_pool: vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
--    template: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template that can be used to create virtual machines for the Kubernetes cluster.
+-    'cluster': vSphere cluster is a name of the collection of ESXi hosts in vSphere.
+-    'datacenter': vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
+-    'datastore': vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
+-    'folder': Virtual machine folder in which to create the virtual machine.
+-    'network': The vSphere network in which the virtual machine will be connected.
+-    'resource_pool': vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    'template': Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template that can be used to create virtual machines for the Kubernetes cluster.
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,13 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
--    'cluster': vSphere cluster is a name of the collection of ESXi hosts in vSphere.
--    'datacenter': vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
--    'datastore': vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
--    'folder': Virtual machine folder in which to create the virtual machine.
--    'network': The vSphere network in which the virtual machine will be connected.
--    'resource_pool': vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
--    'template': Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template that can be used to create virtual machines for the Kubernetes cluster.
+-    `cluster`: vSphere cluster is a name of the collection of ESXi hosts in vSphere.
+-    `datacenter`: vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
+-    `datastore`: vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
+-    `folder`: Virtual machine folder in which to create the virtual machine.
+-    `network`: The vSphere network in which the virtual machine will be connected.
+-    `resource_pool`: vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    `template`: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template that can be used to create virtual machines for the Kubernetes cluster.
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,6 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
+cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
+datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
+datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
+folder: Virtual machine folder to create the virtual machine in.
+network: The vSphere network in which the virtual machine will be connected to.
+resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,13 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
--    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
--    datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
--    datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
--    folder: Virtual machine folder to create the virtual machine in.
--    network: The vSphere network in which the virtual machine will be connected to.
--    resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
--    template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
+-    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere.
+-    datacenter: vSphere datacenter name - This is required if more than one datacenter exists in the vSphere inventory.
+-    datastore: vSphere datastore name - The datastore stores files of the virtual machines. These could be located on a local server, hard drive or across the network on a SAN.
+-    folder: Virtual machine folder in which to create the virtual machine.
+-    network: The vSphere network in which the virtual machine will be connected.
+-    resource_pool: vSphere resource pool name - If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    template: Name of the vSphere template of the base operating system - Konvoy Image Builder will use the base operating system template and configure it. This will produce a new vSphere template that can be used to create virtual machines for the Kubernetes cluster.
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -47,13 +47,13 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
     The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
-cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
-datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
-datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
-folder: Virtual machine folder to create the virtual machine in.
-network: The vSphere network in which the virtual machine will be connected to.
-resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
-template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
+-    cluster: vSphere cluster is a name of the collection of ESXi hosts in vSphere
+-    datacenter: vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
+-    datastore: vSphere datastore name. The datastore stores files of the virtual machines. They could be located on a local server hard drive or across the network on a SAN
+-    folder: Virtual machine folder to create the virtual machine in.
+-    network: The vSphere network in which the virtual machine will be connected to.
+-    resource_pool: vSphere resource pool name. If not set, it will look for the root resource pool of the host or cluster. If a root resource is not found, it will then look for a default resource pool.
+-    template: Name of the vSphere template of the base operating system. konvoy image builder will use the base operating system template and configure it produce new vsphere template. The new vsphere template can be used to create virtual machines for the kubernetes cluster
 
 4. Create the vSphere VM template with the following command:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -44,7 +44,7 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
       distribution_version: "example_7.9"
     ```
 
-    The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables.  However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
+    The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables. However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
 
 <!Shalin - please enter the variables you believe would benefit the customer>
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/create-capi-vm-image/index.md
@@ -44,7 +44,11 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
       distribution_version: "example_7.9"
     ```
 
-1. Create the vSphere VM template with the following command:
+    The website for [Packer](https://www.packer.io/plugins/builders/vsphere/vsphere-clone) gives details around many of these variables.  However, there are fewer configuration variables needed for use in the vSphere KIB provisioning than what is listed on the Packer website. Below are the variables and optional configurations to be used with vSphere:
+
+<!Shalin - please enter the variables you believe would benefit the customer>
+
+4. Create the vSphere VM template with the following command:
 
    ```bash
    konvoy-image build path/to/image.yaml


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/COPS-7272?jql=issuetype%20%3D%20%22Customer%20Issue%22%20and%20Team%20%3D%2044%20and%20resolution%20is%20EMPTY%20

## Description of changes being made
In the page https://docs.d2iq.com/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-capi-vm-image/ it shows several variables needed to be configured when the `image.yaml` file is created.
There is no explanation on what each of the variable is for but as it is based on Packer, we can put in a link in the docs to point to the Packer documentation.
We can add description of the only configuration needed for the vsphere KIB provisioning. 
Stalin can work with Assignee to add those details.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4550.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
