### PR TITLE
[Kaptain]: adding MinIO to the prerequisites of Kaptain

### DIFF
--- a/pages/dkp/kaptain/2.0.0/install/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/index.md
@@ -39,7 +39,7 @@ You can deploy Kaptain on a per-workspace basis.
 
 - [`kubectl`][kubectl] on your installation machine
 
-- MinIO is installed on the cluster where you want to deploy Kaptain 
+- MinIO is installed on the cluster where you want to deploy Kaptain
   (If you are installing Kaptain on an attached cluster, [install MinIO manually](../../../kommander/2.2/workspaces/applications/platform-applications/application-deployment/))
 
 ## Install overview

--- a/pages/dkp/kaptain/2.0.0/install/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/index.md
@@ -39,6 +39,9 @@ You can deploy Kaptain on a per-workspace basis.
 
 - [`kubectl`][kubectl] on your installation machine
 
+- MinIO is installed on the cluster where you want to deploy Kaptain 
+  (If you are installing Kaptain on an attached cluster, [install MinIO manually](../../../kommander/2.2/workspaces/applications/platform-applications/application-deployment/))
+
 ## Install overview
 
 To install and deploy Kaptain for the first time, proceed with these steps:


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-91680 

## Description of changes being made

During testing, it was discovered that MinIO needs to be installed manually in attached clusters when installing Kaptain in said cluster. 
This was added to 2.1 via Confluence already.

### Preview

http://docs-d2iq-com-pr-<4592>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
