### PR TITLE
fix: Update DKP 2.2.2 app versions

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
@@ -72,41 +72,41 @@ When upgrading to this release, the following services and service components ar
 
 | Common Application Name | APP ID | Version | Component Versions |
 |-------------------------|--------|---------|--------------------|
-| Centralized Grafana | centralized-grafana | 33.1.6 | - chart: 33.1.6<br>- grafana: 0.55.0 |
-| Centralized Kubecost | centralized-kubecost | 0.23.3 | - chart: 0.23.3<br>- kubecost: 1.94.3 |
-| Cert Manager | cert-manager | 1.7.1 | - chart: 1.7.1<br>- cert-manager: 1.9.0-beta.1 |
+| Centralized Grafana | centralized-grafana | 33.1.6 | - chart: 33.1.6<br>- prometheus-operator: 0.54.1 |
+| Centralized Kubecost | centralized-kubecost | 0.23.3 | - chart: 0.23.3<br>- kubecost: 1.91.2 |
+| Cert Manager | cert-manager | 1.7.1 | - chart: 1.7.1<br>- cert-manager: 1.7.1 |
 | Chartmuseum | chartmuseum | 3.6.2 | - chart: 3.6.2<br>- chartmuseum: 3.6.2 |
 | Dex | dex | 2.9.18 | - chart: 2.9.18<br>- dex: 2.31.0 |
-| Dex K8s Authenticator | dex-k8s-authenticator | 1.2.9 | - chart: 1.2.9<br>- dex-k8s-authenticator: 1.2.4 |
+| Dex K8s Authenticator | dex-k8s-authenticator | 1.2.9 | - chart: 1.2.9<br>- dex-k8s-authenticator: 1.2.2 |
 | DKP Insights Management | dkp-insights-management | 0.1.6 | - chart: 0.1.6<br>- dkp-insights-management: 0.1.6 |
-| External DNS | external-dns | 6.2.7 | - chart: 6.2.7<br>- external-dns: 0.12.0 |
-| Fluent Bit | fluent-bit | 0.19.20 | - chart: 0.19.20<br>- fluent-bit: 1.9.5 |
-| Gatekeeper | gatekeeper | 3.7.0 | - chart: 3.7.0<br>- gatekeeper: 3.9.0-rc.1 |
-| Gitea | gitea | 5.0.6 | - chart: 5.0.6<br>- gitea: 1.16.8 |
-| Grafana Logging | grafana-logging | 6.22.0 | - chart: 6.22.0<br>- grafana: 9.0.2 |
-| Grafana Loki | grafana-loki | 0.33.1 | - chart: 0.33.1<br>- loki: 2.6.0 |
-| Istio | istio | 1.11.6 | - chart: 1.11.6<br>- istio: 1.14.1 |
-| Jaeger | jaeger | 2.29.0 | - chart: 2.29.0<br>- jaeger: 1.35.0 |
+| External DNS | external-dns | 6.2.7 | - chart: 6.2.7<br>- external-dns: 0.11.0 |
+| Fluent Bit | fluent-bit | 0.19.20 | - chart: 0.19.20<br>- fluent-bit: 1.8.13 |
+| Gatekeeper | gatekeeper | 3.7.0 | - chart: 3.7.0<br>- gatekeeper: 3.7.0 |
+| Gitea | gitea | 5.0.6 | - chart: 5.0.6<br>- gitea: 1.16.6 |
+| Grafana Logging | grafana-logging | 6.22.0 | - chart: 6.22.0<br>- grafana: 8.3.6 |
+| Grafana Loki | grafana-loki | 0.33.1 | - chart: 0.33.1<br>- loki: 2.2.1 |
+| Istio | istio | 1.11.6 | - chart: 1.11.6<br>- istio: 1.11.5 |
+| Jaeger | jaeger | 2.29.0 | - chart: 2.29.0<br>- jaeger: 1.31.0 |
 | Karma | karma | 2.0.1 | - chart: 2.0.1<br>- karma: 0.70 |
-| Kiali | kiali | 1.49.0 | - chart: 1.49.0<br>- kiali: 1.53.0 |
+| Kiali | kiali | 1.49.0 | - chart: 1.49.0<br>- kiali: 1.49.0 |
 | Knative | knative | 0.3.9 | - chart: 0.3.9<br>- knative: 0.22.3 |
 | Kube OIDC Proxy | kube-oidc-proxy | 0.3.1 | - chart: 0.3.1<br>- kube-oidc-proxy: 0.3.0 |
