### PR TITLE
[Kap] Install pages improvements

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -197,6 +197,7 @@ Nouveau
 (nvidia|Nvidia|NVIDIA)
 (OIDC|oidc)
 (onboarding|Onboarding)
+on-premise
 openssl
 (OpsPortal|opsportal)
 overfit(|s|ted|ting)

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
@@ -16,6 +16,14 @@ You can deploy Kaptain to a cluster in a selected workspace. If you do not inten
 
 For reference values of the required number of worker nodes, CPU, RAM, and storage resources, refer to the [requirements](../requirements/) section.
 
+## Prerequisites
+
+Ensure you meet all [prerequisites](../prerequisites/).
+
+<p class="message--note"><strong>NOTE: </strong>Starting from the 1.3 release, Spark Operator is no longer installed by default with Kaptain.</p>
+
+If you need to run Spark jobs on Kubernetes using Spark Operator, you must install it separately. Use the following instructions to install Spark Operator from Kommander Catalog for [DKP 2.x][install-spark-dkp2].
+
 ## DKP 2.1 air-gapped installation
 
 Refer to [DKP install instructions][dkp_install], if you want to deploy Kaptain in a networked environment or to [DKP 2.2 air-gapped instructions][2.2_air] if you are deploying in DKP 2.2.
@@ -24,57 +32,6 @@ Refer to [DKP install instructions][dkp_install], if you want to deploy Kaptain 
 All DKP commands in this page assume the <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
 
 Kaptain supports installation on an air-gapped (offline or private) DKP managed cluster. Before installing Kaptain, follow the [air-gapped installation guide][konvoy-air-gap] to set up the air-gapped DKP managed cluster. The cluster admin is responsible for configuring the DKP cluster correctly and ensuring container images have been pre-loaded to the private registry, before installing Kaptain.
-
-## Prerequisites
-
-- [A DKP cluster][dkp-install] with the following Platform applications enabled:
-
-  - Istio
-  - Knative (optional, if KServe is configured to work in `RawDeployment` mode)
-
-- [`kubectl`][kubectl] on your installation machine
-
-- For customers deploying in a multi-cluster environment (Enterprise): Ensure you have configured [Kaptain to authenticate with a Management Cluster][dex].
-
-- Ensure the following applications are enabled in Kommander:
-
-  1. Use the existing Kommander configuration file, or initialize the default one:
-
-     ```bash
-     dkp install kommander --init > kommander-config.yaml
-     ```
-
-  1. Ensure the following applications are enabled in the config:
-
-     ```yaml
-     apiVersion: config.kommander.mesosphere.io/v1alpha1
-     kind: Installation
-     apps:
-       ...
-       dex:
-       dex-k8s-authenticator:
-       kube-prometheus-stack:
-       istio:
-       knative:
-       minio-operator:
-       traefik:
-       nvidia:  # to enable GPU support
-       ...
-     ```
-
-  1. Apply the new configuration to Kommander:
-
-     ```bash
-     dkp install kommander --installer-config kommander-config.yaml
-     ```
-
-<!-- TODO: Reference doc for DKP, as commands are different depending on the installation and delete only this step or the whole "Ensure the following applications are enabled in Kommander:" part?-->
-
-Review the [Kommander installation documentation][kommander-install] for more information.
-
-<p class="message--note"><strong>NOTE: </strong>Starting from the 1.3 release, Spark Operator is no longer installed by default with Kaptain.</p>
-
-If you need to run Spark jobs on Kubernetes using Spark Operator, you must install it separately. Use the following instructions to install Spark Operator from Kommander Catalog for [DKP 2.x][install-spark-dkp2].
 
 ### Load the Docker images into your Docker registry
 
@@ -154,6 +111,8 @@ If Kaptain was installed using helm, it can be uninstalled with the following:
 ```bash
 helm uninstall kaptain
 ```
