### PR TITLE
[Kap]: downloads now available from support site

### DIFF
--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.1/index.md
@@ -32,7 +32,7 @@ Kaptain supports installation on an air-gapped (offline or private) DKP managed 
 
 ### Load the Docker images into your Docker registry
 
-1.  Download the image bundle file:
+1.  Download the image bundle files from the [support portal](https://support.d2iq.com/hc/en-us/articles/4409164864788):
 
     - Download `kaptain-air-gapped-2.0.0.tar.gz` that will contain the required artifacts to perform an air-gapped installation. Extract the image bundle archive and other files before use.
 	  
@@ -77,7 +77,7 @@ Based on the network latency between the environment of script execution, the Do
 
 1.  Ensure the `KUBECONFIG=clusterKubeconfig.conf` is set.
 
-1.  Download the `kaptain-2.0.0.tgz` chart archive from the link obtained from support.
+1.  Download the `kaptain-2.0.0.tgz` chart archive from the [support portal](https://support.d2iq.com/hc/en-us/articles/4409164864788).
 
 1.  Add the following to a file named 'values.yaml' to pass to the helm install with the following contents:
 

--- a/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
+++ b/pages/dkp/kaptain/2.0.0/install/air-gapped-2.2/index.md
@@ -55,7 +55,7 @@ If you added Kaptain after installing DKP, you must make it available by rerunni
 
 ### Load the Docker images into your Docker registry
 
-1.  Download the image bundle file:
+1.  Download the image bundle files from the [support portal](https://support.d2iq.com/hc/en-us/articles/4409164864788):
 
     - Download `kaptain-air-gapped.tar.gz` that will contain the required artifacts to perform an air-gapped installation. Extract the image bundle archive and other files before use:
 
@@ -82,7 +82,7 @@ If you added Kaptain after installing DKP, you must make it available by rerunni
 
     Based on the network latency between the environment of script execution, the Docker registry, and the disk speed, this can take a while to upload all the images to your image registry.
 
-1.  Download the application bundles and chart archive (get links from support)
+1.  Download the application bundles and chart archive from the [support portal](https://support.d2iq.com/hc/en-us/articles/4409164864788).
 
 1.  Extract the application bundle to the location referenced in the Kommander configuration file above.
 


### PR DESCRIPTION
## Jira Ticket

https://d2iq.atlassian.net/browse/D2IQ-93437

## Description of changes being made

Customers can download all air-gapped bundles for Kaptain from the support site. Therefore adding a link from 2.0 docs. 2.1 and 2.2 will be updated in Confluence.

### Preview

http://docs-d2iq-com-pr-<add_pr_##_here>.s3-website-us-west-2.amazonaws.com/

