### PR TITLE
KIB to DKP compatibility matrix

### DIFF
--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -36,7 +36,6 @@ Along with the KIB Bundle, we publish a file containing checksums for the bundle
 
 | DKP Version  | KIB Version | 
 |------------|----------------------|
-| v2.3.0 | v1.19.9 |
 | V2.2.2 | v1.17.2 |
 | v2.2.1 | v1.13.2 |
 | v2.2.0 | v1.11.0 |

--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -12,23 +12,6 @@ Konvoy Image Builder (KIB) is a complete solution for building
 
 This section describes how to use the KIB to create a Cluster API compliant machine images. Machine images contain configuration information and software to create a specific, pre-configured, operating environment. For example, you can create an image of your current computer system settings and software. The machine image can then be replicated and distributed, creating your computer system for other users. The KIB uses variable overrides to specify base image and container images to use in your new machine image.
 
-## Prerequisites
-
-Before you begin, you must ensure your versions of KIB and DKP are compatible:
-
--  Download the supported version of the KIB bundle from the KIB Version section of the chart below (prefixed with konvoy-image-bundle) for your Operating System.
-### Supported versions
-
-
-| Kubernetes Support  | Version | 
-|------------|----------------------|
-| Minimum | 1.22.0 |
-| Maximum | 1.22.8 |
-| Default | 1.22.0 |
-| EKS Default | 1.22.x |
-
-
--  Create a working `docker` setup.
 
 ## Compatible versions
 Along with the KIB Bundle, we publish a file containing checksums for the bundle files.  The recommendation for using these checksums is to verify the integrity of the downloads.

--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -9,3 +9,40 @@ menuWeight: 70
 
 Konvoy Image Builder (KIB) is a complete solution for building
 [Cluster API](https://cluster-api.sigs.k8s.io/) compliant images.
+
+This section describes how to use the KIB to create a Cluster API compliant machine images. Machine images contain configuration information and software to create a specific, pre-configured, operating environment. For example, you can create an image of your current computer system settings and software. The machine image can then be replicated and distributed, creating your computer system for other users. The KIB uses variable overrides to specify base image and container images to use in your new machine image.
+
+## Prerequisites
+
+Before you begin, you must ensure your versions of KIB and DKP are compatible:
+
+-  Download the supported version of the KIB bundle from the KIB Version section of the chart below (prefixed with konvoy-image-bundle) for your Operating System.
+### Supported versions
+
+
+| Kubernetes Support  | Version | 
+|------------|----------------------|
+| Minimum | 1.22.0 |
+| Maximum | 1.23.x |
+| Default | 1.22.0 |
+| EKS Default | 1.22.x |
+
+
+DKP 2.3 comes with support for Kubernetes 1.23, enabling you to benefit from the latest features and security fixes in upstream Kubernetes. This release comes with approximately 47 enhancements.
+-  Create a working `docker` setup.
+
+## Compatible versions
+Along with the KIB Bundle, we publish a file containing checksums for the bundle files.  The recommendation for using these checksums is to verify the integrity of the downloads.
+
+
+| DKP Version  | KIB Version | 
+|------------|----------------------|
+| v2.3.0 | v1.19.9 |
+| V2.2.2 | v1.17.2 |
+| v2.2.1 | v1.13.2 |
+| v2.2.0 | v1.11.0 |
+| v2.1.x | v1.5.0 |
+
+[KIB Version download release center](https://github.com/mesosphere/konvoy-image-builder/releases)
+
+KIB will run and print out the name of the created image for your infrastructure provider as shown on specific provider pages below.   Use this name when creating a Kubernetes cluster.

--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -28,7 +28,6 @@ Before you begin, you must ensure your versions of KIB and DKP are compatible:
 | EKS Default | 1.22.x |
 
 
-DKP 2.3 comes with support for Kubernetes 1.23, enabling you to benefit from the latest features and security fixes in upstream Kubernetes. This release comes with approximately 47 enhancements.
 -  Create a working `docker` setup.
 
 ## Compatible versions

--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -23,7 +23,7 @@ Before you begin, you must ensure your versions of KIB and DKP are compatible:
 | Kubernetes Support  | Version | 
 |------------|----------------------|
 | Minimum | 1.22.0 |
-| Maximum | 1.23.x |
+| Maximum | 1.22.7 |
 | Default | 1.22.0 |
 | EKS Default | 1.22.x |
 

--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -23,7 +23,7 @@ Before you begin, you must ensure your versions of KIB and DKP are compatible:
 | Kubernetes Support  | Version | 
 |------------|----------------------|
 | Minimum | 1.22.0 |
-| Maximum | 1.22.7 |
+| Maximum | 1.22.8 |
 | Default | 1.22.0 |
 | EKS Default | 1.22.x |
 


### PR DESCRIPTION
## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-92208
<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Take KIB compatibility table from Confluence https://d2iq.atlassian.net/wiki/spaces/DENT/pages/29918909/Konvoy+Image+Builder#Compatible-versions and add through PR to 2.2
### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4603.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
