### PR TITLE
chore(konvoy): add airgapped upgrade

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -54,7 +54,7 @@ Using the [Konvoy Image Builder](../../../image-builder), you can copy the requi
 1.  Download the PIP packages. This bundle includes a few packages required by DKP to bootstrap machines.
 
     ```bash
-    curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/konvoy/airgapped/pip-packages/pip-packages.tar.gz
+    curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/dkp/airgapped/pip-packages/pip-packages.tar.gz
     ```
 
 1.  Export the following environment variables, ensuring that all control plane and worker nodes are included:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -120,22 +120,22 @@ Before creating a Kubernetes cluster you must have the required images in a loca
 
 1.  Ensure you set the REGISTRY_URL and AIRGAPPED_TAR_FILE variable appropriately, then use the following script to load the air-gapped image bundle:
 
-    ``` sh
+    ```bash
     #!/usr/bin/env bash
     set -euo pipefail
     IFS=$'\n\t'
 
-    readonly AIRGAPPED_TAR_FILE=${AIRGAPPED_TAR_FILE:-"kommander-image-bundle.tar"}
+    readonly AIRGAPPED_TAR_FILE=${AIRGAPPED_TAR_FILE:-"konvoy-image-bundle.tar.gz"}
     readonly REGISTRY_URL=${REGISTRY_URL?"Need to set REGISTRY_URL. E.g: 10.23.45.67:5000"}
 
     docker load <"${AIRGAPPED_TAR_FILE}"
 
     while read -r IMAGE; do
       echo "Processing ${IMAGE}"
-      REGISTRY_IMAGE="$(echo "${IMAGE}" | sed -E "s@^(quay|gcr|ghcr|docker|k8s.gcr).io@${REGISTRY_URL}@")"
+      REGISTRY_IMAGE="${REGISTRY_URL}/$(echo "${IMAGE}" | sed -E "s@^(quay|gcr|ghcr|docker|k8s.gcr|us.gcr).io/@@")"
       docker tag "${IMAGE}" "${REGISTRY_IMAGE}"
       docker push "${REGISTRY_IMAGE}"
-    done < <(tar xfO "${AIRGAPPED_TAR_FILE}" "index.json" | grep -oP '(?<="io.containerd.image.name":").*?(?=",)')
+    done < <(jq -r '.[] | .RepoTags[] | .' <(tar xfO "${AIRGAPPED_TAR_FILE}" manifest.json))
     ```
 
 It may take a while to push all the images to your image registry, depending on the performance of the network between the machine you are running the script on and the Docker registry.

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
@@ -234,6 +234,8 @@ Follow these steps only if you are upgrading an air-gapped Cluster.
 
 ## Prepare Artifacts
 
+<p class="message--note"><strong>NOTE: </strong>For upgrading Konvoy Image Builder version [v1.14.0](https://github.com/mesosphere/konvoy-image-builder/releases/tag/v1.14.0) should be used. Later versions will work; however, a containerd bundle must be provided in addition to the stated artifacts.</p>
+
 <!-- NOTE(jkoelker) Vale doesn't like the link or the name of the page. -->
 <!-- vale Vale.Terms = NO -->
 <!-- vale Vale.Avoid = NO -->

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
@@ -8,13 +8,13 @@ beta: true
 enterprise: false
 ---
 
-Follow these steps only if you are upgrading an Air-gapped Cluster.
+Follow these steps only if you are upgrading an air-gapped Cluster.
 
 ## Patch `containerd` config
 
 1.  Download the current `/etc/containerd/config.toml` from one of the nodes.
 
-2.  Edit the `metrics` section, replacing the node's IP address with `{{ inventory_hostname }}`. The section will be the following:
+1.  Edit the `metrics` section, replacing the node's IP address with `{{ inventory_hostname }}`. The section will be the following:
 
     ```toml
     [metrics]
@@ -22,8 +22,7 @@ Follow these steps only if you are upgrading an Air-gapped Cluster.
     grpc_histogram = false
     ```
 
-
-3.  Setup the registry variables:
+1.  Setup the registry variables:
 
     ```bash
     export DOCKER_REGISTRY_HOST=<registry-address>
