### PR TITLE
Re-generate Kaptain docs

### DIFF
--- a/pages/dkp/kaptain/2.1.0/configuration/index.md
+++ b/pages/dkp/kaptain/2.1.0/configuration/index.md
@@ -22,6 +22,7 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | ingress.enabled | bool | `true` | Enable ingress |
 | ingress.externalDexClientId | string | `""` | Dex client ID to use when authenticating with external cluster |
 | ingress.externalDexClientSecret | string | `""` | Dex client secret to use when authenticating with external cluster |
+| ingress.oidcGroupsAllowList | string | `"*"` | List of groups that are allowed to pass authorization |
 | ingress.oidcProviderEndpoint | string | `""` | External OIDC provider endpoint URL |
 | ingress.oidcProviderBase64CaBundle | string | `""` | CA bundle of the OIDC provider endpoint URL encoded in base64 |
 | ingress.kubeflowIngressGatewayServiceAnnotations | object | `{}` | Additional annotations for Kaptain's default gateway |
@@ -31,13 +32,13 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | ingress.namespace | string | `"kaptain-ingress"` | Namespace to install Kaptain Ingress resources |
 | core.enabled | bool | `true` |  |
 | core.namespace | string | `"kubeflow"` |  |
-| core.notebook.defaultImage | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0"` | Default image to use when creating a new notebook server |
-| core.notebook.images[0] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0"` | JupyterLab with Tensorflow, Spark and Horovod pre-installed |
-| core.notebook.images[1] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-tensorflow-2.8.0-gpu"` | JupyterLab with Tensorflow, CUDA, Spark and Horovod pre-installed with GPU support |
-| core.notebook.images[2] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-pytorch-1.11.0"` | JupyterLab with Pytorch, Spark and Horovod pre-installed |
-| core.notebook.images[3] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-pytorch-1.11.0-gpu"` | JupyterLab with Pytorch, CUDA, Spark and Horovod pre-installed with GPU support |
-| core.notebook.images[4] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-mxnet-1.9.0"` | JupyterLab with MXNet, Spark and Horovod pre-installed |
-| core.notebook.images[5] | string | `"mesosphere/kubeflow:2.0.0-jupyter-spark-3.0.0-horovod-0.24.2-mxnet-1.9.0-gpu"` | JupyterLab with MXNet, CUDA, Spark and Horovod pre-installed with GPU support |
+| core.notebook.defaultImage | string | `"mesosphere/kubeflow-dev:9715a1de-jupyter-spark-3.3.0-horovod-0.24.2-tensorflow-2.8.0"` | Default image to use when creating a new notebook server |
+| core.notebook.images[0] | string | `"mesosphere/kubeflow-dev:9715a1de-jupyter-spark-3.3.0-horovod-0.24.2-tensorflow-2.8.0"` | JupyterLab with Tensorflow, Spark and Horovod pre-installed |
+| core.notebook.images[1] | string | `"mesosphere/kubeflow-dev:14894f36-jupyter-spark-3.3.0-horovod-0.24.2-tensorflow-2.8.0-gpu"` | JupyterLab with Tensorflow, CUDA, Spark and Horovod pre-installed with GPU support |
+| core.notebook.images[2] | string | `"mesosphere/kubeflow-dev:58054fea-jupyter-spark-3.3.0-horovod-0.24.2-pytorch-1.11.0"` | JupyterLab with Pytorch, Spark and Horovod pre-installed |
+| core.notebook.images[3] | string | `"mesosphere/kubeflow-dev:ecfaaddd-jupyter-spark-3.3.0-horovod-0.24.2-pytorch-1.11.0-gpu"` | JupyterLab with Pytorch, CUDA, Spark and Horovod pre-installed with GPU support |
+| core.notebook.images[4] | string | `"mesosphere/kubeflow-dev:eed5f454-jupyter-spark-3.3.0-horovod-0.24.2-mxnet-1.9.0"` | JupyterLab with MXNet, Spark and Horovod pre-installed |
+| core.notebook.images[5] | string | `"mesosphere/kubeflow-dev:75dd8b53-jupyter-spark-3.3.0-horovod-0.24.2-mxnet-1.9.0-gpu"` | JupyterLab with MXNet, CUDA, Spark and Horovod pre-installed with GPU support |
 | core.notebook.tolerationGroups | list | `[]` | Pod toleration group configurations for Notebook servers |
 | core.notebook.affinityConfig | list | `[]` | Pod affinity configurations for Notebook servers |
 | core.notebook.enableCulling | bool | `false` | Enables scale down idling notebooks to freeing up the allocated resources. |
@@ -45,6 +46,7 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | core.notebook.cullingCheckPeriodMinutes | int | `1` | Notebook status check period |
 | core.disableAntiAffinity | bool | `false` | Enables single-node installation. **DO NOT USE IN PRODUCTION ENVIRONMENTS!** Disabling anti-affinity allows installing Kaptain on a smaller number of nodes (less than 3) or on a single node. This installation mode must be used **for evaluation purposes only**. No data integrity guarantees in case of a hardware failure! |
 | core.registrationFlow | bool | `false` | Enables automatic profile creation |
+| core.tensorboardImage | string | `"mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0"` | Image to use for a Tensorboard in Kubeflow |
 | core.dashboard.uriPathPrefix | string | `"/dashboard/"` |  |
 | core.dashboard.prometheusPort | int | `9090` |  |
 | core.dashboard.refreshIntervalSeconds | int | `10` |  |
@@ -92,10 +94,16 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | core.pipelines.objectStorePort | int | `80` |  |
 | core.pipelines.workflowsTTLSecondsAfterFinish | int | `86400` | The TTL for Argo Workflow (a single run of a pipeline) to persist after completion (default: 24 hours) |
 | core.pipelines.enableMultiUserSupport | bool | `true` | Enables multi-user support for Pipelines |
+| core.mlflow.bucketName | string | `"mlpipeline"` |  |
+| core.mlflow.bucketPrefix | string | `"mlflow"` |  |
+| core.mlflow.objectStoreHost | string | `"minio"` |  |
+| core.mlflow.objectStorePort | int | `80` |  |
+| core.mlflow.objectStoreProtocol | string | `"http"` |  |
+| core.mlflow.dbName | string | `"mlflow"` |  |
 | kserve.enabled | bool | `true` | Enables KServe |
 | kserve.namespace | string | `"kserve"` |  |
