### PR TITLE
docs: fixing code block for url location

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/create-an-ami/index.md
@@ -61,13 +61,15 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
     ```bash
     curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/dkp/airgapped/pip-packages/pip-packages.tar.gz
     ```
-     NOTE: If you're installing V2.2.0 or V2.2.1, skip to step 9, as those releases did not have separate `containerd` packages.
+
+    NOTE: If you're installing v2.2.0 or v2.2.1, skip to step 9, as those releases did not have separate `containerd` packages.
 
 1. Set a variable that indicates which os-specific `containerd` bundle to download:
 
     ```bash
     export CONTAINERD_OS=centos-7.9-x86_64
     ```
+
     Note: available packages are:
 
     -   `centos-7.9-x86_64`
@@ -79,8 +81,7 @@ Using the [Konvoy Image Builder](../../../../image-builder), you can build an AM
 1. Download the `containerd` bundle.
 
     ```bash
-    curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location 
-    https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
+    curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
     ```
 
 1.  Follow the instructions to [build an AMI][kib_create_ami] in the setting an additional `--overrides overrides/offline.yaml` flag.
@@ -91,7 +92,7 @@ This Docker image includes code from the MinIO Project (“MinIO”), which is �
 https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
 https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 
-For a full list of attributed 3rd party software, see [D2IQ Legal](https://d2iq.com/legal/3rd).
+For a full list of attributed 3rd party software, see [D2iQ Legal](https://d2iq.com/legal/3rd).
 
 [kib_create_ami]: ../../../../image-builder/create-ami/
 [seed-a-registry]: ../seed-a-registry


### PR DESCRIPTION
## Jira Ticket

D2IQ-92978

## Description of changes being made

Just changing the code block so this code block can be copy/pastable.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4629.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
