### PR TITLE
feat: banner routing to new docs site

### DIFF
--- a/layouts/all-products-landing.pug
+++ b/layouts/all-products-landing.pug
@@ -14,6 +14,7 @@ html(lang='en')
       header.header(style='position: fixed;')
         a.header__drawer
           i.header__icon(data-feather='menu')
+        div.header__banner <strong class="header__banner-icon">&#9432;</strong> You are viewing the documentation for older DKP releases. If you're looking for the new help center that includes the latest DKP release, go to <a href="https://docs.d2iq.com/">https://docs.d2iq.com</a>.
         a.header__logo(href='/')
           img.header__logo--mobile(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ')
           img.header__logo--desktop(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ')

--- a/layouts/kaptain-docs-landing.pug
+++ b/layouts/kaptain-docs-landing.pug
@@ -30,6 +30,7 @@ html(lang='en')
       header.header
         a.header__drawer
           i.header__icon(data-feather='menu')
+        div.header__banner <strong class="header__banner-icon">&#9432;</strong> You are viewing the documentation for older DKP releases. If you're looking for the new help center that includes the latest DKP release, go to <a href="https://docs.d2iq.com/">https://docs.d2iq.com</a>.
         a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop

--- a/layouts/kommander-docs-landing.pug
+++ b/layouts/kommander-docs-landing.pug
@@ -30,6 +30,7 @@ html(lang='en')
       header.header
         a.header__drawer
           i.header__icon(data-feather='menu')
+        div.header__banner <strong class="header__banner-icon">&#9432;</strong> You are viewing the documentation for older DKP releases. If you're looking for the new help center that includes the latest DKP release, go to <a href="https://docs.d2iq.com/">https://docs.d2iq.com</a>.
         a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop

--- a/layouts/konvoy-docs-landing.pug
+++ b/layouts/konvoy-docs-landing.pug
@@ -30,6 +30,7 @@ html(lang='en')
       header.header
         a.header__drawer
           i.header__icon(data-feather='menu')
+        div.header__banner <strong class="header__banner-icon">&#9432;</strong> You are viewing the documentation for older DKP releases. If you're looking for the new help center that includes the latest DKP release, go to <a href="https://docs.d2iq.com/">https://docs.d2iq.com</a>.
         a.header__logo(href='/')
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--mobile
           img(src='/assets/D2iQ_Logotype_Color_Positive_Documentation.svg', alt='D2IQ').header__logo--desktop

--- a/layouts/partials/header/header.pug
+++ b/layouts/partials/header/header.pug
@@ -7,6 +7,7 @@
 if draft
   .draft__banner DRAFT
 header.header
+  div.header__banner <strong class="header__banner-icon">&#9432;</strong> You are viewing the documentation for older DKP releases. If you're looking for the new help center that includes the latest DKP release, go to <a href="https://docs.d2iq.com/">https://docs.d2iq.com</a>.
   a.header__drawer
     i.header__icon(data-feather='menu')
   a.header__logo(href='/')

--- a/scss/base/_content.scss
+++ b/scss/base/_content.scss
@@ -21,6 +21,8 @@ $sections-size: 20%;
   }
   &__header {
     z-index: 10;
+    // makes header fully visible with extra space from banner
+    padding-top: 3rem;
     &__row {
       display: flex;
       align-items: flex-start;

--- a/scss/base/_header-dropdown.scss
+++ b/scss/base/_header-dropdown.scss
@@ -17,7 +17,8 @@
         width: 100%;
         height: 100%;
         margin: 0;
-        padding: 110px 0 0;
+        // accommodate extra space for banner message
+        padding: 130px 0 0;
         list-style-type: none;
         display: flex;
         flex-direction: column;

--- a/scss/base/_header.scss
+++ b/scss/base/_header.scss
@@ -1,19 +1,31 @@
 .header {
     position: fixed;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    flex-wrap: wrap;
     width: 100%;
-    height: 80px;
-    // padding: 0 2rem;
     background: $color-light;
     box-shadow: 0 0px 40px rgba(0, 0, 0, 0.1);
     z-index: 20;
+    &__banner {
+        font-size: 14px;
+        border-left: 12px solid $color-purple-d3;
+        color: $color-dark;
+        background: $color-purple-lightest;
+        padding: 10px;
+        border-left: 12px solid $color-purple-d3;
+        &-icon {
+          margin-right: 4px;
+        }
+    }
     &__logo {
         display: none;
+        background: $color-light;
+        margin: 10px;
     }
     &__drawer {
         margin-left: 1rem;
+        display: flex;
+        align-items: center;
     }
     &__dropdown {
         display: flex;
@@ -42,6 +54,7 @@
         flex: 1;
         transition: all 0.2s $ease-in-out-cubic 0.2s;
         opacity: 1;
+        height: 80px;
         &--hide {
             width: 0;
             opacity: 0;
@@ -80,6 +93,8 @@
     }
     &__search {
         display: block;
+        display: flex;
+        align-items: center;
         &-form {
             display: flex;
             align-items: center;
@@ -139,6 +154,7 @@
             display: none;
         }
         &__main {
+            height: auto;
             justify-content: flex-start;
         }
         &__dropdown {
@@ -155,6 +171,10 @@
                 }
             }
         }
+        &__banner {
+            width: 100%;
+            font-size: 16px;
+        }
         &__logo {
             display: block;
             flex-shrink: 0;
@@ -163,7 +183,6 @@
             }
             &--desktop {
                 display: block;
-                // width: 200px;
                 height: 60px;
                 margin-left: 10px;
             }

--- a/scss/pages/_landing.scss
+++ b/scss/pages/_landing.scss
@@ -7,7 +7,7 @@
         flex-direction: column;
         justify-content: flex-end;
         align-items: center;
-        height: 300px;
+        height: 400px;
         padding: 0rem 1rem;
         // background: #131626 url('/assets/k8-hero.png') no-repeat;
         // background-position: 80px bottom;

--- a/scss/pages/_new-landing.scss
+++ b/scss/pages/_new-landing.scss
@@ -8,6 +8,10 @@
     .header__menu a:hover {
         color: $color-dark;
     }
+    &__container {
+      // accommodate extra 80px from banner and nav bar
+      padding-top: 160px;
+    }
 }
 
 .color__grey {
@@ -18,13 +22,13 @@
     &__item {
         @include sm {
             display: flex;
+            padding: 3rem 0;
         }
         border-bottom: 1px solid $color-light-grey-l2;
         transition: all .5s;
         padding: 5rem 0;
-        @include sm {
+        @include md {
           max-height: 300px;
-          padding: 3rem 0;
         }
         &.disabled {
           opacity: 0;


### PR DESCRIPTION
This repo is now for the archived docs site.
These changes are to add a notice that the site has moved.

Closes D2IQ-92031

# Description
We want to include a notice for users to route them to the new docs site - https://docs.d2iq.com. 
The text should read - "You are viewing the documentation for older DKP releases. If you're looking for the new help center that includes the latest DKP release, go to https://docs.d2iq.com/."

I've matched the warning banner to a similar style as the "NOTE:" messages throughout the site to keep a consistent UX for notices. I've included the info icon as another indicator of important information if the blue/purple color alone is not indicative enough, which it may not be for those with visual impairments such as color deficiencies.
The banner will display on the main landing page, and product landing pages for Konvoy, Kommander, and Kaptain (and not for old docs such as DC/OS and Dispatch except for their specific docs pages because there is one component handing that for all products). The banner will also be included throughout the specific docs pages, that way if users had an old link to a specific doc they will still be alerted to route to the new site. This should cover most of our bases. 

The trade-offs with these changes are a lot of style adjustments due to the rigid CSS architecture of the site currently. Adding the extra space for the banner at the top requires some of the main content to be bumped down so it's not cut off. This should be fine as it may be one of the final changes to this repository. I tested these changes on different browsers and different screen sizes.


## Jira Ticket
https://jira.d2iq.com/browse/D2IQ-92031

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

<img width="1221" alt="Screen Shot 2022-09-05 at 1 37 54 PM" src="https://user-images.githubusercontent.com/34781875/188502500-f3ae3725-a5c3-44da-bbe5-255e5ba26f58.png">
<img width="1417" alt="Screen Shot 2022-09-05 at 1 38 37 PM" src="https://user-images.githubusercontent.com/34781875/188502502-ab08d03b-0f8a-4c85-afa1-7a1544fee3a0.png">
<img width="1331" alt="Screen Shot 2022-09-05 at 1 36 50 PM" src="https://user-images.githubusercontent.com/34781875/188502503-b1ee899d-5e48-4d39-ae28-6bc2faf5d53f.png">



You can preview the docs build using the following URL, adding the PR # where specified:

http://docs-d2iq-com-pr-4623.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
