### PR TITLE
Bug: 94862 Calico workaround

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -40,7 +40,7 @@ The following features and capabilities are new for Version 2.2.
 
 ### Integrated DKP Upgrade
 
-You can now upgrade Konvoy and Kommander as a single fluid process using a combination of the [DKP CLI](../cli/dkp) and the UI to upgrade your environment.
+You can now upgrade Konvoy and Kommander as a single fluid process using a combination of the [DKP CLI](../../cli/dkp) and the UI to upgrade your environment.
 
 For more information, see [DKP Upgrade](/dkp/kommander/2.2/dkp-upgrade)
 
@@ -88,7 +88,6 @@ New clusters use the "delete first" strategy by default. Existing clusters are s
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:
 
-
 | Common Application Name | APP ID | Version | Component Versions |
 |----------------------|--------------------- |---------|--------------------|
 | Cert Manager | cert-manager | 1.7.1 | - chart: 1.7.1<br>- cert-manager: 1.7.1 |
@@ -124,7 +123,6 @@ When upgrading to this release, the following services and service components ar
 | Traefik | traefik | 10.9.1 | - chart: 10.9.1<br>- traefik: 2.5.6 |
 | Traefik ForwardAuth | traefik-forward-auth | 0.3.6 | - chart: 0.3.6<br>- traefik-forward-auth: 3.1.0 |
 | Velero | velero | 3.1.5 | - chart: 3.1.5<br>- velero: 1.5.2 |
-
 
 ## Known issues
 
@@ -355,7 +353,7 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
 
 ### Minio Disk insufficient space when upgrading
 
-When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading. 
+When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
 ### Calico not updated during DKP upgrade
 
@@ -365,7 +363,7 @@ Follow these steps to manually correct this issue:
 
 1.  Update the ConfigMap as follows:
 
-    ```
+    ```yaml
     cat <<EOF | kubectl apply -f -
     apiVersion: v1
     data:
@@ -397,7 +395,7 @@ Follow these steps to manually correct this issue:
     EOF
     ```
 
-1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+1.  Execute these commands: `kubectl edit configmap calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -357,6 +357,48 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
 
 When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading. 
 
+### Calico not updated during DKP upgrade
+
+When upgrading a DKP cluster, after what seems to be a successful upgrade, the Calico service might not update as expected and, therefor, is still using the old image. The wrong CNI ClusterResourceSet is being generated and not accounting for Flatcar. This issue only impacts Calico, no other add-ons.
+
+Follow these steps to manually correct this issue:
+
+1.  Update the ConfigMap as follows:
+
+    ```
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    data:
+      custom-resources.yaml: |+
+        # This section includes base Calico installation configuration.
+        # For more information, see: https://docs.projectcalico.org/reference/installation/api
+        apiVersion: operator.tigera.io/v1
+        kind: Installation
+        metadata:
+          name: default
+        spec:
+          # Configures Calico networking.
+          calicoNetwork:
+            # Note: The ipPools section cannot be modified post-install.
+            ipPools:
+            - blockSize: 26
+              cidr: 192.168.0.0/16
+              encapsulation: IPIP
+              natOutgoing: Enabled
+              nodeSelector: all()
+            bgp: Enabled
+            nodeAddressAutodetectionV4:
+              firstFound: true
+          # FlexVolume path must be mounted under /opt on flatcar/coreos systems
+          flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
+    kind: ConfigMap
+    metadata:
+      name: calico-cni-installation-c3-0193d
+    EOF
+    ```
+
+1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -33,13 +33,15 @@ DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster yo
 
 ### ClusterResourceSet deployments create an unbounded number of service-account-tokens (COPS-7267)
 
