### PR TITLE
docs: updated default version of kubernetes

### DIFF
--- a/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
+++ b/pages/dkp/konvoy/2.2/release-notes/2.2.0/index.md
@@ -30,9 +30,9 @@ DKP 2.2 supports Kubernetes versions between 1.21.0 and 1.22.x. Any cluster you 
 
 | Kubernetes Support | Version |
 | ------------------ | ------- |
-|**Minimum** | 1.21.0 |
-|**Maximum** | 1.22.x |
-|**Default** | 1.22.0|
+| **Minimum**        | 1.21.0  |
+| **Maximum**        | 1.22.x  |
+| **Default**        | 1.22.8  |
 
 ## New features and capabilities
 


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

Default version of Kubernetes is incorrect in the 2.2.0 release notes.
It is actually v1.22.8

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4685.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