@@ -39,9 +38,9 @@ Follow these steps only if you are upgrading an Air-gapped Cluster.
     - DOCKER_REGISTRY_USERNAME: the username for registry auth.
     - DOCKER_REGISTRY_PASSWORD: the password for registry auth.
 
-    <p class="message--note"><strong>NOTE: </strong>If your registry does not require auth, you may omit `DOCKER_REGISTRY_USERNAME` and `DOCKER_REGISTRY_PASSWORD` and the `plugins."io.containerd.grpc.v1.cri".registry.configs` section</p>
+    <p class="message--note"><strong>NOTE: </strong>If your registry does not require auth, you may omit <code>DOCKER_REGISTRY_USERNAME</code> and <code>DOCKER_REGISTRY_PASSWORD</code> and the <code>plugins."io.containerd.grpc.v1.cri".registry.configs</code> section</p>
 
-4.  Edit the `plugins."io.containerd.grpc.v1.cri".registry` section and replace the contents with:
+1.  Edit the `plugins."io.containerd.grpc.v1.cri".registry` section and replace the contents with:
 
     ```toml
     [plugins."io.containerd.grpc.v1.cri".registry]
@@ -195,41 +194,40 @@ Follow these steps only if you are upgrading an Air-gapped Cluster.
         base_image_size = ""
         ```
 
-5.  Create a playbook to apply the config to the cluster.
+1.  Create a playbook to apply the config to the cluster.
 
     ```yaml
     cat <<EOF > registry.yaml
-     ---
-     - hosts: node control-plane
-       any_errors_fatal: true
-       name: "add wildcard registry entry"
-       gather_facts: false
-       become: true
-       strategy: linear
+    ---
+    - hosts: node control-plane
+      any_errors_fatal: true
+      name: "add wildcard registry entry"
+      gather_facts: false
+      become: true
+      strategy: linear
 
-       tasks:
-         - name: wait 360 for target connection to become reachable
-           wait_for_connection:
-             timeout: 360
+      tasks:
+        - name: wait 360 for target connection to become reachable
+          wait_for_connection:
+            timeout: 360
 
-         - name: copy containerd config
-           template:
-             src: config.toml
-             dest: /etc/containerd/config.toml
+        - name: copy containerd config
+          template:
+            src: config.toml
+            dest: /etc/containerd/config.toml
 
-         - name: restart containerd
-           service:
-             name: containerd
-             state: restarted
-             enabled: true
+        - name: restart containerd
+          service:
+            name: containerd
+            state: restarted
+            enabled: true
     EOF
     ```
 
-6. Replay the current `/etc/containerd/config.toml` on the nodes.
+1.  Replay the current `/etc/containerd/config.toml` on the nodes.
 
     Run this command:
 
     ```bash
     konvoy run playbook registry.yaml -y
     ```
