### PR TITLE
[Kaptain] REDO: adding cert-manager workaround to 2.1 docs

### DIFF
--- a/pages/dkp/kaptain/2.0.0/release-notes/2.0.0/index.md
+++ b/pages/dkp/kaptain/2.0.0/release-notes/2.0.0/index.md
@@ -94,9 +94,9 @@ This gives you back the capability of launching notebooks in Jupyter:
 
     ```bash
     kubectl delete secret kubeflow-oidc-ca-bundle -n kaptain-ingress --force
-    kubectl -n kubeflow create secret generic kubeflow-oidc-ca-bundle --from-file=oidcCABundle\.crt=ca.crt
+    kubectl -n kaptain-ingress create secret generic kubeflow-oidc-ca-bundle --from-file=oidcCABundle\.crt=ca.crt
     ```
 
-Running this command reloads the pod automatically. Wait a few minutes until you attempt to log in to DKP and Kaptain again. 
+Running this command reloads the pod automatically. Wait a few minutes until you attempt to log in to DKP and Kaptain again.
 
 Test by logging into both and launch a new notebook in Jupyter.

--- a/pages/dkp/kaptain/2.1.0/release-notes/2.1.0/index.md
+++ b/pages/dkp/kaptain/2.1.0/release-notes/2.1.0/index.md
@@ -57,7 +57,7 @@ This gives you back the capability of launching notebooks in Jupyter:
 
     ```bash
     kubectl delete secret kubeflow-oidc-ca-bundle -n kaptain-ingress --force
-    kubectl -n kubeflow create secret generic kubeflow-oidc-ca-bundle --from-file=oidcCABundle\.crt=ca.crt
+    kubectl -n kaptain-ingress create secret generic kubeflow-oidc-ca-bundle --from-file=oidcCABundle\.crt=ca.crt
     ```
 
 Running this command reloads the pod automatically. Wait a few minutes until you attempt to log in to DKP and Kaptain again. 

--- a/pages/dkp/kaptain/2.1.0/release-notes/2.1.0/index.md
+++ b/pages/dkp/kaptain/2.1.0/release-notes/2.1.0/index.md
@@ -17,10 +17,49 @@ D2iQ is announcing Kaptain 2.1 which includes several user experience features, 
 
 ## New features and capabilities
 
-
 ## Fixes and Improvements
 
 * 
+
 ## Software updates
 
 - 
+
+## Known issues
+
+### cert-manager workaround for Kaptain
+
+Some Kommander versions do not properly handle certificate renewal for the Cluster CA and certificates that are created for Kommander applications, which also affects Kaptain. While the effects can vary, the most common failure is the inability to launch Kaptain notebooks in Jupyter.
+
+#### Regenerate the secrets in DKP
+
+A permanent fix for the issue requires upgrading to Kommander 2.2.1 or higher. If you are running other versions of DKP, refer to the cert-manager expiration workaround documentation for DKP [2.1.0](../../../../kommander/2.1/release-notes/2.1.0#cert-manager-expiration-workaround), [2.1.1](../../../../kommander/2.1/release-notes/2.1.1#cert-manager-expiration-workaround) or [2.1.2](../../../../kommander/2.1/release-notes/2.1.2#cert-manager-expiration-workaround) to run a docker container that extends the validity of the Cluster CA to 10 years and fixes the certificate reload issue.
+
+Once this is done, you can fix the issue on Kaptain’s side.
+
+#### Regain access to Kaptain
+
+This gives you back the capability of launching notebooks in Jupyter:
+
+1.  Kaptain has one certificate that you have to delete to force a refresh, and one that you can update manually for Istio:
+
+    ```bash
+    kubectl delete secrets kubeflow-gateway-certs -n kaptain-ingress --force
+    ```
+
+1.  Obtain the CA from one of the other recreated certs:
+
+    ```bash
+    kubectl get secret kommander-traefik-certificate -n kommander -o jsonpath='{.data.ca\.crt}' > ca.crt
+    ```
+
+1.  Use this CA and apply it to the Istio CA:
+
+    ```bash
+    kubectl delete secret kubeflow-oidc-ca-bundle -n kaptain-ingress --force
+    kubectl -n kubeflow create secret generic kubeflow-oidc-ca-bundle --from-file=oidcCABundle\.crt=ca.crt
+    ```
+
+Running this command reloads the pod automatically. Wait a few minutes until you attempt to log in to DKP and Kaptain again. 
+
+Test by logging into both and launch a new notebook in Jupyter.


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/COPS-7287

## Description of changes being made

Added the exact same fix in 1.3 and 2.0 and originally thought the fix was on the way to 2.1. https://github.com/mesosphere/dcos-docs-site/pull/4545
However, this will be handled as a feature in 2.2, so we do need the workaround for 2.1.
Basically a copy and paste from 2.0.

### Preview

http://docs-d2iq-com-pr-4552.s3-website-us-west-2.amazonaws.com/

