### PR TITLE
[Kap] warning on upgrading a Kaptain cluster to 2.x

### DIFF
--- a/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
@@ -12,12 +12,13 @@ enterprise: false
 
 Moving from Konvoy 1.8.x to DKP 2.1.x is not just an upgrade - you are enhancing your existing clusters to use a new architecture. If you currently use Konvoy to manage one cluster, that single-cluster experience continues in DKP 2.1.x, and includes the use of the management tools offered by Kommander. If you currently use Kommander to manage more than one cluster, your multi-cluster experience continues in DKP 2.1.x, with enhanced management and control offered by CAPI.
 
-
 ## Upgrade paths
 
-See the [upgrade table in the DKP 2.3 documentation](https://docs.d2iq.com/dkp/2.3/upgrade-dkp#UpgradeDKP-Supportedupgradepaths) for the full upgrade paths supported. 
+See the [upgrade table in the DKP 2.3 documentation](https://docs.d2iq.com/dkp/2.3/upgrade-dkp#UpgradeDKP-Supportedupgradepaths) for the full upgrade paths supported.
 
 ## Understanding the Major Version Upgrade Process
+
+<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process will possibly get stuck. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
 
 The overall process for upgrading the major version to DKP 2.1 has the following high-level steps:
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
@@ -18,7 +18,7 @@ See the [upgrade table in the DKP 2.3 documentation](https://docs.d2iq.com/dkp/2
 
 ## Understanding the Major Version Upgrade Process
 
-<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process will possibly get stuck. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
+<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process might fail. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
 
 The overall process for upgrading the major version to DKP 2.1 has the following high-level steps:
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
@@ -18,7 +18,7 @@ See the [upgrade table in the DKP 2.3 documentation](https://docs.d2iq.com/dkp/2
 
 ## Understanding the Major Version Upgrade Process
 
-<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process might fail. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
+<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process might fail. For more information on using Kaptain on DKP 2.x, refer to Kaptain's <a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a> documentation.</p>
 
 The overall process for upgrading the major version to DKP 2.1 has the following high-level steps:
 

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/plan/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/plan/index.md
@@ -20,6 +20,6 @@ The following steps represent preparation work that you need to complete before 
 
 1.  **Optional** Create a diagnostics bundle. This is a best practice and will help D2iQ assist in troubleshooting.
 
-<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process might fail. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
+<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process might fail. For more information on using Kaptain on DKP 2.x, refer to Kaptain's <a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a> documentation.</p>
 
 The major version upgrade includes [upgrades to the platform applications](/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps), formerly known as addons, provided with DKP.

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/plan/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/plan/index.md
@@ -20,4 +20,6 @@ The following steps represent preparation work that you need to complete before 
 
 1.  **Optional** Create a diagnostics bundle. This is a best practice and will help D2iQ assist in troubleshooting.
 
+<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process will possibly get stuck. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
+
 The major version upgrade includes [upgrades to the platform applications](/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps), formerly known as addons, provided with DKP.

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/plan/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/plan/index.md
@@ -20,6 +20,6 @@ The following steps represent preparation work that you need to complete before 
 
 1.  **Optional** Create a diagnostics bundle. This is a best practice and will help D2iQ assist in troubleshooting.
 
-<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process will possibly get stuck. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
+<p class="message--warning"><strong>WARNING: </strong>D2iQ does <b>NOT support</b> the upgrade of 1.x clusters to 2.x <b>when Kaptain is enabled</b>. Disable Kaptain before upgrading your clusters to 2.x. Otherwise, your upgrade process might fail. For more information on using Kaptain on DKP 2.x, refer to Kaptain's<a href="https://archive-docs.d2iq.com/dkp/kaptain/2.0.0/fresh-install/">fresh install</a>documentation.</p>
 
 The major version upgrade includes [upgrades to the platform applications](/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps), formerly known as addons, provided with DKP.


### PR DESCRIPTION
## Jira Ticket

https://d2iq.atlassian.net/browse/D2IQ-92075

## Description of changes being made

Upgrading your 1.x installation to 2.1 is not possible when Kaptain is enabled. Since we do not support said migrating Kaptain to 2.x, we decided to add a warning in the Konvoy upgrade docs.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4634.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
