### PR TITLE
[Kap] backporting multi-cluster specifications

### DIFF
--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
@@ -8,9 +8,11 @@ beta: false
 enterprise: false
 ---
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
+<p class="message--note"><strong>NOTE: </strong>
+Ensure that your <code>kubectl</code> configuration <a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/install/prerequisites/#reference-the-cluster-on-which-you-must-execute-the-commands">references the cluster on which you must execute the commands.</a>
+</p>
 
-<p class="message--note"><strong>NOTE: </strong>All DKP commands in this page assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
 
 ## Requirements
 
@@ -27,8 +29,6 @@ If you need to run Spark jobs on Kubernetes using Spark Operator, you must insta
 ## DKP 2.2 air-gapped installation
 
 Refer to [DKP install instructions][dkp_install], if you want to deploy Kaptain in a networked environment or to [DKP 2.1 air-gapped instructions][2.1_air] if you are deploying with DKP 2.1.
-
-
 
 Kaptain supports installation on an air-gapped (a.k.a. offline or private) DKP managed cluster. Before installing Kaptain, please follow the [air-gapped installation guide][konvoy-air-gap] to set up the air-gapped DKP managed cluster. The cluster admin is responsible for configuring the DKP cluster correctly and ensuring container images have been pre-loaded to the private registry before installing Kaptain.
 

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
@@ -9,10 +9,9 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>
-Ensure that your <code>kubectl</code> configuration <a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/install/prerequisites/#reference-the-cluster-on-which-you-must-execute-the-commands">references the cluster on which you must execute the commands.</a>
-</p>
+Ensure that your <code>kubectl</code> configuration <a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/install/prerequisites/#reference-the-cluster-on-which-you-must-execute-the-commands">references the cluster on which you must execute the commands.</a> </p>
 
-<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
+<p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p> 
 
 ## Requirements
 

--- a/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/deploy-kaptain/index.md
@@ -24,8 +24,7 @@ Ensure the cluster that you want to use to deploy Kaptain is the only cluster in
 
   - [Air-gapped environment for 2.2][add_air_2.2]
 
-<p class="message--warning"><strong>WARNING: </strong>
-(<a href="../../../../kommander/2.2/licensing/enterprise/">Enterprise</a> only) If you are installing Kaptain on a Managed or Attached cluster, you must customize the deployment for Kaptain to communicate with the Management cluster via Dex (unless you have a dedicated dex instance running on said cluster). 
+<p class="message--warning"><strong>WARNING: </strong> (<a href="../../../../kommander/2.2/licensing/enterprise/">Enterprise</a> only) If you are installing Kaptain on a Managed or Attached cluster, you must customize the deployment for Kaptain to communicate with the Management cluster via Dex (unless you have a dedicated dex instance running on said cluster). 
 In the following workflow, we will show you when to do this.
 </p>
 
@@ -67,7 +66,7 @@ Follow these steps to enable Kaptain in air-gapped and networked environments fr
 
 1.  Repeat these steps for each additional workspace, if you want to deploy Kaptain to other workspaces.
 
