### PR TITLE
Added workaround - 2.1x to 2.2x upgrade Minio failure

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -355,7 +355,7 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
 
 ### Minio Disk insufficient space when upgrading
 
-When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue,  we recommend that you disable the `fluent-bit` Platform Application before upgrading.   
+When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading. 
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -353,6 +353,10 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
     kubectl delete pod -n $WORKSPACE_NAMESPACE $(kubectl get pod -l app.kubernetes.io/name=$SPARK_OPERATOR_RELEASE_NAME -n $WORKSPACE_NAMESPACE -o jsonpath='{range .items[0]}{.metadata.name}')
     ```
 
+### Minio Disk insufficient space when upgrading
+
+If upgrading DKP version 2.1.x to 2.2.x, there is a bug that does not allow upgrading due to insufficient space on the MinIO Disk. To address this issue, disable `fluent-bit` in the `AppDeployments` before upgrading.
+
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].

--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -355,7 +355,7 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
 
 ### Minio Disk insufficient space when upgrading
 
-If upgrading DKP version 2.1.x to 2.2.x, there is a bug that does not allow upgrading due to insufficient space on the MinIO Disk. To address this issue, disable `fluent-bit` in the `AppDeployments` before upgrading.
+When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue,  we recommend that you disable the `fluent-bit` Platform Application before upgrading.   
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -108,6 +108,10 @@ Before attempting to upgrade an existing cluster to this release, check the `kom
 
 If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
 
+### Minio Disk insufficient space when upgrading
+
+If upgrading DKP version 2.1.x to 2.2.x, there is a bug that does not allow upgrading due to insufficient space on the MinIO Disk. To address this issue, disable `fluent-bit` in the `AppDeployments` before upgrading.
+
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -110,7 +110,7 @@ If any of the these fields are present, then there is a possibility the upgrade 
 
 ### Minio Disk insufficient space when upgrading
 
-If upgrading DKP version 2.1.x to 2.2.x, there is a bug that does not allow upgrading due to insufficient space on the MinIO Disk. To address this issue, disable `fluent-bit` in the `AppDeployments` before upgrading.
+When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue,  we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -110,7 +110,7 @@ If any of the these fields are present, then there is a possibility the upgrade 
 
 ### Minio Disk insufficient space when upgrading
 
-When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue,  we recommend that you disable the `fluent-bit` Platform Application before upgrading.
+When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
@@ -61,7 +61,7 @@ The mesosphere/dex-k8s-authenticator docker container now includes the appropria
 
 ### Minio Disk insufficient space when upgrading
 
-If upgrading DKP version 2.1.x to 2.2.x, there is a bug that does not allow upgrading due to insufficient space on the MinIO Disk. To address this issue, disable `fluent-bit` in the `AppDeployments` before upgrading.
+When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue,  we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
 ## Component and Application updates
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
@@ -57,6 +57,12 @@ The DEX Custom Resource Definitions used for configuring LDAP have been updated 
 
 The mesosphere/dex-k8s-authenticator docker container now includes the appropriate binaries that allow users to download the referenced 'konvoy-async-plugin' after configuring a cluster using an external IDP for authentication.
 
+## Known Issues
+
+### Minio Disk insufficient space when upgrading
+
+If upgrading DKP version 2.1.x to 2.2.x, there is a bug that does not allow upgrading due to insufficient space on the MinIO Disk. To address this issue, disable `fluent-bit` in the `AppDeployments` before upgrading.
+
 ## Component and Application updates
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:

--- a/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
@@ -61,7 +61,7 @@ The mesosphere/dex-k8s-authenticator docker container now includes the appropria
 
 ### Minio Disk insufficient space when upgrading
 
-When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue,  we recommend that you disable the `fluent-bit` Platform Application before upgrading.
+When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
 ## Component and Application updates
 


### PR DESCRIPTION
## Jira Ticket

https://d2iq.atlassian.net/browse/D2IQ-89687

## Description of changes being made
Workaround for 2.1x upgrade to 2.2x, when MinIo insufficient space error.
Added to all 2.2x Release Notes.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/