### PR TITLE
[Kommander] custom domains and certificates for managed clusters

### DIFF
--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -96,7 +96,7 @@ Let's Encrypt is one of the Certificate Authorities (CA) supported by cert-manag
 
 ## Verify the status of the configuration and troubleshoot in case of errors
 
-If you want to ensure the customization for a domain or a certificate is completed, or if you want to obtain more information in case the customization fails, call up a list of statuses for the `KommanderCluster`.
+If you want to ensure the customization for a domain or a certificate is completed, or if you want to obtain more information if the customization fails, display the status information for the `KommanderCluster`.
 
 1.  Inspect the modified `KommanderCluster` object:
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -40,7 +40,7 @@ Refer to the following examples:
     EOF
     ```
 
-    Another option is to use a certificate provided by you and **customized for your hostname**. To do so, create a secret holding the certificate on the target cluster. Reference that secret in the `certificateSecretRef` field and the custom domain in the `hostname` field of the target cluster:
+    Another option is to use a manually created certificate that is **customized for your hostname**. To do so, create a secret holding the certificate on the target cluster. Reference that secret in the `certificateSecretRef` field and the custom domain name in the `hostname` field of the target cluster:
 
     ```yaml
     cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -24,32 +24,32 @@ Use the API yaml to customize the domain (via the `hostname` field), and the cer
 
 You have two options to update and apply the `KommanderCluster` resource with the required ingress. Refer to the following examples:
 
