### PR TITLE
Sortega/d2 iq 91320

### DIFF
--- a/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
@@ -38,7 +38,7 @@ packer:
 ```
 
 After creating the override file for our `source_ami`, we can pass our override file by using the `--overrides` flag when building our image:
-+
+
  ```bash
  ./konvoy-image build images/ami/centos-7.yaml --overrides override-source-ami.yaml
  ```

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
@@ -57,6 +57,7 @@ A complete list of the variables that can be modified for each packer builder, t
 
 [ vSphere packer template ](https://github.com/mesosphere/konvoy-image-builder/blob/v1.12.0/pkg/packer/manifests/vsphere/packer.json.tmpl#L2)
 
+To remove this part:
 
 A base image is a specific AMI image used as the base for your new AMI image. By default, Konvoy Image Builder searches for the latest CentOS 7 `ami` for the base image. The current base image description, at `images/ami/centos-7.yaml`, is similar to the following:
 

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
@@ -13,21 +13,23 @@ When using Konvoy Image Builder (KIB) to create a base OS image, compliant with 
 ```bash
 ./konvoy-image build images/<builder-type>/{os}-{version}.yaml
 ```
-Note:
-In previous versions of the konvoy-image, only azure and aws providers were available, therefore specifying a vsphere was not necessary. 
+
+<p class="message--note"><strong>NOTE: </strong>In previous versions of the konvoy-image, only azure and aws providers were available, therefore specifying a vsphere was not necessary. </p>
 
 Although there are several parameters specified by default in the packer templates for each provider, it is possible to override the default values.  One option is to execute KIB with specific flags to override the values of the source AMI (`--source-ami`), AMI region (`--ami-regions`), AWS EC2 instance type (`--aws-instance-type`), and so on. For a comprehensive list of these flags, please run:
  ```bash
  ./konvoy-image build --help
  ```
-Another option is by creating a file with the parameters to be overriden and specify the `--overrides` flag as shown below (Note: While CLI flags can be used in combination with override files, CLI flags take priority over any override files.):
+Another option is by creating a file with the parameters to be overriden and specify the `--overrides` flag as shown below: 
+
+<p class="message--note"><strong>NOTE: </strong>While CLI flags can be used in combination with override files, CLI flags take priority over any override files.</p>
 
 ```bash
 ./konvoy-image build images/<builder-type>/<os>-<version>.yaml --overrides overrides.yaml
 ```
 
 ### Example 1:
-For example, when using the AWS packer builder to override the above base image with another base image, create an override file and set the source_ami under the packer key. This overrides the image search and forces the use of the specified source_ami.
+For example, when using the AWS Packer builder to override the above base image with another base image, create an override file and set the `source_ami` under the packer key. This overrides the image search and forces the use of the specified `source_ami`.
 
 ```yaml
 ---
@@ -43,7 +45,7 @@ After creating the override file for our `source_ami`, we can pass our override 
 
 ### Example 2:
 
-To abide to best security practices, a user could set their own username and password while creating the base OS image and override the default credentials in KIB by creating a file with the following content:
+To abide to security practices, a user could set their own username and password while creating the base OS image and override the default credentials in KIB by creating a file with the following content:
 
 ```yaml
 ---

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
@@ -8,39 +8,42 @@ enterprise: false
 menuWeight: 85
 ---
 
-When using Konvoy Image Builder (KIB) to create a base OS image, compliant with DKP, the instructions on how to build and configure the image are included in the file located in images/builder-type/os-version.yaml:
+When using Konvoy Image Builder (KIB) to create a base OS image, compliant with DKP, the instructions on how to build and configure the image are included in the file located in `images/<builder-type>/<os>-<version>.yaml`:
 
 ```bash
