### PR TITLE
docs: added dkp v2.2.3 to kib docs

### DIFF
--- a/pages/dkp/konvoy/2.2/image-builder/index.md
+++ b/pages/dkp/konvoy/2.2/image-builder/index.md
@@ -12,18 +12,18 @@ Konvoy Image Builder (KIB) is a complete solution for building
 
 This section describes how to use the KIB to create a Cluster API compliant machine images. Machine images contain configuration information and software to create a specific, pre-configured, operating environment. For example, you can create an image of your current computer system settings and software. The machine image can then be replicated and distributed, creating your computer system for other users. The KIB uses variable overrides to specify base image and container images to use in your new machine image.
 
-
 ## Compatible versions
-Along with the KIB Bundle, we publish a file containing checksums for the bundle files.  The recommendation for using these checksums is to verify the integrity of the downloads.
 
+Along with the KIB Bundle, we publish a file containing checksums for the bundle files. The recommendation for using these checksums is to verify the integrity of the downloads.
 
-| DKP Version | KIB Version | 
+| DKP Version | KIB Version          |
 |-------------|----------------------|
-| v2.2.2      | v1.17.2 |
-| v2.2.1      | v1.13.2 |
-| v2.2.0      | v1.11.0 |
-| v2.1.x      | v1.5.0 |
+| v2.2.3      | v1.17.4              |
+| v2.2.2      | v1.17.4              |
+| v2.2.1      | v1.13.2              |
+| v2.2.0      | v1.11.0              |
+| v2.1.x      | v1.5.0               |
 
 [KIB Version download release center](https://github.com/mesosphere/konvoy-image-builder/releases)
 
-KIB will run and print out the name of the created image for your infrastructure provider as shown on specific provider pages below.   Use this name when creating a Kubernetes cluster.
+KIB will run and print out the name of the created image for your infrastructure provider as shown on specific provider pages below. Use this name when creating a Kubernetes cluster.


### PR DESCRIPTION
## Jira Ticket

Keeping pace with the release that dropped a bit ago.

## Description of changes being made
Adding new row in KIB Version table to include DKP v2.2.3

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4681.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
