### PR TITLE
docs: Remove unused grafana-logging override

### DIFF
--- a/pages/dkp/kommander/2.0/logging/enable-logging/create-appdeployment-workspace/index.md
+++ b/pages/dkp/kommander/2.0/logging/enable-logging/create-appdeployment-workspace/index.md
@@ -70,8 +70,6 @@ To enable logging in DKP using the CLI, follow these steps on the management clu
    spec:
      appRef:
        name: grafana-logging-6.9.1
-     configOverrides:
-       name: workspace-grafana-overrides-cm
    EOF
    ```
 

--- a/pages/dkp/kommander/2.1/logging/enable-logging/create-appdeployment-workspace/index.md
+++ b/pages/dkp/kommander/2.1/logging/enable-logging/create-appdeployment-workspace/index.md
@@ -93,8 +93,6 @@ To enable logging in DKP using the CLI, follow these steps on the **management**
      appRef:
        name: grafana-logging-6.9.1
        kind: ClusterApp
-     configOverrides:
-       name: workspace-grafana-overrides-cm
    EOF
    ```
 

--- a/pages/dkp/kommander/2.2/logging/enable-logging/create-appdeployment-workspace/index.md
+++ b/pages/dkp/kommander/2.2/logging/enable-logging/create-appdeployment-workspace/index.md
@@ -93,8 +93,6 @@ To enable logging in DKP using the CLI, follow these steps on the **management**
      appRef:
        name: grafana-logging-6.9.1
        kind: ClusterApp
-     configOverrides:
-       name: workspace-grafana-overrides-cm
    EOF
    ```
 

--- a/pages/dkp/kommander/2.3/logging/enable-logging/create-appdeployment-workspace/index.md
+++ b/pages/dkp/kommander/2.3/logging/enable-logging/create-appdeployment-workspace/index.md
@@ -93,8 +93,6 @@ To enable logging in DKP using the CLI, follow these steps on the **management**
      appRef:
        name: grafana-logging-6.9.1
        kind: ClusterApp
-     configOverrides:
-       name: workspace-grafana-overrides-cm
    EOF
    ```
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
noticed this when going through logging docs - we don't create this override cm anywhere, we should remove it

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4605.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
