### PR TITLE
docs: Add documentation for containerd bundles for 2.2.2 On Prem Air Gap

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -79,6 +79,35 @@ Using the [Konvoy Image Builder](../../../image-builder), you can copy the requi
     curl --output artifacts/pip-packages.tar.gz --location https://downloads.d2iq.com/dkp/airgapped/pip-packages/pip-packages.tar.gz
     ```
 
+1. Download the Containerd `1.14.13` packages for the OS you plan to provision DKP on.
+
+    Available packages are:
+
+    -   `centos-7.9-x86_64`
+    -   `rhel-7.9-x86_64`
+    -   `rhel-8.2-x86_64`
+    -   `ubuntu-20.04-x86_64`
+    -   `ubuntu-18.04-x86_64`
+
+    ```bash
+    export CONTAINERD_OS=centos-7.9-x86_64
+    ```
+
+    ```bash
+    curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
+    ```
+
+    To get the fips builds append _fips after -x86_64 in the url. To get the fips build for centos-7.9 the url would be
+    https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-centos-7.9-x86_64_fips.tar.gz
+
+    The following OS’s have containerd fips builds:
+
+    -   `centos-7.9`
+    -   `ol-7.9`
+    -   `rhel-7.9`
+    -   `rhel-8.2`
+    -   `rhel-8.4`
+
 1.  Export the following environment variables, ensuring that all control plane and worker nodes are included:
 
     ```bash
@@ -125,7 +154,10 @@ Using the [Konvoy Image Builder](../../../image-builder), you can copy the requi
 1.  Copy the artifacts onto cluster hosts:
 
     ```bash
-    konvoy-image upload artifacts --container-images-dir=./artifacts/images/ --os-packages-bundle=./artifacts/"$VERSION"_"$BUNDLE_OS".tar.gz --pip-packages-bundle=./artifacts/pip-packages.tar.gz
+    konvoy-image upload artifacts --container-images-dir=./artifacts/images/ \
+                  --os-packages-bundle=./artifacts/"$VERSION"_"$BUNDLE_OS".tar.gz \
+                  --pip-packages-bundle=./artifacts/pip-packages.tar.gz \
+                  --containerd-bundle=artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
     ```
 
 ## Seed your docker registry

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -97,7 +97,7 @@ Using the [Konvoy Image Builder](../../../image-builder), you can copy the requi
     curl --output artifacts/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz --location https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-"$CONTAINERD_OS".tar.gz
     ```
 
-    To get the fips builds append _fips after -x86_64 in the url. To get the fips build for centos-7.9 the url would be
+    To get the fips builds append _fips after -x86_64 in the URL. To get the fips build for `centos-7.9` the URL would be
     https://packages.d2iq.com/dkp/containerd/containerd-1.4.13-d2iq.1-centos-7.9-x86_64_fips.tar.gz
 
     The following OS’s have containerd fips builds:


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->
https://d2iq.atlassian.net/browse/D2IQ-93038

## Description of changes being made
This copies over some instructions from the current docs site for 2.3: https://docs.d2iq.com/dkp/2.3/pre-provisioned-prerequisites-air-gapped#id-(2.3)Pre-provisionedPrerequisitesAir-gapped-Copyair-gappedartifactsontoclusterhosts

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
