### PR TITLE
Add AMI in new cluster

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -71,7 +71,7 @@ dkp create cluster aws --cluster-name=${CLUSTER_NAME} \
 
 ## Create a new AWS Kubernetes cluster
 
-1.  Ensure your AWS credentials are up to date. Refresh the credentials if you are using Static Credentials:
+1.  Ensure your AWS credentials are up to date. Use step 1 command to refresh the credentials if you are using Static Credentials, otherwise proceed to Step 2:
 
     ```bash
     dkp update bootstrap credentials aws

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -53,7 +53,7 @@ Below are a few ways to customize your setup. If you prefer to do a basic setup,
 
     This will create a unique name every time you run it, so use it with forethought.
 
-1.  (Optional) To create a cluster using a custom AMI built using [KIB][KIB], first that image must have been built in KIB.  Then perform the export and name the custom AMI. Set the environment variable for the AMI you choose: 
+1.  (Optional) To create a cluster using a custom AMI built using [KIB][KIB], first that image must be built in KIB, then perform the export and name the custom AMI, and then set the environment variable for the AMI you choose: 
 
 ```bash
 export AWS_AMI_ID=ami-<ami-id-here>

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -289,6 +289,7 @@ dkp create cluster aws --cluster-name=${CLUSTER_NAME} \
 - Konvoy generates a set of objects for one Node Pool.
 - Konvoy does not validate edits to cluster objects.
 
+
 [bootstrap]: ../bootstrap
 [capi_concepts]: https://cluster-api.sigs.k8s.io/user/concepts.html
 [download_aws_cli]: https://aws.amazon.com/cli/

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -28,7 +28,7 @@ enterprise: false
     </p>
 
 ## Tips and Tricks
-
+Below are a few ways to customize your setup.   If you prefer to do a basic setup, skip Tips and Tricks and proceed to Create a New AWS Cluster section. 
 1.  To get a list of names used in your AWS account, use the `aws` [CLI][download_aws_cli]. After downloading, use the following command:
 
     ```bash
@@ -53,10 +53,25 @@ enterprise: false
 
     This will create a unique name every time you run it, so use it with forethought.
 
+1.  (Optional) To create a cluster using a custom AMI built using [KIB][KIB], perform the export and name the custom AMI. Set the environment variable for the AMI you choose: 
+
+```bash
+export AWS_AMI_ID=ami-<ami-id-here>
+```
+
+After export, run the following command:
+
+```bash
+dkp create cluster aws --cluster-name=${CLUSTER_NAME} \
+--ami=${AWS_AMI_ID} \
+--dry-run \
+--output=yaml \
+> ${CLUSTER_NAME}.yaml
+```
 
 ## Create a new AWS Kubernetes cluster
 
-1.  Ensure your AWS credentials are up to date. Refresh the credentials:
+1.  Ensure your AWS credentials are up to date. Refresh the credentials if you are using Static Credentials:
 
     ```bash
     dkp update bootstrap credentials aws
@@ -278,3 +293,4 @@ enterprise: false
 [capi_concepts]: https://cluster-api.sigs.k8s.io/user/concepts.html
 [download_aws_cli]: https://aws.amazon.com/cli/
 [k8s_custom_resources]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+[KIB]: ../../../../image-builder/

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -28,7 +28,7 @@ enterprise: false
     </p>
 
 ## Tips and Tricks
-Below are a few ways to customize your setup.   If you prefer to do a basic setup, skip Tips and Tricks and proceed to Create a New AWS Cluster section. 
+Below are a few ways to customize your setup. If you prefer to do a basic setup, skip Tips and Tricks and proceed to Create a New AWS Cluster section. 
 1.  To get a list of names used in your AWS account, use the `aws` [CLI][download_aws_cli]. After downloading, use the following command:
 
     ```bash

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -53,7 +53,7 @@ Below are a few ways to customize your setup.   If you prefer to do a basic setu
 
     This will create a unique name every time you run it, so use it with forethought.
 
-1.  (Optional) To create a cluster using a custom AMI built using [KIB][KIB], perform the export and name the custom AMI. Set the environment variable for the AMI you choose: 
+1.  (Optional) To create a cluster using a custom AMI built using [KIB][KIB], first that image must have been built in KIB.  Then perform the export and name the custom AMI. Set the environment variable for the AMI you choose: 
 
 ```bash
 export AWS_AMI_ID=ami-<ami-id-here>

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/advanced/new/index.md
@@ -71,7 +71,7 @@ dkp create cluster aws --cluster-name=${CLUSTER_NAME} \
 
 ## Create a new AWS Kubernetes cluster
 
-1.  Ensure your AWS credentials are up to date. Use step 1 command to refresh the credentials if you are using Static Credentials, otherwise proceed to Step 2:
+1.  Ensure your AWS credentials are up to date. If you are using Static Credentials use the following command to refresh the credentials. Otherwise, proceed to Step 2:
 
     ```bash
     dkp update bootstrap credentials aws


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-90324. Will add to 2.3 docs in Confluence site
<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
As a user that wants to build a cluster on AWS
I want to have the ami-id flag exposed
so that I know I can deploy a non-default AMI (OS) cluster and not have to find the flag in dkp --help


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4564.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
