### PR TITLE
[Kap]: adding note on not supported certificates

### DIFF
--- a/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
@@ -17,7 +17,7 @@ Configure Kaptain to use the Dex OIDC Provider on a Kommander management cluster
 - The managed cluster is [attached][attached-cluster] to the management cluster (Kommander). (You will need to [create a cluster via Kommander][create-managed-cluster] to have a managed Konvoy cluster.)
 - A Dex Client created on the management cluster.
 
-<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p> 
+<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP Kommander is installed using the default certificate and not a customer-issued or ACME certificate. Otherwise, the installation of Kaptain can  break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later, and DKP versions 2.3 and later.</p> 
 
 ## Kaptain configuration requirements
 

--- a/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
@@ -17,7 +17,7 @@ Configure Kaptain to use the Dex OIDC Provider on a Kommander management cluster
 - The managed cluster is [attached][attached-cluster] to the management cluster (Kommander). (You will need to [create a cluster via Kommander][create-managed-cluster] to have a managed Konvoy cluster.)
 - A Dex Client created on the management cluster.
 
-<p class="message--warning"><strong>WARNING: </strong>Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p> 
+<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p> 
 
 ## Kaptain configuration requirements
 

--- a/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
@@ -17,7 +17,7 @@ Configure Kaptain to use the Dex OIDC Provider on a Kommander management cluster
 - The managed cluster is [attached][attached-cluster] to the management cluster (Kommander). (You will need to [create a cluster via Kommander][create-managed-cluster] to have a managed Konvoy cluster.)
 - A Dex Client created on the management cluster.
 
-<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP Kommander is installed using the default certificate and not a customer-issued or ACME certificate. Otherwise, the installation of Kaptain can  break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later, and DKP versions 2.3 and later.</p> 
+<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP Kommander is installed using the default certificate and not a customer-issued or ACME certificate. Otherwise, the installation of Kaptain can break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later, and DKP versions 2.3 and later.</p> 
 
 ## Kaptain configuration requirements
 

--- a/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
+++ b/pages/dkp/kaptain/2.0.0/configuration/external-dex/index.md
@@ -17,6 +17,8 @@ Configure Kaptain to use the Dex OIDC Provider on a Kommander management cluster
 - The managed cluster is [attached][attached-cluster] to the management cluster (Kommander). (You will need to [create a cluster via Kommander][create-managed-cluster] to have a managed Konvoy cluster.)
 - A Dex Client created on the management cluster.
 
+<p class="message--warning"><strong>WARNING: </strong>Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p> 
+
 ## Kaptain configuration requirements
 
 To use the Kommander Dex instance for authentication with Kaptain you will need to collect the following information:

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -28,7 +28,7 @@ enterprise: false
 
 - Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain **on premises**.
 
-<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP Kommander is installed using the default certificate and not a customer-issued or ACME certificate. Otherwise, the installation of Kaptain can  break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later, and DKP versions 2.3 and later.</p>
+<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP Kommander is installed using the default certificate and not a customer-issued or ACME certificate. Otherwise, the installation of Kaptain can break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later, and DKP versions 2.3 and later.</p>
 
 ### Reference the cluster on which you must execute the commands
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -28,6 +28,8 @@ enterprise: false
 
 - Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain **on premises**.
 
+<p class="message--warning"><strong>WARNING: </strong>Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p>
+
 ### Reference the cluster on which you must execute the commands
 
 You can do this by setting the `KUBECONFIG` environment variable to the appropriate kubeconfig file's location (`KUBECONFIG=clusterKubeconfig.conf`), or by using the `--kubeconfig=cluster_name.conf` flag. For more information, refer to the [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) documentation.

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -28,7 +28,7 @@ enterprise: false
 
 - Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain **on premises**.
 
-<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p>
+<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP Kommander is installed using the default certificate and not a customer-issued or ACME certificate. Otherwise, the installation of Kaptain can  break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later, and DKP versions 2.3 and later.</p>
 
 ### Reference the cluster on which you must execute the commands
 

--- a/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/prerequisites/index.md
@@ -28,7 +28,7 @@ enterprise: false
 
 - Refer to the [on-premise installation](../on-premise/) page, if you are installing Kaptain **on premises**.
 
-<p class="message--warning"><strong>WARNING: </strong>Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p>
+<p class="message--warning"><strong>WARNING:</strong> Ensure that DKP ’s Kommander has been installed using the default certificate and not a customer issued or ACME certificate. Otherwise, the installation of Kaptain will break. Custom and ACME certificates are supported in Kaptain versions 2.2 and later on DKP versions 2.3 and later.</p>
 
 ### Reference the cluster on which you must execute the commands
 


### PR DESCRIPTION
## Jira Ticket

No ticket, but related to:
https://d2iq.atlassian.net/browse/D2IQ-91684
https://d2iq.atlassian.net/browse/D2IQ-91683

## Description of changes being made

Since we have added support for customer-issued and ACME certificates in Kaptain for 2.2, just clarifying that 2.0 and 2.1 don't support it. 
This note was added for 2.1 docs in Confluence already.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4648.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
