### PR TITLE
build: add a manual trigger for the doc generation action

### DIFF
--- a/.github/workflows/dkp-cli.yml
+++ b/.github/workflows/dkp-cli.yml
@@ -2,6 +2,7 @@ name: Update dkp-cli docs
 on:
   schedule:
     - cron: "0 4 * * *"
+  workflow_dispatch:
 
 jobs:
   dkp-cli-docs:


### PR DESCRIPTION
## Jira Ticket
NA
<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Enables manual triggering of the CLI docs generation

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
