### PR TITLE
Missing link to final step in docs to make cluster self managed

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -380,6 +380,8 @@ When you provision the cluster, the configured pod and service subnets will be a
 
 Confirm that your [Calico installation is correct][calico-install].
 
+**Note** When you complete this procedure, move on to [Make Cluster Self-managed](https://docs.d2iq.com/dkp/2.3/pre-provisioned-make-cluster-self-managed) to continue the process.
+
 [calico-install]: #set-the-interface
 [calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods
 [calico-overlay]: https://docs.projectcalico.org/networking/vxlan-ipip

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -380,7 +380,7 @@ When you provision the cluster, the configured pod and service subnets will be a
 
 Confirm that your [Calico installation is correct][calico-install].
 
-**Note** When you complete this procedure, move on to [Make Cluster Self-managed](https://docs.d2iq.com/dkp/2.3/pre-provisioned-make-cluster-self-managed) to continue the process.
+**Note:** When you complete this procedure, move on to [Make Cluster Self-managed](https://archive-docs.d2iq.com/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/self-managed/) to continue the process.
 
 [calico-install]: #set-the-interface
 [calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods

--- a/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/create-cluster/index.md
@@ -380,7 +380,7 @@ When you provision the cluster, the configured pod and service subnets will be a
 
 Confirm that your [Calico installation is correct][calico-install].
 
-**Note:** When you complete this procedure, move on to [Make Cluster Self-managed](https://archive-docs.d2iq.com/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/self-managed/) to continue the process.
+<p class="message--note"><strong>NOTE: </strong>When you complete this procedure, move on to <a href="https://archive-docs.d2iq.com/dkp/konvoy/2.2/choose-infrastructure/pre-provisioned/self-managed/">Make Cluster Self-managed</a> to continue the process.</p>
 
 [calico-install]: #set-the-interface
 [calico-method]: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods


### PR DESCRIPTION
## Jira Ticket
https://d2iq.atlassian.net/browse/D2IQ-92966

Backporting 2.3/2,4 change. This is already approved in Confluence, so just need to merge no review necessary.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4633.s3-website-us-west-2.amazonaws.com/

