### PR TITLE
fix: Konvoy release-notes KBA and Kommander versions

### DIFF
--- a/pages/dkp/konvoy/1.8/release-notes/1.8.5/index.md
+++ b/pages/dkp/konvoy/1.8/release-notes/1.8.5/index.md
@@ -59,8 +59,8 @@ The latest tag for the defaultstorageclassprotection addon's Docker image has be
 - Containerd v1.4.7
 - Docker v19.03.15
 - kubeaddons-dispatch stable-1.20-1.4.6
-- kubeaddons-kommander stable-1.20-1.4.3
-- kubernetes-base-addons stable-1.20-4.3.0
+- kubeaddons-kommander stable-1.20-1.4.4
+- kubernetes-base-addons stable-1.20-4.4.0
 - Kubernetes v1.20.13
 - Kubeaddons v0.26.0
 - Mitogen a60c6c14a2473c895162a1b58a81bad0e63d1718


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

https://jira.d2iq.com/browse/D2IQ-91692

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
