### PR TITLE
changing 2.1.1 to 2.1.4 D2iq-93808

### DIFF
--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/bootstrap/index.md
@@ -14,13 +14,13 @@ Konvoy deploys all cluster lifecycle services to a bootstrap cluster, which depl
 1.  Download the bootstrap docker image on a machine that has access to this artifact.
 
     ```docker
-    curl -O http://downloads.mesosphere.io/konvoy/airgapped/v2.1.1/konvoy-bootstrap_v2.1.1.tar
+    curl -O http://downloads.mesosphere.io/konvoy/airgapped/v2.1.4/konvoy-bootstrap_v2.1.4.tar
     ```
 
 1.  Load the bootstrap docker image on your bastion machine.
 
     ```docker
-    docker load -i konvoy-bootstrap_v2.1.1.tar
+    docker load -i konvoy-bootstrap_v2.1.4.tar
     ```
 
 1.  Create a bootstrap cluster:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/bootstrap/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/bootstrap/index.md
@@ -14,7 +14,7 @@ Konvoy deploys all cluster lifecycle services to a bootstrap cluster, which depl
 1.  Download the bootstrap docker image on a machine that has access to this artifact.
 
     ```docker
-    curl -O http://downloads.mesosphere.io/konvoy/airgapped/v2.1.4/konvoy-bootstrap_v2.1.4.tar
+    curl -O http://downloads.d2iq.com/konvoy/airgapped/v2.1.4/konvoy-bootstrap_v2.1.4.tar
     ```
 
 1.  Load the bootstrap docker image on your bastion machine.

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/aws/air-gapped/seed-a-registry/index.md
@@ -14,7 +14,7 @@ Before creating a Kubernetes cluster you must have the required images in a loca
 1.  Download the images bundle.
 
     ```bash
-    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/konvoy/airgapped/v2.1.1/konvoy_image_bundle_v2.1.1_linux_amd64.tar.gz
+    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/konvoy/airgapped/v2.1.4/konvoy_image_bundle_v2.1.4_linux_amd64.tar.gz
     ```
 
 

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -13,7 +13,7 @@ beta: false
 1.  Download the bootstrap docker image on a machine that has access to this artifact:
 
     ```docker
-    curl --remote-name http://downloads.mesosphere.io/konvoy/airgapped/v2.1.4/konvoy-bootstrap_v2.1.4.tar
+    curl --remote-name http://downloads.d2iq.com/konvoy/airgapped/v2.1.4/konvoy-bootstrap_v2.1.4.tar
     ```
 
 1.  Load the bootstrap docker image on your bastion machine:

--- a/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
+++ b/pages/dkp/konvoy/2.1/choose-infrastructure/pre-provisioned/prerequisites-airgapped/index.md
@@ -13,13 +13,13 @@ beta: false
 1.  Download the bootstrap docker image on a machine that has access to this artifact:
 
     ```docker
-    curl --remote-name http://downloads.mesosphere.io/konvoy/airgapped/v2.1.1/konvoy-bootstrap_v2.1.1.tar
+    curl --remote-name http://downloads.mesosphere.io/konvoy/airgapped/v2.1.4/konvoy-bootstrap_v2.1.4.tar
     ```
 
 1.  Load the bootstrap docker image on your bastion machine:
 
     ```docker
-    docker load -i konvoy-bootstrap_v2.1.1.tar
+    docker load -i konvoy-bootstrap_v2.1.4.tar
     ```
 
 ## Copy air-gapped artifacts onto cluster hosts
@@ -113,7 +113,7 @@ Before creating a Kubernetes cluster you must have the required images in a loca
 1.  Download the images bundle.
 
     ```bash
-    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/konvoy/airgapped/v2.1.1/konvoy_image_bundle_v2.1.1_linux_amd64.tar.gz
+    curl --output konvoy-image-bundle.tar.gz --location https://downloads.d2iq.com/konvoy/airgapped/v2.1.4/konvoy_image_bundle_v2.1.4_linux_amd64.tar.gz
     ```
 
 1.  Place the bundle in a location where you can load and push the images to your private docker registry.

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/index.md
@@ -24,7 +24,7 @@ The overall process for upgrading the major version to DKP 2.1 has the following
 
 -   Upgrade all clusters to [Konvoy 1.8.3](/dkp/konvoy/1.8/release-notes/1.8.3/), [Konvoy 1.8.4](/dkp/konvoy/1.8/release-notes/1.8.4/), or [Konvoy 1.8.5](/dkp/konvoy/1.8/release-notes/1.8.5/)
 
--   [Download and install DKP 2.1.0 or 2.1.1](../download)
+-   [Download and install the latest version of DKP 2.1.x](../download)
 
 -   [Review the CAPI concepts and terms](capi-concepts-and-terms), and [understand the standard configuration](understand-standard-config)
 


### PR DESCRIPTION
Signed-off-by: Casie 2 <casie2@MacBook-Pro-3.local>

https://d2iq.atlassian.net/browse/D2IQ-93808 

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4655.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
