### PR TITLE
The order of the RN was slightly different - fixes that

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DKP 2.2.3 Release Notes
 title: DKP 2.2.3 Release Notes
-menuWeight: 30
+menuWeight: 40
 excerpt: View release-specific information for DKP 2.2.3
 enterprise: false
 beta: false

--- a/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
@@ -31,9 +31,9 @@ DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster yo
 
 ### Workload clusters cannot be successfully attached when the management cluster uses a custom domain and certificate (D2IQ-93002)
 
-A problem that caused the kommander federation-controller to use system certificates instead of the configured custom certificates was corrected. The federation-controller now uses custom certificates if they are present.  
+A problem that caused the Kommander federation-controller to use system certificates instead of the configured custom certificates was corrected. The federation-controller now uses custom certificates if they are present.  
 
-### Missing Cert-manager images in air-gapped bundles (D2IQ-93002)
+### Missing cert-manager images in air-gapped bundles (D2IQ-93002)
 
 The air-gapped image bundles did not include images for cert-manager, which prevented successful deployment of the platform applications to managed and attached clusters in those environments. The bundle has been updated to include the correct images.
 

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.3/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.3/index.md
@@ -2,7 +2,7 @@
 layout: layout.pug
 navigationTitle: DKP 2.2.3 Release Notes
 title: DKP 2.2.3 Release Notes
-menuWeight: 30
+menuWeight: 40
 excerpt: View release-specific information for DKP 2.2.3
 enterprise: false
 beta: false

--- a/pages/dkp/konvoy/2.2/release-notes/2.2.3/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.3/index.md
@@ -31,11 +31,11 @@ DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster yo
 
 ### Workload clusters cannot be successfully attached when the management cluster uses a custom domain and certificate (D2IQ-93002)
 
-A problem that caused the kommander federation-controller to use system certificates instead of the configured custom certificates was corrected.   The federation-controller now uses custom certificates if they are present.  
+A problem that caused the Kommander federation-controller to use system certificates instead of the configured custom certificates was corrected. The federation-controller now uses custom certificates if they are present.  
 
-### Missing Cert-manager images in airgapped bundles (D2IQ-93002)
+### Missing cert-manager images in air-gapped bundles (D2IQ-93002)
 
-The air-gapped image bundles did not include images for cert-manager, which prevented successful deployment of the platform applications to managed and attached clusters in those environments.   The bundle has been updated to include the correct images.
+The air-gapped image bundles did not include images for cert-manager, which prevented successful deployment of the platform applications to managed and attached clusters in those environments. The bundle has been updated to include the correct images.
 
 ## Component and Application updates
 


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made
Just my own vanity saw this and wanted to change it:
![Screen Shot 2022-10-28 at 4 18 49 PM](https://user-images.githubusercontent.com/5703649/198734602-bd497a6d-c26e-4646-8383-e8617208de3a.png)

The rest was just linting

### Preview
![Screen Shot 2022-10-28 at 4 18 37 PM](https://user-images.githubusercontent.com/5703649/198734616-c397db2a-a3c9-4bc9-b1ef-1c2d09bf8c6f.png)

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4656.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
