### PR TITLE
docs: updating 21 migration steps

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -178,7 +178,7 @@ Mesosphere
 mesosphere
 (metallb|Metallb)
 Metalsmith
-middleware
+(middleware|Middleware)
 misconfiguration
 misconfigured
 Mitogen

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
@@ -214,52 +214,7 @@ velero
 
 If there is a timeout error at this step, start `kommander migrate -y` again, and it will eventually continue where this timed out.
 
-When this is complete, you will have to edit a Traefik Middleware in order for Gitea to correctly perform.
-
-To do this, edit the Middleware object:
-
-```bash
-kubectl edit middlewares stripprefixes -nkommander
-```
-
-This file will look something like this:
-
-```yaml
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  annotations:
-    ...
-  name: stripprefixes
-  namespace: kommander
-  ...
-spec:
-  stripPrefix:
-    prefixes:
-    - /dkp/alertmanager
-    - /dkp/api-server
-    - /dkp/kommander/dashboard
-    ...
-```
-
-You will then need to add `/dkp/kommander/git` to the `spec.stripPrefix.prefixes` list:
-
-```yaml
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  ...
-  name: stripprefixes
-  namespace: kommander
-  ...
-spec:
-  stripPrefix:
-    prefixes:
-    ...
-    - /dkp/kommander/git
-```
-
-Then, save this file.
+If you are upgrading to DKP v2.1.4 or below, [check the release notes][traefik-cm-release-notes] you will need to confirm that the Traefik Middleware ConfigMap was updated correctly. If you are on at least DKP v2.1.5, continue below.
 
 Refer to the [Verify installation][verify-install] topic to ensure successful completion.
 
@@ -304,3 +259,4 @@ Refer to the [Verify installation][verify-install] topic to ensure successful co
 
 [download]: ../../../download
 [verify-install]: ../../../install/networked#verify-installation
+[traefik-cm-release-notes]: ../../../release-notes/2.1.4#updating-override-upon-major-version-upgrade-to-ensure-Gitea-functionality

--- a/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
+++ b/pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md
@@ -259,4 +259,4 @@ Refer to the [Verify installation][verify-install] topic to ensure successful co
 
 [download]: ../../../download
 [verify-install]: ../../../install/networked#verify-installation
-[traefik-cm-release-notes]: ../../../release-notes/2.1.4#updating-override-upon-major-version-upgrade-to-ensure-Gitea-functionality
+[traefik-cm-release-notes]: ../../../release-notes/2.1.4#updating-override-upon-major-version-upgrade-to-ensure-gitea-functionality

--- a/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.0/index.md
@@ -222,6 +222,54 @@ To fix the issue on an impacted cluster,  run this command:
 docker run -v <path/to/my_kubeconfig>:/kubeconfig -e KUBECONFIG=/kubeconfig mesosphere/rotate-certificate-hotfix:2.1.1
 ```
 
+### Updating override upon major version upgrade to ensure Gitea functionality
+
+When running the `kommander migrate -y` function is complete, you will have to edit a Traefik Middleware object in order for Gitea to correctly perform.
+
+To do this, edit the ConfigMap that contains the Middleware object:
+
+```bash
+kubectl edit configmap traefik-10.3.0-migration-overrides -nkommander
+```
+
+Search for the yaml snippet that contains the `Middleware` with the name `stripprefixes`. This will look something like this:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    ...
+```
+
+You will then need to add `/dkp/kommander/git` to the `spec.stripPrefix.prefixes` list:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    - /dkp/kommander/git
+```
+
+Then, save this file.
+
 ### Additional resources
 
 <!-- Add links to external documentation as needed -->

--- a/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.1/index.md
@@ -219,6 +219,54 @@ To fix the issue on an impacted cluster,  run this command:
 docker run -v <path/to/my_kubeconfig>:/kubeconfig -e KUBECONFIG=/kubeconfig mesosphere/rotate-certificate-hotfix:2.1.1
 ```
 
+### Updating override upon major version upgrade to ensure Gitea functionality
+
+When running the `kommander migrate -y` function is complete, you will have to edit a Traefik Middleware object in order for Gitea to correctly perform.
+
+To do this, edit the ConfigMap that contains the Middleware object:
+
+```bash
+kubectl edit configmap traefik-10.3.0-migration-overrides -nkommander
+```
+
+Search for the yaml snippet that contains the `Middleware` with the name `stripprefixes`. This will look something like this:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    ...
+```
+
+You will then need to add `/dkp/kommander/git` to the `spec.stripPrefix.prefixes` list:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    - /dkp/kommander/git
+```
+
+Then, save this file.
+
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->

