### PR TITLE
DKP 2.1: Added workarounds to Configure HTTP Proxy page

### DIFF
--- a/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
@@ -79,7 +79,6 @@ Gatekeeper acts as a [Kubernetes mutating webhook](https://kubernetes.io/docs/re
     kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
-
 ## Create Gatekeeper ConfigMap in the kommander namespace
 
 To configure Gatekeeper so that these environment variables are mutated in the pods, create the following `gatekeeper-overrides` ConfigMap in the `kommander` Workspace you created in a previous step:
@@ -139,16 +138,13 @@ To ensure that core components work correctly, always add these addresses to the
 </p>
 
 <p class="message--important"><strong>IMPORTANT: </strong>The <code>NO_PROXY</code> variable contains the Kubernetes Services CIDR. This example uses the default CIDR, <code>10.96.0.0/12</code>. If your cluster's CIDR is different, update the value in <code>NO_PROXY</code>.
-
-Based on the order in which the Gatekeeper Deployment is Ready (in relation to other Deployments), not all the core services are guaranteed to be mutated with the proxy environment variables. Only the user deployed workloads are guaranteed to be mutated with the proxy environment variables. If you need a core service to be mutated with your proxy environment variables, you can restart the AppDeployment for that core service.
-</p>
-
+<br /><br />Based on the order in which the Gatekeeper Deployment is Ready (in relation to other Deployments), not all the core services are guaranteed to be mutated with the proxy environment variables. Only the user deployed workloads are guaranteed to be mutated with the proxy environment variables. If you need a core service to be mutated with your proxy environment variables, you can restart the AppDeployment for that core service.</p>
 
 ## Install Kommander
 
 Kommander installs with a dedicated CLI.
 
-NOTE: To ensure Kommander is installed on the workload cluster, use the `--kubeconfig=cluster_name.conf` flag.
+**NOTE:** To ensure Kommander is installed on the workload cluster, use the `--kubeconfig=<cluster_name>.conf` flag.
 
 1. Install Kommander using the configuration files and ConfigMap from previous steps:
 
@@ -215,7 +211,7 @@ data:
 EOF
 ```
 
-Set the `httpProxy` and `httpsProxy` environment variables to the address of the HTTP and HTTPS proxy server, respectively. Set the `noProxy` environment variable to the addresses that should be accessed directly, not through the proxy. The list of the recommended settings is in the section, _HTTP Proxy Configuration Considerations_ above.
+Set the `httpProxy` and `httpsProxy` environment variables to the address of the HTTP and HTTPS proxy server, respectively. Set the `noProxy` environment variable to the addresses that should be accessed directly, not through the proxy. The list of the recommended settings is in the section, [_HTTP Proxy Configuration Considerations_](#http-proxy-configuration-considerations) above.
 
 # Configure your applications
 
@@ -227,10 +223,9 @@ In a default installation with `gatekeeper` enabled, you can have proxy environm
 
 No further manual changes are required.
 
-
 ## Manually configure your application
 
-<p class="message--important"><strong>IMPORTANT:</strong> If Gatekeeper is not installed, and you need to use an HTTP proxy, you must manually configure your applications. </p>
+<p class="message--important"><strong>IMPORTANT:</strong> If Gatekeeper is not installed, and you need to use an HTTP proxy, you must manually configure your applications.</p>
 
 Some applications follow the convention of `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
 

--- a/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
+++ b/pages/dkp/kommander/2.1/install/configuration/http-proxy/index.md
@@ -27,12 +27,10 @@ In the examples below:
 
 1. The `curl` command-line tool is available on the host.
 1. The proxy server address is `http://proxy.company.com:3128`.
-1. The proxy server address uses the `http` scheme.
+1. The HTTP and HTTPS proxy server addresses use the `http` scheme.
 1. The proxy server can reach `www.google.com` using HTTP or HTTPS.
 
-## Verify the cluster nodes can access the Internet through the proxy server
-
-On each cluster node, run:
+Verify the cluster nodes can access the Internet through the proxy server. On each cluster node, run:
 
 ```bash
 curl --proxy http://proxy.company.com:3128 --head http://www.google.com
@@ -45,17 +43,15 @@ If the proxy is working for HTTP and HTTPS, respectively, the `curl` command ret
 
 Gatekeeper acts as a [Kubernetes mutating webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook). You can use this to mutate the Pod resources with `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.
 
-Kommander installs with a dedicated CLI.
-
-1. Create (if necessary) and update the Kommander installation configuration file. If one does not already exist, then create it using the following commands:
+1. Create (if necessary) or update the Kommander installation configuration file. If one does not already exist, then create it using the following commands:
 
     ```bash
     ./kommander install --init > install.yaml
     ```
 
-1. Append the `apps` section in `install.yaml` with the following values to enable Gatekeeper and configure it to add HTTP proxy settings to the pods.
+1. Append this `apps` section to the `install.yaml` file with the following values to enable Gatekeeper and configure it to add HTTP proxy settings to the pods.
 
-   <p class="message--note"><strong>NOTE: </strong>Only pods created after applying this setting will be mutated. Also, this will only impact pods in the namespace with the <code>"gatekeeper.d2iq.com/mutate=pod-proxy"</code> label.</p>
+   <p class="message--note"><strong>NOTE: </strong>Only pods created after applying this setting will be mutated. Also, this will affect impact pods in the namespace with the <code>"gatekeeper.d2iq.com/mutate=pod-proxy"</code> label.</p>
 
     ```yaml
     apps:
@@ -73,7 +69,7 @@ Kommander installs with a dedicated CLI.
               "gatekeeper.d2iq.com/mutate": "pod-proxy"
     ```
 
-1.  You can create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed, and then label them so the Gatekeeper mutation is active on the namespaces.
+1.  Create the `kommander` and `kommander-flux` namespaces, or the namespace where Kommander will be installed. Label the namespaces to activate the Gatekeeper mutation on them:
 
     ```bash
     kubectl create namespace kommander
@@ -83,30 +79,101 @@ Kommander installs with a dedicated CLI.
     kubectl label namespace kommander-flux gatekeeper.d2iq.com/mutate=pod-proxy
     ```
 
-1. Install Kommander using the above configuration file:
+
+## Create Gatekeeper ConfigMap in the kommander namespace
+
+To configure Gatekeeper so that these environment variables are mutated in the pods, create the following `gatekeeper-overrides` ConfigMap in the `kommander` Workspace you created in a previous step:
+
+```bash
+export NAMESPACE=kommander
+```
+
+```yaml
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatekeeper-overrides
+  namespace: ${NAMESPACE}
+data:
+  values.yaml: |
+    ---
+    # enable mutations
+    mutations:
+      enable: true
+      enablePodProxy: true
+      podProxySettings:
+        noProxy: "127.0.0.1,192.168.0.0/16,10.0.0.0/16,10.96.0.0/12,169.254.169.254,169.254.0.0/24,localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.default.svc.cluster.local,.svc,.svc.cluster,.svc.cluster.local,.svc.cluster.local.,kubecost-prometheus-server.kommander,logging-operator-logging-fluentd.kommander.svc,elb.amazonaws.com"
+        httpProxy: "http://proxy.company.com:3128"
+        httpsProxy: "http://proxy.company.com:3128"
+      excludeNamespacesFromProxy: []
+      namespaceSelectorForProxy:
+        "gatekeeper.d2iq.com/mutate": "pod-proxy"
+EOF
+```
+
+Set the `httpProxy` and `httpsProxy` environment variables to the address of the HTTP and HTTPS proxy server, respectively. Set the `noProxy` environment variable to the addresses that should be accessed directly, not through the proxy.
+
+Performing this step before installing Kommander allows the Flux components to respect the proxy configuration in this ConfigMap.
+
+## HTTP Proxy Configuration Considerations
+
+To ensure that core components work correctly, always add these addresses to the <code>noProxy</code>:
+  <ul>
+      <li>Loopback addresses (<code>127.0.0.1</code> and <code>localhost</code>)</li>
+      <li>Kubernetes API Server addresses</li>
+      <li> Kubernetes Pod IPs (for example, <code>192.168.0.0/16</code>). This comes from two places:
+        <ul>
+        <li>Calico pod CIDR - Defaults to <code>192.168.0.0/16</code></li>
+        <li>The <code>podSubnet</code> is configured in CAPI objects and needs to match above Calico's - Defaults to <code>192.168.0.0/16</code> (same as above)</li>
+        </ul>
+      </li>
+      <li>Kubernetes Service addresses (for example, <code>10.96.0.0/12</code>, <code>kubernetes</code>, <code>kubernetes.default</code>, <code>kubernetes.default.svc</code>, <code>kubernetes.default.svc.cluster</code>, <code>kubernetes.default.svc.cluster.local</code>, <code>.svc</code>, <code>.svc.cluster</code>, <code>.svc.cluster.local</code>, <code>.svc.cluster.local.</code>)</li>
+      <li>Auto-IP addresses <code>169.254.169.254,169.254.0.0/24</code></li>
+  </ul>
+  In addition to the values above, the following settings are needed when installing on AWS:
+  <ul>
+    <li>The default VPC CIDR range of <code>10.0.0.0/16</code> </li>
+    <li><code>kube-apiserver</code> internal/external ELB address</li>
+  </ul>
+</p>
+
+<p class="message--important"><strong>IMPORTANT: </strong>The <code>NO_PROXY</code> variable contains the Kubernetes Services CIDR. This example uses the default CIDR, <code>10.96.0.0/12</code>. If your cluster's CIDR is different, update the value in <code>NO_PROXY</code>.
+
+Based on the order in which the Gatekeeper Deployment is Ready (in relation to other Deployments), not all the core services are guaranteed to be mutated with the proxy environment variables. Only the user deployed workloads are guaranteed to be mutated with the proxy environment variables. If you need a core service to be mutated with your proxy environment variables, you can restart the AppDeployment for that core service.
+</p>
+
+
+## Install Kommander
+
+Kommander installs with a dedicated CLI.
+
+NOTE: To ensure Kommander is installed on the workload cluster, use the `--kubeconfig=cluster_name.conf` flag.
+
+1. Install Kommander using the configuration files and ConfigMap from previous steps:
 
     ```bash
     ./kommander install --installer-config ./install.yaml
     ```
 
-# Configure Workspace (or Project) in which you want to use proxy
+# Configure Workspace or Project
 
-To have Gatekeeper mutate the manifests, create the `Workspace` (or `Project`) with the following label:
+Configure the Workspace or Project in which you want to use the proxy. To have Gatekeeper mutate the manifests, create the `Workspace` (or `Project`) with the following label:
 
 ```yaml
 labels:
   gatekeeper.d2iq.com/mutate: "pod-proxy"
 ```
 
-This can be done when creating the Workspace (or Project) from the UI OR by running the following command from the CLI once the namespace is created:
+This can be done when creating the Workspace (or Project) from the UI, or by running the following command from the CLI after the namespace is created:
 
 ```bash
 kubectl label namespace <NAMESPACE> "gatekeeper.d2iq.com/mutate=pod-proxy"
 ```
 
-## Configure attached clusters with proxy configuration
+## Configure HTTP Proxy in Attached Clusters
 
-In order to ensure that Gatekeeper is deployed before everything else in the attached clusters, you must manually create the exact namespace of the workspace in which the cluster is going to be attached, before attaching the cluster:
+To ensure that Gatekeeper is deployed before everything else in the attached clusters, you must manually create the exact Namespace of the Workspace in which the cluster is going to be attached, _before_ attaching the cluster:
 
 Execute the following command in the attached cluster before attaching it to the host cluster:
 
@@ -114,11 +181,11 @@ Execute the following command in the attached cluster before attaching it to the
 kubectl create namespace <NAMESPACE>
 ```
 
-Then, to configure the pods in this namespace to use proxy configuration, create the `gatekeeper-overrides` configmap described in the next section before attaching the cluster to the host cluster. You must label the workspace with `gatekeeper.d2iq.com/mutate=pod-proxy` when creating it so that Gatekeeper deploys a `validatingwebhook` to mutate the pods with proxy configuration.
+Then, to configure the pods in this namespace to use proxy configuration, you must label the Workspace with `gatekeeper.d2iq.com/mutate=pod-proxy` when creating it so that Gatekeeper deploys a `ValidatingWebhook` to mutate the pods with proxy configuration.
 
-## Create Gatekeeper configmap in Workspace namespace
+## Create Gatekeeper ConfigMap in the Workspace Namespace
 
-To configure Gatekeeper such that these environment variables are mutated in the pods, create the following configmap in the target Workspace:
+To configure Gatekeeper so that these environment variables are mutated in the pods, create the following `gatekeeper-overrides` ConfigMap in the Workspace Namespace:
 
 ```bash
 export NAMESPACE=<workspace-namespace>
@@ -148,36 +215,7 @@ data:
 EOF
 ```
 
-Set the `httpProxy` and `httpsProxy` environment variables to the address of the HTTP and HTTPS proxy server, respectively. Set the `noProxy` environment variable to the addresses that should be accessed directly, not through the proxy.
-
-<p class="message--important"><strong>IMPORTANT: </strong>Both the HTTP and HTTPS proxy server address must use the <code>http</code> scheme.</p>
-
-<p class="message--note">
-<strong>NOTE: </strong>To ensure that core components work correctly, always add these addresses to the <code>noProxy</code>:
-  <ul>
-      <li>Loopback addresses (<code>127.0.0.1</code> and <code>localhost</code>)</li>
-      <li>Kubernetes API Server addresses</li>
-      <li> Kubernetes Pod IPs (for example, <code>192.168.0.0/16</code>). This comes from two places:
-        <ul>
-        <li>Calico pod CIDR - Defaults to <code>192.168.0.0/16</code></li>
-        <li>The <code>podSubnet</code> is configured in CAPI objects and needs to match above Calico's - Defaults to <code>192.168.0.0/16</code> (same as above)</li>
-        </ul>
-      </li>
-      <li>Kubernetes Service addresses (for example, <code>10.96.0.0/12</code>, <code>kubernetes</code>, <code>kubernetes.default</code>, <code>kubernetes.default.svc</code>, <code>kubernetes.default.svc.cluster</code>, <code>kubernetes.default.svc.cluster.local</code>, <code>.svc</code>, <code>.svc.cluster</code>, <code>.svc.cluster.local</code>, <code>.svc.cluster.local.</code>)</li>
-      <li>Auto-IP addresses <code>169.254.169.254,169.254.0.0/24</code></li>
-  </ul>
-  In addition to above, following are needed when installing on AWS:
-  <ul>
-    <li>The default VPC CIDR range of <code>10.0.0.0/16</code> </li>
-    <li><code>kube-apiserver</code> internal/external ELB address</li>
-  </ul>
-</p>
-
-<p class="message--important"><strong>IMPORTANT: </strong>The <code>NO_PROXY</code> variable contains the Kubernetes Services CIDR. This example uses the default CIDR, <code>10.96.0.0/12</code>. If your cluster's CIDR is different, update the value in <code>NO_PROXY</code>.</p>
-
-<p class="message--note">
-<strong>LIMITATION: </strong> Based on the order in which the Gatekeeper Deployment is Ready (in relation to other Deployments), not all the core services are guaranteed to be mutated with the proxy environment variables. Only the user deployed workloads are guaranteed to be mutated with the proxy environment variables. If you need a core service to be mutated with your proxy environment variables, you can restart the AppDeployment for that core service. This behavior will be fixed in a future release of Kommander.
-</p>
+Set the `httpProxy` and `httpsProxy` environment variables to the address of the HTTP and HTTPS proxy server, respectively. Set the `noProxy` environment variable to the addresses that should be accessed directly, not through the proxy. The list of the recommended settings is in the section, _HTTP Proxy Configuration Considerations_ above.
 
 # Configure your applications
 
@@ -189,9 +227,10 @@ In a default installation with `gatekeeper` enabled, you can have proxy environm
 
 No further manual changes are required.
 
-<p class="message--important"><strong>IMPORTANT:</strong> If Gatekeeper is not installed, and you need to use an HTTP proxy you must manually configure your applications as described further in this section. </p>
 
 ## Manually configure your application
+
+<p class="message--important"><strong>IMPORTANT:</strong> If Gatekeeper is not installed, and you need to use an HTTP proxy, you must manually configure your applications. </p>
 
 Some applications follow the convention of `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
 


### PR DESCRIPTION
## Jira Ticket - https://d2iq.atlassian.net/browse/D2IQ-95415 

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made
Added workarounds for getting past the chicken & egg situation described in the Jira ticket. Changes made in 2.1-2.5.

Both of the two reviewers named at the right have already reviewed this content prior to backporting.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4688.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
