### PR TITLE
FIPS Upgrade add to RN

### DIFF
--- a/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
@@ -170,6 +170,7 @@ spec:
 ### FIPS Upgrade from 2.1.x to 2.2.x
 
 If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+
 ```bash
 kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0
 ```

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
@@ -169,7 +169,7 @@ spec:
 
 ### FIPS Upgrade from 2.1.x to 2.2.x
 
-If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it does not get automatically upgraded. To correctly upgrade, run the workaround command shown below:
 
 ```bash
 kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
@@ -167,6 +167,13 @@ spec:
 [...]
 ```
 
+### FIPS Upgrade from 2.1.x to 2.2.x
+
+If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+```bash
+kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0
+```
+
 ### Spark operator failure workaround
 
 Upgrading catalog applications using Spark Operator can fail when running `dkp upgrade catalogapp` due to the operator not starting. If this occurs, use the following workaround:

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
@@ -104,7 +104,7 @@ If any of the these fields are present, then there is a possibility the upgrade 
 
 ### FIPS Upgrade from 2.1.x to 2.2.x
 
-If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it does not get automatically upgraded. To correctly upgrade, run the workaround command shown below:
 
 ```bash
 kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
@@ -105,6 +105,7 @@ If any of the these fields are present, then there is a possibility the upgrade 
 ### FIPS Upgrade from 2.1.x to 2.2.x
 
 If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+
 ```bash
 kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0
 ```

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.1/index.md
@@ -102,6 +102,13 @@ Before attempting to upgrade an existing cluster to this release, check the 'kom
 
 If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
 
+### FIPS Upgrade from 2.1.x to 2.2.x
+
+If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+```bash
+kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0
+```
+
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.2/index.md
@@ -59,7 +59,7 @@ The mesosphere/dex-k8s-authenticator docker container now includes the appropria
 
 ### FIPS Upgrade from 2.1.x to 2.2.x
 
-If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it does not get automatically upgraded. To correctly upgrade, run the workaround command shown below:
 
 ```bash
 kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.2/index.md
@@ -57,6 +57,13 @@ The DEX Custom Resource Definitions used for configuring LDAP have been updated 
 
 The mesosphere/dex-k8s-authenticator docker container now includes the appropriate binaries that allow users to download the referenced 'konvoy-async-plugin' after configuring a cluster using an external IDP for authentication.
 
+### FIPS Upgrade from 2.1.x to 2.2.x
+
+If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+```bash
+kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0
+```
+
 ## Component updates
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.2/index.md
@@ -60,6 +60,7 @@ The mesosphere/dex-k8s-authenticator docker container now includes the appropria
 ### FIPS Upgrade from 2.1.x to 2.2.x
 
 If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
+
 ```bash
 kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=docker.io/mesosphere/kube-proxy:v1.22.8_fips.0
 ```


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://jira.d2iq.com/browse/D2IQ-92258
## Description of changes being made
If upgrading a FIPS cluster, there is a bug in the upgrade of `kube-proxy` `DaemonSet` in that it doesn't get automatically upgraded. To correctly upgrade, run the workaround command shown below:
```bash
kubectl set image -n kube-system daemonset.v1.apps/kube-proxy kube-proxy=[docker.io/mesosphere/kube-proxy:v1.22.8_fips.0](http://docker.io/mesosphere/kube-proxy:v1.22.8_fips.0)
```

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
