### PR TITLE
docs: add v2.5.0 to security updates page

### DIFF
--- a/pages/dkp/security-updates/index.md
+++ b/pages/dkp/security-updates/index.md
@@ -9,5 +9,15 @@ beta: false
 
 The following information describes mitigated or fixed CVEs found in DKP.
 
+## Download
+
+| Product | Version | Link     |
+|---------|---------|----------|
+| DKP     | v2.5.0  | [Download][dkp-v2.5.0-csv] |
+
+## Previous versions
+
 <div class="cve-table-container">Loading...</div>
 <script src="/js/cve.js"></script>
+
+[dkp-v2.5.0-csv]: https://konvoy-staging-devx-cac8-cve-reporter.s3-us-west-2.amazonaws.com/v2.5.0-vulnerabilities.csv


### PR DESCRIPTION
## Jira Ticket

<!-- Before creating this pull request, make sure you have a separate ticket for the docs team to track their work. If you need assistance, ask in the #documentation Slack channel. -->

<!-- Link to JIRA ticket -->

## Description of changes being made


### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4691.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