-./konvoy-image build images/{builder-type}/{os}-{version}.yaml
+./konvoy-image build images/<builder-type>/{os}-{version}.yaml
 ```
+Note:
+In previous versions of the konvoy-image, only azure and aws providers were available, therefore specifying a vsphere was not necessary. 
 
-Although there are several parameters specified by default in the packer templates for each provider, it is possible to override the default values.  One option is to execute KIB with specific flags to override the values of source-ami (--source-ami), ami-region (--ami-regions), aws-instance type (--aws-instance-type), and so on. For a comprehensive list of these flags, please run:
+Although there are several parameters specified by default in the packer templates for each provider, it is possible to override the default values.  One option is to execute KIB with specific flags to override the values of the source AMI (`--source-ami`), AMI region (`--ami-regions`), AWS EC2 instance type (`--aws-instance-type`), and so on. For a comprehensive list of these flags, please run:
+ ```bash
+ ./konvoy-image build --help
+ ```
+Another option is by creating a file with the parameters to be overriden and specify the `--overrides` flag as shown below (Note: While CLI flags can be used in combination with override files, CLI flags take priority over any override files.):
 
 ```bash
-./konvoy-image build --help
+./konvoy-image build images/<builder-type>/<os>-<version>.yaml --overrides overrides.yaml
 ```
-Another option is by creating a file with the parameters to be overriden and specify the `--overrides` flag as shown below:
-
-```bash
-./konvoy-image build images/{builder-type}/{os}-{version}.yaml --overrides overrides.yaml
-```
-
-For example, when using the AWS packer builder to override the above base image with another base image, create an override file and set the source_ami under the packer key. This overrides the image search and forces the use of the specified source_ami.
 
 ### Example 1:
-override-source-ami.yaml
+For example, when using the AWS packer builder to override the above base image with another base image, create an override file and set the source_ami under the packer key. This overrides the image search and forces the use of the specified source_ami.
+
 ```yaml
 ---
 packer:
   source_ami: "ami-0123456789"   
 ```
-and then execute:
-```bash
-./konvoy-image build images/ami/centos-7.yaml --overrides override-source-ami.yaml
-```
+
+After creating the override file for our `source_ami`, we can pass our override file by using the `--overrides` flag when building our image:
++
+ ```bash
+ ./konvoy-image build images/ami/centos-7.yaml --overrides override-source-ami.yaml
+ ```
 
 ### Example 2:
-To abide to best security practices, the user could set their own user and password while creating the base OS image and override the default credentials in KIB by creating a file (overrides-user-password.yaml) with the following content: 
+
+To abide to best security practices, a user could set their own username and password while creating the base OS image and override the default credentials in KIB by creating a file with the following content:
 
 ```yaml
 ---