-

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
@@ -1,0 +1,235 @@
+---
+layout: layout.pug
+navigationTitle: Prepare Air-Gapped Cluster
+title: Prepare Air-Gapped Cluster
+menuWeight: 10
+excerpt: Preparing an air-gapped cluster for upgrade
+beta: true
+enterprise: false
+---
+
+Follow these steps only if you are upgrading an Air-gapped Cluster.
+
+## Patch `containerd` config
+
+1.  Download the current `/etc/containerd/config.toml` from one of the nodes.
+
+2.  Edit the `metrics` section, replacing the node's IP address with `{{ inventory_hostname }}`. The section will be the following:
+
+    ```toml
+    [metrics]
+    address = "{{ inventory_hostname }}:1338"
+    grpc_histogram = false
+    ```
+
+
+3.  Setup the registry variables:
+
+    ```bash
+    export DOCKER_REGISTRY_HOST=<registry-address>
+    export DOCKER_REGISTRY_PORT=<registry-port>
+    export DOCKER_REGISTRY_ADDRESS="<https/http>://${DOCKER_REGISTRY_HOST}:${DOCKER_REGISTRY_PORT}"
+    export DOCKER_REGISTRY_USERNAME=<registry-username>
+    export DOCKER_REGISTRY_PASSWORD=<registry-password>
+    ```
+
+    - DOCKER_REGISTRY_HOST: the hostname / IP address of an existing Docker registry that the cluster nodes use when pulling images.
+    - DOCKER_REGISTRY_PORT: the TCP port the registry listens on.
+    - DOCKER_REGISTRY_ADDRESS: the full address of the registry with the protocol specified (https|http).
+    - DOCKER_REGISTRY_USERNAME: the username for registry auth.
+    - DOCKER_REGISTRY_PASSWORD: the password for registry auth.
+
+    <p class="message--note"><strong>NOTE: </strong>If your registry does not require auth, you may omit `DOCKER_REGISTRY_USERNAME` and `DOCKER_REGISTRY_PASSWORD` and the `plugins."io.containerd.grpc.v1.cri".registry.configs` section</p>
+
+4.  Edit the `plugins."io.containerd.grpc.v1.cri".registry` section and replace the contents with:
+
+    ```toml
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["${DOCKER_REGISTRY_ADDRESS}/v2/","https://registry-1.docker.io"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."*"]
+          endpoint = ["${DOCKER_REGISTRY_ADDRESS}/v2/"]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."${DOCKER_REGISTRY_ADDRESS}".auth]
+            username = "${DOCKER_REGISTRY_USERNAME}"
+            password = "${DOCKER_REGISTRY_PASSWORD}"
+            auth = ""
+            identitytoken = ""
+    ```
+
+    The full contents of the file will be similar to the following:
+
+    ```toml
+    version = 2
+    root = "/var/lib/containerd"
+    state = "/run/containerd"
+    plugin_dir = ""
+    disabled_plugins = []
+    required_plugins = []
+    oom_score = 0
+
+
+    [grpc]
+      address = "/run/containerd/containerd.sock"
+      tcp_address = ""
+      tcp_tls_cert = ""
+      tcp_tls_key = ""
+      uid = 0
+      gid = 0
+      max_recv_message_size = 16777216
+      max_send_message_size = 16777216
+
+    [ttrpc]
+      address = ""
+      uid = 0
+      gid = 0
+
+    [debug]
+      address = ""
+      uid = 0
+      gid = 0
+      level = ""
+
+    [metrics]
+      address = "{{ inventory_hostname }}:1338"
+      grpc_histogram = false
+
+    [cgroup]
+      path = ""
+
+    [timeouts]
+      "io.containerd.timeout.shim.cleanup" = "5s"
+      "io.containerd.timeout.shim.load" = "5s"
+      "io.containerd.timeout.shim.shutdown" = "3s"
+      "io.containerd.timeout.task.state" = "2s"
+
+    [plugins]
+      [plugins."io.containerd.gc.v1.scheduler"]
+        pause_threshold = 0.02
+        deletion_threshold = 0
+        mutation_threshold = 100
+        schedule_delay = "0s"
+        startup_delay = "100ms"
+      [plugins."io.containerd.grpc.v1.cri"]
+        disable_tcp_service = true
+        stream_server_address = "127.0.0.1"
+        stream_server_port = "0"
+        stream_idle_timeout = "4h0m0s"
+        enable_selinux = false
+        sandbox_image = "${DOCKER_REGISTRY_HOST}:${DOCKER_REGISTRY_PORT}/k8s.gcr.io/pause:3.2"
+        stats_collect_period = 10
+        systemd_cgroup = false
+        enable_tls_streaming = false
+        max_container_log_line_size = 16384
+        disable_cgroup = false
+        disable_apparmor = false
+        restrict_oom_score_adj = false
+        max_concurrent_downloads = 3
+        disable_proc_mount = false
+        [plugins."io.containerd.grpc.v1.cri".containerd]
+          snapshotter = "overlayfs"
+          default_runtime_name = "runc"
+          no_pivot = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+            runtime_type = ""
+            runtime_engine = ""
+            runtime_root = ""
+            privileged_without_host_devices = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+            runtime_type = ""
+            runtime_engine = ""
+            runtime_root = ""
+            privileged_without_host_devices = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+              runtime_type = "io.containerd.runc.v1"
+              runtime_engine = ""
+              runtime_root = ""
+              privileged_without_host_devices = false
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime]
+              runtime_type = "io.containerd.runc.v1"
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime.options]
+                BinaryName = "/usr/bin/nvidia-container-runtime"
+        [plugins."io.containerd.grpc.v1.cri".cni]
+          bin_dir = "/opt/cni/bin"
+          conf_dir = "/etc/cni/net.d"
+          max_conf_num = 1
+          conf_template = ""
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+              endpoint = ["${DOCKER_REGISTRY_ADDRESS}/v2/","https://registry-1.docker.io"]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."*"]
+              endpoint = ["${DOCKER_REGISTRY_ADDRESS}/v2/"]
+          [plugins."io.containerd.grpc.v1.cri".registry.configs]
+            [plugins."io.containerd.grpc.v1.cri".registry.configs."${DOCKER_REGISTRY_ADDRESS}".auth]
+                username = "${DOCKER_REGISTRY_USERNAME}"
+                password = "${DOCKER_REGISTRY_PASSWORD}"
+                auth = ""
+                identitytoken = ""
+        [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+          tls_cert_file = ""
+          tls_key_file = ""
+      [plugins."io.containerd.internal.v1.opt"]
+        path = "/opt/containerd"
+      [plugins."io.containerd.internal.v1.restart"]
+        interval = "10s"
+      [plugins."io.containerd.metadata.v1.bolt"]
+        content_sharing_policy = "shared"
+      [plugins."io.containerd.monitor.v1.cgroups"]
+        no_prometheus = false
+      [plugins."io.containerd.runtime.v1.linux"]
+        shim = "containerd-shim"
+        runtime = "runc"
+        runtime_root = ""
+        no_shim = false
+        shim_debug = false
+      [plugins."io.containerd.runtime.v2.task"]
+        platforms = ["linux/amd64"]
+      [plugins."io.containerd.service.v1.diff-service"]
+        default = ["walking"]
+      [plugins."io.containerd.snapshotter.v1.devmapper"]
+        root_path = ""
+        pool_name = ""
+        base_image_size = ""
+        ```
+
+5.  Create a playbook to apply the config to the cluster.
+
+    ```yaml
+    cat <<EOF > registry.yaml
+     ---
+     - hosts: node control-plane
+       any_errors_fatal: true
+       name: "add wildcard registry entry"
+       gather_facts: false
+       become: true
+       strategy: linear
+
+       tasks:
+         - name: wait 360 for target connection to become reachable
+           wait_for_connection:
+             timeout: 360
+
+         - name: copy containerd config
+           template:
+             src: config.toml
+             dest: /etc/containerd/config.toml
+
+         - name: restart containerd
+           service:
+             name: containerd
+             state: restarted
+             enabled: true
+    EOF
+    ```
+
+6. Replay the current `/etc/containerd/config.toml` on the nodes.
+
+    Run this command:
+
+    ```bash
+    konvoy run playbook registry.yaml -y
+    ```
+

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
@@ -231,3 +231,12 @@ Follow these steps only if you are upgrading an air-gapped Cluster.
     ```bash
     konvoy run playbook registry.yaml -y
     ```
