### PR TITLE
[Konvoy] Documentation around configuring kube-vip

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -207,7 +207,8 @@ For more information, see:
 
 ## Use the built-in Virtual IP
 
-As explained in [Define the Control Plane Endpoint][define-control-plane-endpoint], we recommend using an external load balancer for the control plane endpoint, but provide a built-in virtual IP when an external load balancer is not available. The built-in virtual IP uses the [kube-vip][kube-vip] project.
+As explained in [Define the Control Plane Endpoint][define-control-plane-endpoint], we recommend using an external load balancer for the control plane endpoint, but provide a built-in virtual IP when an external load balancer is not available. The control planes  are members of the the same L2 network, the network interface which must be provided. The built-in virtual IP uses the [kube-vip][kube-vip] project.
+
 To use the virtual IP, add these flags to the `create cluster` command:
 
 | Virtual IP Configuration                 | Flag                                 |
@@ -217,12 +218,29 @@ To use the virtual IP, add these flags to the `create cluster` command:
 
 ### Virtual IP Example
 
+Example
+If we have the following networking configurations on the control plane nodes:
+
+```bash
+Control plane node 1:
+ eth0: 1.2.3.4/29
+ eth1: 10.1.2.1/24
+Control plane node 2:
+ eth0: 5.6.7.8/25
+ eth1: 10.1.2.2/24
+Control plane node 3:
+ eth0: 9.10.11.12/30
+ eth1: 10.1.2.3/24
+```
+Then the following command should look like: 
+
 ```bash
 dkp create cluster preprovisioned \
     --cluster-name ${CLUSTER_NAME} \
-    --control-plane-endpoint-host 196.168.1.10 \
+    --control-plane-endpoint-host 10.1.2.0 \
     --virtual-ip-interface eth1
 ```
+Verify that any L2 switches in your infrastructure are not configured to block Gratuitous ARP packets. kube-vip uses Gratutious ARP to advertise the Virtual-IP (VIP) for the control plane; if the switch blocks these packets fail-over between control plane nodes will not work.
 
 Confirm that your [Calico installation is correct][calico-install].
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -240,7 +240,6 @@ dkp create cluster preprovisioned \
     --control-plane-endpoint-host 10.1.2.0 \
     --virtual-ip-interface eth1
 ```
-Verify that any L2 switches in your infrastructure are not configured to block Gratuitous ARP packets. kube-vip uses Gratutious ARP to advertise the Virtual-IP (VIP) for the control plane; if the switch blocks these packets fail-over between control plane nodes will not work.
 
 Confirm that your [Calico installation is correct][calico-install].
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -244,7 +244,7 @@ Then the following command should look like:
 ```bash
 dkp create cluster preprovisioned \
     --cluster-name ${CLUSTER_NAME} \
-    --control-plane-endpoint-host 10.1.2.0 \
+    --control-plane-endpoint-host 10.1.2.5 \
     --virtual-ip-interface eth1
 ```
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -207,7 +207,14 @@ For more information, see:
 
 ## Use the built-in Virtual IP
 
-As explained in [Define the Control Plane Endpoint][define-control-plane-endpoint], we recommend using an external load balancer for the control plane endpoint, but provide a built-in virtual IP when an external load balancer is not available. The control planes  are members of the the same L2 network, the network interface which must be provided. The built-in virtual IP uses the [kube-vip][kube-vip] project.
+As explained in [Define the Control Plane Endpoint][define-control-plane-endpoint], we recommend using an external load balancer for the control plane endpoint, but provide a built-in virtual IP when an external load balancer is not available. 
+
+The built-in virtual IP uses the [kube-vip][kube-vip] project.  If you use the default kube-vip for the endpoint, ensure that:
+
+- The control plane nodes are in the same subnet and layer-2 network.
+- The virtual IP address you specify for the `--control-plane-endpoint` is a free IP address from that subnet
+- The network interface for virtual IP address `--virtual-ip-interface` is the same interface on which kube-apiserver listens. kube-apiserver [listens on a default interface](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options). 
+- Any Layer 2 (L2) switches in your infrastructure do not block Gratuitous ARP packets. kube-vip uses Gratuitous ARP to advertise the virtual IP for the control plane; if the switch blocks these packets then fail-over between control plane nodes will not work.
 
 To use the virtual IP, add these flags to the `create cluster` command:
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-90124

## Description of changes being made

Edited kube-vip section with expanded info.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4557.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
