### PR TITLE
docs: fixing some links in release notes

### DIFF
--- a/pages/dkp/kommander/2.1/release-notes/2.1.3/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.3/index.md
@@ -27,7 +27,7 @@ With this patch release, multiple Availability Zones are now supported when upgr
 
 ### DKP custom credentials plugin restored (COPS-7343)
 
-The mesosphere/dex-k8s-authenticator docker container now includes the appropriate binaries that allow users to download the referenced ‘konvoy-async-plugin’ after configuring a cluster using an external IDP for authentication.
+The mesosphere/dex-k8s-authenticator Docker container now includes the appropriate binaries that allow users to download the referenced `konvoy-async-plugin` after configuring a cluster using an external IDP for authentication.
 
 ## Component updates
 

--- a/pages/dkp/konvoy/2.1/release-notes/2.1.2/index.md
+++ b/pages/dkp/konvoy/2.1/release-notes/2.1.2/index.md
@@ -11,7 +11,7 @@ beta: false
 
 [button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
-To get started with Konvoy, [download](../../download/) and [install](../../install/) the latest version of Konvoy.
+To get started with Konvoy, [download](../../download/) and [install](../../choose-infrastructure/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 
@@ -107,7 +107,6 @@ The following services and service components are upgraded to the listed version
 - traefik-forward-auth: 0.3.2
 - velero: 3.1.5
 
-
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->
@@ -117,9 +116,7 @@ For more information about working with native Kubernetes, see the [Kubernetes d
 For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd).
 
 [kubernetes-doc]: https://kubernetes.io/docs/home/
-[attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
 [konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/advanced/self-managed
-[project-custom-applications-git-repo]: ../../projects/applications/catalog-applications/custom-applications/add-create-git-repo
 [flux-cli]: https://fluxcd.io/docs/installation/
 [acme]: https://cert-manager.io/docs/configuration/acme/
 [config_kub]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/

--- a/pages/dkp/konvoy/2.1/release-notes/2.1.3/index.md
+++ b/pages/dkp/konvoy/2.1/release-notes/2.1.3/index.md
@@ -12,7 +12,7 @@ beta: false
 
 [button color="purple" href="https://support.d2iq.com/hc/en-us/articles/4409215222932-Product-Downloads"]Download Konvoy[/button]
 
-To get started with Konvoy, [download](../../download/) and [install](../../install/) the latest version of Konvoy.
+To get started with Konvoy, [download](../../download/) and [install](../../choose-infrastructure/) the latest version of Konvoy.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download this product. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install Konvoy.</p>
 
@@ -28,7 +28,7 @@ With this patch release, multiple Availability Zones are now supported when upgr
 
 ### DKP custom credentials plugin restored (COPS-7343)
 
-The mesosphere/dex-k8s-authenticator docker container now includes the appropriate binaries that allow users to download the referenced ‘konvoy-async-plugin’ after configuring a cluster using an external IDP for authentication.
+The mesosphere/dex-k8s-authenticator Docker container now includes the appropriate binaries that allow users to download the referenced `konvoy-async-plugin` after configuring a cluster using an external IDP for authentication.
 
 ## Component updates
 
@@ -76,9 +76,7 @@ For more information about working with native Kubernetes, see the [Kubernetes d
 For a full list of attributed 3rd party software, see [d2iq.com/legal/3rd](http://d2iq.com/legal/3rd).
 
 [kubernetes-doc]: https://kubernetes.io/docs/home/
-[attach-cluster]: ../../clusters/attach-cluster#attaching-a-cluster
 [konvoy-self-managed]: /dkp/konvoy/2.1/choose-infrastructure/aws/advanced/self-managed
-[project-custom-applications-git-repo]: ../../projects/applications/catalog-applications/custom-applications/add-create-git-repo
 [flux-cli]: https://fluxcd.io/docs/installation/
 [acme]: https://cert-manager.io/docs/configuration/acme/
 [config_kub]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
@@ -14,7 +14,7 @@ beta: false
 
 **Note:** In DKP 2.2 the Konvoy and Kommander binaries have been merged into a single binary, which you can find by selecting the DKP button above.
 
-[Download](../download/) and [install](../choose-infrastructure) the latest version to get started.
+[Download](../../download/) and [install](../../choose-infrastructure) the latest version to get started.
 
 <p class="message--note"><strong>NOTE: </strong>You must be a registered user and logged on to the support portal to download Kommander. New customers must contact their sales representative or <a href="mailto:sales@d2iq.com">sales@d2iq.com</a> before attempting to download or install this product.</p>
 
@@ -40,7 +40,7 @@ The following features and capabilities are new for Version 2.2.
 
 ### Integrated DKP Upgrade
 
-You can now upgrade Konvoy and Kommander as a single fluid process using a combination of the [DKP CLI](../cli/dkp) and the UI to upgrade your environment.
+You can now upgrade Konvoy and Kommander as a single fluid process using a combination of the [DKP CLI](../../cli/dkp) and the UI to upgrade your environment.
 
 For more information, see [DKP Upgrade](/dkp/kommander/2.2/dkp-upgrade)
 
@@ -52,7 +52,7 @@ You can use CAPI vSphere Provider while provisioning a [DKP cluster on vSphere](
 
 You can now use your laptop or USB drive to transfer pre-created air-gapped bundles, including OS dependencies and DKP binaries into your air-gapped environment with no external connectivity. This improves the availability of the DKP air-gapped deployment and productivity of your IT operations team.
 
-For more information, see the [air-gapped bundle](../choose-infrastructure) documentation in the choose infrastructure topics.
+For more information, see the [air-gapped bundle](../../choose-infrastructure) documentation in the choose infrastructure topics.
 
 ### Unified DKP user interfaces
 
@@ -87,7 +87,6 @@ New clusters use the "delete first" strategy by default. Existing clusters are s
 ## Component updates
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:
-
 
 | Common Application Name | APP ID | Version | Component Versions |
 |----------------------|--------------------- |---------|--------------------|


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

Mostly just fixing some links I noticed needed to be updated.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