@@ -49,44 +52,12 @@ packer:
   ssh_password: "<PASSWORD>"  
 ```
 
-A complete list of the variables that can be modified for each packer builder, the user can refer to: 
+For a complete list of the variables that can be modified for each packer builder, users can refer to: 
 
-[ AWS packer template ](https://github.com/mesosphere/konvoy-image-builder/blob/v1.12.0/pkg/packer/manifests/aws/packer.json.tmpl#L2)
+[AWS packer template](https://github.com/mesosphere/konvoy-image-builder/blob/main/pkg/packer/manifests/aws/packer.json.tmpl#L2)
 
-[ Azure packer template ](https://github.com/mesosphere/konvoy-image-builder/blob/v1.12.0/pkg/packer/manifests/azure/packer.json.tmpl#L2)
+[Azure packer template](https://github.com/mesosphere/konvoy-image-builder/blob/main/pkg/packer/manifests/azure/packer.json.tmpl#L2)
 
-[ vSphere packer template ](https://github.com/mesosphere/konvoy-image-builder/blob/v1.12.0/pkg/packer/manifests/vsphere/packer.json.tmpl#L2)
+[GCP packer template](https://github.com/mesosphere/konvoy-image-builder/blob/main/pkg/packer/manifests/gcp/packer.json.tmpl#L2)
 
-To remove this part:
-
-A base image is a specific AMI image used as the base for your new AMI image. By default, Konvoy Image Builder searches for the latest CentOS 7 `ami` for the base image. The current base image description, at `images/ami/centos-7.yaml`, is similar to the following:
-
-```yaml
----
-# Example images/ami/centos-7.yaml
-download_images: true
-packer:
-  ami_filter_name: "CentOS 7.9.2009 x86_64"
-  ami_filter_owners: "125523088429"
-  distribution: "CentOS"
-  distribution_version: "7"
-  source_ami: ""
-  ssh_username: "centos"
-  root_device_name: "/dev/sda1"
-build_name: "centos-7"
-packer_builder_type: "amazon"
-python_path: ""
-```
-
-<p class="message--note"><strong>NOTE: </strong>You can specify a base image to build on, using the <code>--source-ami</code> command line flag:<br />
-<code>konvoy-image build --source-ami=ami-12345abcdef <path/to/image.yaml></code></p>
-
-To override the above base image with another base image, create an `override` file and set the `source_ami` under the `packer` key. This overrides the image search and forces the use of the specified `source_ami`.
-
-```yaml
-# Example override-source-ami.yaml
----
-packer:
-  source_ami: "ami-0123456789"
-```
-See [Supported Operating Systems](../../../../supported-operating-systems) for details.
+[vSphere packer template](https://github.com/mesosphere/konvoy-image-builder/blob/main/pkg/packer/manifests/vsphere/packer.json.tmpl#L2)

--- a/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/override-files/create-custom-or-files/baseimage-or-files/index.md
@@ -8,6 +8,56 @@ enterprise: false
 menuWeight: 85
 ---
 
+When using Konvoy Image Builder (KIB) to create a base OS image, compliant with DKP, the instructions on how to build and configure the image are included in the file located in images/builder-type/os-version.yaml:
+
+```bash
+./konvoy-image build images/{builder-type}/{os}-{version}.yaml
+```
+
+Although there are several parameters specified by default in the packer templates for each provider, it is possible to override the default values.  One option is to execute KIB with specific flags to override the values of source-ami (--source-ami), ami-region (--ami-regions), aws-instance type (--aws-instance-type), and so on. For a comprehensive list of these flags, please run:
+
+```bash
+./konvoy-image build --help
+```
+Another option is by creating a file with the parameters to be overriden and specify the `--overrides` flag as shown below:
+
+```bash
+./konvoy-image build images/{builder-type}/{os}-{version}.yaml --overrides overrides.yaml
+```
+
+For example, when using the AWS packer builder to override the above base image with another base image, create an override file and set the source_ami under the packer key. This overrides the image search and forces the use of the specified source_ami.
+
+### Example 1:
+override-source-ami.yaml
+```yaml
+---
+packer:
+  source_ami: "ami-0123456789"   
+```
+and then execute:
+```bash
+./konvoy-image build images/ami/centos-7.yaml --overrides override-source-ami.yaml
+```
+
+### Example 2:
+To abide to best security practices, the user could set their own user and password while creating the base OS image and override the default credentials in KIB by creating a file (overrides-user-password.yaml) with the following content: 
+
+```yaml
+---
+packer:
+  ssh_username: "<USERNAME>"
+  ssh_password: "<PASSWORD>"  
+```
+
+A complete list of the variables that can be modified for each packer builder, the user can refer to: 
+
+[ AWS packer template ](https://github.com/mesosphere/konvoy-image-builder/blob/v1.12.0/pkg/packer/manifests/aws/packer.json.tmpl#L2)
+
+[ Azure packer template ](https://github.com/mesosphere/konvoy-image-builder/blob/v1.12.0/pkg/packer/manifests/azure/packer.json.tmpl#L2)
+
+[ vSphere packer template ](https://github.com/mesosphere/konvoy-image-builder/blob/v1.12.0/pkg/packer/manifests/vsphere/packer.json.tmpl#L2)
+
+
 A base image is a specific AMI image used as the base for your new AMI image. By default, Konvoy Image Builder searches for the latest CentOS 7 `ami` for the base image. The current base image description, at `images/ami/centos-7.yaml`, is similar to the following:
 
 ```yaml
@@ -38,5 +88,4 @@ To override the above base image with another base image, create an `override` f
 packer:
   source_ami: "ami-0123456789"
 ```
-
 See [Supported Operating Systems](../../../../supported-operating-systems) for details.


### PR DESCRIPTION
## Jira Ticket


https://jira.d2iq.com/browse/D2IQ-91320

## Description of changes being made

Improving explanation on how overriding works in KIB.
Current content focuses on centos-7. We think that it should be explained for all providers and OSes. 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4604.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
