### PR TITLE
Update tutorials and configuration with 2.1.0 release versions in docs page

### DIFF
--- a/pages/dkp/kaptain/2.1.0/configuration/index.md
+++ b/pages/dkp/kaptain/2.1.0/configuration/index.md
@@ -30,15 +30,16 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | ingress.base64CustomCertificate | string | `""` | base64-encoded contents of a custom certificate file (.crt) to use with the provided custom domain name |
 | ingress.base64CustomCertificateKey | string | `""` | base64-encoded contents of a custom certificate private key file (.key) to use with the provided custom domain name |
 | ingress.namespace | string | `"kaptain-ingress"` | Namespace to install Kaptain Ingress resources |
+| ingress.kommanderTraefikCertificateName | string | `"kommander-traefik-tls"` | The name of the Kommander Traefik certificate |
 | core.enabled | bool | `true` |  |
 | core.namespace | string | `"kubeflow"` |  |
-| core.notebook.defaultImage | string | `"mesosphere/kubeflow:2.1.0-rc.0-jupyter-spark-3.3.0-horovod-0.24.2-tensorflow-2.8.0"` | Default image to use when creating a new notebook server |
-| core.notebook.images[0] | string | `"mesosphere/kubeflow:2.1.0-rc.0-jupyter-spark-3.3.0-horovod-0.24.2-tensorflow-2.8.0"` | JupyterLab with Tensorflow, Spark and Horovod pre-installed |
-| core.notebook.images[1] | string | `"mesosphere/kubeflow:2.1.0-rc.0-jupyter-spark-3.3.0-horovod-0.24.2-tensorflow-2.8.0-gpu"` | JupyterLab with Tensorflow, CUDA, Spark and Horovod pre-installed with GPU support |
-| core.notebook.images[2] | string | `"mesosphere/kubeflow:2.1.0-rc.0-jupyter-spark-3.3.0-horovod-0.24.2-pytorch-1.11.0"` | JupyterLab with Pytorch, Spark and Horovod pre-installed |
-| core.notebook.images[3] | string | `"mesosphere/kubeflow:2.1.0-rc.0-jupyter-spark-3.3.0-horovod-0.24.2-pytorch-1.11.0-gpu"` | JupyterLab with Pytorch, CUDA, Spark and Horovod pre-installed with GPU support |
-| core.notebook.images[4] | string | `"mesosphere/kubeflow:2.1.0-rc.0-jupyter-spark-3.3.0-horovod-0.24.2-mxnet-1.9.0"` | JupyterLab with MXNet, Spark and Horovod pre-installed |
-| core.notebook.images[5] | string | `"mesosphere/kubeflow:2.1.0-rc.0-jupyter-spark-3.3.0-horovod-0.24.2-mxnet-1.9.0-gpu"` | JupyterLab with MXNet, CUDA, Spark and Horovod pre-installed with GPU support |
+| core.notebook.defaultImage | string | `"mesosphere/kubeflow:2.1.0-jupyter-spark-3.3.0-tensorflow-2.9.1"` | Default image to use when creating a new notebook server |
+| core.notebook.images[0] | string | `"mesosphere/kubeflow:2.1.0-jupyter-spark-3.3.0-tensorflow-2.9.1"` | JupyterLab with Tensorflow and Spark pre-installed |
+| core.notebook.images[1] | string | `"mesosphere/kubeflow:2.1.0-jupyter-spark-3.3.0-tensorflow-2.9.1-gpu"` | JupyterLab with Tensorflow, CUDA and Spark pre-installed with GPU support |
+| core.notebook.images[2] | string | `"mesosphere/kubeflow:2.1.0-jupyter-spark-3.3.0-pytorch-1.11.0"` | JupyterLab with Pytorch and Spark pre-installed |
+| core.notebook.images[3] | string | `"mesosphere/kubeflow:2.1.0-jupyter-spark-3.3.0-pytorch-1.11.0-gpu"` | JupyterLab with Pytorch, CUDA and Spark pre-installed with GPU support |
+| core.notebook.images[4] | string | `"mesosphere/kubeflow:2.1.0-jupyter-spark-3.3.0-mxnet-1.9.0"` | JupyterLab with MXNet and Spark pre-installed |
+| core.notebook.images[5] | string | `"mesosphere/kubeflow:2.1.0-jupyter-spark-3.3.0-mxnet-1.9.0-gpu"` | JupyterLab with MXNet, CUDA and Spark pre-installed with GPU support |
 | core.notebook.tolerationGroups | list | `[]` | Pod toleration group configurations for Notebook servers |
 | core.notebook.affinityConfig | list | `[]` | Pod affinity configurations for Notebook servers |
 | core.notebook.enableCulling | bool | `false` | Enables scale down idling notebooks to freeing up the allocated resources. |