-| kserve.agent.image | string | `"kserve/agent:v0.7.0"` |  |
-| kserve.storage.image | string | `"mesosphere/kubeflow:storage-initializer-v0.7.0"` |  |
+| kserve.agent.image | string | `"kserve/agent:v0.8.0"` |  |
+| kserve.storage.image | string | `"mesosphere/kubeflow:e95f67a2-storage-initializer-v0.8.0"` |  |
 | kserve.storage.s3.accessKeyIdName | string | `"awsAccessKeyID"` |  |
 | kserve.storage.s3.secretAccessKeyName | string | `"awsSecretAccessKey"` |  |
 | kserve.controller.deploymentMode | string | `"Serverless"` |  |
@@ -103,42 +111,38 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | kserve.controller.gateway.localGateway.gateway | string | `"cluster-local-gateway.knative-serving"` |  |
 | kserve.controller.gateway.localGateway.gatewayService | string | `"cluster-local-gateway.istio-system.svc.cluster.local"` |  |
 | kserve.controller.gateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |
-| kserve.controller.gateway.ingressGateway.gatewayService | string | `"kaptain-ingress.kubeflow.svc.{{ .Values.global.clusterDomainName }}"` |  |
-| kserve.controller.image | string | `"mesosphere/kubeflow:kserve-controller-v0.7.0-65a6f7c5"` |  |
+| kserve.controller.gateway.ingressGateway.gatewayService | string | `"kaptain-ingress.kubeflow.svc.{{.Values.global.clusterDomainName}}"` |  |
+| kserve.controller.image | string | `"mesosphere/kubeflow:kserve-controller-v0.8.0-4668ae5"` |  |
 | kserve.controller.resources.limits.cpu | string | `"100m"` |  |
 | kserve.controller.resources.limits.memory | string | `"300Mi"` |  |
 | kserve.controller.resources.requests.cpu | string | `"100m"` |  |
 | kserve.controller.resources.requests.memory | string | `"300Mi"` |  |
-| kserve.servingruntime.tfserving.image | string | `"tensorflow/serving"` |  |
-| kserve.servingruntime.tfserving.defaultVersion | string | `"1.14.0"` |  |
-| kserve.servingruntime.tfserving.defaultGpuVersion | string | `"1.14.0-gpu"` |  |
-| kserve.servingruntime.onnx.image | string | `"mcr.microsoft.com/onnxruntime/server"` |  |
-| kserve.servingruntime.onnx.defaultVersion | string | `"v1.0.0"` |  |
-| kserve.servingruntime.sklearn.v1.image | string | `"kserve/sklearnserver"` |  |
-| kserve.servingruntime.sklearn.v1.defaultVersion | string | `"v0.7.0"` |  |
-| kserve.servingruntime.sklearn.v2.image | string | `"docker.io/seldonio/mlserver"` |  |
-| kserve.servingruntime.sklearn.v2.defaultVersion | string | `"0.2.1"` |  |
-| kserve.servingruntime.xgboost.v1.image | string | `"kserve/xgbserver"` |  |
-| kserve.servingruntime.xgboost.v1.defaultVersion | string | `"v0.7.0"` |  |
-| kserve.servingruntime.xgboost.v2.image | string | `"docker.io/seldonio/mlserver"` |  |
-| kserve.servingruntime.xgboost.v2.defaultVersion | string | `"0.2.1"` |  |
-| kserve.servingruntime.pytorch.v1.image | string | `"mesosphere/kubeflow"` |  |
-| kserve.servingruntime.pytorch.v1.defaultVersion | string | `"v0.7.0-pytorchserver-1.11.0"` |  |
-| kserve.servingruntime.pytorch.v1.defaultGpuVersion | string | `"v0.7.0-gpu"` |  |
-| kserve.servingruntime.pytorch.v2.image | string | `"pytorch/torchserve-kfs"` |  |
-| kserve.servingruntime.pytorch.v2.defaultVersion | string | `"0.4.1"` |  |
-| kserve.servingruntime.pytorch.v2.defaultGpuVersion | string | `"0.4.1-gpu"` |  |
-| kserve.servingruntime.triton.image | string | `"nvcr.io/nvidia/tritonserver"` |  |
-| kserve.servingruntime.triton.defaultVersion | string | `"21.09-py3"` |  |
-| kserve.servingruntime.pmml.image | string | `"kserve/pmmlserver"` |  |
-| kserve.servingruntime.pmml.defaultVersion | string | `"v0.7.0"` |  |
-| kserve.servingruntime.lightgbm.image | string | `"kserve/lgbserver"` |  |
-| kserve.servingruntime.lightgbm.defaultVersion | string | `"v0.7.0"` |  |
-| kserve.servingruntime.paddle.image | string | `"kserve/paddleserver"` |  |
-| kserve.servingruntime.paddle.defaultVersion | string | `"v0.7.0"` |  |
+| kserve.servingruntime.modelNamePlaceholder | string | `"{{.Name}}"` |  |
+| kserve.servingruntime.tensorflow.image | string | `"tensorflow/serving"` |  |
+| kserve.servingruntime.tensorflow.tag | string | `"2.6.2"` |  |
+| kserve.servingruntime.mlserver.image | string | `"docker.io/seldonio/mlserver"` |  |
+| kserve.servingruntime.mlserver.tag | string | `"0.5.3"` |  |
+| kserve.servingruntime.mlserver.modelClassPlaceholder | string | `"{{.Labels.modelClass}}"` |  |
+| kserve.servingruntime.sklearnserver.image | string | `"kserve/sklearnserver"` |  |
+| kserve.servingruntime.sklearnserver.tag | string | `"v0.8.0"` |  |
+| kserve.servingruntime.xgbserver.image | string | `"kserve/xgbserver"` |  |
+| kserve.servingruntime.xgbserver.tag | string | `"v0.8.0"` |  |
+| kserve.servingruntime.tritonserver.image | string | `"nvcr.io/nvidia/tritonserver"` |  |
+| kserve.servingruntime.tritonserver.tag | string | `"21.09-py3"` |  |
+| kserve.servingruntime.pmmlserver.image | string | `"kserve/pmmlserver"` |  |
+| kserve.servingruntime.pmmlserver.tag | string | `"v0.8.0"` |  |
+| kserve.servingruntime.paddleserver.image | string | `"kserve/paddleserver"` |  |
+| kserve.servingruntime.paddleserver.tag | string | `"v0.8.0"` |  |
+| kserve.servingruntime.lgbserver.image | string | `"kserve/lgbserver"` |  |
+| kserve.servingruntime.lgbserver.tag | string | `"v0.8.0"` |  |
+| kserve.servingruntime.torchserve.image | string | `"kserve/torchserve-kfs"` |  |
+| kserve.servingruntime.torchserve.tag | string | `"0.5.2"` |  |
+| kserve.servingruntime.torchserve.serviceEnvelopePlaceholder | string | `"{{.Labels.serviceEnvelope}}"` |  |
 | kserve.servingruntime.alibi.image | string | `"kserve/alibi-explainer"` |  |
