### PR TITLE
docs: adding nodepool biz to konvoy upgrade

### DIFF
--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/enterprise/index.md
@@ -9,25 +9,25 @@ menuWeight: 30
 ---
 ## Prerequisites
 
-* Create an [on-demand backup][backup] of your current configuration with Velero.
+-   Create an [on-demand backup][backup] of your current configuration with Velero.
 
-* Follow the steps listed in the [DKP upgrade overview][dkpup].
+-   Follow the steps listed in the [DKP upgrade overview][dkpup].
 
-* Ensure that all platform applications in the management cluster have been upgraded to avoid compatibility issues with the [Kubernetes version][releasenotes] included in this release. This is done automatically when [upgrading Kommander][upgradekomm], so ensure that you upgrade Kommander prior to upgrading Konvoy.
+-   Ensure that all platform applications in the management cluster have been upgraded to avoid compatibility issues with the [Kubernetes version][releasenotes] included in this release. This is done automatically when [upgrading Kommander][upgradekomm], so ensure that you upgrade Kommander prior to upgrading Konvoy.
 
-* For air-gapped: Download the required bundles either at our [support site][supportsite] or by using the CLI.
+-   For air-gapped: Download the required bundles either at our [support site][supportsite] or by using the CLI.
 
-* For Azure, set the required [environment variables][envariables].
+-   For Azure, set the required [environment variables][envariables].
 
-* For AWS, set the required [environment variables][envariables2].
+-   For AWS, set the required [environment variables][envariables2].
 
 The following infrastructure environments are supported:
 
-* Amazon Web Services (AWS)
+-   Amazon Web Services (AWS)
 
-* Microsoft Azure
+-   Microsoft Azure
 
-* Pre-provisioned environments
+-   Pre-provisioned environments
 
 ## Overview
 
@@ -53,14 +53,12 @@ If you are running on more than one management cluster (Kommander cluster), you 
 
 <p class="message--warning"><strong>IMPORTANT:</strong>Ensure your <code>dkp</code> configuration references the management cluster where you want to run the upgrade by setting the <code>KUBECONFIG</code> environment variable, or using the <code>--kubeconfig</code> flag, <a href="https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/">in accordance with Kubernetes conventions</a>.
 
-
 1.  If your cluster was upgraded to 2.1 from 1.8, prepare the old cert-manager installation for upgrade:
 
     ```bash
     helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
     kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
     ```
-
 
 1.  For <strong>all</strong> clusters, upgrade capi-components:
 
@@ -83,8 +81,6 @@ The command should output something similar to the following:
 ✓ Deleting Outdated Global ClusterResourceSets
 ```
 
-
-
 If the upgrade fails, review the prerequisites section and ensure that you've followed the steps in the [DKP upgrade overview][dkpup].
 
 ## Upgrade the core addons
@@ -105,6 +101,7 @@ Examples:
 export CLUSTER_NAME=my-azure-cluster
 dkp upgrade addons azure --cluster-name=${CLUSTER_NAME}
 ```
+
 OR
 
 ```bash
@@ -114,7 +111,7 @@ dkp upgrade addons aws --cluster-name=${CLUSTER_NAME}
 
 The output for the AWS example should be similar to:
 
-```text
+```sh
 Generating addon resources
 clusterresourceset.addons.cluster.x-k8s.io/calico-cni-installation-my-aws-cluster upgraded
 configmap/calico-cni-installation-my-aws-cluster upgraded
@@ -130,7 +127,8 @@ clusterresourceset.addons.cluster.x-k8s.io/nvidia-feature-discovery-my-aws-clust
 configmap/nvidia-feature-discovery-my-aws-cluster upgraded
 ```
 
-### See also ###
+### See also
+
 [DKP upgrade addons](/../../dkp/konvoy/2.2/cli/dkp/upgrade/addons/)
 
 Once complete, begin upgrading the Kubernetes version.
