### PR TITLE
[Kommander]: new terminal for port-forward command

### DIFF
--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
@@ -225,13 +225,15 @@ The `kommander migrate` command requires a connection from your environment to t
     127.0.0.1   localhost localhost.localdomain <ingress_domain_name>
     ```
 
-1.  Create a TCP connection to Traefik on your cluster:
+1.  Open a separate terminal window to create a TCP connection to Traefik on your cluster:
 
     ```bash
     kubectl --kubeconfig admin.conf -n kommander port-forward svc/kommander-traefik 443:443
     ```
 
-1.  Continue with the [Move your applications](#move-your-applications) section.
+    <p class="message--note"><strong>NOTE: </strong>It is necessary that you open a new terminal window because the `kubectl port-forward` command does not return, and you need to leave this connection open for the duration of the migration.</p>
+
+1.  On your standard terminal window, continue with the [Move your applications](#move-your-applications) section.
 
     <p class="message--important"><strong>IMPORTANT: </strong>Once the migration is completed, revert the changes in your hosts `/etc/hosts` file.</p>
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-87523

## Description of changes being made

Providing additional explanation for one of the steps. The `port-forward` command freezes your terminal, so the customer should run said command on a separate terminal to be able to continue with the migration in the original terminal window.

### Preview

http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/