-| kserve.servingruntime.alibi.defaultVersion | string | `"v0.7.0"` |  |
+| kserve.servingruntime.alibi.defaultVersion | string | `"v0.8.0"` |  |
 | kserve.servingruntime.art.image | string | `"kserve/art-explainer"` |  |
-| kserve.servingruntime.art.defaultVersion | string | `"v0.7.0"` |  |
+| kserve.servingruntime.art.defaultVersion | string | `"v0.8.0"` |  |
 | kserve.servingruntime.aix.image | string | `"kserve/aix-explainer"` |  |
-| kserve.servingruntime.aix.defaultVersion | string | `"v0.7.0"` |  |
+| kserve.servingruntime.aix.defaultVersion | string | `"v0.8.0"` |  |
+
+For a full list of attributed 3rd party software, see d2iq.com/legal/3rd

--- a/pages/dkp/kaptain/2.1.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/katib/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz | tar xz
 ```
 
 </p>
@@ -87,7 +87,7 @@ Note that you typically use (YAML) resource definitions for Kubernetes from the 
 Of course, if you are more familiar or comfortable with `kubectl` and the command line, feel free to use a local CLI or the embedded terminals from the Jupyter Lab launch screen.
 
 
-```bash
+```python
 TF_EXPERIMENT_FILE = "katib-tfjob-experiment.yaml"
 PYTORCH_EXPERIMENT_FILE = "katib-pytorchjob-experiment.yaml"
 ```
@@ -95,7 +95,7 @@ PYTORCH_EXPERIMENT_FILE = "katib-pytorchjob-experiment.yaml"
 Set the following constants depending on whether you want to use GPUs or a custom image.
 
 
-```bash
+```python
 GPUS = 1  # set to 0 if the experiment should not use GPUs
 PARALLEL_TRIAL_COUNT = 3
 TOTAL_TRIAL_COUNT = 9
@@ -104,7 +104,7 @@ TOTAL_TRIAL_COUNT = 9
 Make the defined constants available as shell environment variables. They parameterize the `Experiment` manifests below.
 
 
-```bash
+```python
 %env GPUS $GPUS
 %env TF_EXPERIMENT_FILE $TF_EXPERIMENT_FILE
 %env PYTORCH_EXPERIMENT_FILE $PYTORCH_EXPERIMENT_FILE
