### PR TITLE
docs: adding new version for flatcar

### DIFF
--- a/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
+++ b/pages/dkp/konvoy/2.1/supported-operating-systems/index.md
@@ -23,7 +23,6 @@ Konvoy supports the following base Operating Systems.
 | [RHEL 7.9][rhel_7_9] | 3.10.0-1160.el7.x86_64 | Yes | Yes | Yes |  | Yes | Yes |
 | [RHEL 8.2][rhel_8_2] | 4.18.0-193.6.3.el8_2.x86_64 | Yes | Yes | Yes | Yes | Yes | Yes |
 | [RHEL 8.4][rhel_8_4] | 4.18.0-193.6.3.el8_2.x86_64 | Yes | Yes |  | Yes |  | Yes |
-| [Flatcar][flatcar] | 2905.2.1 |  |  |  |  |  | Yes |
 | [Ubuntu 18.04 (Bionic Beaver)][ubuntu_18] |  | Yes |  |  |  |  | Yes |
 | [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |  | Yes |  |  |  | Yes | Yes |
 | [SUSE Linux Enterprise Server 15][sles_15] |  | Yes |  |  |  | Yes | Yes |
@@ -40,7 +39,7 @@ Konvoy supports the following base Operating Systems.
 | [RHEL 7.9][rhel_7_9] | 3.10.0-1160.el7.x86_64 |  |  |  |  |  | Yes |
 | [RHEL 8.2][rhel_8_2] | 4.18.0-193.6.3.el8_2.x86_64 |  |  |  |  |  | Yes |
 | [RHEL 8.4][rhel_8_4] | 4.18.0-193.6.3.el8_2.x86_64 |  |  |  |  |  | Yes |
-| [Flatcar][flatcar] | 2905.2.1 | Yes |  |  |  |  | Yes |
+| [Flatcar][flatcar] | 2905.2.1,2905.2.6 | Yes |  |  |  |  | Yes |
 | [Ubuntu 20.04 (Focal Fossa)][ubuntu_20] |  |  |  |  |  |  | Yes |
 | [SUSE Linux Enterprise Server 15][sles_15] |  |  |  |  |  |  | Yes |
 


### PR DESCRIPTION
## Jira Ticket

[D2IQ-93481](https://d2iq.atlassian.net/browse/D2IQ-93481)

## Description of changes being made

Updating version of qualified Flatcar to include   OS Image:                   Flatcar Container Linux by Kinvolk 2905.2.6 (Oklo)

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