@@ -141,33 +139,44 @@ When upgrading the Kubernetes version of a cluster, first upgrade the control pl
 
 <p class="message--note"><strong>NOTE:</strong> If an AMI was specified when initially creating a cluster, you must build a new one with <a href="/dkp/konvoy/2.2/image-builder/">Konvoy Image Builder</a> and pass it with <code>--ami</code>.
 
-1. Upgrade the Kubernetes version of the control plane.
+1.  Upgrade the Kubernetes version of the control plane.
 
-```bash
-dkp update controlplane aws --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
-```
+    ```bash
+    dkp update controlplane aws --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
+    ```
+
+    The output should be similar to:
+
+    ```sh
+    Updating control plane resource controlplane.cluster.x-k8s.io/v1beta1, Kind=KubeadmControlPlane default/my-aws-cluster-control-plane
+    Waiting for control plane update to finish.
+     ✓ Updating the control plane
+    ```
+
+1.  Upgrade the Kubernetes version of each of your node pools. Get a list of all node pools available in your cluster by running the following command:
+
+    ```bash
+    dkp get nodepool --cluster-name ${CLUSTER_NAME}
+    ```
+
+1.  Replace `my-nodepool` with the name of the node pool.
+
+    ```bash
+    export NODEPOOL_NAME=<my-nodepool>
+    ```
+
+    ```bash
+    dkp update nodepool aws ${NODEPOOL_NAME} --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
+    ```
 
 The output should be similar to:
 
-```text
-Updating control plane resource controlplane.cluster.x-k8s.io/v1beta1, Kind=KubeadmControlPlane default/my-aws-cluster-control-plane
-Waiting for control plane update to finish.
- ✓ Updating the control plane
-```
-
-2. Upgrade the Kubernetes version of each of your node pools. Replace `my-nodepool` with the name of the node pool.
-
-```bash
-export NODEPOOL_NAME=my-nodepool
-dkp update nodepool aws ${NODEPOOL_NAME} --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
-```
-The output should be similar to:
-
-```text
+```sh
 Updating node pool resource cluster.x-k8s.io/v1beta1, Kind=MachineDeployment default/my-aws-cluster-my-nodepool
 Waiting for node pool update to finish.
  ✓ Updating the my-aws-cluster-my-nodepool node pool
 ```
+
 Repeat this step for each additional node pool.
 
 For the overall process for upgrading to the latest version of DKP, refer back to [DKP Upgrade][dkpup]

--- a/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
+++ b/pages/dkp/konvoy/2.2/dkp-upgrade/upgrade-konvoy/essential/index.md
@@ -9,25 +9,25 @@ menuWeight: 30
 ---
 ## Prerequisites
 
-* Create an [on-demand backup][backup] of your current configuration with Velero.
+-   Create an [on-demand backup][backup] of your current configuration with Velero.
 
-* Follow the steps listed in the [DKP upgrade overview][dkpup].
+-   Follow the steps listed in the [DKP upgrade overview][dkpup].
 
-* Ensure that all platform applications in the management cluster have been upgraded to avoid compatibility issues with the [Kubernetes version][releasenotes] included in this release. This is done automatically when [upgrading Kommander][upgradekomm], so ensure that you upgrade Kommander prior to upgrading Konvoy.
+-   Ensure that all platform applications in the management cluster have been upgraded to avoid compatibility issues with the [Kubernetes version][releasenotes] included in this release. This is done automatically when [upgrading Kommander][upgradekomm], so ensure that you upgrade Kommander prior to upgrading Konvoy.
 
-* For air-gapped: Download the required bundles either at our [support site][supportsite] or by using the CLI.
+-   For air-gapped: Download the required bundles either at our [support site][supportsite] or by using the CLI.
 
-* For Azure, set the required [environment variables][envariables].
+-   For Azure, set the required [environment variables][envariables].
 
-* For AWS, set the required [environment variables][envariables2].
+-   For AWS, set the required [environment variables][envariables2].
 
 The following infrastructure environments are supported:
 
-* Amazon Web Services (AWS)
+-   Amazon Web Services (AWS)
 
-* Microsoft Azure
+-   Microsoft Azure
 
-* Pre-provisioned environments
+-   Pre-provisioned environments
 
 ## Overview
 
@@ -55,7 +55,6 @@ New versions of DKP come pre-bundled with newer versions of CAPI, newer versions
     helm -n cert-manager get manifest cert-manager-kubeaddons | kubectl label -f - clusterctl.cluster.x-k8s.io/core=cert-manager
     kubectl delete validatingwebhookconfigurations/cert-manager-kubeaddons-webhook mutatingwebhookconfigurations/cert-manager-kubeaddons-webhook
     ```
