### PR TITLE
docs: adding clarifying language to major upgrade

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -193,6 +193,7 @@ mypy
 Nagios
 namespac(e|es|ed|ing)
 (nginx|NGINX)
+nodepool
 Nouveau
 (nvidia|Nvidia|NVIDIA)
 (OIDC|oidc)

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
@@ -27,7 +27,7 @@ After adopting the cluster, you use this AMI to scale up, or replace a failed in
 
     The output appears similar to this:
 
-    ```bash
+    ```sh
     writing new packer configuration to work/centos-7-1637107496-rPzRE
     starting packer build
     centos-7: output will be in this color.
@@ -597,8 +597,7 @@ The Dex Addon acts as the cluster's OpenID Connect identity provider. You must c
 
 ## Update the cluster worker node pool to Kubernetes version v1.21.6
 
-1.  If your cluster is in multiple Availability Zones, repeat the following for the number of zones, using values 0,1,2 in `{.items[0].metadata.name}` when exporting `MACHINEDEPLOYMENT_NAME`.
-
+<p class="message--note"><strong>NOTE: </strong>If your <strong>cluster is in multiple Availability Zones</strong>, repeat the following for the number of zones, using values <code>0</code>,<code>1</code>,<code>2</code> in <code>{.items[0].metadata.name}</code> when exporting <code>MACHINEDEPLOYMENT_NAME</code>.</p>
 
 1.  Add your Kubernetes v1.21.6 AMI to your environment:
 
@@ -693,6 +692,11 @@ The Dex Addon acts as the cluster's OpenID Connect identity provider. You must c
                 $(kubectl --kubeconfig=admin.conf get machinedeployment ${MACHINEDEPLOYMENT_NAME} -ojsonpath='{.status.updatedReplicas}')
       ]]; do sleep 30; done"
     ```
+
+    <p class="message--note"><strong>NOTE: </strong>As stated above, if your <strong>cluster is in multiple Availability Zones</strong>, return to step 3 in this section.
+    Edit the <code>export MACHINEDEPLOYMENT_NAME</code> section that has the number of zones, and increment it by one (for example if you had <code>export MACHINEDEPLOYMENT_NAME= ...'{.items[0].metadata.name}'</code> - adjust this to say <code>export MACHINEDEPLOYMENT_NAME= ...'{.items[1].metadata.name}'</code>.
+    Then, follow the steps until the <code>machinedeployment</code> update is complete.
+    Repeat these steps for all of the Availability Zones for your cluster.</p>
 
 [kib]: ../../../image-builder
 [kib-releases]: https://github.com/mesosphere/konvoy-image-builder/releases

--- a/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
@@ -18,7 +18,7 @@ Konvoy supports the following base Operating Systems.
 <!-- vale Vale.Terms = NO -->
 
 | Operating System | Kernel | Default Config | FIPS | Air Gapped | FIPS + AG | GPU Support | Konvoy Image Builder |
-|--------------------------|--------|----------------|------|------------|-------------|-------------|-------------
+|--------------------------|--------|----------------|------|------------|-------------|-------------|-------------|
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64 | Yes | Yes | Yes | Yes | Yes | Yes |
 | [RHEL 7.9][rhel_7_9] | 3.10.0-1160.el7.x86_64 | Yes | Yes | Yes |  | Yes | Yes |
 | [RHEL 8.2][rhel_8_2] | 4.18.0-193.6.3.el8_2.x86_64 | Yes | Yes | Yes | Yes | Yes | Yes |
@@ -29,15 +29,13 @@ Konvoy supports the following base Operating Systems.
 | [SUSE Linux Enterprise Server 15][sles_15] |  | Yes |  |  |  | Yes | Yes |
 | [Oracle Linux RHCK 7.9][RHCK] | kernel-3.10.0-1160.el7 | Yes | Yes | Yes | Yes |  | Yes |
 
-
-
 ## Pre-Provisioned/On Premises
 
 <!-- vale Vale.Spelling = NO -->
 <!-- vale Vale.Terms = NO -->
 
 | Operating System | Kernel | Default Config | FIPS | Air Gapped | FIPS + AG | GPU Support | Konvoy Image Builder |
-|--------------------------|--------|----------------|------|------------|-------------|-------------|-------------
+|--------------------------|--------|----------------|------|------------|-------------|-------------|-------------|
 | [CentOS 7.9][centos7] | 3.10.0-1160.el7.x86_64 | Yes | Yes | Yes |  |  | Yes |
 | [RHEL 7.9][rhel_7_9] | 3.10.0-1160.el7.x86_64 |  |  |  |  |  | Yes |
 | [RHEL 8.2][rhel_8_2] | 4.18.0-193.6.3.el8_2.x86_64 |  |  |  |  |  | Yes |
@@ -46,14 +44,12 @@ Konvoy supports the following base Operating Systems.
 | [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |  |  |  |  |  |  | Yes |
 | [SUSE Linux Enterprise Server 15][sles_15] |  |  |  |  |  |  | Yes |
 
-
-
 ## Azure
 
 <!-- vale Vale.Spelling = NO -->
 <!-- vale Vale.Terms = NO -->
 | Operating System                        | Kernel | Default Config | FIPS | Air Gapped | GPU Support | KIB <!-- vale Vale.Spelling = YES --> <!-- vale Vale.Terms = YES --> |
-|-----------------------------------------|--------|----------------|------|------------|-------------|-------------
+|-----------------------------------------|--------|----------------|------|------------|-------------|-------------|
 | [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |        | Yes            |      |            |             |
 
 [centos7]: https://wiki.centos.org/action/show/Manuals/ReleaseNotes/CentOS7.2003


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

From a slack conversation - we wanted to add a clarifying note to repeat these steps for each additional multi avail zone upon major version upgrade.

Hitchhiker fix for some markdown thing I saw on os support page, no content change here, solely markdown.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4621.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