@@ -46,14 +47,14 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | core.notebook.cullingCheckPeriodMinutes | int | `1` | Notebook status check period |
 | core.disableAntiAffinity | bool | `false` | Enables single-node installation. **DO NOT USE IN PRODUCTION ENVIRONMENTS!** Disabling anti-affinity allows installing Kaptain on a smaller number of nodes (less than 3) or on a single node. This installation mode must be used **for evaluation purposes only**. No data integrity guarantees in case of a hardware failure! |
 | core.registrationFlow | bool | `false` | Enables automatic profile creation |
-| core.tensorboardImage | string | `"mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0"` | Image to use for a Tensorboard in Kubeflow |
+| core.tensorboardImage | string | `"mesosphere/kubeflow:2.1.0-tensorflow-2.9.1"` | Image to use for a Tensorboard in Kubeflow |
 | core.dashboard.uriPathPrefix | string | `"/dashboard/"` |  |
 | core.dashboard.prometheusPort | int | `9090` |  |
 | core.dashboard.refreshIntervalSeconds | int | `10` |  |
 | core.dashboard.gunicornWorkers | int | `3` |  |
 | core.dashboard.gunicornThreads | int | `3` |  |
 | core.dashboard.logLevel | string | `"debug"` |  |
-| core.workflows.executorImage | string | `"gcr.io/ml-pipeline/argoexec:v3.2.3-license-compliance"` |  |
+| core.workflows.executorImage | string | `"gcr.io/ml-pipeline/argoexec:v3.3.8-license-compliance"` |  |
 | core.workflows.containerRuntimeExecutor | string | `"emissary"` | Argo Workflows Executor |
 | core.workflows.artifactRepository.bucket | string | `"mlpipeline"` | Bucket to store artifacts |
 | core.workflows.artifactRepository.keyPrefix | string | <code>"artifacts/{{worklow.name}}/yyyy/mm/dd/{{pod.name}}"</code> | Bucket prefix |
@@ -121,7 +122,7 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | kserve.servingruntime.tensorflow.image | string | `"tensorflow/serving"` |  |
 | kserve.servingruntime.tensorflow.tag | string | `"2.6.2"` |  |
 | kserve.servingruntime.mlserver.image | string | `"docker.io/seldonio/mlserver"` |  |
-| kserve.servingruntime.mlserver.tag | string | `"1.0.0"` |  |
+| kserve.servingruntime.mlserver.tag | string | `"1.1.0"` |  |
 | kserve.servingruntime.mlserver.modelClassPlaceholder | string | `"{{.Labels.modelClass}}"` |  |
 | kserve.servingruntime.sklearnserver.image | string | `"kserve/sklearnserver"` |  |
 | kserve.servingruntime.sklearnserver.tag | string | `"v0.9.0"` |  |
