### PR TITLE
adding packer builder type D2IQ-91418

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-capi-vm-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/air-gapped/create-capi-vm-image/index.md
@@ -28,6 +28,8 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 1. Create an `image.yaml` file and add the following variables for vSphere. DKP uses this file and these variables as inputs in the next step.
 
    ```yaml
+   build_name: "vsphere-rhel-79"
+   packer_builder_type: "vsphere"
    packer:
      cluster: "example_zone"
      datacenter: "example_datacenter"
@@ -47,7 +49,7 @@ Using the base OS image created in a previous procedure, DKP creates the new vSp
 1. Create a vSphere VM template with the following command:
 
    ```bash
-   konvoy-image build path/to/image.yaml /
+   konvoy-image build path/to/image.yaml \
      --overrides /path/to/overrides/offline.yaml
    ```
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/D2IQ-91418

## Description of changes being made
Adding the packer builder type to the file images.yaml, specifically the following 2 lines:

```
build_name: "vsphere-rhel-79"
packer_builder_type: "vsphere"
```

without these two lines the following exception is returned:

```
./konvoy-image build images.yaml --overrides offline.yaml
2022/07/08 20:01:15 writing new packer configuration to work/provision_build-1657310475-PSrOj
ERRO error during run: build failure: /packer_builder_type is not defined in image manifest
error encountered: exit status 3
```

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
