### PR TITLE
[DKP] upgrade matrix

### DIFF
--- a/pages/dkp/kommander/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/kommander/2.2/dkp-upgrade/index.md
@@ -11,12 +11,7 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
 
 ## Supported upgrade paths
 
-| From Version | To Version |       |       |
-| :----------: | :--------: | :---: | :---: |
-|    1.8.4     |   1.8.5    | 2.1.0 | 2.1.1 |
-|    1.8.5     |   2.1.0    | 2.1.1 |       |
-|    2.1.0     |   2.2.0    |       |       |
-|    2.1.1     |   2.2.0    |       |       |
+See the [upgrade table](https://docs.d2iq.com/dkp/latest/upgrade-dkp#UpgradeDKP-Supportedupgradepaths) in the documentation of the latest DKP version for the full upgrade paths supported.
 
 ## Understand the upgrade process
 

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/index.md
@@ -11,7 +11,7 @@ The DKP upgrade represents an important step of your environment's lifecycle, as
 
 ## Supported upgrade paths
 
-See the [upgrade table in the DKP 2.3 documentation](https://docs.d2iq.com/dkp/2.3/upgrade-dkp#UpgradeDKP-Supportedupgradepaths) for the full upgrade paths supported. 
+See the [upgrade table](https://docs.d2iq.com/dkp/latest/upgrade-dkp#UpgradeDKP-Supportedupgradepaths) in the documentation of the latest DKP version for the full upgrade paths supported.
 
 ## Understand the upgrade process
 


### PR DESCRIPTION
## Jira Ticket

https://d2iq.atlassian.net/browse/D2IQ-93416

## Description of changes being made

The 2.2 documentation explicitly referred to 2.3 docs for a table of the supported upgrade paths. However, it should reference the `latest` version of DKP instead of 2.4. 

Streamlining to Konvoy and Kommander docs as they were separate and duplicate for 2.2


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
