### PR TITLE
[Konvoy] Adding step to download containerd bundle for airgapped builds

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -63,7 +63,8 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```
      NOTE: If you're installing V2.2.0 or V2.2.1, skip to step 9, as those releases did not have separate `containerd` packages.
 
-1. Set your `containerd` operating system:
+1. Set a variable that indicates which os-specific `containerd` bundle to download:
+2. ```
 
     ```bash
     export CONTAINERD_OS=centos-7.9-x86_64

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -68,13 +68,13 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```bash
     export CONTAINERD_OS=centos-7.9-x86_64
     ```
-Note: available packages are:
+    Note: available packages are:
 
--   `centos-7.9-x86_64`
--   `rhel-7.9-x86_64`
--   `rhel-8.2-x86_64`
--   `ubuntu-20.04-x86_64`
--   `ubuntu-18.04-x86_64`
+    -   `centos-7.9-x86_64`
+    -   `rhel-7.9-x86_64`
+    -   `rhel-8.2-x86_64`
+    -   `ubuntu-20.04-x86_64`
+    -   `ubuntu-18.04-x86_64`
 
 1. Download the `containerd` bundle.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -79,9 +79,10 @@ Note: available packages are:
 
 1. Download the `containerd` bundle.
 
-```bash
-curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
-```
+    ```bash
+    curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location 
+    https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
+    ```
 
 1.  Follow the instructions to [build an AMI][kib_create_ami] in the setting an additional `--overrides overrides/offline.yaml` flag.
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -64,7 +64,6 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
      NOTE: If you're installing V2.2.0 or V2.2.1, skip to step 9, as those releases did not have separate `containerd` packages.
 
 1. Set a variable that indicates which os-specific `containerd` bundle to download:
-2. ```
 
     ```bash
     export CONTAINERD_OS=centos-7.9-x86_64

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -77,7 +77,7 @@ Note: available packages are:
 -   `ubuntu-20.04-x86_64`
 -   `ubuntu-18.04-x86_64`
 
-1. Download the the `containerd` bundle.
+1. Download the `containerd` bundle.
 
 ```bash
 curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -61,7 +61,7 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```bash
     curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/dkp/airgapped/pip-packages/pip-packages.tar.gz
     ```
-NOTE: If you're installing on v2.2.2 or above, you will need to continue onto step 7.
+     NOTE: If you're installing V2.2.0 or V2.2.1, skip to step 9, as those releases did not have separate `containerd` packages.
 
 1. Set your `containerd` operating system:
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -61,12 +61,32 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```bash
     curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/dkp/airgapped/pip-packages/pip-packages.tar.gz
     ```
+NOTE: If you're installing on v2.2.2 or above, you will need to continue onto step 7.
+
+1. Set your `containerd` operating system:
+
+    ```bash
+    export CONTAINERD_OS=centos-7.9-x86_64
+    ```
+Note: available packages are:
+
+-   `centos-7.9-x86_64`
+-   `rhel-7.9-x86_64`
+-   `rhel-8.2-x86_64`
+-   `ubuntu-20.04-x86_64`
+-   `ubuntu-18.04-x86_64`
+
+1. Download the the `containerd` bundle.
+
+```bash
+curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
+```
 
 1.  Follow the instructions to [build an AMI][kib_create_ami] in the setting an additional `--overrides overrides/offline.yaml` flag.
 
 Then, you can [seed your docker registry][seed-a-registry].
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the GNU Affero General Public License 3.0. The complete source code for the versions of MinIO packaged with DKP/Kommander/Konvoy 2.2.1 are available at these URLs: 
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the GNU Affero General Public License 3.0. The complete source code for the versions of MinIO packaged with DKP/Kommander/Konvoy 2.2.1 are available at these URLs:
 https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
 https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -67,13 +67,13 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```bash
     export CONTAINERD_OS=centos-7.9-x86_64
     ```
-Available packages are:
+    Available packages are:
 
--   `centos-7.9-x86_64`
--   `rhel-7.9-x86_64`
--   `rhel-8.2-x86_64`
--   `ubuntu-20.04-x86_64`
--   `ubuntu-18.04-x86_64`
+    -   `centos-7.9-x86_64`
+    -   `rhel-7.9-x86_64`
+    -   `rhel-8.2-x86_64`
+    -   `ubuntu-20.04-x86_64`
+    -   `ubuntu-18.04-x86_64`
 
 1. Download the `containerd` bundle.
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -61,7 +61,6 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```bash
     curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/dkp/airgapped/pip-packages/pip-packages.tar.gz
     ```
-    <p class="message--note"><strong>NOTE: If you're installing on DKP v2.2.2 or above, you will need to continue onto step 7.</p>
 
 1. Set your `containerd` operating system:
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -76,7 +76,7 @@ Available packages are:
 -   `ubuntu-20.04-x86_64`
 -   `ubuntu-18.04-x86_64`
 
-1. Download the the `containerd` bundle.
+1. Download the `containerd` bundle.
 
     ```bash
     curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -61,6 +61,26 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```bash
     curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/dkp/airgapped/pip-packages/pip-packages.tar.gz
     ```
+    <p class="message--note"><strong>NOTE: If you're installing on DKP v2.2.2 or above, you will need to continue onto step 7.</p>
+
+1. Set your `containerd` operating system:
+
+    ```bash
+    export CONTAINERD_OS=centos-7.9-x86_64
+    ```
+Available packages are:
+
+-   `centos-7.9-x86_64`
+-   `rhel-7.9-x86_64`
+-   `rhel-8.2-x86_64`
+-   `ubuntu-20.04-x86_64`
+-   `ubuntu-18.04-x86_64`
+
+1. Download the the `containerd` bundle.
+
+    ```bash
+    curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
+    ```
 
 1.  Follow the instructions to [build an AMI][kib_create_ami] in the setting an additional `--overrides overrides/offline.yaml` flag.
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-90568

## Description of changes being made

Added some steps to AMI creation.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4558.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