+
+## Prepare Artifacts
+
+<!-- NOTE(jkoelker) Vale doesn't like the link or the name of the page. -->
+<!-- vale Vale.Terms = NO -->
+<!-- vale Vale.Avoid = NO -->
+1. Follow the directions for loading the airgapped artifacts from [Prerequisites when Air-Gapped](../../../choose-infrastructure/pre-provisioned/prerequisites-airgapped/).
+<!-- vale Vale.Avoid = YES -->
+<!-- vale Vale.Terms = YES-->

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
@@ -224,9 +224,7 @@ Follow these steps only if you are upgrading an air-gapped Cluster.
     EOF
     ```
 
-1.  Replay the current `/etc/containerd/config.toml` on the nodes.
-
-    Run this command:
+1.  Replay the current `/etc/containerd/config.toml` onto the nodes, by running this command:
 
     ```bash
     konvoy run playbook registry.yaml -y

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
@@ -192,7 +192,7 @@ Follow these steps only if you are upgrading an air-gapped Cluster.
         root_path = ""
         pool_name = ""
         base_image_size = ""
-        ```
+    ```
 
 1.  Create a playbook to apply the config to the cluster.
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-air-gapped/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: Prepare Air-Gapped Cluster
 title: Prepare Air-Gapped Cluster
-menuWeight: 10
+menuWeight: 15
 excerpt: Preparing an air-gapped cluster for upgrade
 beta: true
 enterprise: false


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-84226

## Description of changes being made

Add section to document additional steps needed to successfully upgrade an air-gapped cluster

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4551.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