@@ -129,20 +130,18 @@ This page lists Kaptain configuration properties that can be adjusted during the
 | kserve.servingruntime.xgbserver.tag | string | `"v0.9.0"` |  |
 | kserve.servingruntime.tritonserver.image | string | `"nvcr.io/nvidia/tritonserver"` |  |
 | kserve.servingruntime.tritonserver.tag | string | `"21.09-py3"` |  |
-| kserve.servingruntime.pmmlserver.image | string | `"kserve/pmmlserver"` |  |
-| kserve.servingruntime.pmmlserver.tag | string | `"v0.9.0"` |  |
-| kserve.servingruntime.paddleserver.image | string | `"kserve/paddleserver"` |  |
-| kserve.servingruntime.paddleserver.tag | string | `"v0.9.0"` |  |
+| kserve.servingruntime.pmmlserver.image | string | `"mesosphere/kubeflow"` |  |
+| kserve.servingruntime.pmmlserver.tag | string | `"kserve-pmmlserver-v0.9.0-3994c63-cve-patch"` |  |
+| kserve.servingruntime.paddleserver.image | string | `"mesosphere/kubeflow"` |  |
+| kserve.servingruntime.paddleserver.tag | string | `"kserve-paddleserver-v0.9.0-3994c63-cve-patch"` |  |
 | kserve.servingruntime.lgbserver.image | string | `"kserve/lgbserver"` |  |
 | kserve.servingruntime.lgbserver.tag | string | `"v0.9.0"` |  |
 | kserve.servingruntime.torchserve.image | string | `"pytorch/torchserve-kfs"` |  |
 | kserve.servingruntime.torchserve.tag | string | `"0.6.0"` |  |
 | kserve.servingruntime.torchserve.serviceEnvelopePlaceholder | string | `"{{.Labels.serviceEnvelope}}"` |  |
-| kserve.servingruntime.alibi.image | string | `"kserve/alibi-explainer"` |  |
-| kserve.servingruntime.alibi.defaultVersion | string | `"v0.9.0"` |  |
-| kserve.servingruntime.art.image | string | `"kserve/art-explainer"` |  |
-| kserve.servingruntime.art.defaultVersion | string | `"v0.9.0"` |  |
-| kserve.servingruntime.aix.image | string | `"kserve/aix-explainer"` |  |
-| kserve.servingruntime.aix.defaultVersion | string | `"v0.9.0"` |  |
+| kserve.servingruntime.alibi.image | string | `"mesosphere/kubeflow"` |  |
+| kserve.servingruntime.alibi.defaultVersion | string | `"kserve-alibi-explainer-v0.9.0-5b00d22-cve-patch"` |  |
+| kserve.servingruntime.art.image | string | `"mesosphere/kubeflow"` |  |
+| kserve.servingruntime.art.defaultVersion | string | `"kserve-art-explainer-v0.9.0-5b00d22-cve-patch"` |  |
 
 For a full list of attributed 3rd party software, see d2iq.com/legal/3rd

--- a/pages/dkp/kaptain/2.1.0/tutorials/katib/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/katib/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -166,7 +166,7 @@ The following YAML file describes an `Experiment` object:
 
 
 ```python
-%env IMAGE mesosphere/kubeflow:2.1.0-rc.0-mnist-tensorflow-2.8.0-gpu
+%env IMAGE mesosphere/kubeflow:2.1.0-mnist-tensorflow-2.9.1-gpu
 ```
 
 
@@ -278,7 +278,7 @@ Again, use a random search:
 
 
 ```python
-%env IMAGE mesosphere/kubeflow:2.1.0-rc.0-mnist-pytorch-1.11.0-gpu
+%env IMAGE mesosphere/kubeflow:2.1.0-mnist-pytorch-1.11.0-gpu
 ```
 
 

--- a/pages/dkp/kaptain/2.1.0/tutorials/pipelines/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/pipelines/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -465,7 +465,7 @@ For GPU support, please add the "-gpu" suffix to the base image.
 
 
 ```python
-BASE_IMAGE = "mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0"
+BASE_IMAGE = "mesosphere/kubeflow:2.1.0-tensorflow-2.9.1"
 ```
 
 