-Alternately, you can use the [CLI](#enable-and-deploy-kaptain-using-the-dkp-cli) to enable your catalog applications.
+Alternately, you can use the [CLI](#enable-and-deploy-kaptain-using-the-dkp-cli-essential-only) to enable your catalog applications.
 
 ### Verify the status of deployment using the DKP UI
 
@@ -86,6 +85,8 @@ Follow these steps to verify the deployment of Kaptain:
 ## Enable and deploy Kaptain using the DKP CLI (Essential only)
 
 Follow these steps to enable Kaptain in air-gapped and networked environments from the DKP CLI:
+
+1.  Ensure you [reference the cluster on which you want to deploy Kaptain](https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/install/prerequisites/#install-dependencies#reference-the-cluster-on-which-you-must-execute-the-commands). For customers with an Essential license and a single-cluster experience, the `clusterKubeconfig.conf` is your Essential cluster. For customers with an Enterprise license and multi-cluster experience, your `clusterKubeconfig.conf` is the managed or attached cluster where you will install Kaptain.
 
 1.  Enable Kaptain to deploy to [your existing Management, Managed and Attached clusters][existcluster] with an `AppDeployment` resource.
 
@@ -112,6 +113,8 @@ Follow these steps to enable Kaptain in air-gapped and networked environments fr
 <p class="message--important"><strong>IMPORTANT: </strong>If you are deploying Kaptain to a managed or attached cluster, ensure that the <code>ConfigMap</code> contains the <code>${WORKSPACE_NAMESPACE}</code> in the <code>global.workspace</code> section of the <code>values.yaml</code>, as shown in the following example.</p>
 
 If you want to customize your installation and modify the custom domain name, external Dex, creation of profiles, certificates, for example, continue with these steps:
+
+1.  Ensure you [reference the cluster on which you want to deploy Kaptain](https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/install/prerequisites/#install-dependencies#reference-the-cluster-on-which-you-must-execute-the-commands). For customers with an Essential license and a single-cluster experience, the `clusterKubeconfig.conf` is your Essential cluster. For customers with an Enterprise license and multi-cluster experience, your `clusterKubeconfig.conf` is the managed or attached cluster where you will install Kaptain.
 
 1.  Create the `ConfigMap` with the custom configuration. In the following example, the ConfigMap is configuring Kaptain to communicate with the [Management cluster via Dex](../../configuration/external-dex/), which is a necessary step when deploying Kaptain to a Managed or Attached cluster ([Enterprise](../../../../kommander/2.2/licensing/enterprise/) only). Other configurations can be made in the same way.
 

--- a/pages/dkp/kaptain/2.0.0/install/dkp/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/dkp/index.md
@@ -9,8 +9,7 @@ enterprise: false
 ---
 
 <p class="message--note"><strong>NOTE: </strong>
-<strong>All DKP commands on this page</strong> assume <code>KUBECONFIG=clusterKubeconfig.conf</code> is set.
-</p>
+Ensure that your <code>kubectl</code> configuration <a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/install/prerequisites/#reference-the-cluster-on-which-you-must-execute-the-commands">references the cluster on which you must execute the commands.</a> </p>
 
 <p class="message--important"><strong>IMPORTANT: </strong>Ensure the cluster that you want to use to deploy Kaptain is the only cluster in its workspace. <b>Kaptain is meant to be deployed on workspaces with a single cluster</b>.</p>
 
@@ -34,6 +33,8 @@ If you installed DKP with Kaptain as a workspace application in the Kommander in
 If you added Kaptain after installing DKP, you must make it available by creating a Git Repository. Use the CLI to create the GitRepository resource and add a new repository.
 
 ### Create a Git repository for Kaptain
+
+1.  Ensure you [reference the cluster on which you want to deploy Kaptain](https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/install/prerequisites/#install-dependencies#reference-the-cluster-on-which-you-must-execute-the-commands). For customers with an Essential license and a single-cluster experience, the `clusterKubeconfig.conf` is your Essential cluster. For customers with an Enterprise license and multi-cluster experience, your `clusterKubeconfig.conf` is the managed or attached cluster where you will install Kaptain. 
 
 1.  Ensure the `KUBECONFIG=clusterKubeconfig.conf` is set.
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -21,14 +21,18 @@ enterprise: false
 - The following **Platform applications** (dependencies) enabled in the cluster where you want to install Kaptain:
 
   - **Istio**
-  - **MinIO Operator** (installed by default in some clusters, not on attached clusters) 
+  - **MinIO Operator** (installed by default in some clusters, not on attached clusters)
   - **Knative**, if you are running the [serverless installation of KServe](https://kserve.github.io/website/0.9/admin/serverless/), which is the default mode that comes pre-bundled with Kaptain. (Not required if you are using the [RawDeployment installation mode](https://kserve.github.io/website/0.9/admin/kubernetes_deployment/))
 
   You have two options to install these applications. For more instructions, refer to the [Install dependencies section](#install-dependencies).
 
 - Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain **on premises**.
 
-## Install dependencies 
+- #### Reference the cluster on which you must execute the commands
+
+  You can do this by setting the `KUBECONFIG` environment variable to the appropriate kubeconfig file's location (`KUBECONFIG=clusterKubeconfig.conf`), or by using the `--kubeconfig=cluster_name.conf` flag. For more information, refer to the [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) documentation.
+
+## Install dependencies
 
 ### Install dependencies on any type of cluster (Essential and Enterprise)
 
@@ -40,7 +44,9 @@ To install any of the previous applications after you have installed DKP, follow
 
 You can install the applications Kaptain requires during the installation of DKP by adapting the configuration file:
 
-<p class="message--note"><strong>NOTE: </strong>All DKP commands in this section assume KUBECONFIG=clusterKubeconfig.conf is set.</p>
+<p class="message--note"><strong>NOTE: </strong>When installing these applications, <a href="#reference_the_cluster_on_which_you_must_execute_the_commands">set the environment variable</a> to the workspace of the cluster where you will install Kaptain. For customers with an Essential license and a single-cluster experience, the <code>clusterKubeconfig.conf</code> is your Essential cluster. For customers with an Enterprise license and multi-cluster experience, your <code>clusterKubeconfig.conf</code> is the managed or attached cluster where Kaptain should be installed.</p>
+
+1.  Ensure that your `kubectl` configuration [references the cluster on which you must execute the commands](#reference-the-cluster-on-which-you-must-execute-the-commands). For customers with an Essential license and a single-cluster experience, reference your Essential cluster.
 
 1.  Use the existing Kommander configuration file `kommander.yaml`, or initialize the default one, if you have not done so yet:
 
@@ -50,7 +56,7 @@ You can install the applications Kaptain requires during the installation of DKP
 
     Review the [Customizing the configuration file](../../../../kommander/2.2/install/configuration/) page to gain more understanding on how to use a configuration file to install DKP.
 
-1.  Ensure the following applications are enabled in the config: 
+1.  Ensure the following applications are enabled in the config:
 
     ```bash
     apiVersion: config.kommander.mesosphere.io/v1alpha1
@@ -70,7 +76,7 @@ You can install the applications Kaptain requires during the installation of DKP
 
     For GPU deployment, follow the instructions in the [Kommander GPU documentation](../../../../kommander/2.2/gpu/kommander-config/).
 
-1.  Apply the new configuration to Kommander: 
+1.  Apply the new configuration to Kommander:
 
     ```bash
     dkp install kommander --installer-config kommander-config.yaml

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -28,9 +28,9 @@ enterprise: false
 
 - Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain **on premises**.
 
-- #### Reference the cluster on which you must execute the commands
+### Reference the cluster on which you must execute the commands
 
-  You can do this by setting the `KUBECONFIG` environment variable to the appropriate kubeconfig file's location (`KUBECONFIG=clusterKubeconfig.conf`), or by using the `--kubeconfig=cluster_name.conf` flag. For more information, refer to the [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) documentation.
+You can do this by setting the `KUBECONFIG` environment variable to the appropriate kubeconfig file's location (`KUBECONFIG=clusterKubeconfig.conf`), or by using the `--kubeconfig=cluster_name.conf` flag. For more information, refer to the [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) documentation.
 
 ## Install dependencies
 


### PR DESCRIPTION
## Jira Ticket

https://jira.d2iq.com/browse/D2IQ-91603 

## Description of changes being made

Backporting changes that were made and approved in Confluence to archived Kaptain 2.0 documentation.
### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4625.s3-website-us-west-2.amazonaws.com/

## Checklist