-
 
 1.  For <strong>all</strong> clusters, upgrade capi-components:
 
@@ -98,6 +97,7 @@ Examples:
 export CLUSTER_NAME=my-azure-cluster
 dkp upgrade addons azure --cluster-name=${CLUSTER_NAME}
 ```
+
 OR
 
 ```bash
@@ -105,10 +105,9 @@ export CLUSTER_NAME=my-aws-cluster
 dkp upgrade addons aws --cluster-name=${CLUSTER_NAME}
 ```
 
-
 The output for the AWS example should be similar to:
 
-```text
+```sh
 Generating addon resources
 clusterresourceset.addons.cluster.x-k8s.io/calico-cni-installation-my-aws-cluster upgraded
 configmap/calico-cni-installation-my-aws-cluster upgraded
@@ -123,7 +122,9 @@ configmap/node-feature-discovery-my-aws-cluster upgraded
 clusterresourceset.addons.cluster.x-k8s.io/nvidia-feature-discovery-my-aws-cluster upgraded
 configmap/nvidia-feature-discovery-my-aws-cluster upgraded
 ```
-### See also ###
+
+### See also
+
 [DKP upgrade addons](/../../dkp/konvoy/2.2/cli/dkp/upgrade/addons/)
 
 Once complete, begin upgrading the Kubernetes version.
@@ -134,7 +135,7 @@ When upgrading the Kubernetes version of a cluster, first upgrade the control pl
 
 <p class="message--note"><strong>NOTE:</strong> If an AMI was specified when initially creating a cluster, you must build a new one with <a href="/dkp/konvoy/2.2/image-builder/">Konvoy Image Builder</a> and pass it with <code>--ami</code>.
 
-1. Upgrade the Kubernetes version of the control plane.
+1.  Upgrade the Kubernetes version of the control plane.
 
     ```bash
     dkp update controlplane aws --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
@@ -142,21 +143,31 @@ When upgrading the Kubernetes version of a cluster, first upgrade the control pl
 
     The output should be similar to:
 
-    ```text
+    ```sh
     Updating control plane resource controlplane.cluster.x-k8s.io/v1beta1, Kind=KubeadmControlPlane default/my-aws-cluster-control-plane
     Waiting for control plane update to finish.
     ✓  Updating the control plane
     ```
 
-2. Upgrade the Kubernetes version of each of your node pools. Replace `my-nodepool` with the name of the node pool.
+1.  Upgrade the Kubernetes version of each of your node pools. Get a list of all node pools available in your cluster by running the following command:
 
     ```bash
-    export NODEPOOL_NAME=my-nodepool
+    dkp get nodepool --cluster-name ${CLUSTER_NAME}
+    ```
+
+1.  Replace `my-nodepool` with the name of the node pool.
+
+    ```bash
+    export NODEPOOL_NAME=<my-nodepool>
+    ```
+
+    ```bash
     dkp update nodepool aws ${NODEPOOL_NAME} --cluster-name=${CLUSTER_NAME} --kubernetes-version=v1.22.8
     ```
+
 The output should be similar to:
 
-```text
+```sh
 Updating node pool resource cluster.x-k8s.io/v1beta1, Kind=MachineDeployment default/my-aws-cluster-my-nodepool
 Waiting for node pool update to finish.
  ✓ Updating the my-aws-cluster-my-nodepool node pool


### PR DESCRIPTION
## Jira Ticket

N/A

## Description of changes being made

This is basically this, but I am NOW adding it to the konvoy upgrade page:
https://github.com/mesosphere/dcos-docs-site/pull/4692

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4693.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