+
+Refer to the [installation overview](../../install#installation-overview) for next steps.
 
 [install-spark-dkp2]: /dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/spark-operator/
 [kommander-install]: /dkp/kommander/latest/install/

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
@@ -8,9 +8,9 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--warning"><strong>WARNING: </strong>
-You can deploy Kaptain to a cluster in a selected workspace. If you do not intend to deploy Kaptain to a certain cluster, you must switch the workspace you are deploying to or move that cluster to another workspace.
-</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+
+<p class="message--note"><strong>NOTE: </strong>All DKP commands in this page assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
 
 ## Requirements
 
@@ -27,9 +27,6 @@ If you need to run Spark jobs on Kubernetes using Spark Operator, you must insta
 ## DKP 2.1 air-gapped installation
 
 Refer to [DKP install instructions][dkp_install], if you want to deploy Kaptain in a networked environment or to [DKP 2.2 air-gapped instructions][2.2_air] if you are deploying in DKP 2.2.
-
-<p class="message--note"><strong>NOTE: </strong>
-All DKP commands in this page assume the <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
 
 Kaptain supports installation on an air-gapped (offline or private) DKP managed cluster. Before installing Kaptain, follow the [air-gapped installation guide][konvoy-air-gap] to set up the air-gapped DKP managed cluster. The cluster admin is responsible for configuring the DKP cluster correctly and ensuring container images have been pre-loaded to the private registry, before installing Kaptain.
 

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
 
 <p class="message--note"><strong>NOTE: </strong>All DKP commands in this page assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
 

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
@@ -16,6 +16,14 @@ You can deploy Kaptain to a cluster in a selected workspace. If you do not inten
 
 For reference values of the required number of worker nodes, CPU, RAM, and storage resources, refer to the [requirements](../requirements/) section.
 
+## Prerequisites
+
+Ensure you meet all [prerequisites](../prerequisites/).
+
+<p class="message--note"><strong>NOTE: </strong>Starting from the 1.3 release, Spark Operator is no longer installed by default with Kaptain.</p>
+
+If you need to run Spark jobs on Kubernetes using Spark Operator, you must install it separately. Use the following instructions to install Spark Operator from Kommander Catalog for [DKP 2.x][install-spark-dkp2].
+
 ## DKP 2.2 air-gapped installation
 
 Refer to [DKP install instructions][dkp_install], if you want to deploy Kaptain in a networked environment or to [DKP 2.1 air-gapped instructions][2.1_air] if you are deploying with DKP 2.1.
@@ -23,41 +31,6 @@ Refer to [DKP install instructions][dkp_install], if you want to deploy Kaptain 
 <p class="message--note"><strong>NOTE: </strong>All DKP commands in this page assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
 
 Kaptain supports installation on an air-gapped (a.k.a. offline or private) DKP managed cluster. Before installing Kaptain, please follow the [air-gapped installation guide][konvoy-air-gap] to set up the air-gapped DKP managed cluster. The cluster admin is responsible for configuring the DKP cluster correctly and ensuring container images have been pre-loaded to the private registry before installing Kaptain.
-
-## Prerequisites
-
-- [A DKP cluster][dkp-install] with the following Platform applications enabled:
-
-  - Istio
-  - Knative (optional, if KServe is configured to work in `RawDeployment` mode)
-
-- [`kubectl`][kubectl] on your installation machine
-
-- For customers deploying in a multi-cluster environment (Enterprise): Ensure you have configured [Kaptain to authenticate with a Management Cluster][dex].
-
-- Ensure the following applications are enabled in Kommander.
-
-  Review the [Kommander installation documentation][kommander-install] for more information.
-
-      ```yaml
-      apiVersion: config.kommander.mesosphere.io/v1alpha1
-      kind: Installation
-      apps:
-        ...
-        dex:
-        dex-k8s-authenticator:
-        kube-prometheus-stack:
-        istio:
-        knative:
-        minio-operator:
-        traefik:
-        nvidia:  # to enable GPU support
-        ...
-      ```
-
-<p class="message--note"><strong>NOTE: </strong>Starting from the 1.3 release, Spark Operator is no longer installed by default with Kaptain.</p>
-
-If you need to run Spark jobs on Kubernetes using Spark Operator, you must install it separately. Use the following instructions to install Spark Operator from Kommander Catalog for [DKP 2.x][install-spark-dkp2].
 
 ## Add Kaptain to your Kommander Install
 
@@ -124,6 +97,8 @@ If you added Kaptain after installing DKP, you must make it available by rerunni
     ```bash
     dkp push chart kaptain-2.0.0.tgz
     ```
+
+Refer to the [installation overview](../../install#installation-overview) for next steps.
 
 ## Deploy Kaptain on selected workspaces
 

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
@@ -8,9 +8,9 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--warning"><strong>WARNING: </strong>
-You can deploy Kaptain to a cluster in a selected workspace. If you do not intend to deploy Kaptain to a certain cluster, you must switch the workspace you are deploying to or move that cluster to another workspace.
-</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+
+<p class="message--note"><strong>NOTE: </strong>All DKP commands in this page assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
 
 ## Requirements
 
@@ -28,7 +28,7 @@ If you need to run Spark jobs on Kubernetes using Spark Operator, you must insta
 
 Refer to [DKP install instructions][dkp_install], if you want to deploy Kaptain in a networked environment or to [DKP 2.1 air-gapped instructions][2.1_air] if you are deploying with DKP 2.1.
 
-<p class="message--note"><strong>NOTE: </strong>All DKP commands in this page assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
+
 
 Kaptain supports installation on an air-gapped (a.k.a. offline or private) DKP managed cluster. Before installing Kaptain, please follow the [air-gapped installation guide][konvoy-air-gap] to set up the air-gapped DKP managed cluster. The cluster admin is responsible for configuring the DKP cluster correctly and ensuring container images have been pre-loaded to the private registry before installing Kaptain.
 

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
@@ -8,7 +8,7 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
 
 <p class="message--note"><strong>NOTE: </strong>All DKP commands in this page assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
 

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -14,13 +14,22 @@ Ensure the cluster that you want to use to deploy Kaptain is the only cluster in
 
 ## Prerequisites
 
-Ensure you add Kaptain to your DKP Catalog applications before you deploy it to your clusters. Refer to the corresponding documentation for your environment:
+- Ensure you meet all [prerequisites](../prerequisites/).
 
-[Add Kaptain to your DKP Catalog applications in a networked environment][add_dkp]
+- Ensure you have added Kaptain to your DKP Catalog applications before you deploy it to your clusters. Refer to the corresponding documentation for your environment:
 
-[Add Kaptain to your DKP Catalog applications in an air-gapped environment for 2.1][add_air_2.1]
+  - [Networked environment][add_dkp]
 
-[Add Kaptain to your DKP Catalog applications in an air-gapped environment for 2.2][add_air_2.2]
+  - [Air-gapped environment for 2.1][add_air_2.1]
+
+  - [Air-gapped environment for 2.2][add_air_2.2]
+
+<p class="message--warning"><strong>WARNING: </strong>
+(<a href="../../../../kommander/2.2/licensing/enterprise/">Enterprise</a> only) If you are installing Kaptain on a Managed or Attached cluster, you must customize the deployment for Kaptain to communicate with the Management cluster via Dex (unless you have a dedicated dex instance running on said cluster). 
+In the following workflow, we will show you when to do this.
+</p>
+
+<p class="message--note"><strong>NOTE: </strong>You have different <a href="../../../2.0.0/configuration/">configuration options</a> for Kaptain. Some must take place during the deployment of the Kaptain instance, or the installation could fail.</p>
 
 ## Enable and deploy Kaptain using the DKP UI
 
@@ -42,15 +51,16 @@ Follow these steps to enable Kaptain in air-gapped and networked environments fr
 
 1.  Select a version from the drop-down menu, if available. This drop-down menu will only be visible if there is more than one version.
 
-1.  (Optional) If you want to override the default configuration values, copy your customized values into the text editor under **Configure Service** or upload your yaml file that contains the values. For example:
+1.  **Enterprise only**: Customize the deployment so Kaptain can communicate with the [Management cluster via Dex](../../configuration/external-dex/). For this, copy the required values or upload your customized YAML to the **Configure Service**. Here is an example:
 
     ```yaml
     ingress:
       externalDexClientId: dex-controller-kubeflow-authservice
       externalDexClientSecret: kubeflow-authservice
-      oidcProviderEndpoint: https://a0d231e9c62a4487dad581981c82719f-19533575.us-west-2.elb.amazonaws.com/dex
-      oidcProviderBase64CaBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJiekNDQVJXZ0F3SUJBZ0lSQUlGbWwrS0JXYmtSY0NlOUJuWXpXNVF3Q2dZSUtvWkl6ajBFQXdJd0Z6RVYKTUJNR0ExVUVBeE1NYTI5dGJXRnVaR1Z5TFdOaE1CNFhEVEl5TURReE9ERTROREkxTkZvWERUSXlNRGN4TnpFNApOREkxTkZvd0Z6RVZNQk1HQTFVRUF4TU1hMjl0YldGdVpHVnlMV05oTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJCnpqMERBUWNEUWdBRTAwMk1KVEYyUGZoNWRIdjZBSzhudFlCQmtoK3RMQ3Q3TzNmNVN1b1RWMVI4UW1UcE9uTVEKWEduY3NqN1hhY3hWUSt2L0xUTzlzN1lGUkZTMVcrZ1dsS05DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4RwpBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZPYkVuMUkzZFFaOGZQUW1ad3RpZFJyVSsxekFNQW9HCkNDcUdTTTQ5QkFNQ0EwZ0FNRVVDSUE3QXR2c21BUkwzUFJDLzhVanV0SGFXc1BudGVqRnh4N0JieDZVVmF2NlcKQWlFQTFoQTdKamd4d2tJV01uSmlUM0ViVmdDaEo4bWV2NGRjOU1VZVp0VFV5YUU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+      oidcProviderEndpoint: https://management_cluster_endpoint/dex
+      oidcProviderBase64CaBundle: LS0tLS1CRUd...
     ```
+1.  **Optional**: If you want to override the default configuration values, copy any other [customized configuration values](../../configuration/) into the text editor under Configure Service or upload your YAML file that contains the values.
 
 1.  Confirm the details are correct, and then select the **Enable** button to enable and trigger deployment.
     The status changes to **Enabled**.
@@ -73,7 +83,7 @@ Follow these steps to verify the deployment of Kaptain:
 
 <p class="message--note"><strong>NOTE: </strong>It can take several minutes until provisioning finishes and status changes to <b>Deployed</b>.</p>
 
-## Enable and deploy Kaptain using the DKP CLI
+## Enable and deploy Kaptain using the DKP CLI (Essential only)
 
 Follow these steps to enable Kaptain in air-gapped and networked environments from the DKP CLI:
 
@@ -97,13 +107,36 @@ Follow these steps to enable Kaptain in air-gapped and networked environments fr
 
 1.  Create the resource in the workspace you just created, which instructs Kommander to deploy the `AppDeployment` to the `KommanderCluster`s in the same workspace.
 
-<p class="message--important"><strong>IMPORTANT: </strong>If you are deploying Kaptain to an attached cluster, ensure that either the <code>defaults</code> or <code>overrides</code> contain the <code>${WORKSPACE_NAMESPACE}</code> in the <code>global.workspace</code> section of the <code>values.yaml</code>. For an example of this, observe the <code>ConfigMap</code> configuration in the <a href="#enable-kaptain-with-a-custom-configuration-using-the-cli">Enable Kaptain with a custom configuration using the CLI</a> section.</p>
+## Enable Kaptain with a custom configuration using the CLI (Essential and Enterprise)
 
-## Enable Kaptain with a custom configuration using the CLI
+<p class="message--important"><strong>IMPORTANT: </strong>If you are deploying Kaptain to a managed or attached cluster, ensure that the <code>ConfigMap</code> contains the <code>${WORKSPACE_NAMESPACE}</code> in the <code>global.workspace</code> section of the <code>values.yaml</code>, as shown in the following example.</p>
 
 If you want to customize your installation and modify the custom domain name, external Dex, creation of profiles, certificates, for example, continue with these steps:
 
-1.  Provide the name of a `ConfigMap` in the `AppDeployment`, which provides custom configuration on top of the default configuration:
+1.  Create the `ConfigMap` with the custom configuration. In the following example, the ConfigMap is configuring Kaptain to communicate with the [Management cluster via Dex](../../configuration/external-dex/), which is a necessary step when deploying Kaptain to a Managed or Attached cluster (Enterprise only). Other configurations can be made in the same way.
+
+    ```yaml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      namespace: ${WORKSPACE_NAMESPACE}
+      name: kaptain-overrides
+    data:
+      values.yaml: |
+        global:
+          workspace: ${WORKSPACE_NAMESPACE}
+        core:
+          registrationFlow: true
+        ingress:
+          externalDexClientId: dex-controller-kubeflow-authservice
+          externalDexClientSecret: kubeflow-authservice
+          oidcProviderEndpoint: https://management_cluster_endpoint/dex
+          oidcProviderBase64CaBundle: LS0tLS1CRUd...
+    EOF
+    ```
+
+1.  Provide the name of the `ConfigMap` you created in the `AppDeployment`, which provides custom configuration on top of the default configuration:
 
     ```yaml
     cat <<EOF | kubectl apply -f -
@@ -121,26 +154,6 @@ If you want to customize your installation and modify the custom domain name, ex
     EOF
     ```
 
-1.  Create the `ConfigMap` with the name provided in the step above, with the custom configuration:
-
-    <p class="message--important"><strong>IMPORTANT: </strong>If you are deploying Kaptain to an attached cluster, ensure that the <code>ConfigMap</code> contains the <code>${WORKSPACE_NAMESPACE}</code> in the <code>global.workspace</code> section of the <code>values.yaml</code>, as shown in the following example.</p>
-
-    ```yaml
-    cat <<EOF | kubectl apply -f -
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      namespace: ${WORKSPACE_NAMESPACE}
-      name: kaptain-overrides
-    data:
-      values.yaml: |
-        global:
-          workspace: ${WORKSPACE_NAMESPACE}
-        core:
-          registrationFlow: true
-    EOF
-    ```
-
 Kommander waits for the `ConfigMap` to be present before deploying the `AppDeployment` to the attached clusters.
 
 ### Verify the status of deployment using the DKP CLI
@@ -150,6 +163,8 @@ With Kaptain enabled, connect to the cluster and check the `HelmReleases` to ver
 ```bash
 kubectl get helmreleases -n ${WORKSPACE_NAMESPACE}
 ```
+
+The output should look like this: 
 
 ```sh
 NAME                      AGE     READY   STATUS

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -113,7 +113,7 @@ Follow these steps to enable Kaptain in air-gapped and networked environments fr
 
 If you want to customize your installation and modify the custom domain name, external Dex, creation of profiles, certificates, for example, continue with these steps:
 
-1.  Create the `ConfigMap` with the custom configuration. In the following example, the ConfigMap is configuring Kaptain to communicate with the [Management cluster via Dex](../../configuration/external-dex/), which is a necessary step when deploying Kaptain to a Managed or Attached cluster (Enterprise only). Other configurations can be made in the same way.
+1.  Create the `ConfigMap` with the custom configuration. In the following example, the ConfigMap is configuring Kaptain to communicate with the [Management cluster via Dex](../../configuration/external-dex/), which is a necessary step when deploying Kaptain to a Managed or Attached cluster ([Enterprise](../../../../kommander/2.2/licensing/enterprise/) only). Other configurations can be made in the same way.
 
     ```yaml
     cat <<EOF | kubectl apply -f -

--- a/pages/dkp/kaptain/2.0.0/install/dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/dkp/index.md
@@ -12,9 +12,7 @@ enterprise: false
 <strong>All DKP commands on this page</strong> assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.
 </p>
 
-<p class="message--warning"><strong>WARNING: </strong>
-You can deploy Kaptain to a cluster in a selected workspace. If you do not intend to deploy Kaptain to a certain cluster, you must switch the workspace you are deploying to or move that cluster to another workspace.
-</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
 
 ## Requirements
 

--- a/pages/dkp/kaptain/2.0.0/install/dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/dkp/index.md
@@ -12,7 +12,7 @@ enterprise: false
 <strong>All DKP commands on this page</strong> assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.
 </p>
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
 
 ## Requirements
 

--- a/pages/dkp/kaptain/2.0.0/install/dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/dkp/index.md
@@ -22,54 +22,7 @@ For reference values of the required number of worker nodes, CPU, RAM, and stora
 
 ## Prerequisites
 
--   [A DKP cluster][dkp-install] with the following Platform applications enabled:
-
-    - Istio
-    - Knative (optional, if KServe is configured to work in `RawDeployment` mode)
-
--   [`kubectl`][kubectl] on your installation machine
-
--   For customers deploying in a multi-cluster environment (Enterprise): Ensure you have configured [Kaptain to authenticate with a Management Cluster][dex].
-
--   Ensure you enable the following applications in Kommander:
-
-    <p class="message--note"><strong>NOTE: </strong>
-    All DKP commands in this section assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.
-    </p>
-
-    1.  Use the existing Kommander configuration file, or initialize the default one:
-
-        ```bash
-        dkp install kommander --init > kommander-config.yaml
-        ```
-
-    1.  Ensure the following applications are enabled in the config:
-
-        ```yaml
-        apiVersion: config.kommander.mesosphere.io/v1alpha1
-        kind: Installation
-        apps:
-          ...
-          dex:
-          dex-k8s-authenticator:
-          kube-prometheus-stack:
-          istio:
-          knative:
-          minio-operator:
-          traefik:
-          nvidia:  # to enable GPU support
-          ...
-        ```
-
-    1.  For GPU deployment, follow the instructions in [Kommander GPU documentation][kommander-gpu].
-
-    1.  Apply the new configuration to Kommander:
-
-        ```bash
-        dkp install kommander --installer-config kommander-config.yaml
-        ```
-
-  Check [Kommander installation documentation][kommander-install] for more information.
+Ensure you meet all [prerequisites](../prerequisites/).
 
 <p class="message--note"><strong>NOTE: </strong>Starting from the 1.3 release, Spark Operator is no longer installed by default with Kaptain.</p>
 
@@ -123,9 +76,7 @@ If you added Kaptain after installing DKP, you must make it available by creatin
     kaptain-catalog-applications https://github.com/mesosphere/kaptain-catalog-applications                True    Fetched revision: master/6c54bd1722604bd03d25dcac7a31c44ff4e03c6a   11m
     ```
 
-## Deploy Kaptain on selected workspaces
-
-You have now added Kaptain to your DKP Catalog applications. The next step is to enable and deploy Kaptain on all clusters in a selected workspace. For this, refer to [Deploy Kaptain][deploy] instructions.
+Refer to the [installation overview](../../install#installation-overview) for next steps.
 
 [download]: ../../download/
 [install-spark-dkp2]: /dkp/kommander/2.2/workspaces/applications/catalog-applications/dkp-applications/spark-operator/

--- a/pages/dkp/kaptain/2.0.0/install/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/index.md
@@ -10,6 +10,8 @@ enterprise: false
 
 <p class="message--important"><strong>IMPORTANT: </strong>Refer to the <a href="../fresh-install">Kaptain fresh install instructions</a>, if you already have Kaptain and want to move from 1.x to 2.x. Note that it is not possible to migrate your data.</p>
 
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. **Kaptain is meant to be deployed on workspaces with a single cluster**.</p>
+
 How do you want to deploy Kaptain?
 
 You can install Kaptain:
@@ -20,6 +22,22 @@ You can install Kaptain:
 
 The infrastructure you select determines the specific requirements for a successful installation.
 
+## Installation overview
+
+To install and deploy Kaptain for the first time, proceed with these steps:
+
+1.  Ensure you have reviewed all [prerequisites](../install/prerequisites/).
+
+1.  Add Kaptain to your DKP Catalog Applicationd according to your set-up: 
+
+    a. [Networked environment][add_dkp]
+
+    b. [Air-gapped environment for DKP 2.1][add_air_2.1]
+
+    c. [Air-gapped environment for DKP 2.2][add_air_2.2]
+
+1.  [Deploy Kaptain on a per-Workspace basis and verify the status of deployment][deploy].
+
 ## Before you begin
 
 Kaptain is a DKP Catalog application. To use it, add it to your repository and then deploy it on selected workspaces. No downloads are necessary for networked environments. For users deploying to air-gapped environments, refer to the [download][download] page.
@@ -29,32 +47,6 @@ You can deploy Kaptain to single and multi-cluster environments. The difference 
 You can deploy Kaptain on a per-workspace basis.
 
 <p class="message--warning"><strong>WARNING: </strong>You can deploy Kaptain to a cluster in a selected workspace. If you do not intend to deploy Kaptain to a certain cluster, you must switch the workspace you are deploying to or move that cluster to another workspace.</p>
-
-## Prerequisites
-
-- A DKP cluster with the following Platform applications enabled:
-
-  - Istio
-  - Knative (optional, if KServe is configured to work in `RawDeployment` mode)
-
-- [`kubectl`][kubectl] on your installation machine
-
-- MinIO is installed on the cluster where you want to deploy Kaptain
-  (If you are installing Kaptain on an attached cluster, [install MinIO manually](../../../kommander/2.2/workspaces/applications/platform-applications/application-deployment/))
-
-## Install overview
-
-To install and deploy Kaptain for the first time, proceed with these steps:
-
-1.  [Add Kaptain to your DKP Catalog applications in a networked environment][add_dkp],
-
-    [Add Kaptain to your DKP Catalog applications in an air-gapped environment for DKP 2.1][add_air_2.1],
-
-    OR
-
-    [Add Kaptain to your DKP Catalog applications in an air-gapped environment for DKP 2.2][add_air_2.2].
-
-1.  [Deploy Kaptain on a per-Workspace basis and verify the status of deployment][deploy].
 
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [add_dkp]: dkp/

--- a/pages/dkp/kaptain/2.0.0/install/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 <p class="message--important"><strong>IMPORTANT: </strong>Refer to the <a href="../fresh-install">Kaptain fresh install instructions</a>, if you already have Kaptain and want to move from 1.x to 2.x. Note that it is not possible to migrate your data.</p>
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
 
 How do you want to deploy Kaptain?
 
@@ -45,8 +45,6 @@ Kaptain is a DKP Catalog application. To use it, add it to your repository and t
 You can deploy Kaptain to single and multi-cluster environments. The difference between these setups is the following: In a single-cluster environment (with an Essential license), you deploy on one Management cluster only. In a multi-cluster environment (with an Enterprise license), Kaptain is deployed to either one or several Managed clusters or to Attached clusters.
 
 You can deploy Kaptain on a per-workspace basis.
-
-<p class="message--warning"><strong>WARNING: </strong>You can deploy Kaptain to a cluster in a selected workspace. If you do not intend to deploy Kaptain to a certain cluster, you must switch the workspace you are deploying to or move that cluster to another workspace.</p>
 
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [add_dkp]: dkp/

--- a/pages/dkp/kaptain/2.0.0/install/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/index.md
@@ -10,7 +10,7 @@ enterprise: false
 
 <p class="message--important"><strong>IMPORTANT: </strong>Refer to the <a href="../fresh-install">Kaptain fresh install instructions</a>, if you already have Kaptain and want to move from 1.x to 2.x. Note that it is not possible to migrate your data.</p>
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. **Kaptain is meant to be deployed on workspaces with a single cluster**.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
 
 How do you want to deploy Kaptain?
 
@@ -26,7 +26,7 @@ The infrastructure you select determines the specific requirements for a success
 
 To install and deploy Kaptain for the first time, proceed with these steps:
 
-1.  Ensure you have reviewed all [prerequisites](../install/prerequisites/).
+1.  Ensure you have reviewed all [prerequisites](../install/prerequisites/). If you are installing Kaptain on premises, also review the [on-premise prerequisites](../install/on-premise/) page.
 
 1.  Add Kaptain to your DKP Catalog Applicationd according to your set-up: 
 

--- a/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
@@ -13,7 +13,7 @@ Ensure you meet all [prerequisites](../prerequisites/).
 
 ## On-Premise Installation
 
-Kaptain natively supports the installation on an on premise cluster. Before installing Kaptain, please follow the [Konvoy On Premises Installation Guide][konvoy-on-prem] or [Kommander Installation Guide in a networked environment][dkp-install] to set up the on premise cluster. The cluster admin is responsible for configuring the cluster correctly and ensuring the requisite cluster-level applications are enabled.
+Kaptain natively supports the installation on an on-premise cluster. Before installing Kaptain, please follow the [Konvoy On Premises Installation Guide][konvoy-on-prem] or [Kommander Installation Guide in a networked environment][dkp-install] to set up the on-premise cluster. The cluster admin is responsible for configuring the cluster correctly and ensuring the requisite cluster-level applications are enabled.
 
 Please note that the IP address of the Kaptain UI will come from the IP address range that is configured in the [MetalLB load balancer][metallb-load-balancer].
 

--- a/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/on-premise/index.md
@@ -7,6 +7,9 @@ excerpt: Install Kaptain on an on-premises cluster
 beta: false
 enterprise: false
 ---
+## Prerequisites
+
+Ensure you meet all [prerequisites](../prerequisites/).
 
 ## On-Premise Installation
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -8,14 +8,14 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
 
 - [`kubectl`][kubectl] on your installation machine 
 
 - A DKP cluster, either one of the following, depending on your license 
 
-  - An **Essential cluster** for customers with an [Essential license](../../../../kommander/2.2/licensing/essential/)
-  - A **Managed** or **Attached** cluster for customers with an [Enterprise license](../../../../kommander/2.2/licensing/enterprise/), in which case, said cluster needs to be the only one in its workspace
+  - An **Essential cluster** for customers with an [Essential](../../../../kommander/2.2/licensing/essential/) license
+  - A **Managed** or **Attached** cluster for customers with an [Enterprise](../../../../kommander/2.2/licensing/enterprise/) license, in which case, said cluster needs to be the only one in its workspace
 
 - The following **Platform applications** (dependencies) enabled in the cluster where you want to install Kaptain:
 
@@ -25,7 +25,7 @@ enterprise: false
 
   You have two options to install these applications. For more instructions, refer to the [Install dependencies section](#install-dependencies).
 
-- Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain on premises.
+- Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain **on premises**.
 
 ## Install dependencies 
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -25,7 +25,7 @@ enterprise: false
 
   You have two options to install these applications. For more instructions, refer to the [Install dependencies section](#install-dependencies).
 
-- Refer to the [on premise installation](../on-premise/) page, if you are installing Kaptain on premises.
+- Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain on premises.
 
 ## Install dependencies 
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -14,8 +14,9 @@ enterprise: false
 
 - A DKP cluster, either one of the following, depending on your license 
 
-  - An **Essential cluster** for [Essential customers][Essential_page]
-  - A **Managed** or **Attached** cluster [Enterprise customers][Enterprise_page], in which case, said cluster must be the only one in its workspace
+  - An **Essential cluster**. Refer to [this page][Essential_page] for more information on the Essential license.
+  - A **Managed** or **Attached** cluster for Enterprise customers. Refer to [this page][Enterprise_page] for more information on the license. In this case, said cluster must be the only one in its workspace. 
+    D2iQ recommends that you install it on a separate attached or managed cluster, as the management cluster is intended to be a pane of glass for running other clusters and is not intended for workloads.
 
 - The following **Platform applications** (dependencies) enabled in the cluster where you want to install Kaptain:
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -25,7 +25,7 @@ enterprise: false
 
   You have two options to install these applications. For more instructions, refer to the [Install dependencies section](#install-dependencies).
 
-- Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain on premises.
+- Refer to the [on premise installation](../on-premise/) page, if you are installing Kaptain on premises.
 
 ## Install dependencies 
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -13,7 +13,7 @@ enterprise: false
 - A DKP cluster, either one of the following, depending on your license 
 
   - An **Essential cluster** for customers with an [Essential license](../../../../kommander/2.2/licensing/essential/)
-  - A **Managed** or **Attached** cluster for customers with an [Enterprise licence](../../../../kommander/2.2/licensing/enterprise/), in which case, said cluster needs to be the only one in its workspace
+  - A **Managed** or **Attached** cluster for customers with an [Enterprise license](../../../../kommander/2.2/licensing/enterprise/), in which case, said cluster needs to be the only one in its workspace
 
 - The following **Platform applications** (dependencies) enabled in the cluster where you want to install Kaptain:
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -14,8 +14,8 @@ enterprise: false
 
 - A DKP cluster, either one of the following, depending on your license 
 
-  - An **Essential cluster** for [Essential customers](../../../../kommander/2.2/licensing/essential/)
-  - A **Managed** or **Attached** cluster [Enterprise customers](../../../../kommander/2.2/licensing/enterprise/) license, in which case, said cluster must be the only one in its workspace
+  - An **Essential cluster** for [Essential customers][Essential_page]
+  - A **Managed** or **Attached** cluster [Enterprise customers][Enterprise_page], in which case, said cluster must be the only one in its workspace
 
 - The following **Platform applications** (dependencies) enabled in the cluster where you want to install Kaptain:
 
@@ -84,3 +84,5 @@ Verify if the applications have been deployed successfully. For this, refer to t
 Refer to the [installation overview](../../install#installation-overview) for next steps.
 
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[Essential_page]: ../../../../kommander/2.2/licensing/essential/
+[Enterprise_page]: ../../../../kommander/2.2/licensing/enterprise/

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -14,8 +14,8 @@ enterprise: false
 
 - A DKP cluster, either one of the following, depending on your license 
 
-  - An **Essential cluster** for customers with an [Essential](../../../../kommander/2.2/licensing/essential/) license
-  - A **Managed** or **Attached** cluster for customers with an [Enterprise](../../../../kommander/2.2/licensing/enterprise/) license, in which case, said cluster needs to be the only one in its workspace
+  - An **Essential cluster** for [Essential customers](../../../../kommander/2.2/licensing/essential/)
+  - A **Managed** or **Attached** cluster [Enterprise customers](../../../../kommander/2.2/licensing/enterprise/) license, in which case, said cluster must be the only one in its workspace
 
 - The following **Platform applications** (dependencies) enabled in the cluster where you want to install Kaptain:
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -2,13 +2,11 @@
 layout: layout.pug
 navigationTitle: Prerequisites
 title: Prerequisites for installing Kaptain
-menuWeight: 6
-excerpt: Review the prerequisites that must be met before installing Kaptain
+menuWeight: 2
+excerpt: Ensure these prerequisites are met before installing Kaptain
 beta: false
 enterprise: false
 ---
-
-## Prerequisites
 
 - [`kubectl`][kubectl] on your installation machine 
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -1,0 +1,86 @@
+---
+layout: layout.pug
+navigationTitle: Prerequisites
+title: Prerequisites for installing Kaptain
+menuWeight: 6
+excerpt: Review the prerequisites that must be met before installing Kaptain
+beta: false
+enterprise: false
+---
+
+## Prerequisites
+
+- [`kubectl`][kubectl] on your installation machine 
+
+- A DKP cluster, either one of the following, depending on your license 
+
+  - An **Essential cluster** for customers with an [Essential license](../../../../kommander/2.2/licensing/essential/)
+  - A **Managed** or **Attached** cluster for customers with an [Enterprise licence](../../../../kommander/2.2/licensing/enterprise/), in which case, said cluster needs to be the only one in its workspace
+
+- The following **Platform applications** (dependencies) enabled in the cluster where you want to install Kaptain:
+
+  - **Istio**
+  - **MinIO Operator** (installed by default in some clusters, not on attached clusters) 
+  - **Knative**, if you are running the [serverless installation of KServe](https://kserve.github.io/website/0.9/admin/serverless/), which is the default mode that comes pre-bundled with Kaptain. (Not required if you are using the [RawDeployment installation mode](https://kserve.github.io/website/0.9/admin/kubernetes_deployment/))
+
+  You have two options to install these applications. For more instructions, refer to the [Install dependencies section](#install-dependencies).
+
+- Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain on premises.
+
+## Install dependencies 
+
+### Install dependencies on any type of cluster (Essential and Enterprise)
+
+To install any of the previous applications after you have installed DKP, follow the instructions in the [Application Deployment](../../../../kommander/2.2/workspaces/applications/platform-applications/application-deployment/) page.
+
+<p class="message--note"><strong>NOTE: </strong>When installing these applications, set the environment variable to the workspace of the cluster where you want to install Kaptain. </p>
+
+### Install dependencies during the installation of DKP (Essential only)
+
+You can install the applications Kaptain requires during the installation of DKP by adapting the configuration file:
+
+<p class="message--note"><strong>NOTE: </strong>All DKP commands in this section assume KUBECONFIG=clusterKubeconfig.conf is set.</p>
+
+1.  Use the existing Kommander configuration file `kommander.yaml`, or initialize the default one, if you have not done so yet:
+
+    ```bash
+    dkp install kommander --init > kommander-config.yaml
+    ```
+
+    Review the [Customizing the configuration file](../../../../kommander/2.2/install/configuration/) page to gain more understanding on how to use a configuration file to install DKP.
+
+1.  Ensure the following applications are enabled in the config: 
+
+    ```bash
+    apiVersion: config.kommander.mesosphere.io/v1alpha1
+    kind: Installation
+    apps:
+      ...
+      dex:
+      dex-k8s-authenticator:
+      kube-prometheus-stack:
+      istio:
+     knative:
+      minio-operator:
+      traefik:
+      nvidia:  # to enable GPU support
+      [...]
+    ```
+
+    For GPU deployment, follow the instructions in the [Kommander GPU documentation](../../../../kommander/2.2/gpu/kommander-config/).
+
+1.  Apply the new configuration to Kommander: 
+
+    ```bash
+    dkp install kommander --installer-config kommander-config.yaml
+    ```
+
+    This customized configuration file will enable these applications to deploy when installing DKP.
+
+### Verify the deployment
+
+Verify if the applications have been deployed successfully. For this, refer to the [Verify Applications](../../../../kommander/2.2/workspaces/applications/platform-applications/application-deployment#verify-applications) section.
+
+Refer to the [installation overview](../../install#installation-overview) for next steps.
+
+[kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -8,6 +8,8 @@ beta: false
 enterprise: false
 ---
 
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <bold>Kaptain is meant to be deployed on workspaces with a single cluster**</bold>.</p>
+
 - [`kubectl`][kubectl] on your installation machine 
 
 - A DKP cluster, either one of the following, depending on your license 
@@ -73,7 +75,7 @@ You can install the applications Kaptain requires during the installation of DKP
     dkp install kommander --installer-config kommander-config.yaml
     ```
 
-    This customized configuration file will enable these applications to deploy when installing DKP.
+    This customized configuration file will enable these applications to deploy when installing DKP. For more information, refer to the [Customizing the configuration file](../../../../kommander/2.2/install/configuration/) page.
 
 ### Verify the deployment
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-92429

## Description of changes being made

Hi. We made a lot of improvements to the Kaptain installation docs in Confluence for 2.1. We are NOT bringing all of those improvements to 2.0 because we need to prioritize other tickets. However, in this ticket, we are trying to bring the most important of those improvements to 2.0: 

- Dedicated prerequisite section with more instructions on how to install dependencies
- "Configure Kap to comunicate with Mgmt via Dex" on the right spot in the documentation
- Better overview of install process

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4616.s3-website-us-west-2.amazonaws.com/

