### PR TITLE
docs: removing fix for calico in 2x

### DIFF
--- a/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.0/index.md
@@ -355,50 +355,6 @@ Upgrading catalog applications using Spark Operator can fail when running `dkp u
 
 When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
-### Calico not updated during DKP upgrade on Flatcar
-
-When upgrading a DKP cluster running on Flatcar OS, you may find that after the upgrade the Calico services were not updated. This occurs because the upgrade procedure is not correctly updating the Flatcar specific CNI ClusterResourceSet(CRS). This issue only impacts the Calico CRS.
-
-Follow these steps to manually correct this issue:
-
-1.  Update the ConfigMap as follows:
-
-    ```yaml
-    cat <<EOF | kubectl apply -f -
-    apiVersion: v1
-    data:
-      custom-resources.yaml: |+
-        # This section includes base Calico installation configuration.
-        # For more information, see: https://docs.projectcalico.org/reference/installation/api
-        apiVersion: operator.tigera.io/v1
-        kind: Installation
-        metadata:
-          name: default
-        spec:
-          # Configures Calico networking.
-          calicoNetwork:
-            # Note: The ipPools section cannot be modified post-install.
-            ipPools:
-            - blockSize: 26
-              cidr: 192.168.0.0/16
-              encapsulation: IPIP
-              natOutgoing: Enabled
-              nodeSelector: all()
-            bgp: Enabled
-            nodeAddressAutodetectionV4:
-              firstFound: true
-          # FlexVolume path must be mounted under /opt on flatcar/coreos systems
-          flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
-    kind: ConfigMap
-    metadata:
-      name: calico-cni-installation-$CLUSTER_NAME
-    EOF
-    ```
-
-1.  Run these commands: 
-
-`kubectl edit clusterresourceset calico-cni-installation-$CLUSTER_NAME` and update `spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`.
-
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].

--- a/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.1/index.md
@@ -114,54 +114,6 @@ If any of the these fields are present, the upgrade can fail. If you encounter t
 
 When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
-### Calico not updated during DKP upgrade on Flatcar
-
-When upgrading a DKP cluster running on Flatcar OS, you may find that after the upgrade the Calico services were not updated. This occurs because the upgrade procedure is not correctly updating the Flatcar specific CNI ClusterResourceSet(CRS). This issue only impacts the Calico CRS.
-
-Follow these steps to manually correct this issue:
-
-1.  Update the ConfigMap as follows:
-
-    ```yaml
-    cat <<EOF | kubectl apply -f -
-    apiVersion: v1
-    data:
-      custom-resources.yaml: |+
-        # This section includes base Calico installation configuration.
-        # For more information, see: https://docs.projectcalico.org/reference/installation/api
-        apiVersion: operator.tigera.io/v1
-        kind: Installation
-        metadata:
-          name: default
-        spec:
-          # Configures Calico networking.
-          calicoNetwork:
-            # Note: The ipPools section cannot be modified post-install.
-            ipPools:
-            - blockSize: 26
-              cidr: 192.168.0.0/16
-              encapsulation: IPIP
-              natOutgoing: Enabled
-              nodeSelector: all()
-            bgp: Enabled
-            nodeAddressAutodetectionV4:
-              firstFound: true
-          # FlexVolume path must be mounted under /opt on flatcar/coreos systems
-          flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
-    kind: ConfigMap
-    metadata:
-      name: calico-cni-installation-$CLUSTER_NAME
-    EOF
-    ```
-
-1.  Run these commands: 
-
-`kubectl edit clusterresourceset calico-cni-installation-$CLUSTER_NAME` 
-
-and update 
-
-`spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`
-
 ## Additional resources
 
 For more information about working with native Kubernetes, see the [Kubernetes documentation][kubernetes-doc].

--- a/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
+++ b/pages/dkp/kommander/2.2/release-notes/2.2.2/index.md
@@ -63,54 +63,6 @@ The mesosphere/dex-k8s-authenticator docker container now includes the appropria
 
 When upgrading DKP from v2.1.x to v2.2.x, the upgrade can fail due to insufficient space on the MinIO Disk. To avoid this issue, we recommend that you disable the `fluent-bit` Platform Application before upgrading.
 
-### Calico not updated during DKP upgrade on Flatcar
-
-When upgrading a DKP cluster running on Flatcar OS, you may find that after the upgrade the Calico services were not updated. This occurs because the upgrade procedure is not correctly updating the Flatcar specific CNI ClusterResourceSet(CRS). This issue only impacts the Calico CRS.
-
-Follow these steps to manually correct this issue:
-
-1.  Update the ConfigMap as follows:
-
-    ```yaml
-    cat <<EOF | kubectl apply -f -
-    apiVersion: v1
-    data:
-      custom-resources.yaml: |+
-        # This section includes base Calico installation configuration.
-        # For more information, see: https://docs.projectcalico.org/reference/installation/api
-        apiVersion: operator.tigera.io/v1
-        kind: Installation
-        metadata:
-          name: default
-        spec:
-          # Configures Calico networking.
-          calicoNetwork:
-            # Note: The ipPools section cannot be modified post-install.
-            ipPools:
-            - blockSize: 26
-              cidr: 192.168.0.0/16
-              encapsulation: IPIP
-              natOutgoing: Enabled
-              nodeSelector: all()
-            bgp: Enabled
-            nodeAddressAutodetectionV4:
-              firstFound: true
-          # FlexVolume path must be mounted under /opt on flatcar/coreos systems
-          flexVolumePath: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/
-    kind: ConfigMap
-    metadata:
-      name: calico-cni-installation-$CLUSTER_NAME
-    EOF
-    ```
-
-Run these commands: 
-
-`kubectl edit clusterresourceset calico-cni-installation-$CLUSTER_NAME` 
-
-and update 
-
-`spec.clusterSelector.matchLabels.konvoy.d2iq.io/osHint` to `konvoy.d2iq.io/osHint: flatcar`.
-
 ## Component and Application updates
 
 When upgrading to this release, the following services and service components are upgraded to the listed version:


### PR DESCRIPTION
## Jira Ticket

Undoing the changes found here:
https://github.com/mesosphere/dcos-docs-site/pull/4676/files

Under advisement from @dkoshkin 
https://d2iq.atlassian.net/browse/D2IQ-94862

## Description of changes being made
Undoing the manual fix in the Release Notes

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4678.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
