### PR TITLE
Update old CVE page to point to new CVE page

### DIFF
--- a/pages/dkp/security-updates/index.md
+++ b/pages/dkp/security-updates/index.md
@@ -7,6 +7,6 @@ menuWeight: 1000
 beta: false
 ---
 
-The Security Updates page was moved to D2iQ Help Center. To view CVE security scans and update information for D2iQ products, refer to:
+The Security Updates page was moved to the D2iQ Help Center. To view CVE security scans for D2iQ products, refer to:
 
 [Security Updates](https://docs.d2iq.com/dkp/latest/d2iq-security-updates)

--- a/pages/dkp/security-updates/index.md
+++ b/pages/dkp/security-updates/index.md
@@ -7,6 +7,6 @@ menuWeight: 1000
 beta: false
 ---
 
-The Security Updates page has been moved to D2iQ Help Center. To view CVE security scans and update information for D2iQ products, refer to:
+The Security Updates page was moved to D2iQ Help Center. To view CVE security scans and update information for D2iQ products, refer to:
 
 [Security Updates](https://docs.d2iq.com/dkp/latest/d2iq-security-updates)

--- a/pages/dkp/security-updates/index.md
+++ b/pages/dkp/security-updates/index.md
@@ -7,6 +7,6 @@ menuWeight: 1000
 beta: false
 ---
 
-The Security Updates page was moved to the D2iQ Help Center. To view CVE security scans for D2iQ products, refer to:
+The Security Updates page was moved to the D2iQ Help Center. To view CVE security scans for D2iQ products, see:
 
 [Security Updates](https://docs.d2iq.com/dkp/latest/d2iq-security-updates)

--- a/pages/dkp/security-updates/index.md
+++ b/pages/dkp/security-updates/index.md
@@ -7,17 +7,6 @@ menuWeight: 1000
 beta: false
 ---
 
-The following information describes mitigated or fixed CVEs found in DKP.
+The Security Updates page has been moved to D2iQ Help Center. To view CVE security scans and update information for D2iQ products, refer to:
 
-## Download
-
-| Product | Version | Link     |
-|---------|---------|----------|
-| DKP     | v2.5.0  | [Download][dkp-v2.5.0-csv] |
-
-## Previous versions
-
-<div class="cve-table-container">Loading...</div>
-<script src="/js/cve.js"></script>
-
-[dkp-v2.5.0-csv]: https://konvoy-staging-devx-cac8-cve-reporter.s3-us-west-2.amazonaws.com/v2.5.0-vulnerabilities.csv
+[Security Updates](https://docs.d2iq.com/dkp/latest/d2iq-security-updates)


### PR DESCRIPTION
## Jira Ticket

https://d2iq.atlassian.net/browse/D2IQ-98178 

## Description of changes being made

The team has migrated the CVE page from our old site to our new site in: https://docs.d2iq.com/dkp/2.6/d2iq-security-updates
Deleting the content of the CVE page in the old site, and adding wording so that it points to the new Confluence-based site.

### Preview

You can preview the docs build using the following URL, adding the PR # where specified:
http://docs-d2iq-com-pr-4701.s3-website-us-west-2.amazonaws.com/