--- a/pages/dkp/kaptain/2.1.0/tutorials/sdk/image-builder/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/sdk/image-builder/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -274,7 +274,7 @@ requirements = "requirements.txt"
 extra_files = [requirements, "mnist.py", "datasets"]
 
 # Image used in the FROM instruction of the Dockerfile
-base_image = "mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0"
+base_image = "mesosphere/kubeflow:2.1.0-tensorflow-2.9.1"
 
 # Name of the final image
 image_name = f"mesosphere/kubeflow:kaptain-sdk-mnist-tf-{timestamp}"
@@ -348,16 +348,16 @@ builder.build_image()
     2021-11-02 14:11:59,918 kaptain-log[INFO]: Waiting for Image Build to start...
     2021-11-02 14:12:03,869 kaptain-log[INFO]: Image Build started in pod: kaniko-ffccde4355a4a541-hz9pl.
     2021-11-02 14:12:05,996 kaptain-log[INFO]: [kaniko-ffccde4355a4a541-hz9pl/kaniko] logs:
-    [0001] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
-    [0001] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
-    [0001] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
-    [0001] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
+    [0001] Retrieving image manifest mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
+    [0001] Retrieving image mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
+    [0001] Retrieving image manifest mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
+    [0001] Retrieving image mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
     [0002] Built cross stage deps: map[]                
     2021-11-02 14:12:57,247 kaptain-log[INFO]: [kaniko-ffccde4355a4a541-hz9pl/kaniko] logs:
-    [0002] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
-    [0002] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
-    [0003] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
-    [0003] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0 
+    [0002] Retrieving image manifest mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
+    [0002] Retrieving image mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
+    [0003] Retrieving image manifest mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
+    [0003] Retrieving image mesosphere/kubeflow:2.1.0-tensorflow-2.9.1 
     [0004] Executing 0 build triggers                   
     [0004] Unpacking rootfs as cmd COPY . /workdir requires it. 
     [0054] Taking snapshot of full filesystem...        

--- a/pages/dkp/kaptain/2.1.0/tutorials/sdk/pytorch/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/sdk/pytorch/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -76,7 +76,7 @@ A simple `import` will suffice.
 
 <p class="message--warning"><strong>WARNING: </strong>Please do not store passwords directly in notebooks.
     Ideally, credentials are stored safely inside secrets management solutions or provided with service accounts.
-    Please check the section on <a href="https://docs.d2iq.com/dkp/kaptain/">how to manage secrets</a> in the official Kaptain documentation for more details on how to set up Docker credentials that you can attach to a notebook server.
+    Please check the section on how to manage secrets in the <a href="https://docs.d2iq.com/dkap/">official Kaptain documentation</a> for more details on how to set up Docker credentials that you can attach to a notebook server.
     This notebook should be used for demonstration purposes only!</p>
 
 Please type in the container registry username by running the next cell:
