### PR TITLE
[Kommander] http bug fix for 2.1

### DIFF
--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
@@ -140,6 +140,8 @@ If none of the conditions apply to your cluster, then you can skip to next secti
 
 ## Move your applications
 
+If your environment has a HTTP proxy configured, create a [TCP connection](#environments-with-an-http-proxy-server) before running the following command.
+
 To adapt your existing platform applications to Kommander enter the following command:
 
 ```bash
@@ -211,6 +213,25 @@ velero
 ```
 
 Refer to the [Verify installation][verify-install] topic to ensure successful completion.
+
+### Environments with an HTTP proxy server
+
+The `kommander migrate` command requires a connection from your environment to the Traefik ingress controller in your cluster. If your environment demands the use of an HTTP proxy server, establish an alternative connection to the Traefik ingress controller by running a port-forward into Traefik on a local host.
+
+1.  Ensure you create or modify the `127.0.0.1` record to include the ingress domain name in your hosts file:
+
+    ```bash
+    [root@sv-2000lvp233 kaas-8002-baseline]# cat /etc/hosts
+    127.0.0.1   localhost localhost.localdomain <ingress_domain_name>
+    ```
+
+1.  Create a TCP connection to Traefik on your cluster:
+
+    ```bash
+    kubectl --kubeconfig admin.conf -n kommander port-forward svc/kommander-traefik 443:443
+    ```
+
+1.  Continue with the [Move your applications](#move-your-applications) section.
 
 ## Post-upgrade cleanup
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-87523

## Description of changes being made

When an environment requires the use of an HTTP proxy server, the `migrate` command fails to establish a connection to the Traefik ingress controller (which is required for migration). Here, we provide a workaround on how to establish a connection for migration to be possible.

### Preview

http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

