### PR TITLE
[Kommander: gatekeeper bug for migration to 2.1]

### DIFF
--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
@@ -45,7 +45,7 @@ To successfully adapt your applications, you must have:
 Check for the following on your existing `cluster.yaml`:
 
 - One or more of `spec.kubernetes.networking.noProxy`, `spec.kubernetes.networking.httpProxy` or `spec.kubernetes.networking.httpsProxy` is set in `ClusterConfiguration`.
-- Enabled `gatekeeper` with custom `values` field in `ClusterConfiguration` in `cluster.yaml`.
+- Enabled Gatekeeper on your cluster. Gatekeeper is enabled by default, but if you have manually disabled it, re-enable the application by changing the enabled field from `false` to `true` in the `addons` object of the cluster's `ClusterConfiguration`. The enabled Gatekeeper application must include the custom `values` field.
 
 If none of the conditions apply to your cluster, then you can skip to next section.
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-88375

## Description of changes being made

It is important to enable Gatekeeper before going from 1.8 to 2.1. Otherwise, an error message will appear and the migration of applications will not be possible.

### Preview

http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/