@@ -444,7 +444,7 @@ Finally, a `Model` instance requires providing a base Docker image (`base_image`
 ```python
 # as the trainer file depends on the model file, the model file should be provided as a dependency via 'extra_files'
 extra_files = ["datasets/MNIST", "model.py"]
-base_image = "mesosphere/kubeflow:2.1.0-rc.0-pytorch-1.11.0"
+base_image = "mesosphere/kubeflow:2.1.0-pytorch-1.11.0"
 # replace with your docker repository with a tag (optional), e.g. "repository/image"  or "repository/image:tag"
 image_name = "mesosphere/kubeflow:mnist-sdk-example-pytorch"
 # name of the file with additional python packages to install into the model image (e.g. "requirements.txt")

--- a/pages/dkp/kaptain/2.1.0/tutorials/sdk/quick-start/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/sdk/quick-start/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -31,7 +31,7 @@ will likely not work.</p>
 
 ## Introduction
 
-This notebook shows how to build and deploy ML models by using different popular machine learning frameworks. This example will be based on `scikit-learn` library, but because model building will be handled by Kubernetes Job, you can choose to use any other ML library (that can be installed with `pip`). Currently, the SDK supports XGBoost, Onnx and LightGBM as well as PyTorch and TensorFlow for model deployment. See [Kaptain documentation](https://docs.d2iq.com/dkp/kaptain/) for more info.
+This notebook shows how to build and deploy ML models by using different popular machine learning frameworks. This example will be based on `scikit-learn` library, but because model building will be handled by Kubernetes Job, you can choose to use any other ML library (that can be installed with `pip`). Currently, the SDK supports XGBoost, Onnx and LightGBM as well as PyTorch and TensorFlow for model deployment. See [Kaptain documentation](https://docs.d2iq.com/dkap/) for more info.
 
 To perform [distributed training](../../training/) on a cluster's resources, conduct [experiments with multiple parallel trials](../../katib/) to obtain the best hyperparameters, and [deploying a trained or tuned model](../../pipelines/) typically requires additional steps, such as building a Docker image and providing framework-specific specifications for Kubernetes.
 This places the burden on each data scientist to learn all the details of all the components.
@@ -74,7 +74,7 @@ A simple `import` will suffice.
 
 <p class="message--warning"><strong>WARNING: </strong>Please do not store passwords directly in notebooks.
     Ideally, credentials are stored safely inside secrets management solutions or provided with service accounts.
-    Please check the section on <a href="https://docs.d2iq.com/dkp/kaptain/">how to manage secrets</a> in the official Kaptain documentation for more details on how to set up Docker credentials that you can attach to a notebook server.
+    Please check the section on how to manage secrets in the <a href="https://docs.d2iq.com/dkap">official Kaptain documentation</a> for more details on how to set up Docker credentials that you can attach to a notebook server.
     This notebook should be used for demonstration purposes only!
 </p>
 
@@ -238,7 +238,7 @@ Finally, a `Model` instance requires providing a base Docker image (`base_image`
 
 
 ```python
-base_image = "mesosphere/kubeflow:2.1.0-rc.0-base"
+base_image = "mesosphere/kubeflow:2.1.0-base"
 image_name = "mesosphere/kubeflow:mnist-sklearn-sdk"
 
 # name of the file with additional python packages to install into the model image (e.g. "requirements.txt")
@@ -310,16 +310,16 @@ model.train(cpu=cpu, memory=memory, hyperparameters={})
     2022-07-13 10:53:27,083 kaptain-log[INFO]: Waiting for Image Build to start...
     2022-07-13 10:53:32,251 kaptain-log[INFO]: Image Build started in pod: kaniko-796a4baf6ede29c6--1-crzlx.
     2022-07-13 10:53:34,534 kaptain-log[INFO]: [kaniko-796a4baf6ede29c6--1-crzlx/kaniko] logs:
-    [36mINFO[0m[0000] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-base 
-    [36mINFO[0m[0000] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-base 
-    [36mINFO[0m[0001] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-base 
-    [36mINFO[0m[0001] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-base 
+    [36mINFO[0m[0000] Retrieving image manifest mesosphere/kubeflow:2.1.0-base 
+    [36mINFO[0m[0000] Retrieving image mesosphere/kubeflow:2.1.0-base 
+    [36mINFO[0m[0001] Retrieving image manifest mesosphere/kubeflow:2.1.0-base 
+    [36mINFO[0m[0001] Retrieving image mesosphere/kubeflow:2.1.0-base 
     [36mINFO[0m[0002] Built cross stage deps: map[]                
     2022-07-13 10:54:14,026 kaptain-log[INFO]: [kaniko-796a4baf6ede29c6--1-crzlx/kaniko] logs:
-    [36mINFO[0m[0002] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-base 
-    [36mINFO[0m[0002] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-base 
-    [36mINFO[0m[0003] Retrieving image manifest mesosphere/kubeflow:2.1.0-rc.0-base 
-    [36mINFO[0m[0003] Retrieving image mesosphere/kubeflow:2.1.0-rc.0-base 
+    [36mINFO[0m[0002] Retrieving image manifest mesosphere/kubeflow:2.1.0-base 
+    [36mINFO[0m[0002] Retrieving image mesosphere/kubeflow:2.1.0-base 
+    [36mINFO[0m[0003] Retrieving image manifest mesosphere/kubeflow:2.1.0-base 
+    [36mINFO[0m[0003] Retrieving image mesosphere/kubeflow:2.1.0-base 
     [36mINFO[0m[0004] Executing 0 build triggers                   
     [36mINFO[0m[0004] Unpacking rootfs as cmd COPY . /kaptain requires it. 
     [36mINFO[0m[0041] Taking snapshot of full filesystem...        

--- a/pages/dkp/kaptain/2.1.0/tutorials/sdk/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/sdk/tensorflow/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -78,7 +78,7 @@ A simple `import` will suffice.
 
 <p class="message--warning"><strong>WARNING: </strong>Please do not store passwords directly in notebooks.
     Ideally, credentials are stored safely inside secrets management solutions or provided with service accounts.
-    Please check the section on <a href="https://docs.d2iq.com/dkp/kaptain/">how to manage secrets</a> in the official Kaptain documentation for more details on how to set up Docker credentials that you can attach to a notebook server.
+    Please check the section on how to manage secrets in the <a href="https://docs.d2iq.com/dkap/">official Kaptain documentation</a> for more details on how to set up Docker credentials that you can attach to a notebook server.
     This notebook should be used for demonstration purposes only!
 </p>
 
@@ -263,7 +263,7 @@ The central abstraction of the Kaptain SDK is a model:
 
 ```python
 extra_files = ["datasets/mnist"]
-base_image = "mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0"
+base_image = "mesosphere/kubeflow:2.1.0-tensorflow-2.9.1"
 # replace with your docker repository with a tag (optional), e.g. "repository/image"  or "repository/image:tag"
 image_name = "mesosphere/kubeflow:mnist-sdk-example"
 # name of the file with additional python packages to install into model image (e.g. "requirements.txt")

--- a/pages/dkp/kaptain/2.1.0/tutorials/training/mxnet/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/training/mxnet/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>

--- a/pages/dkp/kaptain/2.1.0/tutorials/training/pytorch/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/training/pytorch/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -659,7 +659,7 @@ It uses [containerd](https://containerd.io/) to run workloads (only) instead.
 The Dockerfile looks as follows:
 
 ```
-FROM mesosphere/kubeflow:2.1.0-rc.0-pytorch-1.11.0-gpu
+FROM mesosphere/kubeflow:2.1.0-pytorch-1.11.0-gpu
 ADD mnist.py /
 ADD datasets /datasets
 
@@ -676,11 +676,11 @@ docker build -t <docker_image_name_with_tag> .
 docker push <docker_image_name_with_tag>
 ```
 
-The image is available as `mesosphere/kubeflow:2.1.0-rc.0-mnist-pytorch-1.11.0-gpu` in case you want to skip it for now.
+The image is available as `mesosphere/kubeflow:2.1.0-mnist-pytorch-1.11.0-gpu` in case you want to skip it for now.
 
 
 ```python
-%env IMAGE mesosphere/kubeflow:2.1.0-rc.0-mnist-pytorch-1.11.0-gpu
+%env IMAGE mesosphere/kubeflow:2.1.0-mnist-pytorch-1.11.0-gpu
 ```
 
 ## How to Create a Distributed `PyTorchJob`

--- a/pages/dkp/kaptain/2.1.0/tutorials/training/tensorflow/index.md
+++ b/pages/dkp/kaptain/2.1.0/tutorials/training/tensorflow/index.md
@@ -13,12 +13,12 @@ enterprise: false
 [//]: # "WARNING: This page is auto-generated from Jupyter notebooks and should not be modified directly."
 
 <p class="message--note"><strong>NOTE: </strong>All tutorials in Jupyter Notebook format are available for
-<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz">download</a>. You can either
+<a href="https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz">download</a>. You can either
 download them to a local computer and upload to the running Jupyter Notebook or run the following command
 from a Jupyter Notebook Terminal running in your Kaptain installation:
 
 ```bash
-curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0-rc.0.tar.gz | tar xz
+curl -L https://downloads.d2iq.com/kaptain/d2iq-tutorials-2.1.0.tar.gz | tar xz
 ```
 
 </p>
@@ -297,14 +297,14 @@ def main():
         metavar="N",
         help="Accelerates SGD in the relevant direction and dampens oscillations (default: 0.1)",
     )
-    
+
     parser.add_argument(
         "--log-dir",
         default="/home/kubeflow/tf-logs",
         type=str,
         help="the path of the directory where to save the log files to be parsed by TensorBoard",
     )
-    
+
 
     args, _ = parser.parse_known_args()
 
@@ -339,9 +339,9 @@ def main():
         model = compile_model(args=args)
 
     log_dir = args.log_dir + "/" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-    # setting 'profile_batch' to 0 to disable batch profiling. 
+    # setting 'profile_batch' to 0 to disable batch profiling.
     tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1, profile_batch=0)
-    
+
     # You cannot set `steps_per_epoch = None` with MirroredStrategy
     # See: https://github.com/tensorflow/tensorflow/issues/25254
     model.fit(train_datasets_sharded, epochs=args.epochs, steps_per_epoch=args.steps, callbacks=[tensorboard_callback])
@@ -449,7 +449,7 @@ It uses [containerd](https://containerd.io/) to run workloads (only) instead.
 The Dockerfile looks as follows:
 
 ```
-FROM mesosphere/kubeflow:2.1.0-rc.0-tensorflow-2.8.0-gpu
+FROM mesosphere/kubeflow:2.1.0-tensorflow-2.9.1-gpu
 ADD mnist.py /
 ADD datasets /datasets
 
@@ -466,11 +466,11 @@ docker build -t <docker_image_name_with_tag> .
 docker push <docker_image_name_with_tag>
 ```
 
-The image is available as `mesosphere/kubeflow:2.1.0-rc.0-mnist-tensorflow-2.8.0-gpu` in case you want to skip it for now.
+The image is available as `mesosphere/kubeflow:2.1.0-mnist-tensorflow-2.9.1-gpu` in case you want to skip it for now.
 
 
 ```python
-%env IMAGE mesosphere/kubeflow:2.1.0-rc.0-mnist-tensorflow-2.8.0-gpu
+%env IMAGE mesosphere/kubeflow:2.1.0-mnist-tensorflow-2.9.1-gpu
 ```
 
 ## How to Create a Distributed `TFJob`
@@ -720,7 +720,7 @@ kubectl delete ${TF_JOB}
 
 ## TensorBoard
 
-TensorBoard is a tool for providing the measurements and visualizations needed during the machine learning workflow. 
+TensorBoard is a tool for providing the measurements and visualizations needed during the machine learning workflow.
 This section shows how to create a TensorBoard instance using the log data from a previously created distributed `TFJob`.
 You can create a new TensorBoard instance by clicking the "Tensorboards" menu item page in the central dashboard or by applying the following resource using the PVC created in the previous step of this tutorial:
 


### PR DESCRIPTION
Signed-off-by: Alex Lembiyeuski <alembiyeuski@d2iq.com>

## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

[Update tutorials with 2.1.0 release versions in docs page](https://jira.d2iq.com/browse/D2IQ-91193)

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
