### PR TITLE
fix: remove vsphere centos7 support

### DIFF
--- a/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.2/supported-operating-systems/index.md
@@ -43,7 +43,6 @@ Konvoy supports the following base Operating Systems.
 <!-- vale Vale.Spelling = NO -->
 | Operating System      | Kernel                           | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
 |-----------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
-| [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64           | Yes            |      |            |                      |             |
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64           | Yes            | Yes  | Yes        |                      | Yes         |
 | [RHEL 8.4][rhel_8_4]  | 4.18.0-305.el8.x86_64            | Yes            | Yes  | Yes        |                      | Yes         |
 

--- a/pages/dkp/konvoy/2.3/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.3/supported-operating-systems/index.md
@@ -43,7 +43,6 @@ Konvoy supports the following base Operating Systems.
 <!-- vale Vale.Spelling = NO -->
 | Operating System      | Kernel                           | Default Config | FIPS | Air Gapped | FIPS with Air Gapped | GPU Support <!-- vale Vale.Spelling = YES --> |
 |-----------------------|----------------------------------|----------------|------|------------|----------------------|-------------|
-| [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64           | Yes            |      |            |                      |             |
 | [RHEL 7.9][rhel_7_9]  | 3.10.0-1160.el7.x86_64           | Yes            | Yes  | Yes        |                      | Yes         |
 | [RHEL 8.4][rhel_8_4]  | 4.18.0-305.el8.x86_64            | Yes            | Yes  | Yes        |                      | Yes         |
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

closes - https://jira.d2iq.com/browse/D2IQ-91902 

## Description of changes being made
 
According to https://jira.d2iq.com/browse/D2IQ-89269 we do not have this feature yet. So removing it from our list

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