-| Kube Prometheus Stack | kube-prometheus-stack | 33.1.6 | - chart: 33.1.6<br>- grafana: 8.5.0<br>- prometheus-operator: 0.55.0<br>- prometheus: 2.34.0<br>- prometheus-alertmanager: 0.24.0 |
-| Kubecost | kubecost | 0.23.3 | - chart: 0.23.3<br>- kubecost: 1.94.3 |
+| Kube Prometheus Stack | kube-prometheus-stack | 33.1.6 | - chart: 33.1.6<br>- prometheus-operator: 0.54.1<br>- prometheus: 2.33.4<br>- prometheus-alertmanager: 0.23.0<br>- grafana: 8.3.6 |
+| Kubecost | kubecost | 0.23.3 | - chart: 0.23.3<br>- kubecost: 1.91.2 |
 | Kubefed | kubefed | 0.9.2 | - chart: 0.9.2<br>- kubefed: 0.9.2 |
-| Kubernetes Dashboard | kubernetes-dashboard | 5.1.1 | - chart: 5.1.1<br>- kubernetes-dashboard: 2.6.0 |
-| Kubetunnel | kubetunnel | 0.0.11 | - chart: 0.0.11<br>- kubetunnel: 0.0.13 |
-| Logging Operator | logging-operator | 3.17.2 | - chart: 3.17.2<br>- logging-operator: 3.17.7 |
+| Kubernetes Dashboard | kubernetes-dashboard | 5.1.1 | - chart: 5.1.1<br>- kubernetes-dashboard: 2.4.0 |
+| Kubetunnel | kubetunnel | 0.0.11 | - chart: 0.0.11<br>- kubetunnel: 0.0.11 |
+| Logging Operator | logging-operator | 3.17.2 | - chart: 3.17.2<br>- logging-operator: 3.17.2 |
 | Metallb | metallb | 0.12.3 | - chart: 0.12.3<br>- metallb: 0.8.1 |
-| MinIO Operator | minio-operator | 4.4.10 | - chart: 4.4.10<br>- minio-operator: 4.4.25 |
+| MinIO Operator | minio-operator | 4.4.10 | - chart: 4.4.10<br>- minio-operator: 4.4.10 |
 | NFS Server Provisioner | nfs-server-provisioner | 0.6.0 | - chart: 0.6.0<br>- nfs-server-provisioner: 2.3.0 |
 | Nvidia | nvidia | 0.4.4 | - chart: 0.4.4<br>- nvidia-device-plugin: 0.1.4 |
-| Grafana (project) | project-grafana-logging | 6.22.0 | - chart: 6.22.0<br>- grafana: 9.0.2 |
-| Grafana Loki (project) | project-grafana-loki | 0.33.1 | - chart: 0.33.1<br>- loki: 2.6.0 |
+| Grafana (project) | project-grafana-logging | 6.22.0 | - chart: 6.22.0<br>- grafana: 8.3.6 |
+| Grafana Loki (project) | project-grafana-loki | 0.33.1 | - chart: 0.33.1<br>- loki: 2.2.1 |
 | Prometheus Adapter | prometheus-adapter | 2.17.1 | - chart: 2.17.1<br>- prometheus-adapter: 0.9.1 |
-| Reloader | reloader | 0.0.104 | - chart: 0.0.104<br>- reloader: 0.0.117 |
+| Reloader | reloader | 0.0.104 | - chart: 0.0.104<br>- reloader: 0.0.104 |
 | Thanos | thanos | 0.4.6 | - chart: 0.4.6<br>- thanos: 0.17.1 |
-| Traefik | traefik | 10.9.1 | - chart: 10.9.1<br>- traefik: 2.8.0 |
+| Traefik | traefik | 10.9.1 | - chart: 10.9.1<br>- traefik: 2.5.6 |
 | Traefik ForwardAuth | traefik-forward-auth | 0.3.8 | - chart: 0.3.8<br>- traefik-forward-auth: 3.1.0 |
 | Velero | velero | 3.1.5 | - chart: 3.1.5<br>- velero: 1.5.2 |
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[<!-- Link to JIRA ticket -->](https://jira.d2iq.com/browse/D2IQ-91419)

## Description of changes being made

My automation script was reporting the wrong application versions (it was getting the latest). This fix corrects the previous PR.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4587.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