--- a/pages/dkp/kommander/2.1/release-notes/2.1.2/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.2/index.md
@@ -259,6 +259,54 @@ flux reconcile -n kommander-flux source git management --kubeconfig MANAGED_KUBE
 ✔ fetched revision main/GIT_HASH
 ```
 
+### Updating override upon major version upgrade to ensure Gitea functionality
+
+When running the `kommander migrate -y` function is complete, you will have to edit a Traefik Middleware object in order for Gitea to correctly perform.
+
+To do this, edit the ConfigMap that contains the Middleware object:
+
+```bash
+kubectl edit configmap traefik-10.3.0-migration-overrides -nkommander
+```
+
+Search for the yaml snippet that contains the `Middleware` with the name `stripprefixes`. This will look something like this:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    ...
+```
+
+You will then need to add `/dkp/kommander/git` to the `spec.stripPrefix.prefixes` list:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    - /dkp/kommander/git
+```
+
+Then, save this file.
+
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->

--- a/pages/dkp/kommander/2.1/release-notes/2.1.3/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.3/index.md
@@ -123,6 +123,54 @@ flux reconcile -n kommander-flux source git management --kubeconfig MANAGED_KUBE
 ✔ fetched revision main/GIT_HASH
 ```
 
+### Updating override upon major version upgrade to ensure Gitea functionality
+
+When running the `kommander migrate -y` function is complete, you will have to edit a Traefik Middleware object in order for Gitea to correctly perform.
+
+To do this, edit the ConfigMap that contains the Middleware object:
+
+```bash
+kubectl edit configmap traefik-10.3.0-migration-overrides -nkommander
+```
+
+Search for the yaml snippet that contains the `Middleware` with the name `stripprefixes`. This will look something like this:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    ...
+```
+
+You will then need to add `/dkp/kommander/git` to the `spec.stripPrefix.prefixes` list:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    - /dkp/kommander/git
+```
+
+Then, save this file.
+
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->

--- a/pages/dkp/kommander/2.1/release-notes/2.1.4/index.md
+++ b/pages/dkp/kommander/2.1/release-notes/2.1.4/index.md
@@ -117,6 +117,54 @@ flux reconcile -n kommander-flux source git management --kubeconfig MANAGED_KUBE
 ✔ fetched revision main/GIT_HASH
 ```
 
+### Updating override upon major version upgrade to ensure Gitea functionality
+
+When running the `kommander migrate -y` function is complete, you will have to edit a Traefik Middleware object in order for Gitea to correctly perform.
+
+To do this, edit the ConfigMap that contains the Middleware object:
+
+```bash
+kubectl edit configmap traefik-10.3.0-migration-overrides -nkommander
+```
+
+Search for the yaml snippet that contains the `Middleware` with the name `stripprefixes`. This will look something like this:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    ...
+```
+
+You will then need to add `/dkp/kommander/git` to the `spec.stripPrefix.prefixes` list:
+
+```yaml
+              apiVersion: traefik.containo.us/v1alpha1
+              kind: Middleware
+              metadata:
+                name: stripprefixes
+                ...
+              spec:
+                stripPrefix:
+                  prefixes:
+                    - /dkp/alertmanager
+                    - /dkp/api-server
+                    - /dkp/kommander/dashboard
+                    - /dkp/kommander/gitserver
+                    - /dkp/kommander/git
+```
+
+Then, save this file.
+
 ## Additional resources
 
 <!-- Add links to external documentation as needed -->

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/aws/index.md
@@ -46,6 +46,33 @@ After adopting the cluster, you use this AMI to scale up, or replace a failed in
     us-west-2: ami-03364d732f61fb1e2
     ```
 
+    <p class="message--note"><strong>NOTE: </strong>The source AMI may have moved since Konvoy Image Builder v1.5.0 was released. You may need to update the iamge `yaml` file to the following:</p>
+
+    ```yaml
+    cat <<EOF > images/ami/updated-centos-7.yaml
+    download_images: true
+    
+    packer:
+      ami_filter_name: "CentOS Linux 7*"
+      ami_filter_owners: "125523088429"
+      distribution: "CentOS"
+      distribution_version: "7.9"
+      source_ami: ""
+      ssh_username: "centos"
+      root_device_name: "/dev/sda1"
+    
+    build_name: "centos-7"
+    packer_builder_type: "amazon"
+    python_path: ""
+    EOF
+    ```
+
+    Then run the image build command:
+
+    ```bash
+    konvoy-image build images/ami/updated-centos-7.yaml --overrides kubever.yaml
+    ```
+
 1.  Add the new AMI IDs to the Konvoy 1.8 configuration. In the example above the AMI that was created is `ami-03364d732f61fb1e2`. Add a `postAdoptImageID:` to every node pool in `cluster.yaml`, setting its value to the AMI ID created in the previous step:
 
     ```yaml
@@ -144,6 +171,8 @@ The following steps are only required if your cluster is in multiple Availabilit
 1. Tag the Subnets used by the control-plane nodepool with `konvoy/subnet=control_plane`.
 
 ## Create DKP Bootstrap Controllers on Konvoy 1.8 Cluster
+
+Before proceeding with this step, you must download the `dkp` binary and put it in this directory.
 
 You must configure the adopted cluster as self-managed. The bootstrap controllers must successfully deploy on the cluster for it to become self-managed. Do not begin the other cluster adoption steps until this is successful.
 
