### PR TITLE
bugfix: Wrong filename in vsphere download instructions

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
@@ -24,7 +24,7 @@ When creating an air-gapped vSphere cluster, the bastion VM hosts the installati
 
     - dkp_v2.2.1_linux_amd64.tar.gz
 
-    - dkp_image_bundle_v2.2.1_linux_amd64.tar.gz (air-gapped) - This bundle contains air-gapped images that you must push to a registry.)
+    - konvoy_image_bundle_v2.2.1_linux_amd64.tar.gz (air-gapped) - This bundle contains air-gapped images that you must push to a registry.)
 
     - konvoy-bootstrap_v2.2.1.tar (air-gapped) - This bundle contains the KIND bootstrap image to load with the `docker load` command when you create the bootstrap cluster in a later step.
 

--- a/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
+++ b/pages/dkp/konvoy/2.3/choose-infrastructure/vsphere/air-gapped/create-bastion-vm/index.md
@@ -24,7 +24,7 @@ When creating an air-gapped vSphere cluster, the bastion VM hosts the installati
 
     - dkp_v2.3.0_linux_amd64.tar.gz
 
-    - dkp_image_bundle_v2.3.0_linux_amd64.tar.gz (air-gapped) - This bundle contains air-gapped images that you must push to a registry.)
+    - konvoy_image_bundle_v2.3.0_linux_amd64.tar.gz (air-gapped) - This bundle contains air-gapped images that you must push to a registry.)
 
     - konvoy-bootstrap_v2.3.0.tar (air-gapped) - This bundle contains the KIND bootstrap image to load with the `docker load` command when you create the bootstrap cluster in a later step.
 


### PR DESCRIPTION
## Jira Ticket

No ticket

## Description of changes being made

In following the vsphere docs it tells you to download the file dkp_image_bundle_v2.2.1_linux_amd64.tar.gz but this file does not exist.   It is named 'konvoy_image_bundle_v2.2.1_linux_amd64.tar.gz'

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4570.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
