### PR TITLE
docs: adding vsphere kib image security details

### DIFF
--- a/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-base-os-image/index.md
+++ b/pages/dkp/konvoy/2.2/choose-infrastructure/vsphere/create-base-os-image/index.md
@@ -13,24 +13,25 @@ Creating a base OS image from DVD ISO files is a one-time process. Building a ba
 
 While creating the base OS image, it is important to take into consideration the following elements:
 
-1. Storage configuration: D2iQ recommends customizing disk partitions and not configuring a SWAP partition.
+1.  Storage configuration: D2iQ recommends customizing disk partitions and not configuring a SWAP partition.
 
-2. Network configuration: as KIB must download and install packages, activating the network is required. 
+1.  Network configuration: as KIB must download and install packages, activating the network is required.
 
-3. Connect to Red Hat: if using RHEL, registering with Red Hat is required to configure software repositories and install software packages. 
+1.  Connect to Red Hat: if using RHEL, registering with Red Hat is required to configure software repositories and install software packages.
 
-4. Software selection: D2iQ recommends choosing **Minimal Install**.
+1.  Software selection: D2iQ recommends choosing **Minimal Install**.
 
-5. Create User: In the packer template, a user "builder" with password "builder" is configured by default, so creating this user with administration privileges is a requirement. Please note that, it is possible to configure a custom user and password when building the OS image, however, that requires the Konvoy Image Builder (KIB) configuration to be overridden. To override the default credentials in KIB, a file (overrides.yaml) with the following content should be created:
+1.  Create User: Depending on the cluster-api provider, a packer user configuration will vary. For vSphere, a password is [required by default by packer][kib-packer-info]. This user should have administrator privileges. It is possible to configure a custom user and password when building the OS image. However, that requires the Konvoy Image Builder (KIB) configuration to be overridden. DKP advises not to use static usernames and passwords for security reasons, but instead passwords should be generated and a minimum of 20 characters long. To override the default credentials in KIB, a file (`overrides.yaml`) with the following content should be created:
 
-```
+```yaml
 ---
-packer:  
-  ssh_username: "<USERNAME>"    
+packer:
+  ssh_username: "<USERNAME>"
   ssh_password: "<PASSWORD>"
 ```
 
 Next, [create a vSphere VM template][create-vsphere-template] that contains the CAPI and Kubernetes objects.
 
-[vsphere-doc-base-image]: https://docs.vmware.com/en/VMware-vSphere/index.html
 [create-vsphere-template]: ../create-capi-vm-image/
+[kib-packer-info]: https://github.com/mesosphere/konvoy-image-builder/blob/eecdd73ec9a1ca07c24962e2637bbab01a44d347/pkg/packer/manifests/vsphere/packer.json.tmpl#L15-L17
+[vsphere-doc-base-image]: https://docs.vmware.com/en/VMware-vSphere/index.html


### PR DESCRIPTION
## Jira Ticket

n/a

## Description of changes being made

Changing the user/pw situation for vsphere for KIB.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4694.s3-website-us-west-2.amazonaws.com/

## Checklist

- [ ] Test all commands and procedures, if applicable.
- [ ] Update all links if you are moving a page.
- [ ] Add release date to Release Notes page in the following format: <Package> was released on <Day>, <Month> <Year> Example: `Mesosphere® DC/OS™ 2.1.0 was released on 9, June 2020`

See the [contribution guidelines](https://github.com/mesosphere/dcos-docs-site/blob/main/CONTRIBUTING.md) for more information.