@@ -463,6 +492,33 @@ You use this AMI to update the cluster Kubernetes version to v1.21.6.
     us-west-2: ami-0e7253eeb699eddca
     ```
 
+    <p class="message--note"><strong>NOTE: </strong>The source AMI may have moved since Konvoy Image Builder v1.5.0 was released. You may need to update the image yaml file to the following:</p>
+
+    ```yaml
+    cat <<EOF > images/ami/updated-centos-7.yaml
+    download_images: true
+    
+    packer:
+      ami_filter_name: "CentOS Linux 7*"
+      ami_filter_owners: "125523088429"
+      distribution: "CentOS"
+      distribution_version: "7.9"
+      source_ami: ""
+      ssh_username: "centos"
+      root_device_name: "/dev/sda1"
+    
+    build_name: "centos-7"
+    packer_builder_type: "amazon"
+    python_path: ""
+    EOF
+    ```
+
+    Then run the image build command:
+
+    ```bash
+    konvoy-image build images/ami/updated-centos-7.yaml --overrides kubever.yaml
+    ```
+
 ## Prepare the Dex Addon for Kubernetes v1.21.6
 
 The Dex Addon acts as the cluster's OpenID Connect identity provider. You must change its configuration so that it works correctly with both Kubernetes v1.21.6 and v1.20.13.
@@ -501,10 +557,10 @@ The Dex Addon acts as the cluster's OpenID Connect identity provider. You must c
           # Temporarily we're going to use our custom built container. Documentation
           # for how to build a new version: https://github.com/mesosphere/dex/blob/v2.27.0-d2iq/README.d2iq.md
           env:
-          - name: KUBERNETES_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+            - name: KUBERNETES_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           image: mesosphere/dex
           ...
     ```
@@ -604,10 +660,10 @@ The Dex Addon acts as the cluster's OpenID Connect identity provider. You must c
     generic-konvoy184-cfe1-control-plane-bnwpn       generic-konvoy184-cfe1   83m     aws:///us-west-2c/i-05482170a16ad0ced   Running   v1.21.6
     generic-konvoy184-cfe1-control-plane-kkjct       generic-konvoy184-cfe1   78m     aws:///us-west-2c/i-02a0d48730c8d3404   Running   v1.21.6
     generic-konvoy184-cfe1-control-plane-nl2fr       generic-konvoy184-cfe1   72m     aws:///us-west-2c/i-04f671f7535bbed72   Running   v1.21.6
-    generic-konvoy184-cfe1-worker-79c76c8fbb-4sp2z   generic-konvoy184-cfe1   7m17s   aws:///us-west-2c/i-095ab521c28558fc8   Running   v1.21.6
-    generic-konvoy184-cfe1-worker-79c76c8fbb-f9c7h   generic-konvoy184-cfe1   11m     aws:///us-west-2c/i-07d3ffe6b542df611   Running   v1.21.6
-    generic-konvoy184-cfe1-worker-79c76c8fbb-hb8vs   generic-konvoy184-cfe1   60m     aws:///us-west-2c/i-0306bcaf8fa3f5e7d   Running   v1.21.6
-    generic-konvoy184-cfe1-worker-79c76c8fbb-nlvml   generic-konvoy184-cfe1   64m     aws:///us-west-2c/i-0426b95370f68d01e   Running   v1.21.6
+    generic-konvoy184-cfe1-worker-79c76c8fbb-4sp2z   generic-konvoy184-cfe1   7m17s   aws:///us-west-2c/i-095ab521c28558fc8   Running   v1.20.13
+    generic-konvoy184-cfe1-worker-79c76c8fbb-f9c7h   generic-konvoy184-cfe1   11m     aws:///us-west-2c/i-07d3ffe6b542df611   Running   v1.20.13
+    generic-konvoy184-cfe1-worker-79c76c8fbb-hb8vs   generic-konvoy184-cfe1   60m     aws:///us-west-2c/i-0306bcaf8fa3f5e7d   Running   v1.20.13
+    generic-konvoy184-cfe1-worker-79c76c8fbb-nlvml   generic-konvoy184-cfe1   64m     aws:///us-west-2c/i-0426b95370f68d01e   Running   v1.20.13
     ```
 
     You can exit this monitoring at any time by pressing CTRL + C.

--- a/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-local-environment/index.md
+++ b/pages/dkp/konvoy/2.1/major-version-upgrade/upgrade/prepare-local-environment/index.md
@@ -125,6 +125,7 @@ enterprise: false
     etcd-encryption-config.yaml
     front-proxy-ca.crt
     front-proxy-ca.key
+    nodes.yaml
     sa.key
     sa.pub
     ```


### PR DESCRIPTION
## Jira Ticket

[D2IQ-94600](https://d2iq.atlassian.net/browse/D2IQ-94600)

## Description of changes being made

There are some other edits, but the gist is in `pages/dkp/kommander/2.1/major-upgrade/upgrade-clusters/migrate-platform-apps/index.md`

Where not everything was getting deployed correctly for migrated clusters re: gitea. This makes it work.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4669.s3-website-us-west-2.amazonaws.com/

## Checklist

- [x] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