-An issue with the ClusterResourceSet controller in 2.2.0 caused an unbounded number of service account tokens to be created for each ClusterResourceSet.    The problem has been corrected.   A remediation is also available to identify and remove the excess secrets;  see this [knowledge base](https://support.d2iq.com/hc/en-us/articles/6019137621908-Customer-Advisory-D2iQ-2022-0002-Unbounded-Number-of-Service-Account-Token-Secrets-Created) article for more information.
+An issue with the ClusterResourceSet controller in 2.2.0 caused an unbounded number of service account tokens to be created for each ClusterResourceSet. The problem has been corrected. A remediation is also available to identify and remove the excess secrets;  see this [knowledge base](https://support.d2iq.com/hc/en-us/articles/6019137621908-Customer-Advisory-D2iQ-2022-0002-Unbounded-Number-of-Service-Account-Token-Secrets-Created) article for more information.
 
 ### Certs showing as updated but not reloading in Kommander pods (COPS-7212)
 
 Previous Kommander 2.x versions did not properly handle certificate renewal for the Cluster CA and the certificates that are created for Kommander applications. When the certificates expired, some Kommander applications and pods failed to receive the renewed certificate information, causing them to stop working upon expiration. This problem has been corrected.
 
+<!-- vale Microsoft.HeadingColons = NO -->
 ### kube-oidc-proxy error: certificate signed by unknown authority (COPS-7217)
+<!-- vale Microsoft.HeadingColons = YES -->
 
 When adding a new Attached Cluster to the Management Cluster, using a custom domain and TLS certificate issued by Let's Encrypt, the kube-oidc-proxy helm chart in the Attached Cluster did not complete installation and the associated pod returned an error.
 
@@ -106,7 +108,7 @@ Before attempting to upgrade an existing cluster to this release, check the `kom
 - kommanderAppManagementImageRepository
 - kommanderChartsVersion
 
-If any of the these fields are present, then there is a possibility the upgrade can fail.  If you encounter this situation, file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
+If any of the these fields are present, then there is a possibility the upgrade can fail. If you encounter this situation, file a support ticket for advice on how to remediate the issue before attempting to continue the upgrade.
 
 ### Minio Disk insufficient space when upgrading
 
@@ -120,7 +122,7 @@ Follow these steps to manually correct this issue:
 
 1.  Update the ConfigMap as follows:
 
-    ```
+    ```yaml
     cat <<EOF | kubectl apply -f -
     apiVersion: v1
     data:
@@ -152,7 +154,7 @@ Follow these steps to manually correct this issue:
     EOF
     ```
 
-1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+1.  Execute these commands: `kubectl edit configmap calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -112,6 +112,48 @@ If any of the these fields are present, then there is a possibility the upgrade 
 
 When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
+### Calico not updated during DKP upgrade
+
+When upgrading a DKP cluster, after what seems to be a successful upgrade, the Calico service might not update as expected and, therefor, is still using the old image. The wrong CNI ClusterResourceSet is being generated and not accounting for Flatcar. This issue only impacts Calico, no other add-ons.
+
+Follow these steps to manually correct this issue:
+
+1.  Update the ConfigMap as follows:
+
+    ```
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    data:
+      custom-resources.yaml: |+
+        # This section includes base Calico installation configuration.
+        # For more information, see: https://docs.projectcalico.org/reference/installation/api
+        apiVersion: operator.tigera.io/v1
+        kind: Installation
+        metadata:
+          name: default
+        spec:
+          # Configures Calico networking.
+          calicoNetwork:
+            # Note: The ipPools section cannot be modified post-install.
+            ipPools:
+            - blockSize: 26
+              cidr: 192.168.0.0/16
+              encapsulation: IPIP
+              natOutgoing: Enabled
+              nodeSelector: all()
+            bgp: Enabled
+            nodeAddressAutodetectionV4:
+              firstFound: true
+          # FlexVolume path must be mounted under /opt on flatcar/coreos systems
+          flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
+    kind: ConfigMap
+    metadata:
+      name: calico-cni-installation-c3-0193d
+    EOF
+    ```
+
+1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].

--- a/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
@@ -71,7 +71,7 @@ Follow these steps to manually correct this issue:
 
 1.  Update the ConfigMap as follows:
 
-    ```
+    ```yaml
     cat <<EOF | kubectl apply -f -
     apiVersion: v1
     data:
@@ -103,7 +103,7 @@ Follow these steps to manually correct this issue:
     EOF
     ```
 
-1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+1.  Execute these commands: `kubectl edit configmap calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`.
 
 ## Component and Application updates
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
@@ -63,6 +63,48 @@ The mesosphere/dex-k8s-authenticator docker container now includes the appropria
 
 When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
+### Calico not updated during DKP upgrade
+
+When upgrading a DKP cluster, after what seems to be a successful upgrade, the Calico service might not update as expected and, therefor, is still using the old image. The wrong CNI ClusterResourceSet is being generated and not accounting for Flatcar. This issue only impacts Calico, no other add-ons.
+
+Follow these steps to manually correct this issue:
+
+1.  Update the ConfigMap as follows:
+
+    ```
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    data:
+      custom-resources.yaml: |+
+        # This section includes base Calico installation configuration.
+        # For more information, see: https://docs.projectcalico.org/reference/installation/api
+        apiVersion: operator.tigera.io/v1
+        kind: Installation
+        metadata:
+          name: default
+        spec:
+          # Configures Calico networking.
+          calicoNetwork:
+            # Note: The ipPools section cannot be modified post-install.
+            ipPools:
+            - blockSize: 26
+              cidr: 192.168.0.0/16
+              encapsulation: IPIP
+              natOutgoing: Enabled
+              nodeSelector: all()
+            bgp: Enabled
+            nodeAddressAutodetectionV4:
+              firstFound: true
+          # FlexVolume path must be mounted under /opt on flatcar/coreos systems
+          flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
+    kind: ConfigMap
+    metadata:
+      name: calico-cni-installation-c3-0193d
+    EOF
+    ```
+
+1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+
 ## Component and Application updates
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:

--- a/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
@@ -29,11 +29,13 @@ DKP 2.2.x supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster yo
 
 ## Fixes and Improvements
 
+<!-- vale Vale.Avoid = NO -->
 ### Workload clusters cannot be successfully attached when the management cluster uses a custom domain and certificate (D2IQ-93002)
 
 A problem that caused the Kommander federation-controller to use system certificates instead of the configured custom certificates was corrected. The federation-controller now uses custom certificates if they are present.  
 
 ### Missing cert-manager images in air-gapped bundles (D2IQ-93002)
+<!-- vale Vale.Avoid = YES -->
 
 The air-gapped image bundles did not include images for cert-manager, which prevented successful deployment of the platform applications to managed and attached clusters in those environments. The bundle has been updated to include the correct images.
 
@@ -102,7 +104,7 @@ Follow these steps to manually correct this issue:
 
 1.  Update the ConfigMap as follows:
 
-    ```
+    ```yaml
     cat <<EOF | kubectl apply -f -
     apiVersion: v1
     data:
@@ -134,7 +136,7 @@ Follow these steps to manually correct this issue:
     EOF
     ```
 
-1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+1.  Execute these commands: `kubectl edit configmap calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`.
 
 ## Additional resources
 

--- a/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.3/index.md
@@ -90,6 +90,52 @@ When upgrading to this release, the following services and service components ar
 | Traefik ForwardAuth | traefik-forward-auth | 0.3.8 | - chart: 0.3.8<br>- traefik-forward-auth: 3.1.0 |
 | Velero | velero | 3.1.5 | - chart: 3.1.5<br>- velero: 1.5.2 |
 
+## Known Issues
+
+The following items are known issues with this release.
+
+### Calico not updated during DKP upgrade
+
+When upgrading a DKP cluster, after what seems to be a successful upgrade, the Calico service might not update as expected and, therefor, is still using the old image. The wrong CNI ClusterResourceSet is being generated and not accounting for Flatcar. This issue only impacts Calico, no other add-ons.
+
+Follow these steps to manually correct this issue:
+
+1.  Update the ConfigMap as follows:
+
+    ```
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    data:
+      custom-resources.yaml: |+
+        # This section includes base Calico installation configuration.
+        # For more information, see: https://docs.projectcalico.org/reference/installation/api
+        apiVersion: operator.tigera.io/v1
+        kind: Installation
+        metadata:
+          name: default
+        spec:
+          # Configures Calico networking.
+          calicoNetwork:
+            # Note: The ipPools section cannot be modified post-install.
+            ipPools:
+            - blockSize: 26
+              cidr: 192.168.0.0/16
+              encapsulation: IPIP
+              natOutgoing: Enabled
+              nodeSelector: all()
+            bgp: Enabled
+            nodeAddressAutodetectionV4:
+              firstFound: true
+          # FlexVolume path must be mounted under /opt on flatcar/coreos systems
+          flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
+    kind: ConfigMap
+    metadata:
+      name: calico-cni-installation-c3-0193d
+    EOF
+    ```
+
+1.  Execute these commands: `kubectl edit calico-cni-installation-c3-0193d` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
+
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].


### PR DESCRIPTION
C

https://d2iq.atlassian.net/browse/D2IQ-94862

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4672.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
