### PR TITLE
Added remaining kernel versions for every supported OS

### DIFF
--- a/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
@@ -50,9 +50,9 @@ Konvoy supports the following base Operating Systems.
 ## Azure
 
 <!-- vale Vale.Spelling = NO -->
-| Operating System       | Kernel                           | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
-|------------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
-| [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] | 5.13.0-1031-aws | Yes            |      |            |                      |             |
+| Operating System       | Kernel                             | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
+|------------------------|------------------------------------|----------------|------|------------|----------------------|-------------|
+| [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] | 5.11.0-1028-azure | Yes            |      |            |                      |             |
 
 ## EKS
 


### PR DESCRIPTION
Also fixed a few formatting things on the page

## Description of changes being made
We got info on the remaining kernals that we support for this release, so I added them into the external docs along with a few formatting improvements on the page.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4554.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