-  1. One option is to use a certificate that is managed automatically and supported by cert-manager like ACME (if you use Let's Encrypt, refer to the [example below](#example-configure-a-custom-certificate-with-lets-encrypt). For this, reference the **name of the `Issuer` or `ClusterIssuer` that contains your ACME provider information** in the `issuerRef` field, and enter the custom domain name in the `hostname` field of the target cluster:
+1.  One option is to use a certificate that is managed automatically and supported by cert-manager like ACME (if you use Let's Encrypt, refer to the [example below](#example-configure-a-custom-certificate-with-lets-encrypt). For this, reference the **name of the `Issuer` or `ClusterIssuer` that contains your ACME provider information** in the `issuerRef` field, and enter the custom domain name in the `hostname` field of the target cluster:
 
-  ```yaml
-  cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
-  kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
-  spec:
-    ingress:
-      hostname: <cluster_hostname>
-      issuerRef:
-        name: <issuer_name>
-        kind: ClusterIssuer # or Issuer depending on the issuer config
-  EOF
-  ```
+    ```yaml
+    cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
+    kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
+    spec:
+      ingress:
+        hostname: <cluster_hostname>
+        issuerRef:
+          name: <issuer_name>
+          kind: ClusterIssuer # or Issuer depending on the issuer config
+    EOF
+    ```
 
-  1. Another option is to use a manually created certificate that is **customized for your hostname**. To do so, create a [TLS Secret holding the certificate](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) on the target cluster. Reference that secret in the `certificateSecretRef` field and the custom domain name in the `hostname` field of the target cluster:
+1.  Another option is to use a manually created certificate that is **customized for your hostname**. To do so, create a [TLS Secret holding the certificate](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) on the target cluster. Reference that secret in the `certificateSecretRef` field and the custom domain name in the `hostname` field of the target cluster:
 
-  ```yaml
-  cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
-  kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
-  spec:
-    ingress:
-      hostname: <cluster_hostname>
-      certificateSecretRef:
-        name: <secret_name>
-  EOF
-  ```
+    ```yaml
+    cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
+    kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
+    spec:
+      ingress:
+        hostname: <cluster_hostname>
+        certificateSecretRef:
+          name: <secret_name> 
+    EOF
+    ```
 
 <p class="message--note"><strong>NOTE: </strong>It is not possible to configure the namespace of the secret with a command. Ensure the secret is stored in the workspace namespace of the target cluster.</p>
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -26,7 +26,7 @@ Refer to the following examples:
 
 1.  You have two options to create or update and apply the `KommanderCluster` object with the wanted ingress.
 
-    One option is to use a certificate that is managed automatically and supported by cert-manager like ACME (if you use Let's Encrypt, refer to the [example below](#example-configure-a-custom-certificate-with-lets-encrypt). For this, reference the `Issuer` or `ClusterIssuer` on the target cluster **to be used by cert-manager** in the `issuerRef` field, and enter the custom domain in the `hostname` field of the target cluster:
+    One option is to use a certificate that is managed automatically and supported by cert-manager like ACME (if you use Let's Encrypt, refer to the [example below](#example-configure-a-custom-certificate-with-lets-encrypt). For this, reference the **name of the `Issuer` or `ClusterIssuer` that contains your ACME provider information** in the `issuerRef` field, and enter the custom domain name in the `hostname` field of the target cluster:
 
     ```yaml
     cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -16,7 +16,7 @@ To customize the domain or certificate for a specific cluster after the installa
 
 <p class="message--warning"><strong>IMPORTANT:</strong> Ensure your <code>dkp</code> configuration references the management cluster of the environment where you want to customize the domain or certificate by setting the <code>KUBECONFIG=<path></code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-To customize the domain or certificate of a cluster, alter the `issuer` object in the `ingress` values of the `KommanderCluster`. Note that you can reference an issuer as an `issuerRef` **OR** a secret as a `certificateSecretRef`, as long as the object is created on the cluster where you want to customize the configuration.
+To customize the domain or certificate of a cluster, alter the `spec` values of the `ingress` object in the `KommanderCluster`. Note that you can reference an issuer as an `issuerRef` **OR** a secret as a `certificateSecretRef`, as long as the object is created on the cluster where you want to customize the configuration.
 
 In the Management cluster, both the `KommanderCluster` and `issuerRef` or `certificateSecretRef` objects are on the same cluster. In Managed and Attached clusters, the `KommanderCluster` object is stored on the Management cluster, and the `issuerRef` or `certificateSecretRef` object is on the Managed or Attached cluster.
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 This section describes how to enable custom domains and certificates in your **Management and any Managed or Attached** clusters after the installation of DKP. If you want to set up a custom domain and certificate for your Management Cluster **during the installation**, refer to the [Customize a domain and certificate during installation][management] documentation.
 
-To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` that will allow DKP to implement the established adjustments on top of the default or any previous configuration you have made.
+To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` that allows DKP to implement the established adjustments on top of the default, or any previous configuration, you have made.
 
 ## Configure custom domains or custom certificates
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -12,15 +12,21 @@ This section describes how to enable custom domains and certificates in your **M
 
 To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` that will allow Kommander to implement the established adjustments on top of the default or any previous configuration you have made.
 
+Note that the `Issuer` object must be created on the cluster where you want to customize the configuration. In the Management cluster, both the `KommanderCluster` and `Issuer` objects are on the same cluster. In Managed and Attached clusters, the `KommanderCluster` object is stored on Management cluster, and the `Issuer` object is on the Managed or Attached cluster.
+
 ## Configure custom domains or custom certificates
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster of the environment where you want to customize the domain or certificate by setting the <code>KUBECONFIG=<path></code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-Use the API yaml to customize the domain (via the `hostname` field), the certificate (via the `issuerRef` or `certificateSecretRef` field), or both. For this, refer to the following examples:
+To customize the domain or certificate of a cluster, alter the `ingress` values of the `KommanderCluster`. Note that the `Issuer` object must be created on the cluster where you want to customize the configuration. In the Management cluster, both the `KommanderCluster` and `Issuer` objects are on the same cluster. In Managed and Attached clusters, the `KommanderCluster` object is stored on Management cluster, and the `Issuer` object is on the Managed or Attached cluster.
 
-1.  You have two options to create or update and apply the `KommanderCluster` object with the wanted ingress. Remember to specify the cluster in the `kubeconfigRef` name field.
+Use the API yaml to customize the domain (via the `hostname` field), the certificate (via the `issuerRef` or `certificateSecretRef` field), or both.
 
-    One option is to use a certificate that is managed automatically by cert-manager with the ACME protocol like Let's Encrypt. For this, reference the `Issuer` or `ClusterIssuer` **to be used by cert-manager** in the `issuerRef` field, and enter the custom domain in the `hostname` field of the target cluster:
+For this, refer to the following examples:
+
+1.  You have two options to create or update and apply the `KommanderCluster` object with the wanted ingress.
+
+    One option is to use a certificate that is managed automatically and supported by cert-manager like ACME (if you use Let's Encrypt, refer to the [example below](#example-configure-a-custom-certificate-with-lets-encrypt). For this, reference the `Issuer` or `ClusterIssuer` on the target cluster **to be used by cert-manager** in the `issuerRef` field, and enter the custom domain in the `hostname` field of the target cluster:
 
     ```yaml
     cat <<EOF | kubectl apply -f -
@@ -43,7 +49,7 @@ Use the API yaml to customize the domain (via the `hostname` field), the certifi
     EOF
     ```
 
-    Another option is to use a certificate provided by you and **customized for your hostname**. To do so, enter the secret in the `certificateSecretRef` field and the custom domain in the `hostname` field of the target cluster:
+    Another option is to use a certificate provided by you and **customized for your hostname**. To do so, create a secret holding the certificate on the target cluster. Reference that secret in the `certificateSecretRef` field and the custom domain in the `hostname` field of the target cluster:
 
     ```yaml
     cat <<EOF | kubectl apply -f -
@@ -66,6 +72,12 @@ Use the API yaml to customize the domain (via the `hostname` field), the certifi
     EOF
     ```
 
+### Example: Configure a custom certificate with Let's Encrypt
+
+Let's Encrypt is one of the Certificate Authorities (CA) supported by cert-manager. To set up a Let's Encrypt certificate, provide a `Issuer` or `ClusterIssuer` on the target cluster in the `issuerRef` field:
+
+<!-- TODO: example for let's encrypt -->
+
 ## Verify the status of the configuration and troubleshoot in case of errors
 
 If you want to ensure the customization for a domain or a certificate is completed, or if you want to obtain more information in case the customization fails, call up a list of statuses for the `KommanderCluster`.
@@ -78,7 +90,7 @@ If you want to ensure the customization for a domain or a certificate is complet
 
     If the ingress is still being provisioned, the output looks similar to this:
 
-    ```bash
+    ```yaml
       conditions:
       - lastTransitionTime: "2022-06-24T07:48:31Z"
         message: Ingress service object was not found in the cluster
@@ -89,7 +101,7 @@ If you want to ensure the customization for a domain or a certificate is complet
 
     If the provisioning has been completed, the output looks similar to this:
 
-    ```bash
+    ```yaml
       - lastTransitionTime: "2022-06-24T07:58:48Z"
         message: Ingress service address has been provisioned
         reason: IngressServiceAddressFound
@@ -104,77 +116,10 @@ If you want to ensure the customization for a domain or a certificate is complet
 
 You can also call up the actual customized values, by inspecting the `KommanderCluster.Status.Ingress`. Here is an example:
 
-```bash
+```yaml
   ingress:
     address: 172.20.255.180
     caBundle: LS0tLS1CRUdJTiBD...<output has been shortened>...DQVRFLS0tLS0K
 ```
-
-## Automatic certificate management (ACME)
-
-Your managed or attached cluster can be configured to automatically issue a trusted certificate for the configured custom domain and renew it before expiration.
-
-### Let's encrypt
-
-Set up a Let’s Encrypt certificate for the cluster ingress, to validate the certificate for the cluster. Because ACME does not set up a CA bundle, some of the platform applications must be customized to use the certificate created by the ACME issuer:
-
-```yaml
-apiVersion: config.kommander.mesosphere.io/v1alpha1
-kind: Installation
-clusterHostname: mycluster.domain.dom
-acme:
-  email: <your_email>
-apps:
-  traefik-forward-auth-mgmt:
-    values: |
-      traefikForwardAuth:
-        caSecretName: null
-  kube-oidc-proxy:
-    values: |
-      oidc:
-        caSystemDefault: true
-  dex-k8s-authenticator:
-    values: |
-      caCerts:
-        caSecretName: null
-        useSystemDefault: true
-```
-
-### Other ACME issuers
-
-You can use other issuers that support the ACME protocol by configuring the issuer's server in the installation configuration. For example, to use the ZeroSSL service:
-
-```yaml
-acme:
-  email: <your_email>
-  server: https://acme.zerossl.com/v2/DV90
-[...]
-```
-
-### Customize issuer details
-
-By default, `kommander install` sets up a working ACME solver using HTTP01 challenges. If further control over the certificate issuing is needed, you can modify the pre-configured `ClusterIssuer`. For example, you can use a DNS01 challenge:
-
-```yaml
-cat <<EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: kommander-acme-issuer
-spec:
-  acme:
-    email: <your_email>
-    server: https://acme-v02.api.letsencrypt.org/directory
-    privateKeySecretRef:
-      name: kommander-acme-issuer-account
-    solvers:
-      - dns01:
-          route53:
-            region: us-east-1
-            role: arn:aws:iam::YYYYYYYYYYYY:role/dns-manager
-EOF
-```
-
-For more information on the available options, refer to the [ACME section in the cert-manager documentation](https://cert-manager.io/docs/configuration/acme/).
 
 [management]: ../../../install/configuration/custom-domain/

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -14,7 +14,7 @@ To customize the domain or certificate for a specific cluster after the installa
 
 ## Configure custom domains or custom certificates
 
-<p class="message--warning"><strong>IMPORTANT:</strong> Ensure your <code>dkp</code> configuration references the management cluster of the environment where you want to customize the domain or certificate by setting the <code>KUBECONFIG=<path></code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
+<p class="message--warning"><strong>IMPORTANT:</strong> Ensure your <code>dkp</code> configuration references the Management cluster of the environment where you want to customize the domain or certificate by setting the <code>KUBECONFIG=<path></code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
 To customize the domain or certificate of a cluster, alter the `spec` values of the `ingress` object in the `KommanderCluster` resource. Note that you can reference an issuer as an `issuerRef` **OR** a secret as a `certificateSecretRef`, as long as the object is created in the cluster where you want to customize the configuration.
 
@@ -119,17 +119,17 @@ If the provisioning has been completed, the output looks similar to this:
 
 ```yaml
 [...]
-    Conditions:
-      Last Transition Time:  2022-06-28T13:43:33Z
-      Message:               Ingress service address has been provisioned
-      Reason:                IngressServiceAddressFound
-      Status:                True
-      Type:                  IngressAddressReady
-      Last Transition Time:  2022-06-28T13:42:24Z
-      Message:               Certificate is up to date and has not expired
-      Reason:                Ready
-      Status:                True
-      Type:                  IngressCertificateReady
+Conditions:
+  Last Transition Time:  2022-06-28T13:43:33Z
+  Message:               Ingress service address has been provisioned
+  Reason:                IngressServiceAddressFound
+  Status:                True
+  Type:                  IngressAddressReady
+  Last Transition Time:  2022-06-28T13:42:24Z
+  Message:               Certificate is up to date and has not expired
+  Reason:                Ready
+  Status:                True
+  Type:                  IngressCertificateReady
 [...]
 ```
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -16,48 +16,46 @@ To customize the domain or certificate for a specific cluster after the installa
 
 <p class="message--warning"><strong>IMPORTANT:</strong> Ensure your <code>dkp</code> configuration references the management cluster of the environment where you want to customize the domain or certificate by setting the <code>KUBECONFIG=<path></code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-To customize the domain or certificate of a cluster, alter the `spec` values of the `ingress` object in the `KommanderCluster`. Note that you can reference an issuer as an `issuerRef` **OR** a secret as a `certificateSecretRef`, as long as the object is created on the cluster where you want to customize the configuration.
+To customize the domain or certificate of a cluster, alter the `spec` values of the `ingress` object in the `KommanderCluster` resource. Note that you can reference an issuer as an `issuerRef` **OR** a secret as a `certificateSecretRef`, as long as the object is created in the cluster where you want to customize the configuration.
 
 In the Management cluster, both the `KommanderCluster` and `issuerRef` or `certificateSecretRef` objects are on the same cluster. In Managed and Attached clusters, the `KommanderCluster` object is stored on the Management cluster, and the `issuerRef` or `certificateSecretRef` object is on the Managed or Attached cluster.
 
 Use the API yaml to customize the domain (via the `hostname` field), and the certificate (via the `issuerRef` or `certificateSecretRef` field).
 
-Refer to the following examples:
+You have two options to update and apply the `KommanderCluster` resource with the required ingress. Refer to the following examples:
 
-1.  You have two options to create or update and apply the `KommanderCluster` object with the wanted ingress.
+  1. One option is to use a certificate that is managed automatically and supported by cert-manager like ACME (if you use Let's Encrypt, refer to the [example below](#example-configure-a-custom-certificate-with-lets-encrypt). For this, reference the **name of the `Issuer` or `ClusterIssuer` that contains your ACME provider information** in the `issuerRef` field, and enter the custom domain name in the `hostname` field of the target cluster:
 
-    One option is to use a certificate that is managed automatically and supported by cert-manager like ACME (if you use Let's Encrypt, refer to the [example below](#example-configure-a-custom-certificate-with-lets-encrypt). For this, reference the **name of the `Issuer` or `ClusterIssuer` that contains your ACME provider information** in the `issuerRef` field, and enter the custom domain name in the `hostname` field of the target cluster:
+  ```yaml
+  cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
+  kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
+  spec:
+    ingress:
+      hostname: <cluster_hostname>
+      issuerRef:
+        name: <issuer_name>
+        kind: ClusterIssuer # or Issuer depending on the issuer config
+  EOF
+  ```
 
-    ```yaml
-    cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
-    kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
-    spec:
-      ingress:
-        hostname: <cluster_hostname>
-        issuerRef:
-          name: <issuer_name>
-          kind: ClusterIssuer # or Issuer depending on the issuer config
-    EOF
-    ```
+  1. Another option is to use a manually created certificate that is **customized for your hostname**. To do so, create a [TLS Secret holding the certificate](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) on the target cluster. Reference that secret in the `certificateSecretRef` field and the custom domain name in the `hostname` field of the target cluster:
 
-    Another option is to use a manually created certificate that is **customized for your hostname**. To do so, create a secret holding the certificate on the target cluster. Reference that secret in the `certificateSecretRef` field and the custom domain name in the `hostname` field of the target cluster:
-
-    ```yaml
-    cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
-    kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
-    spec:
-      ingress:
-        hostname: <cluster_hostname>
-        certificateSecretRef:
-          name: <secret_name>
-    EOF
-    ```
+  ```yaml
+  cat <<EOF | kubectl -n <workspace_namespace> --kubeconfig <management_cluster_kubeconfig> patch \ 
+  kommandercluster <cluster_name>  --type='merge' --patch-file=/dev/stdin
+  spec:
+    ingress:
+      hostname: <cluster_hostname>
+      certificateSecretRef:
+        name: <secret_name>
+  EOF
+  ```
 
 <p class="message--note"><strong>NOTE: </strong>It is not possible to configure the namespace of the secret with a command. Ensure the secret is stored in the workspace namespace of the target cluster.</p>
 
 ### Example: Configure a custom certificate with Let's Encrypt
 
-Let's Encrypt is one of the Certificate Authorities (CA) supported by cert-manager. To set up a Let's Encrypt certificate, provide an `Issuer` or `ClusterIssuer` on the target cluster in the `issuerRef` field.
+Let's Encrypt is one of the Certificate Authorities (CA) supported by cert-manager. To set up a Let's Encrypt certificate, create an `Issuer` or `ClusterIssuer` in the target cluster and then reference it in the `issuerRef` field of the `KommanderCluster` resource.
 
 1.  Create the Let's Encrypt ACME cert-manager issuer:
 
@@ -81,7 +79,7 @@ Let's Encrypt is one of the Certificate Authorities (CA) supported by cert-manag
     EOF
     ```
 
-1.  Configure the Management cluster to use your `custom-domain.example.com` with a certificate issued by Let's Encrypt.
+1.  Configure the Management cluster to use your `custom-domain.example.com` with a certificate issued by Let's Encrypt by referencing the created `ClusterIssuer`:
 
     ```yaml
     cat <<EOF | kubectl -n kommander --kubeconfig <management_cluster_kubeconfig> patch \ kommandercluster host-cluster  --type='merge' --patch-file=/dev/stdin
@@ -96,46 +94,53 @@ Let's Encrypt is one of the Certificate Authorities (CA) supported by cert-manag
 
 ## Verify the status of the configuration and troubleshoot in case of errors
 
-If you want to ensure the customization for a domain or a certificate is completed, or if you want to obtain more information if the customization fails, display the status information for the `KommanderCluster`.
+If you want to ensure the customization for a domain and certificate is completed, or if you want to obtain more information on the status of the customization, display the status information for the `KommanderCluster`.
 
-1.  Inspect the modified `KommanderCluster` object:
+Inspect the modified `KommanderCluster` object:
 
-    ```bash
-    kubectl -n <workspace_namespace> get kommandercluster <cluster_name> -o yaml
-    ```
+```bash
+kubectl describe kommandercluster -n <workspace_name> <cluster_name>
+```
 
-    If the ingress is still being provisioned, the output looks similar to this:
-
-    ```yaml
-      conditions:
-      - lastTransitionTime: "2022-06-24T07:48:31Z"
-        message: Ingress service object was not found in the cluster
-        reason: IngressServiceNotFound
-        status: "False"
-        type: IngressAddressReady
-    ```
-
-    If the provisioning has been completed, the output looks similar to this:
-
-    ```yaml
-      - lastTransitionTime: "2022-06-24T07:58:48Z"
-        message: Ingress service address has been provisioned
-        reason: IngressServiceAddressFound
-        status: "True"
-        type: IngressAddressReady
-      - lastTransitionTime: "2022-06-24T07:58:50Z"
-        message: Certificate is up to date and has not expired
-        reason: Ready
-        status: "True"
-        type: IngressCertificateReady
-    ```
-
-You can also call up the actual customized values, by inspecting the `KommanderCluster.Status.Ingress`. Here is an example:
+If the ingress is still being provisioned, the output looks similar to this:
 
 ```yaml
-  ingress:
+[...]
+Conditions:
+  Last Transition Time:  2022-06-24T07:48:31Z
+  Message:               Ingress service object was not found in the cluster
+  Reason:                IngressServiceNotFound
+  Status:                False
+  Type:                  IngressAddressReady
+[...]
+```
+
+If the provisioning has been completed, the output looks similar to this:
+
+```yaml
+[...]
+    Conditions:
+      Last Transition Time:  2022-06-28T13:43:33Z
+      Message:               Ingress service address has been provisioned
+      Reason:                IngressServiceAddressFound
+      Status:                True
+      Type:                  IngressAddressReady
+      Last Transition Time:  2022-06-28T13:42:24Z
+      Message:               Certificate is up to date and has not expired
+      Reason:                Ready
+      Status:                True
+      Type:                  IngressCertificateReady
+[...]
+```
+
+The same command also prints the actual customized values for the `KommanderCluster.Status.Ingress`. Here is an example:
+
+```yaml
+[...]
+   ingress:
     address: 172.20.255.180
     caBundle: LS0tLS1CRUdJTiBD...<output has been shortened>...DQVRFLS0tLS0K
+[...]
 ```
 
 [management]: ../../../install/configuration/custom-domain/

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 This section describes how to enable custom domains and certificates in your **Management and any Managed or Attached** clusters after the installation of DKP. If you want to set up a custom domain and certificate for your Management Cluster **during the installation**, refer to the [Customize a domain and certificate during installation][management] documentation.
 
-To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` that allows DKP to implement the established adjustments on top of the default, or any previous configuration, you have made.
+To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` to specify the custom domain and certification details.
 
 ## Configure custom domains or custom certificates
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -101,7 +101,7 @@ If you want to ensure the customization for a domain or a certificate is complet
 1.  Inspect the modified `KommanderCluster` object:
 
     ```bash
-    kubect -n <workspace_namespace> get kommandercluster <cluster_name> -o yaml
+    kubectl -n <workspace_namespace> get kommandercluster <cluster_name> -o yaml
     ```
 
     If the ingress is still being provisioned, the output looks similar to this:

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/configuration/index.md
@@ -12,13 +12,11 @@ This section describes how to enable custom domains and certificates in your **M
 
 To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` that will allow Kommander to implement the established adjustments on top of the default or any previous configuration you have made.
 
-Note that the `Issuer` object must be created on the cluster where you want to customize the configuration. In the Management cluster, both the `KommanderCluster` and `Issuer` objects are on the same cluster. In Managed and Attached clusters, the `KommanderCluster` object is stored on Management cluster, and the `Issuer` object is on the Managed or Attached cluster.
-
 ## Configure custom domains or custom certificates
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster of the environment where you want to customize the domain or certificate by setting the <code>KUBECONFIG=<path></code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-To customize the domain or certificate of a cluster, alter the `ingress` values of the `KommanderCluster`. Note that the `Issuer` object must be created on the cluster where you want to customize the configuration. In the Management cluster, both the `KommanderCluster` and `Issuer` objects are on the same cluster. In Managed and Attached clusters, the `KommanderCluster` object is stored on Management cluster, and the `Issuer` object is on the Managed or Attached cluster.
+To customize the domain or certificate of a cluster, alter the `Ingress` value of the `KommanderCluster`. Note that the `Issuer` object must be created on the cluster where you want to customize the configuration. In the Management cluster, both the `KommanderCluster` and `Issuer` objects are on the same cluster. In Managed and Attached clusters, the `KommanderCluster` object is stored on Management cluster, and the `Issuer` object is on the Managed or Attached cluster.
 
 Use the API yaml to customize the domain (via the `hostname` field), the certificate (via the `issuerRef` or `certificateSecretRef` field), or both.
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
@@ -16,19 +16,19 @@ The configuration path is the same regardless of whether you are configuring a c
 
 [Customize a domain or certificate in the [**Management or a Managed/Attached Cluster**][managed] (after installation).
 
-## Why to customize domains
+## Reasons for using a custom DNS domain
 
 DKP supports the customization of domains to allow you to use your own domain or hostname for your services.
 
 For example, you can set up your DKP UI to be accessible with your custom domain name instead of the domain provided by default. You can also use your domain to enable your company to access back-end services, or your customers to access front-end services with a specific domain. Or you can configure a cluster to be accessible with a specific domain.
 
-## Why to customize certificates
+## Reasons for using a custom certificate
 
 DKP’s default CA identity supports the encryption of data exchange and traffic (between your client and your environment’s server). To configure an additional security layer that validates your environment’s server authenticity, DKP supports configuring a custom certificate issued by a trusted Certificate Authority either directly in a Secret or managed automatically using the ACME protocol (for example, Let’s Encrypt).
 
 Changing the default certificate for any of your clusters can be helpful, for example, you can adapt it to classify your DKP UI or any other type of service as trusted (when accessing a service via a browser).
 
-<p class="message--note"><strong>NOTE: </strong>Let’s Encrypt and ACME do not work in air-gapped scenarios, as they require connection to the Internet for their setup. For air-gapped environments, you are able to use the certificates issued by the cluster (selfSigned, which is the default configuration), or a certificate created specifically for this purpose (which you can use so no browser warnings appear when calling up your URL).</p>
+<p class="message--note"><strong>NOTE: </strong>Using Let’s Encrypt or other ACME certificate authorities does not work in air-gapped scenarios, as these services require connection to the Internet for their setup. For air-gapped environments, you can either use self signed certificates issued by the cluster (the default configuration), or a certificate created manually using a trusted Certificate Authority.</p>
 
 [management]: ../../install/configuration/custom-domain/
 [managed]: ../custom-domain-certificate/configuration/

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 DKP supports configuring a custom domain name per cluster, so users can access the DKP UI and other platform services via that domain. Additionally, you can provide a custom certificate for the domain, or one can be issued automatically by Let's Encrypt (or other certificate authorities supporting the ACME protocol).
 
-The configuration path is the same regardless of whether you are configuring a custom domain and certificate on the management, or a workload (managed or attached) cluster. However, you can choose to set up a customized domain and certificate for the management cluster during the installation of DKP.
+The configuration path is the same regardless of whether you are configuring a custom domain and certificate on the Management, or a Workload (Managed or Attached) cluster. However, you can choose to set up a customized domain and certificate for the Management cluster during the installation of DKP.
 
 [Customize a domain or certificate in the **Management Cluster**][management] (during installation).
 
@@ -18,9 +18,7 @@ The configuration path is the same regardless of whether you are configuring a c
 
 ## Reasons for using a custom DNS domain
 
-DKP supports the customization of domains to allow you to use your own domain or hostname for your services.
-
-For example, you can set up your DKP UI to be accessible with your custom domain name instead of the domain provided by default. You can also use your domain to enable your company to access back-end services, or your customers to access front-end services with a specific domain. Or you can configure a cluster to be accessible with a specific domain.
+DKP supports the customization of domains to allow you to use your own domain or hostname for your services. For example, you can set up your DKP UI or any of your clusters to be accessible with your custom domain name instead of the domain provided by default.
 
 ## Reasons for using a custom certificate
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
@@ -8,9 +8,9 @@ beta: false
 enterprise: false
 ---
 
-DKP supports configuring a custom domain name per cluster, so users can access the DKP UI and other platform services via that domain. Additionally, you can provide a custom certificate for the domain, or one can be issued automatically by Let's Encrypt, or other certificate authorities supporting the ACME protocol.
+DKP supports configuring a custom domain name per cluster, so users can access the DKP UI and other platform services via that domain. Additionally, you can provide a custom certificate for the domain, or one can be issued automatically by Let's Encrypt (or other certificate authorities supporting the ACME protocol).
 
-The configuration path is the same regardless of whether you are configuring a custom domain and certificate on the management, or a managed/attached cluster. However, you can choose to set up a customized domain and certificate for the management cluster during the installation of DKP.
+The configuration path is the same regardless of whether you are configuring a custom domain and certificate on the management, or a workload (managed or attached) cluster. However, you can choose to set up a customized domain and certificate for the management cluster during the installation of DKP.
 
 [Customize a domain or certificate in the **Management Cluster**][management] (during installation).
 
@@ -31,4 +31,4 @@ Changing the default certificate for any of your clusters can be helpful, for ex
 <p class="message--note"><strong>NOTE: </strong>Let’s Encrypt and ACME do not work in air-gapped scenarios, as they require connection to the Internet for their setup. For air-gapped environments, you are able to use the certificates issued by the cluster (selfSigned, which is the default configuration), or a certificate created specifically for this purpose (which you can use so no browser warnings appear when calling up your URL).</p>
 
 [management]: ../../install/configuration/custom-domain/
-[managed]: ../custom-domain-certificate/managed/
+[managed]: ../custom-domain-certificate/configuration/

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
@@ -24,7 +24,7 @@ DKP supports the customization of domains to allow you to use your own domain or
 
 DKP’s default CA identity supports the encryption of data exchange and traffic (between your client and your environment’s server). To configure an additional security layer that validates your environment’s server authenticity, DKP supports configuring a custom certificate issued by a trusted Certificate Authority either directly in a Secret or managed automatically using the ACME protocol (for example, Let’s Encrypt).
 
-Changing the default certificate for any of your clusters can be helpful, for example, you can adapt it to classify your DKP UI or any other type of service as trusted (when accessing a service via a browser).
+Changing the default certificate for any of your clusters can be helpful. For example, you can adapt it to classify your DKP UI or any other type of service as trusted (when accessing a service via a browser).
 
 <p class="message--note"><strong>NOTE: </strong>Using Let’s Encrypt or other ACME certificate authorities does not work in air-gapped scenarios, as these services require connection to the Internet for their setup. For air-gapped environments, you can either use self signed certificates issued by the cluster (the default configuration), or a certificate created manually using a trusted Certificate Authority.</p>
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
@@ -14,7 +14,7 @@ The configuration path is the same regardless of whether you are configuring a c
 
 [Customize a domain or certificate in the **Management Cluster**][management] (during installation).
 
-[Customize a domain or certificate in the [**Management or a Managed/Attached Cluster**][managed] (after installation).
+[Customize a domain or certificate in the **Management or a Managed/Attached Cluster**][managed] (after installation).
 
 ## Reasons for using a custom DNS domain
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
@@ -8,25 +8,25 @@ beta: false
 enterprise: false
 ---
 
-DKP supports configuring a custom domain name for accessing the DKP UI and other platform services. Additionally, you can provide a custom certificate for each domain, or one can be issued automatically by Let's Encrypt, or other certificate authorities supporting the ACME protocol.
+DKP supports configuring a custom domain name per cluster, so users can access the DKP UI and other platform services via that domain. Additionally, you can provide a custom certificate for the domain, or one can be issued automatically by Let's Encrypt, or other certificate authorities supporting the ACME protocol.
 
-The configuration path is different depending on the cluster for which you want to customize the domain or certificate.
+The configuration path is the same regardless of whether you are configuring a custom domain and certificate on the management, or a managed/attached cluster. However, you can choose to set up a customized domain and certificate for the management cluster during the installation of DKP.
 
 [Customize a domain or certificate in the **Management Cluster**][management] (during installation).
 
-[Customize a domain or certificate in a **Managed Cluster**][managed] (after installation).
+[Customize a domain or certificate in the [**Management or a Managed/Attached Cluster**][managed] (after installation).
 
 ## Why to customize domains
 
-DKP’s default configuration supports the customization of domains to allow you to use your own domain or hostname for your services.
+DKP supports the customization of domains to allow you to use your own domain or hostname for your services.
 
-For example, you can set up your DKP UI to be accessible via the provided domain instead of the URL provided by default. You can also use your domain to enable your company to access back end services, or your customers to access front end services via a specific domain. Or you can configure a custom domain to make a cluster accessible with a specific domain.
+For example, you can set up your DKP UI to be accessible with your custom domain name instead of the domain provided by default. You can also use your domain to enable your company to access back-end services, or your customers to access front-end services with a specific domain. Or you can configure a cluster to be accessible with a specific domain.
 
 ## Why to customize certificates
 
-DKP’s default CA identity supports the encryption of data exchange and traffic (between your client and your environment’s server). To configure an additional security layer that validates your environment’s server authenticity, DKP supports configuring a custom certificate by a Certificate Authority with an ACME protocol like Let’s Encrypt, or a custom certificate created specifically for your organization.
+DKP’s default CA identity supports the encryption of data exchange and traffic (between your client and your environment’s server). To configure an additional security layer that validates your environment’s server authenticity, DKP supports configuring a custom certificate issued by a trusted Certificate Authority either directly in a Secret or managed automatically using the ACME protocol (for example, Let’s Encrypt).
 
-Changing the default certificate for any of your clusters by modifying the ingress via an API can be helpful. For example, you can adapt it to classify your DKP UI or any other type of service as trusted (when accessing a service via a browser).
+Changing the default certificate for any of your clusters can be helpful, for example, you can adapt it to classify your DKP UI or any other type of service as trusted (when accessing a service via a browser).
 
 <p class="message--note"><strong>NOTE: </strong>Let’s Encrypt and ACME do not work in air-gapped scenarios, as they require connection to the Internet for their setup. For air-gapped environments, you are able to use the certificates issued by the cluster (selfSigned, which is the default configuration), or a certificate created specifically for this purpose (which you can use so no browser warnings appear when calling up your URL).</p>
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/index.md
@@ -1,0 +1,34 @@
+---
+layout: layout.pug
+navigationTitle: Custom domain and certificate
+title: Configure a custom domain and certificate
+menuWeight: 30
+excerpt: Configure a custom domain and certificate for your Management or any Managed/Attached cluster
+beta: false
+enterprise: false
+---
+
+DKP supports configuring a custom domain name for accessing the DKP UI and other platform services. Additionally, you can provide a custom certificate for each domain, or one can be issued automatically by Let's Encrypt, or other certificate authorities supporting the ACME protocol.
+
+The configuration path is different depending on the cluster for which you want to customize the domain or certificate.
+
+[Customize a domain or certificate in the **Management Cluster**][management] (during installation).
+
+[Customize a domain or certificate in a **Managed Cluster**][managed] (after installation).
+
+## Why to customize domains
+
+DKP’s default configuration supports the customization of domains to allow you to use your own domain or hostname for your services.
+
+For example, you can set up your DKP UI to be accessible via the provided domain instead of the URL provided by default. You can also use your domain to enable your company to access back end services, or your customers to access front end services via a specific domain. Or you can configure a custom domain to make a cluster accessible with a specific domain.
+
+## Why to customize certificates
+
+DKP’s default CA identity supports the encryption of data exchange and traffic (between your client and your environment’s server). To configure an additional security layer that validates your environment’s server authenticity, DKP supports configuring a custom certificate by a Certificate Authority with an ACME protocol like Let’s Encrypt, or a custom certificate created specifically for your organization.
+
+Changing the default certificate for any of your clusters by modifying the ingress via an API can be helpful. For example, you can adapt it to classify your DKP UI or any other type of service as trusted (when accessing a service via a browser).
+
+<p class="message--note"><strong>NOTE: </strong>Let’s Encrypt and ACME do not work in air-gapped scenarios, as they require connection to the Internet for their setup. For air-gapped environments, you are able to use the certificates issued by the cluster (selfSigned, which is the default configuration), or a certificate created specifically for this purpose (which you can use so no browser warnings appear when calling up your URL).</p>
+
+[management]: ../../install/configuration/custom-domain/
+[managed]: ../custom-domain-certificate/managed/

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-This section describes how to enable custom domains and certificates in your **managed and attached** clusters. Refer to the [Customize a domain and certificate in the Management Cluster][management] documentation, if you want to set up custom domains and certificates for your **Management Cluster** during the installation of DKP.
+This section describes how to enable custom domains and certificates in your **Management and any Managed or Attached** clusters after the installation of DKP. If you want to set up a custom domain and certificate for your Management Cluster **during the installation**, refer to the [Customize a domain and certificate during installation][management] documentation.
 
 To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` that will allow Kommander to implement the established adjustments on top of the default or any previous configuration you have made.
 

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
@@ -20,7 +20,7 @@ Use the API yaml to customize the domain (via the `hostname` field), the certifi
 
 1.  Create or update and apply the `KommanderCluster` object with the wanted ingress. Remember to specify the cluster in the `kubeconfigRef` name field.
 
-    a. In this example, you can enter the custom domain in the `hostname` field, and an **issuer to be used by cert-manager** to issue a certificate for the domain in the `issuerRef` field.
+    In this example, you can enter the custom domain in the `hostname` field, and an **issuer to be used by cert-manager** to issue a certificate for the domain in the `issuerRef` field.
 
     ```bash
     cat <<EOF | kubectl apply -f -
@@ -43,7 +43,7 @@ Use the API yaml to customize the domain (via the `hostname` field), the certifi
     EOF
     ```
 
-    b. In this example, you can enter the custom domain in the `hostname` field, and the secret in the `certificateSecretRef` field for **customized certificates created for your hostname**:
+    In this example, you can enter the custom domain in the `hostname` field, and the secret in the `certificateSecretRef` field for **customized certificates created for your hostname**:
 
     ```bash
     cat <<EOF | kubectl apply -f -

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
@@ -22,7 +22,7 @@ Use the API yaml to customize the domain (via the `hostname` field), the certifi
 
     In this example, you can enter the custom domain in the `hostname` field, and an **issuer to be used by cert-manager** to issue a certificate for the domain in the `issuerRef` field.
 
-    ```bash
+    ```yaml
     cat <<EOF | kubectl apply -f -
     apiVersion: kommander.mesosphere.io/v1beta1
     kind: KommanderCluster
@@ -45,7 +45,7 @@ Use the API yaml to customize the domain (via the `hostname` field), the certifi
 
     In this example, you can enter the custom domain in the `hostname` field, and the secret in the `certificateSecretRef` field for **customized certificates created for your hostname**:
 
-    ```bash
+    ```yaml
     cat <<EOF | kubectl apply -f -
     apiVersion: kommander.mesosphere.io/v1beta1
     kind: KommanderCluster

--- a/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
+++ b/pages/dkp/kommander/2.3/clusters/custom-domain-certificate/managed/index.md
@@ -1,0 +1,146 @@
+---
+layout: layout.pug
+navigationTitle: Managed Cluster 
+title: Customize a domain and certificate in a Managed Cluster
+menuWeight: 20
+excerpt: Configure a custom domain and certificate in a Managed or Attached Cluster
+beta: false
+enterprise: false
+---
+
+This section describes how to enable custom domains and certificates in your **managed and attached** clusters. Refer to the [Customize a domain and certificate in the Management Cluster][management] documentation, if you want to set up custom domains and certificates for your **Management Cluster** during the installation of DKP.
+
+To customize the domain or certificate for a specific cluster after the installation of DKP, adapt or create an API `yaml` that will allow Kommander to implement the established adjustments on top of the default or any previous configuration you have made.
+
+## Configure custom domains or custom certificates
+
+<p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster of the environment where you want to customize the domain or certificate by setting the <code>KUBECONFIG=<path></code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
+
+Use the API yaml to customize the domain (via the `hostname` field), the certificate (via the `issuerRef` or `certificateSecretRef` field), or both. For this, refer to the following examples:
+
+1.  Create or update and apply the `KommanderCluster` object with the wanted ingress. Remember to specify the cluster in the `kubeconfigRef` name field.
+
+    a. In this example, you can enter the custom domain in the `hostname` field, and an **issuer to be used by cert-manager** to issue a certificate for the domain in the `issuerRef` field.
+
+    ```bash
+    cat <<EOF | kubectl apply -f -
+    apiVersion: kommander.mesosphere.io/v1beta1
+    kind: KommanderCluster
+    metadata:
+      name: <cluster_name>
+      namespace: <workspace_namespace>
+    spec:
+      kubeconfigRef:
+        name: <cluster_name>-kubeconfig
+      clusterRef:
+        capiCluster:
+          name: <cluster_name>
+    ingress:
+      hostname: <cluster_hostname>
+      issuerRef:
+        namespace: <issuer_namespace>
+        name: <issuer_name>
+    EOF
+    ```
+
+    b. In this example, you can enter the custom domain in the `hostname` field, and the secret in the `certificateSecretRef` field for **customized certificates created for your hostname**:
+
+    ```bash
+    cat <<EOF | kubectl apply -f -
+    apiVersion: kommander.mesosphere.io/v1beta1
+    kind: KommanderCluster
+    metadata:
+      name: <cluster_name>
+      namespace: <workspace_namespace>
+    spec:
+      kubeconfigRef:
+        name: <cluster_name>-kubeconfig
+      clusterRef:
+        capiCluster:
+          name: <cluster_name>
+    ingress:
+      hostname: <cluster_hostname>
+      certificateSecretRef:
+        namespace: <secret_namespace>
+        name: <secret_name>
+    EOF
+    ```
+
+<!-- 1.  TODO: Dev - Are there other steps, is there some sort of confirmation message or output?  -->
+
+## Troubleshooting
+
+If you want to ensure the customization for a domain or a certificate is completed, or if you want to obtain more information in case the customization fails, call up a list of statuses for the `KommanderCluster`:
+
+<!-- 1.  TODO: DEV - provide command -->
+
+<!-- 1.  TODO: DEV - provide example output -->
+
+## Automatic certificate management (ACME)
+
+Your managed or attached cluster can be configured to automatically issue a trusted certificate for the configured custom domain and renew it before expiration.
+
+### Let's encrypt
+
+Set up a Let’s Encrypt certificate for the cluster ingress, to validate the certificate for the cluster. Because ACME does not set up a CA bundle, some of the platform applications must be customized to use the certificate created by the ACME issuer:
+
+```yaml
+apiVersion: config.kommander.mesosphere.io/v1alpha1
+kind: Installation
+clusterHostname: mycluster.domain.dom
+acme:
+  email: <your_email>
+apps:
+  traefik-forward-auth-mgmt:
+    values: |
+      traefikForwardAuth:
+        caSecretName: null
+  kube-oidc-proxy:
+    values: |
+      oidc:
+        caSystemDefault: true
+  dex-k8s-authenticator:
+    values: |
+      caCerts:
+        caSecretName: null
+        useSystemDefault: true
+```
+
+### Other ACME issuers
+
+You can use other issuers that support the ACME protocol by configuring the issuer's server in the installation configuration. For example, to use the ZeroSSL service:
+
+```yaml
+acme:
+  email: <your_email>
+  server: https://acme.zerossl.com/v2/DV90
+[...]
+```
+
+### Customize issuer details
+
+By default, `kommander install` sets up a working ACME solver using HTTP01 challenges. If further control over the certificate issuing is needed, you can modify the pre-configured `ClusterIssuer`. For example, you can use a DNS01 challenge:
+
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: kommander-acme-issuer
+spec:
+  acme:
+    email: <your_email>
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: kommander-acme-issuer-account
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-1
+            role: arn:aws:iam::YYYYYYYYYYYY:role/dns-manager
+EOF
+```
+
+For more information on the available options, refer to the [ACME section in the cert-manager documentation](https://cert-manager.io/docs/configuration/acme/).
+
+[management]: ../../../install/configuration/custom-domain/

--- a/pages/dkp/kommander/2.3/install/configuration/custom-domain/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/custom-domain/index.md
@@ -67,9 +67,7 @@ Kommander can be configured to automatically issue a trusted certificate for the
 ### Let's encrypt
 
 In this section, we will walk you through how to set up a Let’s Encrypt certificate for the cluster ingress. This would allow most browsers to validate the certificate for the cluster when the users try to log into the ops portal.
-ACME must be enabled in the installation config file. The provided email is used to register with Let's encrypt, who will use this to contact you about expiring certificates, and issues related to your account.
-
-Because ACME does not set up a CA bundle, some of the platform applications must be customized to use the certificate created by the ACME issuer:
+ACME must be enabled in the installation config file. The provided email is used to register with Let's encrypt, who will use this to contact you about expiring certificates, and issues related to your account:
 
 ```yaml
 apiVersion: config.kommander.mesosphere.io/v1alpha1

--- a/pages/dkp/kommander/2.3/install/configuration/custom-domain/index.md
+++ b/pages/dkp/kommander/2.3/install/configuration/custom-domain/index.md
@@ -77,20 +77,6 @@ kind: Installation
 clusterHostname: mycluster.domain.dom
 acme:
   email: <your_email>
-apps:
-  traefik-forward-auth-mgmt:
-    values: |
-      traefikForwardAuth:
-        caSecretName: null
-  kube-oidc-proxy:
-    values: |
-      oidc:
-        caSystemDefault: true
-  dex-k8s-authenticator:
-    values: |
-      caCerts:
-        caSecretName: null
-        useSystemDefault: true
 ```
 
 ### Other ACME issuers

--- a/pages/dkp/kommander/2.3/release-notes/2.3.0/index.md
+++ b/pages/dkp/kommander/2.3/release-notes/2.3.0/index.md
@@ -8,7 +8,7 @@ enterprise: false
 beta: false
 ---
 
-**D2iQ&reg; Kommander&reg; (DKP&reg;) version 2.3 was released on xxxxx.**
+**D2iQ&reg; Kommander&reg; (DKP&reg;) version 2.3 was released on <!-- xxxxx -->.**
 
 [button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download DKP[/button]
 
@@ -37,6 +37,11 @@ The following features and capabilities are new for Version 2.2.
 
 ### Feature 1
 
+<!-- placeholder -->
+
+### Custom domains and certificates for Workload (Managed and Attached) clusters
+
+If you have an Enterprise license, you can now set up a custom domain and certificate for your Managed or Attached cluster. For more information on how to do this, refer to the [Configuration instructions](../../clusters/custom-domain-certificate/configuration/).
 
 ## Component updates
 
@@ -71,7 +76,7 @@ When upgrading to this release, the following services and service components ar
 | Grafana (project) | project-grafana-logging| 6.20.6 | - chart: 6.20.6<br>- grafana: 8.3.6 |
 | Loki (project) | project-grafana-loki | 0.33.2 | - chart: 0.33.1<br>- loki: 2.2.1 |
 |  | project-logging | 1.0.0 |  |
-| Prometheus Adapter  | prometheus-adapter | 2.17.1 | - chart: 2.17.1<br>- prometheus-adapter: 0.9.1 |
+| Prometheus Adapter | prometheus-adapter | 2.17.1 | - chart: 2.17.1<br>- prometheus-adapter: 0.9.1 |
 | Reloader | reloader | 0.0.104 | - chart: 0.0.104<br>- reloader: 0.0.104 |
 | Thanos | thanos | 0.4.6 | - chart: 0.4.6<br>- thanos: 0.9.0 |
 | Traefik | traefik | 10.9.1 | - chart: 10.9.1<br>- traefik: 2.5.6 |


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-90373

## Description of changes being made

From 2.3 is it possible to customize the domains and certificates for managed/attached clusters after the installation of DKP (hence the location of this topic in the "managing clusters" section). 
In the past, custom domains and certs were only possible for the management cluster and during installation.


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4553.s3-website-us-west-2.amazonaws.com/