@@ -122,7 +122,7 @@ Make the defined constants available as shell environment variables. They parame
 Define a helper function to capture output from a cell that usually looks like `some-resource created`, using [`%%capture`](https://ipython.readthedocs.io/en/stable/interactive/magics.html#cellmagic-capture):
 
 
-```bash
+```python
 import re
 
 from IPython.utils.capture import CapturedIO
@@ -165,8 +165,8 @@ Please note that [discrete values (e.g. epochs) and categorical values (e.g. opt
 The following YAML file describes an `Experiment` object:
 
 
-```bash
-%env IMAGE mesosphere/kubeflow:2.0.0-mnist-tensorflow-2.8.0-gpu
+```python
+%env IMAGE mesosphere/kubeflow-dev:7b20f4d2-mnist-tensorflow-2.8.0-gpu
 ```
 
 
@@ -277,8 +277,8 @@ Run up to 9 trials with three such trials in parallel.
 Again, use a random search:
 
 
-```bash
-%env IMAGE mesosphere/kubeflow:2.0.0-mnist-pytorch-1.11.0-gpu
+```python
+%env IMAGE mesosphere/kubeflow-dev:616a6a45-mnist-pytorch-1.11.0-gpu
 ```
 
 
@@ -376,7 +376,7 @@ You can either execute these commands on your local machine with `kubectl` or yo
 If you do run these locally, you cannot rely on cell magic, so you have to manually copy-paste the experiment name wherever you see `$EXPERIMENT`.
 If you intend to run the following command locally, you have to set the user namespace for all subsequent commands:
 
-```bash
+```
 kubectl config set-context --current --namespace=<insert-namespace>
 ```
 
@@ -385,19 +385,19 @@ Please change the namespace to whatever has been set up by your administrator.
 Pick one of the following depending on which framework you want to use.
 
 
-```bash
+```python
 %env EXPERIMENT_FILE $PYTORCH_EXPERIMENT_FILE
 ```
 
 
-```bash
+```python
 %env EXPERIMENT_FILE $TF_EXPERIMENT_FILE
 ```
 
 To submit the experiment, execute:
 
 
-```bash
+```python
 %%capture kubectl_output --no-stderr
 %%sh
 kubectl apply -f "${EXPERIMENT_FILE}"
@@ -406,14 +406,14 @@ kubectl apply -f "${EXPERIMENT_FILE}"
 The cell magic grabs the output of the `kubectl` command and stores it in an object named `kubectl_output`:
 
 
-```bash
+```python
 %env EXPERIMENT {get_resource(kubectl_output)}
 ```
 
 To see the status, run:
 
 
-```bash
+```sh
 %%sh
 kubectl describe experiment.kubeflow.org $EXPERIMENT
 ```
@@ -421,7 +421,7 @@ kubectl describe experiment.kubeflow.org $EXPERIMENT
 To see experiment suggestions:
 
 
-```bash
+```sh
 %%sh
 kubectl describe suggestions.kubeflow.org $EXPERIMENT
 ```
@@ -429,7 +429,7 @@ kubectl describe suggestions.kubeflow.org $EXPERIMENT
 To get the list of created trials, use the following command:
 
 
-```bash
+```sh
 %%sh
 kubectl get trials.kubeflow.org -l katib.kubeflow.org/experiment=$EXPERIMENT
 ```
@@ -443,7 +443,7 @@ kubectl get trials.kubeflow.org -l katib.kubeflow.org/experiment=$EXPERIMENT
 To fetch the logs of a particular trial, use the following command:
 
 
-```bash
+```sh
 %%sh
 kubectl logs -l job-name=<trial-name> --all-containers --prefix=true
 ```
@@ -451,7 +451,7 @@ kubectl logs -l job-name=<trial-name> --all-containers --prefix=true
 After the experiment is completed, use `describe` to get the best trial results:
 
 
-```bash
+```sh
 %%sh
 kubectl describe experiment.kubeflow.org $EXPERIMENT
 ```
@@ -481,7 +481,7 @@ Status:
 If an Experiment needs to be deleted, including deleting it from the "Experiments (AutoML)" page:
 
 
-```bash
+```sh
 %%sh
 kubectl delete experiments.kubeflow.org $EXPERIMENT 
 ```
@@ -498,3 +498,7 @@ Select "Experiments (AutoML)" in the navigation menu.
 To see detailed information, such as trial results, metrics, and a plot, click on the experiment itself.
 
 ![Katib monitor](./img/katib-2.png)
+
+This tutorial includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with Kaptain 2.1.0 are available at these URLs: [https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z](https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z) and [https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z](https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z)
+
+For a full list of attributed 3rd party software, see d2iq.com/legal/3rd

--- a/pages/dkp/kaptain/2.1.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/pipelines/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz | tar xz
 ```
 
 </p>
@@ -71,22 +71,9 @@ This notebook.
 Ensure Kubeflow Pipelines is available:
 
 
-```bash
-%%sh
-pip show kfp
+```python
+pip install kfp==1.8.5
 ```
-
-    Name: kfp
-    Version: 0.5.0
-    Summary: KubeFlow Pipelines SDK
-    Home-page: UNKNOWN
-    Author: google
-    Author-email: None
-    License: UNKNOWN
-    Location: /opt/conda/lib/python3.7/site-packages
-    Requires: Deprecated, PyYAML, requests-toolbelt, cloudpickle, kubernetes, strip-hints, google-cloud-storage, google-auth, argo-models, click, tabulate, kfp-server-api, jsonschema
-    Required-by:
-
 
 ## How to Configure Credentials
 In order for KFServing to access MinIO, the credentials must be added to the default service account.
@@ -97,7 +84,7 @@ In order for KFServing to access MinIO, the credentials must be added to the def
 </p>
 
 
-```bash
+```python
 %%writefile minio_secret.yaml
 apiVersion: v1
 kind: Secret
@@ -123,7 +110,7 @@ secrets:
 
 
 
-```bash
+```sh
 %%sh
 kubectl apply -f minio_secret.yaml
 ```
@@ -137,7 +124,7 @@ kubectl apply -f minio_secret.yaml
 First, configure credentials for `mc`, the MinIO command line client.
 
 
-```bash
+```sh
 %%sh
 set -o errexit
 
@@ -157,18 +144,18 @@ Use it to create a bucket, upload the dataset to it, and set access policy so th
 You may want to change the default bucket names used by this tutorial, since MinIO buckets are global resources shared between all cluster users.
 
 
-```bash
+```python
 INPUT_BUCKET = "pipelines-tutorial-data"
 EXPORT_BUCKET = "pipelines-tutorial-model"
 ```
 
 
-```bash
+```python
 %env INPUT_BUCKET $INPUT_BUCKET
 ```
 
 
-```bash
+```sh
 %%sh
 mc --no-color mb "minio/${INPUT_BUCKET}"
 ```
@@ -177,7 +164,7 @@ mc --no-color mb "minio/${INPUT_BUCKET}"
 
 
 
-```bash
+```sh
 %%sh
 set -o errexit
 tar --dereference -czf datasets.tar.gz ./datasets
@@ -478,7 +465,7 @@ For GPU support, please add the "-gpu" suffix to the base image.
 
 
 ```python
-BASE_IMAGE = "mesosphere/kubeflow:2.0.0-tensorflow-2.8.0"
+BASE_IMAGE = "mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0"
 ```
 
 
@@ -687,7 +674,7 @@ with open("input.json", "w") as json_file:
 ```
 
 
-```bash
+```sh
 %%sh
 set -o errexit
 model="mnist"
@@ -702,7 +689,7 @@ curl --fail -L "${url}" -d@input.json -o output.json
 
 
 
-```bash
+```sh
 %%sh
 jq -M . output.json
 ```
@@ -729,7 +716,7 @@ The probabilities for each class (0-9) are shown in the `predictions` response.
 The model believes the image shows a "9", which indeed it does!
 
 
-```bash
+```sh
 %%sh
 jq -M --exit-status '.predictions[0] | indices(max)[0] == 9' output.json
 ```
@@ -740,3 +727,5 @@ jq -M --exit-status '.predictions[0] | indices(max)[0] == 9' output.json
 For more details on the URL, please check out this [example](https://github.com/kserve/kserve/tree/master/docs/samples/v1beta1/tensorflow#run-a-prediction).
 
 This tutorial includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with Kaptain 2.1.0 are available at these URLs: [https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z](https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z) and [https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z](https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z)
+
+For a full list of attributed 3rd party software, see d2iq.com/legal/3rd

--- a/pages/dkp/kaptain/2.1.0/tutorials/sdk/image-builder/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/sdk/image-builder/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz | tar xz
 ```
 
 </p>
@@ -51,11 +51,11 @@ Please note that this notebook is interactive!
 Kaptain SDK 1.0.0 or later:
 
 
-```bash
+```sh
 %%sh
 pip show d2iq-kaptain
 ```
-```sh
+
     Name: d2iq-kaptain
     Version: 1.0.0
     Summary: A pack-and-ship SDK for Kaptain
@@ -65,8 +65,8 @@ pip show d2iq-kaptain
     License: Apache
     Location: /opt/conda/lib/python3.7/site-packages
     Requires: python-dxf, retrying, botocore, kubernetes, types-requests, object-mapper, boto3, torch-model-archiver, kfserving, kubeflow-katib, kubeflow-training, tqdm, humanize, tenacity, typing
-    Required-by:
-```
+    Required-by: 
+
 
 ### Prepare the training code and datasets
 The examples in this tutorial require a trainer code file `mnist.py` and a dataset to be present in the current folder.
@@ -165,7 +165,7 @@ def main():
         metavar="N",
         help="Accelerates SGD in the relevant direction and dampens oscillations (default: 0.1)",
     )
-
+    
     args, _ = parser.parse_known_args()
 
     strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()
@@ -274,7 +274,7 @@ requirements = "requirements.txt"
 extra_files = [requirements, "mnist.py", "datasets"]
 
 # Image used in the FROM instruction of the Dockerfile
-base_image = "mesosphere/2.0.0-tensorflow-2.8.0"
+base_image = "mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0"
 
 # Name of the final image
 image_name = f"mesosphere/kubeflow:kaptain-sdk-mnist-tf-{timestamp}"
@@ -340,7 +340,7 @@ Finally, the following cell will run the image build using the Dockerfile with a
 ```python
 builder.build_image()
 ```
-```sh
+
     2021-11-02 14:11:59,714 kaptain-log[INFO]: Building Docker image.
     2021-11-02 14:11:59,714 kaptain-log[INFO]: Creating secret docker-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:11:59,728 kaptain-log[INFO]: Creating secret context-ffccde4355a4a541 in namespace user1.
@@ -348,18 +348,18 @@ builder.build_image()
     2021-11-02 14:11:59,918 kaptain-log[INFO]: Waiting for Image Build to start...
     2021-11-02 14:12:03,869 kaptain-log[INFO]: Image Build started in pod: kaniko-ffccde4355a4a541-hz9pl.
     2021-11-02 14:12:05,996 kaptain-log[INFO]: [kaniko-ffccde4355a4a541-hz9pl/kaniko] logs:
-    [0001] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
-    [0001] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
-    [0001] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
-    [0001] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
+    [0001] Retrieving image manifest mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
+    [0001] Retrieving image mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
+    [0001] Retrieving image manifest mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
+    [0001] Retrieving image mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
     [0002] Built cross stage deps: map[]                
     2021-11-02 14:12:57,247 kaptain-log[INFO]: [kaniko-ffccde4355a4a541-hz9pl/kaniko] logs:
-    [0002] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
-    [0002] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
-    [0003] Retrieving image manifest mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
-    [0003] Retrieving image mesosphere/kubeflow:2.0.0-tensorflow-2.8.0
+    [0002] Retrieving image manifest mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
+    [0002] Retrieving image mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
+    [0003] Retrieving image manifest mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
+    [0003] Retrieving image mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0 
     [0004] Executing 0 build triggers                   
-    [0004] Unpacking rootfs as cmd COPY . /workdir requires it.
+    [0004] Unpacking rootfs as cmd COPY . /workdir requires it. 
     [0054] Taking snapshot of full filesystem...        
     2021-11-02 14:13:54,353 kaptain-log[INFO]: [kaniko-ffccde4355a4a541-hz9pl/kaniko] logs:
     [0111] WORKDIR /workdir                             
@@ -371,7 +371,7 @@ builder.build_image()
     [0111] RUN pip install -r requirements.txt          
     [0111] cmd: /bin/bash                               
     [0111] args: [-cu pip install -r requirements.txt]  
-    [0111] Running: [/bin/bash -cu pip install -r requirements.txt]
+    [0111] Running: [/bin/bash -cu pip install -r requirements.txt] 
     Requirement already satisfied: scikit-learn in /opt/conda/lib/python3.7/site-packages (from -r requirements.txt (line 2)) (0.24.2)
     Requirement already satisfied: numpy in /opt/conda/lib/python3.7/site-packages (from -r requirements.txt (line 3)) (1.19.5)
     Requirement already satisfied: scipy>=0.19.1 in /opt/conda/lib/python3.7/site-packages (from scikit-learn->-r requirements.txt (line 2)) (1.7.1)
@@ -379,16 +379,16 @@ builder.build_image()
     Requirement already satisfied: threadpoolctl>=2.0.0 in /opt/conda/lib/python3.7/site-packages (from scikit-learn->-r requirements.txt (line 2)) (2.2.0)
     WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
     [0113] ENTRYPOINT ["python", "-u", "mnist.py"]      
-    [0113] LABEL checksum=dd270080d096520306e0cb72857bd859
-    [0113] Applying label checksum=dd270080d096520306e0cb72857bd859
+    [0113] LABEL checksum=dd270080d096520306e0cb72857bd859 
+    [0113] Applying label checksum=dd270080d096520306e0cb72857bd859 
     [0113] Taking snapshot of full filesystem...        
     2021-11-02 14:15:06,233 kaptain-log[INFO]: Image build completed successfully. Image pushed: mesosphere/kubeflow:kaptain-sdk-mnist-tf-1635862297
     2021-11-02 14:15:06,234 kaptain-log[INFO]: Deleting job kaniko-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:15:06,243 kaptain-log[INFO]: Deleting secret docker-ffccde4355a4a541 in namespace user1.
     2021-11-02 14:15:06,253 kaptain-log[INFO]: Deleting secret context-ffccde4355a4a541 in namespace user1.
-```
 
-That's it! Image build has been completed and the image with required packages and files has been pushed to the Docker registry.
+
+That's it! Image build has been completed and the image with required packages and files has been pushed to the Docker registry. 
 
 ## Option 2: Build-Push-Run
 
@@ -422,7 +422,7 @@ model.train(
     hyperparameters={"--learning-rate": 0.1, "--momentum": 0.02, "--epochs": 5,},
 )
 ```
-```sh
+
     2021-11-02 18:37:40,752 kaptain-log[INFO]: Skipping image build for the model - the image 'mesosphere/kubeflow:kaptain-sdk-mnist-tf-1635862297' with the same contents has already been published to the registry.
     2021-11-02 18:37:40,755 kaptain-log[INFO]: Creating secret train-d5fd784b5409a57f in namespace user1.
     2021-11-02 18:37:40,768 kaptain-log[INFO]: Creating secret train-registry-c33ad3a574d5dee2 in namespace user1.
@@ -450,8 +450,10 @@ model.train(
     2021-11-02 18:38:30,371 kaptain-log[INFO]: Deleting secret train-d5fd784b5409a57f in namespace user1.
     2021-11-02 18:38:30,378 kaptain-log[INFO]: Deleting secret train-registry-c33ad3a574d5dee2 in namespace user1.
     2021-11-02 18:38:30,384 kaptain-log[INFO]: Model training is completed.
-```
+
 
 To learn more about creating and deploying machine learninig models with Kaptain SDK, refer to [Kaptain SDK with Tensorflow](../tensorflow) or [Kaptain SDK with Pytorch](../pytorch) tutorials.
 
 This tutorial includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with Kaptain 2.1.0 are available at these URLs: [https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z](https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z) and [https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z](https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z)
+
+For a full list of attributed 3rd party software, see d2iq.com/legal/3rd

--- a/pages/dkp/kaptain/2.1.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/sdk/tensorflow/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz | tar xz
 ```
 
 </p>
@@ -27,7 +27,7 @@ tested on D2iQ's Kaptain. Without the requisite Kubernetes operators and custom 
 will likely not work.</p>
 
 
-<p class="message--note"><strong>NOTE: </strong>This notebook requires Kaptain SDK 0.4.x or later.
+<p class="message--warning"><strong>NOTE: </strong>This notebook requires Kaptain SDK 0.4.x or later.
 </p>
 
 # Kaptain SDK: Training, Tuning, and Deploying
@@ -55,7 +55,7 @@ All you need is this notebook.
 Before proceeding, check you are using the correct notebook image, that is, [TensorFlow](https://www.tensorflow.org/api_docs/) is available:
 
 
-```bash
+```sh
 %%sh
 pip list | grep tensorflow
 ```
@@ -246,7 +246,7 @@ def main():
     ModelExportUtil().upload_model("mnist")
 
     eval_loss, eval_acc = model.evaluate(test_dataset_sharded, verbose=0, steps=args.steps)
-
+    
     # Record the evaluation metrics for use with the hyperparameter tuner
     MetadataUtil.record_metrics({"loss": eval_loss, "accuracy": eval_acc})
 
@@ -263,7 +263,7 @@ The central abstraction of the Kaptain SDK is a model:
 
 ```python
 extra_files = ["datasets/mnist"]
-base_image = "mesosphere/kubeflow:2.0.0-tensorflow-2.8.0"
+base_image = "mesosphere/kubeflow-dev:305a2b36-tensorflow-2.8.0"
 # replace with your docker repository with a tag (optional), e.g. "repository/image"  or "repository/image:tag"
 image_name = "mesosphere/kubeflow:mnist-sdk-example"
 # name of the file with additional python packages to install into model image (e.g. "requirements.txt")
@@ -326,10 +326,10 @@ model.train(
     memory=memory,
     gpus=gpus,
     hyperparameters={"--steps": 10, "--epochs": 5},
-    args={}, # additional command line arguments for the training job.
+    args={}, # additional command line arguments for the training job. 
 )
 ```
-```sh
+
     ...
     10/10 [==============================] - 0s 48ms/step - accuracy: 0.2516 - loss: 2.2895
     [I 201214 11:18:01 kubernetes:190] Epoch 2/5
@@ -344,12 +344,12 @@ model.train(
     [I 201214 11:18:06 kubernetes:190] INFO:root:Metrics saved.
     [I 201214 11:18:07 job_runner:58] Waiting for the training job to complete...
     [I 201214 11:18:07 models:332] Training result: Succeeded
-```
+
 
 The default `gpus` argument is 0, but it is shown here as an explicit option.
 Use `?Model.train` to see all supported arguments.
 
-<p class="message--note"><strong>NOTE: </strong>When resource quotas are set for a namespace, users have to specify <code>cpu</code> and <code>memory</code> explicitly in the SDK.
+<p class="message--note"><strong>NOTE: </strong>When resource quotas are set for a namespace, users have to specify <code>cpu</code> and <code>memory</code> explicitly in the SDK. 
 Otherwise, tasks such as training and tuning will fail with <code>Error creating: pods ... is forbidden: failed quota: kf-resource-quota: must specify cpu,memory</code>.
 These fields are optional when resource quotas are not set.
 In case the issue appears for other types of workloads, it is recommended to configure defaults for the user namespace using the <a href="https://kubernetes.io/docs/concepts/policy/limit-range/">Limit Range</a>.
@@ -360,7 +360,7 @@ The low accuracy of the model is to make the demonstration of distributed traini
 ### Verify the Model is Exported to MinIO
 
 
-```bash
+```sh
 %%sh
 set -o errexit
 
@@ -412,16 +412,16 @@ hyperparams = {
 }
 
 model.tune(
-    trials=trials,
-    parallel_trials=parallel_trials,
+    trials=trials, 
+    parallel_trials=parallel_trials, 
     workers=workers,
     cpu=cpu,
     memory=memory,
-    gpus=gpus,
-    hyperparameters=hyperparams,
-    objectives=["accuracy"],
+    gpus=gpus, 
+    hyperparameters=hyperparams, 
+    objectives=["accuracy"], 
     objective_goal=0.99,
-    args={}, # additional command line arguments to pass to a Trial (TFJob).
+    args={}, # additional command line arguments to pass to a Trial (TFJob). 
 )
 ```
 
@@ -445,7 +445,7 @@ Available options are:
 
 The Kaptain SDK allows individual trials to be run in parallel as well as trained in a distributed manner each.
 
-<p class="message--warning"><strong>WARNING: </strong>With a large number of parallel trials <i>and</i> a fair number of workers per trial, it is easy to max out on the available resources.
+<p class="message--warning"><strong>BEWARE! </strong>With a large number of parallel trials <i>and</i> a fair number of workers per trial, it is easy to max out on the available resources.
     If the worker quota for the namespace is <i>Q</i>, the number of parallel trials is <i>P</i>, and the number of workers per trial is <i>W</i>, please ensure that <i>P</i> &times; <i>W</i> &leq; <i>Q</i></p>
 
 ## Run canary rollout
@@ -503,7 +503,7 @@ with open("input.json", "w") as json_file:
 ```
 
 
-```bash
+```sh
 %%sh
 set -o errexit
 model_name="dev-mnist"
@@ -527,3 +527,5 @@ curl --location \
 The last class has the largest probability; the neural network correctly predicts the image to be a 9.
 
 This tutorial includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with Kaptain 2.1.0 are available at these URLs: [https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z](https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z) and [https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z](https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z)
+
+For a full list of attributed 3rd party software, see d2iq.com/legal/3rd

--- a/pages/dkp/kaptain/2.1.0/tutorials/training/mxnet/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/training/mxnet/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz | tar xz
 ```
 
 </p>
@@ -44,14 +44,15 @@ All you need is this notebook.
 Before proceeding, check you are using the correct notebook image, that is, [MXNet](https://mxnet.apache.org/api/python/docs/api/) is available:
 
 
-```bash
+```sh
 %%sh
 pip list | grep mxnet
 ```
-```sh
+
     mxnet-cu102mkl           1.6.0
 
-```
+Yes!
+
 Import the necessary Python modules and load the data:
 
 
@@ -154,9 +155,9 @@ mnist["train_label"][42]
 
 
 
-```sh
+
     7
-```
+
 
 
 Just to be on the safe side, check the pixel values have already been scaled into the [0, 1] range:
@@ -169,9 +170,10 @@ min(flattened), max(flattened)
 
 
 
-```sh
+
     (0.0, 1.0)
-```
+
+
 
 ## How to Train the Model
 
@@ -373,7 +375,7 @@ Invoke it with the defaults (and the pre-defined parameters):
 ```python
 model, acc = train(mnist, context, epochs, batch_size)
 ```
-```sh
+
     INFO:root:Epoch[0] Batch [0-100]	Speed: 1353.96 samples/sec	accuracy=0.114356
     INFO:root:Epoch[0] Batch [100-200]	Speed: 1438.84 samples/sec	accuracy=0.113700
     INFO:root:Epoch[0] Batch [200-300]	Speed: 1464.64 samples/sec	accuracy=0.112600
@@ -454,7 +456,7 @@ model, acc = train(mnist, context, epochs, batch_size)
     INFO:root:Epoch[9] Train-accuracy=0.990800
     INFO:root:Epoch[9] Time cost=48.257
     INFO:root:Epoch[9] Validation-accuracy=0.987700
-```
+
 
 <div style="color: #31708f; background-color: #d9edf7; border-color: #bce8f1; padding: 15px; margin-top: 10px; margin-bottom: 10px; border: 1px solid transparent; border-radius: 4px;">
     <b>A Note on Accuracy</b><br>
@@ -469,7 +471,7 @@ Because you wrapped the training process in a function, you can easily see the i
 ```python
 model_relu, acc_relu = train(mnist, context, epochs, batch_size, activation="relu")
 ```
-```sh
+
     INFO:root:Epoch[0] Batch [0-100]	Speed: 1693.27 samples/sec	accuracy=0.111089
     INFO:root:Epoch[0] Batch [100-200]	Speed: 1739.83 samples/sec	accuracy=0.118500
     INFO:root:Epoch[0] Batch [200-300]	Speed: 1768.59 samples/sec	accuracy=0.105400
@@ -550,7 +552,7 @@ model_relu, acc_relu = train(mnist, context, epochs, batch_size, activation="rel
     INFO:root:Epoch[9] Train-accuracy=0.992583
     INFO:root:Epoch[9] Time cost=34.517
     INFO:root:Epoch[9] Validation-accuracy=0.987800
-```
+
 
 
 ```python
@@ -585,7 +587,7 @@ prob[24], prob_relu[24]
 
 
 
-```sh
+
     (
      [3.88936355e-10 5.50869439e-09 1.38218335e-08 1.33717464e-11
       9.99999046e-01 1.08974885e-09 3.25030669e-07 8.28973228e-08
@@ -595,7 +597,7 @@ prob[24], prob_relu[24]
      [6.4347176e-08 7.3004806e-08 3.4015596e-08 5.8196594e-09 9.9998724e-01
       1.2476704e-07 1.9580840e-07 3.0599865e-06 1.2806310e-08 9.1640350e-06]
      <NDArray 10 @cpu(0)>)
-```
+
 
 
 The highest probability is observed for the fourth index (i.e. the digit '4'):
@@ -607,7 +609,7 @@ np.argmax(prob[24]), np.argmax(prob_relu[24])
 
 
 
-```sh
+
     (
      [4.]
      <NDArray 1 @cpu(0)>,
@@ -615,7 +617,7 @@ np.argmax(prob[24]), np.argmax(prob_relu[24])
      [4.]
      <NDArray 1 @cpu(0)>)
 
-```
+
 
 Since you did not shuffle data for the iterator `test_iter` that was used to generate probabilities, you can use the same index to obtain the label to verify that the model predicts the digit correctly:
 
@@ -626,7 +628,11 @@ mnist["test_label"][24]
 
 
 
-```sh
-    4
-```
 
+    4
+
+
+
+This tutorial includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with Kaptain 2.1.0 are available at these URLs: [https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z](https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z) and [https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z](https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z)
+
+For a full list of attributed 3rd party software, see d2iq.com/legal/3rd

--- a/pages/dkp/kaptain/2.1.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/training/pytorch/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-dev.tar.gz | tar xz
 ```
 
 </p>
@@ -59,7 +59,7 @@ If you prefer to create your Docker image locally, you must also have a Docker c
 Before proceeding, check you are using the correct notebook image, that is, [PyTorch](https://pytorch.org/docs/stable/torch.html) is available:
 
 
-```bash
+```sh
 %%sh
 pip list | grep torch
 ```
@@ -119,7 +119,7 @@ mnist
 ```
 
 
-```sh
+
 
     Dataset MNIST
         Number of datapoints: 60000
@@ -127,7 +127,7 @@ mnist
         Split: Train
         StandardTransform
     Transform: ToTensor()
-```
+
 
 
 
@@ -137,9 +137,9 @@ list(mnist.data.size())
 
 
 
-```sh
+
     [60000, 28, 28]
-```
+
 
 
 That shows there are 60,000 28&times;28 pixel grayscale images.
@@ -152,9 +152,9 @@ mnist.data.float().min(), mnist.data.float().max()
 
 
 
-```sh
+
     (tensor(0.), tensor(255.))
-```
+
 
 
 
@@ -188,9 +188,9 @@ example_label
 
 
 
-```sh
+
     7
-```
+
 
 
 Normalize the data set to improve the training speed, which means you need to know the mean and standard deviation:
@@ -202,9 +202,9 @@ mnist.data.float().mean() / 255, mnist.data.float().std() / 255
 
 
 
-```sh
+
     (tensor(0.1307), tensor(0.3081))
-```
+
 
 
 These are the values hard-coded in the transformations within the model.
@@ -257,10 +257,10 @@ Make the defined constants available as shell environment variables. They parame
 %env EPOCHS $EPOCHS
 %env GPUS $GPUS
 ```
-```sh
+
     env: EPOCHS=5
     env: GPUS=1
-```
+
 
 ## How to Train the Model in the Notebook
 
@@ -519,9 +519,9 @@ def main():
 if __name__ == "__main__":
     main()
 ```
-```sh
+
     Writing mnist.py
-```
+
 
 That saves the file as defined by `TRAINER_FILE` but it does not run it.
 
@@ -580,7 +580,7 @@ Run the code from within the notebook to check that it is correct:
 ```python
 %run $TRAINER_FILE --epochs $EPOCHS --log-interval 128
 ```
-``sh
+
     INFO:root:Epoch: 1 (  0.0%) - Loss: 2.293032646179199
     INFO:root:Epoch: 1 ( 13.6%) - Loss: 0.5257666110992432
     INFO:root:Epoch: 1 ( 27.3%) - Loss: 0.08510863780975342
@@ -636,7 +636,7 @@ Run the code from within the notebook to check that it is correct:
     INFO:root:Test accuracy: 9909/10000 ( 99.1%)
     INFO:root:loss=0.0306
     INFO:root:accuracy=0.9909
-```
+
 
 
     <Figure size 432x288 with 0 Axes>
@@ -659,7 +659,7 @@ It uses [containerd](https://containerd.io/) to run workloads (only) instead.
 The Dockerfile looks as follows:
 
 ```
-FROM mesosphere/kubeflow:2.0.0-pytorch-1.11.0-gpu
+FROM mesosphere/kubeflow-dev:06de0f2c-pytorch-1.11.0-gpu
 ADD mnist.py /
 ADD datasets /datasets
 
@@ -676,11 +676,11 @@ docker build -t <docker_image_name_with_tag> .
 docker push <docker_image_name_with_tag>
 ```
 
-The image is available as `mesosphere/kubeflow:2.0.0-mnist-pytorch-1.11.0-gpu` in case you want to skip it for now.
+The image is available as `mesosphere/kubeflow-dev:616a6a45-mnist-pytorch-1.11.0-gpu` in case you want to skip it for now.
 
 
 ```python
-%env IMAGE mesosphere/kubeflow:2.0.0-mnist-pytorch-1.11.0-gpu
+%env IMAGE mesosphere/kubeflow-dev:616a6a45-mnist-pytorch-1.11.0-gpu
 ```
 
 ## How to Create a Distributed `PyTorchJob`
@@ -797,7 +797,7 @@ kubectl create -f "${KUBERNETES_FILE}"
 Check the status like so:
 
 
-```bash
+```sh
 %%sh
 kubectl describe $PYTORCH_JOB
 ```
@@ -821,16 +821,16 @@ Events:
 You should now be able to see the pods created, matching the specified number of replicas.
 
 
-```bash
+```sh
 %%sh
 kubectl get pods -l job-name=pytorchjob-mnist
 ```
-```sh
+
     NAME                         READY   STATUS    RESTARTS   AGE
-    pytorchjob-mnist-master-0    1/1     Running   0          34s
-    pytorchjob-mnist-worker-0    1/1     Running   0          34s
-    pytorchjob-mnist-worker-1    1/1     Running   0          34s
-```
+    pytorchjob-mnist-master-0   1/1     Running   0          34s
+    pytorchjob-mnist-worker-0   1/1     Running   0          34s
+    pytorchjob-mnist-worker-1   1/1     Running   0          34s
+
 
 The job name matches `metadata.name` from the YAML.
 
@@ -838,11 +838,11 @@ As per the specification, the training runs for 15 epochs.
 During that time, stream the logs from the `Master` pod to follow the progress:
 
 
-```bash
+```sh
 %%sh
 kubectl logs -f pytorchjob-mnist-master-0
 ```
-```sh
+
     Using distributed PyTorch with gloo backend
     Epoch: 1 (  0.0%) - Loss: 2.3082287311553955
     Epoch: 1 ( 81.8%) - Loss: 0.04400685429573059
@@ -919,7 +919,7 @@ kubectl logs -f pytorchjob-mnist-master-0
     Test accuracy: 9911/10000 ( 99.1%)
     loss=0.0267
     accuracy=0.9911
-```
+
 
 Note that it may take a while when the image has to be pulled from the registry.
 It usually takes a few minutes, depending on the arguments and resources of the cluster, for the status for all pods to be 'Running'.
@@ -927,11 +927,11 @@ It usually takes a few minutes, depending on the arguments and resources of the 
 The setting `spec.ttlSecondsAfterFinished` will result in the cleanup of the created job:
 
 
-```bash
+```sh
 %%sh
 kubectl get pytorchjobs -w
 ```
-```sh
+
     NAME               STATE     AGE
     pytorchjob-mnist   Created   0s
     pytorchjob-mnist   Running   2s
@@ -939,10 +939,10 @@ kubectl get pytorchjobs -w
     pytorchjob-mnist   Succeeded   70s
     pytorchjob-mnist   Succeeded   70s
     pytorchjob-mnist   Succeeded   11m
-```
 
 
-```bash
+
+```sh
 %%sh
 kubectl get pytorchjob pytorchjob-mnist
 ```
@@ -950,7 +950,11 @@ kubectl get pytorchjob pytorchjob-mnist
 To delete the job manually, execute:
 
 
-```bash
+```sh
 %%sh
 kubectl delete $PYTORCH_JOB
 ```
+
+This tutorial includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the [GNU Affero General Public License 3.0](https://www.gnu.org/licenses/agpl-3.0.en.html). The complete source code for the versions of MinIO packaged with Kaptain 2.1.0 are available at these URLs: [https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z](https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z) and [https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z](https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z)
+
+For a full list of attributed 3rd party software, see d2iq.com/legal/3rd


### PR DESCRIPTION
Signed-off-by: Alex Lembiyeuski <alembiyeuski@d2iq.com>

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Update Kaptain generated documentation

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4565.s3-website-us-west-2.amazonaws.com/

## Checklist

- [x] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
