### PR TITLE
docs: Update dkp versions in 2.2 docs to latest 2.2.2

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -25,27 +25,27 @@ This section describes how to upgrade your Kommander Management cluster and all 
   Download the Kommander application definitions:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.1/kommander-applications-v2.2.1.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.2/kommander-applications-v2.2.2.tar.gz"
   ```
 
   Download the Kommander charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-kommander-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+  wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-kommander-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
   ```
 
   If you have any DKP Catalog Applications, download the DKP Catalog Application charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+  wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
   ```
 
 -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
 
-  Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.1`:
+  Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.2`:
 
   ```yaml
-    disableMutation: false # <-- this value is new in 2.2.1
+    disableMutation: false # <-- this value is new in 2.2.2
     mutations:
       enablePodProxy: true
       podProxySettings:
@@ -124,13 +124,13 @@ Before running the following command, ensure that your `dkp` configuration **ref
     -   For air-gapped:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz --kommander-applications-repository kommander-applications-v2.2.1.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz --kommander-applications-repository kommander-applications-v2.2.2.tar.gz
         ```
 
     -   For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz --kommander-applications-repository kommander-applications-v2.2.1.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz --kommander-applications-repository kommander-applications-v2.2.2.tar.gz
         ```
 
         After the upgrade, follow the [DKP Catalog Applications configuration page](../../install/configuration/enterprise-catalog#air-gapped-catalog-configuration) to update the Git repository.

--- a/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/catalog/index.md
@@ -25,29 +25,29 @@ Depending on your configuration, there are three different ways you can install 
 1.  Download the DKP image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/kommander-image-bundle-v2.2.1.tar" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/kommander-image-bundle-v2.2.2.tar" -O - | tar -xvf -
     ```
 
 1.  Optionally download the DKP catalog applications image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-image-bundle-v2.2.1.tar" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-image-bundle-v2.2.2.tar" -O - | tar -xvf -
     ```
 
 1.  Optionally download the DKP insights image bundle file:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-insights-image-bundle-v2.2.1.tar"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-insights-image-bundle-v2.2.2.tar"
     ```
 
-1.  See the NOTICES.txt file for 3rd party software attributions and place the kommander-image-bundle-v2.2.1.tar and dkp-catalog-applications-image-bundle-v2.2.1.tar bundles within a location where you can load and push the images to your private Docker registry.
+1.  See the NOTICES.txt file for 3rd party software attributions and place the kommander-image-bundle-v2.2.2.tar and dkp-catalog-applications-image-bundle-v2.2.2.tar bundles within a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
     ```bash
-    dkp push image-bundle --image-bundle kommander-image-bundle-v2.2.1.tar --to-registry <REGISTRY_URL>
-    dkp push image-bundle --image-bundle dkp-catalog-applications-image-bundle-v2.2.1.tar --to-registry <REGISTRY_URL>`
-    dkp push image-bundle --image-bundle dkp-insights-image-bundle-v2.2.1.tar --to-registry <REGISTRY_URL>`
+    dkp push image-bundle --image-bundle kommander-image-bundle-v2.2.2.tar --to-registry <REGISTRY_URL>
+    dkp push image-bundle --image-bundle dkp-catalog-applications-image-bundle-v2.2.2.tar --to-registry <REGISTRY_URL>`
+    dkp push image-bundle --image-bundle dkp-insights-image-bundle-v2.2.2.tar --to-registry <REGISTRY_URL>`
     ```
 
 ## Install air-gapped Kommander with the DKP Catalog Applications
@@ -61,25 +61,25 @@ To use the DKP Catalog Applications in an air-gapped environment, you need the f
 1.  Download the DKP catalog application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-v2.2.2.tar.gz"
     ```
 
 1.  Download the [DKP catalog applications](/wiki/spaces/DENT/pages/29919387) chart bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-kommander-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-kommander-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
     ```
 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/kommander-applications-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/kommander-applications-v2.2.2.tar.gz"
     ```
 
 ### Install Kommander
@@ -118,9 +118,9 @@ Follow these steps:
 
     ```bash
     dkp install kommander --installer-config ./install.yaml\
-    --kommander-applications-repository kommander-applications-v2.2.1.tar.gz\
-    --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz\
-    --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz
+    --kommander-applications-repository kommander-applications-v2.2.2.tar.gz\
+    --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz\
+    --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz
     ```
 
 1.  [Verify your installation](https:...).
@@ -136,25 +136,25 @@ If you are utilizing [DKP Insights](/wiki/spaces/DINS) in an air-gapped environm
 1.  Download the DKP Insights catalog:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-insights-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-insights-v2.2.2.tar.gz"
     ```
 
 1.  Download the DKP Insights chart bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-insights-charts-bundle-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-insights-charts-bundle-v2.2.2.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-kommander-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-kommander-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
     ```
 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/kommander-applications-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/kommander-applications-v2.2.2.tar.gz"
     ```
 
 ### Install Kommander
@@ -185,22 +185,22 @@ If you are utilizing [DKP Insights](/wiki/spaces/DINS) in an air-gapped environm
           labels:
             kommander.d2iq.io/workspace-default-catalog-repository: "true"
             kommander.d2iq.io/gitapps-gitrepository-type: "dkp"
-          path: ./dkp-insights-v2.2.1.tar.gz
+          path: ./dkp-insights-v2.2.2.tar.gz
     ```
 
 1.  Push the DKP Insights charts bundle:
 
     ```bash
-    dkp push chart-bundle dkp-insights-charts-bundle-v2.2.1.tar.gz
+    dkp push chart-bundle dkp-insights-charts-bundle-v2.2.2.tar.gz
     ```
 
 1.  Install DKP with Insights enabled by running:
 
     ```bash
     dkp install kommander --installer-config ./install.yaml\
-    --kommander-applications-repository kommander-applications-v2.2.1.tar.gz\
-    --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz\
-    --charts-bundle dkp-insights-charts-bundle-v2.2.1.tar.gz
+    --kommander-applications-repository kommander-applications-v2.2.2.tar.gz\
+    --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz\
+    --charts-bundle dkp-insights-charts-bundle-v2.2.2.tar.gz
     ```
 
 1.  [Verify your installation](...).
@@ -216,37 +216,37 @@ Follow these steps:
 1.  Download the DKP catalog application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-v2.2.2.tar.gz"
     ```
 
 1.  Download the [DKP catalog applications](/wiki/spaces/DENT/pages/29919387) chart bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
     ```
 
 1.  Download the DKP Insights catalog:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-insights-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-insights-v2.2.2.tar.gz"
     ```
 
 1.  Download the DKP Insights chart bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-insights-charts-bundle-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-insights-charts-bundle-v2.2.2.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-kommander-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-kommander-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
     ```
 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/kommander-applications-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/kommander-applications-v2.2.2.tar.gz"
     ```
 
 ### Install Kommander
@@ -279,7 +279,7 @@ Follow these steps:
           labels:
             kommander.d2iq.io/workspace-default-catalog-repository: "true"
             kommander.d2iq.io/gitapps-gitrepository-type: "dkp"
-          path: ./dkp-insights-v2.2.1.tar.gz
+          path: ./dkp-insights-v2.2.2.tar.gz
         - name: dkp-catalog-applications
           labels:
             kommander.d2iq.io/project-default-catalog-repository: "true"
@@ -294,10 +294,10 @@ Follow these steps:
 
     ```bash
     dkp install kommander --installer-config ./install.yaml\
-    --kommander-applications-repository kommander-applications-v2.2.1.tar.gz\
-    --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz\
-    --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz\
-    --charts-bundle dkp-insights-charts-bundle-v2.2.1.tar.gz
+    --kommander-applications-repository kommander-applications-v2.2.2.tar.gz\
+    --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz\
+    --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz\
+    --charts-bundle dkp-insights-charts-bundle-v2.2.2.tar.gz
     ```
 
 1.  [Verify your installation](https://d2iq.atlassian.net/wiki/spaces/DENT/pages/29892245/Install+Kommander+in+a+Networked+Environment#Verify-installation).

--- a/pages/dkp/kommander/2.2/install/air-gapped/index.md
+++ b/pages/dkp/kommander/2.2/install/air-gapped/index.md
@@ -84,12 +84,12 @@ Check the built-in help text for each command for more information.
 
 ### Load the Docker images into your Docker registry
 
-1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.2.1.tar.gz` and `dkp-catalog-applications-image-bundle-v2.2.1.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
+1.  See the `NOTICES.txt` file for 3rd party software attributions and place the `kommander-image-bundle-v2.2.2.tar.gz` and `dkp-catalog-applications-image-bundle-v2.2.2.tar.gz` bundles within a location where you can load and push the images to your private Docker registry.
 
 1.  Run the following command to load the air-gapped image bundle into your private Docker registry:
 
     ```bash
-    dkp push image-bundle --image-bundle kommander-image-bundle-v2.2.1.tar.gz --to-registry <REGISTRY_URL>
+    dkp push image-bundle --image-bundle kommander-image-bundle-v2.2.2.tar.gz --to-registry <REGISTRY_URL>
     ```
 
 It may take a while to push all the images to your image registry, depending on the performance of the network between the machine you are running the script on and the Docker registry.
@@ -121,21 +121,21 @@ It may take a while to push all the images to your image registry, depending on 
 1.  Download the Kommander application definitions:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/kommander-applications-v2.2.1.tar.gz"
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/kommander-applications-v2.2.2.tar.gz"
     ```
 
 1.  Download the Kommander charts bundle:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-kommander-charts-bundle-v2.2.1.tar.gz" -O - | tar -xvf -
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-kommander-charts-bundle-v2.2.2.tar.gz" -O - | tar -xvf -
     ```
 
 1.  To install Kommander in your air-gapped environment using the above configuration file, enter the following command:
 
     ```bash
     dkp install kommander --installer-config ./install.yaml \
-    --kommander-applications-repository kommander-applications-v2.2.1.tar.gz \
-    --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz
+    --kommander-applications-repository kommander-applications-v2.2.2.tar.gz \
+    --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz
     ```
 
 1.  [Verify your installation](../networked#verify-installation).

--- a/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
+++ b/pages/dkp/kommander/2.2/install/configuration/enterprise-catalog/index.md
@@ -27,7 +27,7 @@ catalog:
       gitRepositorySpec:
         url: https://github.com/mesosphere/dkp-catalog-applications
         ref:
-          tag: v2.2.1
+          tag: v2.2.2
 ```
 
 Use this configuration when installing or reconfiguring Kommander by passing it to the `dkp install kommander` command:
@@ -55,7 +55,7 @@ When running in air-gapped environments, update the configuration by replacing `
 1.  Download the DKP catalog application Git repository archive:
 
     ```bash
-    wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-v2.2.1.tar.gz" -O dkp-catalog-applications.tar.gz
+    wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-v2.2.2.tar.gz" -O dkp-catalog-applications.tar.gz
     ```
 
 <p class="message--note"><strong>NOTE: </strong>This docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU Affero General Public License 3.0</a>. Complete source code for MinIO is available <a href="https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z">here</a>, <a href="https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z">here</a>, and <a href="https://github.com/minio/minio/tree/RELEASE.2022-01-08T03-11-54Z">here</a></p>

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/bootstrap/index.md
@@ -14,13 +14,13 @@ Konvoy deploys all cluster lifecycle services to a bootstrap cluster, which depl
 1.  Download the bootstrap docker image on a machine that has access to this artifact.
 
     ```docker
-    curl -O https://downloads.d2iq.com/dkp/v2.2.1/konvoy-bootstrap_v2.2.1.tar
+    curl -O https://downloads.d2iq.com/dkp/v2.2.2/konvoy-bootstrap_v2.2.2.tar
     ```
 
 1.  Load the bootstrap docker image on your bastion machine.
 
     ```docker
-    docker load -i konvoy-bootstrap_v2.2.1.tar
+    docker load -i konvoy-bootstrap_v2.2.2.tar
     ```
 
 1.  Create a bootstrap cluster:

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
@@ -14,7 +14,7 @@ Before creating a Kubernetes cluster you must have the required images in a loca
 1.  Download the images bundle.
 
     ```bash
-    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/dkp/v2.2.1/konvoy_image_bundle_v2.2.1_linux_amd64.tar.gz
+    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/dkp/v2.2.2/konvoy_image_bundle_v2.2.2_linux_amd64.tar.gz
     ```
 
 
@@ -40,7 +40,7 @@ Then, [begin creating the bootstrap cluster][bootstrap].
 
 [bootstrap]: ../bootstrap
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the GNU Affero General Public License 3.0. The complete source code for the versions of MinIO packaged with DKP/Kommander/Konvoy 2.2.1 are available at these URLs: 
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the GNU Affero General Public License 3.0. The complete source code for the versions of MinIO packaged with DKP/Kommander/Konvoy 2.2.2 are available at these URLs: 
 https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
 https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -15,13 +15,13 @@ The instructions below outline how to fulfill the prerquisites for using pre-pro
 1.  Download the bootstrap docker image on a machine that has access to this artifact:
 
     ```docker
-    curl --remote-name https://downloads.d2iq.com/dkp/v2.2.1/konvoy-bootstrap_v2.2.1.tar
+    curl --remote-name https://downloads.d2iq.com/dkp/v2.2.2/konvoy-bootstrap_v2.2.2.tar
     ```
 
 1.  Load the bootstrap Docker image on your bastion machine:
 
     ```docker
-    docker load -i konvoy-bootstrap_v2.2.1.tar
+    docker load -i konvoy-bootstrap_v2.2.2.tar
     ```
 
 ## Copy air-gapped artifacts onto cluster hosts
@@ -135,7 +135,7 @@ Before creating a Kubernetes cluster you must have the required images in a loca
 1.  Download the images bundle:
 
     ```bash
-    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/dkp/v2.2.1/konvoy_image_bundle_v2.2.1_linux_amd64.tar.gz
+    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/dkp/v2.2.2/konvoy_image_bundle_v2.2.2_linux_amd64.tar.gz
     ```
 
 1.  Place the bundle in a location where you can load and push the images to your private docker registry.
@@ -158,7 +158,7 @@ Then [begin creating the bootstrap cluster][bootstrap].
 
 [bootstrap]: ../bootstrap
 
-This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the GNU Affero General Public License 3.0. The complete source code for the versions of MinIO packaged with DKP/Kommander/Konvoy 2.2.1 are available at these URLs: 
+This Docker image includes code from the MinIO Project (“MinIO”), which is © 2015-2021 MinIO, Inc. MinIO is made available subject to the terms and conditions of the GNU Affero General Public License 3.0. The complete source code for the versions of MinIO packaged with DKP/Kommander/Konvoy 2.2.2 are available at these URLs: 
 https://github.com/minio/minio/tree/RELEASE.2022-02-24T22-12-01Z
 https://github.com/minio/minio/tree/RELEASE.2021-02-14T04-01-33Z
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-kommander/index.md
@@ -25,27 +25,27 @@ This section describes how to upgrade your Kommander Management cluster and all 
   Download the Kommander application definitions:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.1/kommander-applications-v2.2.1.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.2/kommander-applications-v2.2.2.tar.gz"
   ```
 
   Download the Kommander charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-kommander-charts-bundle-v2.2.1.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-kommander-charts-bundle-v2.2.2.tar.gz"
   ```
 
   If you have any DKP Catalog Applications, download the DKP Catalog Application charts bundle:
 
   ```bash
-  wget "https://downloads.d2iq.com/dkp/v2.2.1/dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz"
+  wget "https://downloads.d2iq.com/dkp/v2.2.2/dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz"
   ```
 
 -   For clusters upgrading from 2.1.1 with HTTP Proxy installed:
 
-  Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.1`:
+  Edit the `gatekeeper-overrides`, and add a new configuration property, `disableMutation`, with the value `false`. This is required because the Gatekeeper configuration was changed between versions `v2.1.1` and `v2.2.2`:
 
   ```yaml
-    disableMutation: false # <-- this value is new in 2.2.1 
+    disableMutation: false # <-- this value is new in 2.2.2 
     mutations:
       enablePodProxy: true
       podProxySettings:
@@ -124,13 +124,13 @@ Before running the following command, ensure that your `dkp` configuration **ref
     -   For air-gapped:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz --kommander-applications-repository kommander-applications-v2.2.1.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz --kommander-applications-repository kommander-applications-v2.2.2.tar.gz
         ```
 
     -   For air-gapped **with** DKP Catalog Applications in a multi-cluster environment:
 
         ```bash
-        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.1.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.1.tar.gz --kommander-applications-repository kommander-applications-v2.2.1.tar.gz
+        dkp upgrade kommander --charts-bundle dkp-kommander-charts-bundle-v2.2.2.tar.gz --charts-bundle dkp-catalog-applications-charts-bundle-v2.2.2.tar.gz --kommander-applications-repository kommander-applications-v2.2.2.tar.gz
         ```
 
         After the upgrade, follow the [DKP Catalog Applications configuration page](../../../../kommander/2.2/install/configuration/enterprise-catalog#air-gapped-catalog-configuration) to update the Git repository.

--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -17,12 +17,12 @@ This section describes how to use the KIB to create a Cluster API compliant mach
 Along with the KIB Bundle, we publish a file containing checksums for the bundle files.  The recommendation for using these checksums is to verify the integrity of the downloads.
 
 
-| DKP Version  | KIB Version | 
-|------------|----------------------|
-| V2.2.2 | v1.17.2 |
-| v2.2.1 | v1.13.2 |
-| v2.2.0 | v1.11.0 |
-| v2.1.x | v1.5.0 |
+| DKP Version | KIB Version | 
+|-------------|----------------------|
+| v2.2.2      | v1.17.2 |
+| v2.2.1      | v1.13.2 |
+| v2.2.0      | v1.11.0 |
+| v2.1.x      | v1.5.0 |
 
 [KIB Version download release center](https://github.com/mesosphere/konvoy-image-builder/releases)
 


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
We missed updating lots of 2.2 docs with the latest 2.2.2 version when it was released (e.g. airgapped bundles)

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
