### PR TITLE
fix: update dkp-cli URL

### DIFF
--- a/ci/update-dkp-cli-docs.sh
+++ b/ci/update-dkp-cli-docs.sh
@@ -7,7 +7,7 @@ TARGET_PATH=${TARGET_PATH:-"/dkp/kommander/2.3/cli/"}
 
 TMP_DIR=`mktemp -d`
 trap "rm -r $TMP_DIR" EXIT
-curl -fsSL "https://s3.amazonaws.com/downloads.mesosphere.io/dkp-cli/dkp_${DKP_CLI_VERSION}_linux_amd64.tar.gz" | tar xz -O dkp > $TMP_DIR/dkp
+curl -fsSL "https://s3.amazonaws.com/downloads.mesosphere.io/dkp/${DKP_CLI_VERSION}/dkp_${DKP_CLI_VERSION}_linux_amd64.tar.gz" | tar xz -O dkp > $TMP_DIR/dkp
 chmod +x $TMP_DIR/dkp
 mkdir -p $TMP_DIR/docs
 


### PR DESCRIPTION
## Jira Ticket
NA

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
The CLI docs automation was using an outdated URL for the DKP CLI. This fixes it.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
